### PR TITLE
feat(daemon): restrict RPC socket to mode 0600

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ The harness daemon coordinates AI agents, manages PTY sessions, and routes tools
      └────────────────┘
 ```
 
+## Status
+
+RevDev is pre-1.0 and the three components have different distribution maturity:
+
+| Component | Status | How to get it today |
+|-----------|--------|---------------------|
+| Studio | Buildable, unsigned | `pnpm --filter studio tauri build` — produces a local binary. Signed/notarized auto-update pipeline defined in `.github/workflows/studio-release.yml` but not yet cutting public releases. |
+| Console | Buildable | `go build -o rvui ./apps/console` — no release automation yet. |
+| Harness Daemon | Buildable, not published | Not on npm. Build from source with `pnpm --filter @revdev/daemon build`; run the CLI at `packages/daemon/dist/cli.js`. |
+
+Integration test coverage is thin on the Studio-to-daemon Tauri bridge (`vault.rs`, `spawner.rs`, `harness.rs` commands). Treat Studio as development-preview quality until those land.
+
 ## License
 
 Studio and Console: MIT

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -9,7 +9,7 @@
  * without human relay," proven at the RPC layer.
  */
 
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, stat } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -86,6 +86,14 @@ afterAll(async () => {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe('socket hardening', () => {
+  it('socket file is mode 0600 (restricted to owning UID)', async () => {
+    const s = await stat(socketPath);
+    // Mask to the permission bits; ignore the type bits (0o140000 = socket).
+    expect(s.mode & 0o777).toBe(0o600);
+  });
+});
 
 describe('two-agent coordination', () => {
   let alice: string;

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -26,6 +26,16 @@ const EXEMPT_METHODS = new Set([
  * Returns the detected tier, or 'free' if no valid license is found.
  * The daemon runs in degraded mode on free tier: session management
  * works, but spawning, inference, and merge pipeline are gated.
+ *
+ * TODO(licensing): the current format `RVUI-<tier>-<32 hex chars>` is not
+ * cryptographically bound — any regex-matching string is accepted as valid.
+ * Planned upgrade: `RVUI.v2.<tier>.<expiresAt>.<ed25519-sig-base64url>` with:
+ *   - Ed25519 signature over `<tier>.<expiresAt>` verified against a vendor
+ *     public key baked into the daemon binary.
+ *   - `expiresAt` unix timestamp; keys reject after that point.
+ *   - Vendor-side key-generation CLI; signing private key stored in revvault.
+ * Blocks casual forgery; determined attackers can still patch the binary,
+ * but that is a separate threat model from tier-gate enforcement.
  */
 export function checkLicense(): { tier: LicenseTier; valid: boolean } {
   const key = process.env.REVEALUI_LICENSE_KEY;

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -602,7 +602,7 @@ export async function startDaemon(
   console.log('[daemon] Schema initialized');
 
   // Remove stale socket
-  const { unlink } = await import('node:fs/promises');
+  const { unlink, chmod } = await import('node:fs/promises');
   await unlink(cfg.socketPath).catch(() => {});
 
   // Start Unix socket server
@@ -704,9 +704,34 @@ export async function startDaemon(
     socket.on('error', () => {});
   });
 
-  return new Promise((resolve) => {
-    server.listen(cfg.socketPath, () => {
-      console.log(`[daemon] Listening on ${cfg.socketPath}`);
+  return new Promise((resolve, reject) => {
+    // Restrict the socket to the owning UID. umask 0o077 causes bind(2) to
+    // create the socket file with mode 0600 from the moment it exists — no
+    // race window where another local user could open it. The follow-up
+    // chmod is belt-and-suspenders if something mutated umask concurrently.
+    const prevUmask = process.umask(0o077);
+    let umaskRestored = false;
+    const restoreUmask = () => {
+      if (!umaskRestored) {
+        process.umask(prevUmask);
+        umaskRestored = true;
+      }
+    };
+
+    server.once('error', (err) => {
+      restoreUmask();
+      reject(err);
+    });
+
+    server.listen(cfg.socketPath, async () => {
+      restoreUmask();
+      try {
+        await chmod(cfg.socketPath, 0o600);
+      } catch (err) {
+        reject(err);
+        return;
+      }
+      console.log(`[daemon] Listening on ${cfg.socketPath} (mode 0600)`);
       console.log('[daemon] Ready for connections');
 
       resolve({


### PR DESCRIPTION
## Summary

- Tighten the Harness Daemon Unix socket to mode 0600 so only the owning UID can connect. Previously the socket was created with process umask (typically mode 755), meaning any local user could open it and call `session.register` to spoof agent identity.
- Add an integration test in `coordination.test.ts` that verifies the socket mode after startup.
- Scope the planned Ed25519 license-key upgrade as a TODO in `license.ts` for a separate follow-up (current regex-only format is not cryptographically bound).

## Implementation

- `packages/daemon/src/server.ts`: set umask to `0o077` before `server.listen()` so `bind(2)` creates the socket with mode 0600 from the moment it exists (no race window). Add a belt-and-suspenders `chmod(0o600)` after listen. Restore previous umask on both success and bind-error paths.
- `packages/daemon/src/__tests__/coordination.test.ts`: new `describe('socket hardening')` block asserting `stat(socketPath).mode & 0o777 === 0o600`.
- `packages/daemon/src/license.ts`: doc-only TODO scoping the planned format upgrade (format, signing, vendor-side key management). No behavior change.

## Test plan

- [x] `pnpm --filter @revdev/daemon typecheck` — clean
- [x] `pnpm --filter @revdev/daemon test` — 52/52 pass (new test + 51 pre-existing)
- [x] `pnpm lint` — no new warnings
- [ ] Manual: start daemon, `stat ~/.local/share/revealui/harness.sock` shows `srw-------`
