### PR TITLE
test(tauri): add 22 unit tests for harness bridge + spawner

### DIFF
--- a/apps/studio/src-tauri/src/commands/harness.rs
+++ b/apps/studio/src-tauri/src/commands/harness.rs
@@ -152,11 +152,7 @@ pub async fn harness_broadcast(
     .map_err(|e| StudioError::Other(e))?;
 
     // Returns { sent: number, recipients: number, broadcast: true }
-    let sent = result
-        .get("sent")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
-    Ok(sent)
+    Ok(parse_broadcast_sent(&result))
 }
 
 #[tauri::command]
@@ -168,6 +164,47 @@ pub async fn harness_mark_read(message_ids: Vec<i64>) -> Result<(), StudioError>
     .await
     .map_err(|e| StudioError::Other(e))?;
     Ok(())
+}
+
+// ── Pure parsers (testable without a daemon) ────────────────────────────────
+
+/// Parse the response shape of `tasks.claim` into a typed struct.
+/// Missing fields default to `{ success: false, owner: None }`.
+fn parse_claim_result(val: &serde_json::Value) -> HarnessClaimResult {
+    HarnessClaimResult {
+        success: val.get("success").and_then(|v| v.as_bool()).unwrap_or(false),
+        owner: val
+            .get("owner")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+    }
+}
+
+/// Parse the response shape of `files.reserve` into a typed struct.
+/// The daemon returns `{ success, conflicts: [{ path, holder }] }` — we
+/// surface the first conflict's holder to the UI.
+fn parse_reserve_result(val: &serde_json::Value) -> HarnessReserveResult {
+    let success = val.get("success").and_then(|v| v.as_bool()).unwrap_or(false);
+    let holder = val
+        .get("conflicts")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|o| o.get("holder"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    HarnessReserveResult { success, holder }
+}
+
+/// Parse `mail.broadcast` → returns the count of recipients that received
+/// the message. Missing or non-numeric `sent` defaults to 0.
+fn parse_broadcast_sent(val: &serde_json::Value) -> i64 {
+    val.get("sent").and_then(|v| v.as_i64()).unwrap_or(0)
+}
+
+/// Parse a success flag keyed at `ok` (used by `tasks.complete` /
+/// `tasks.release`). Missing or non-bool defaults to false.
+fn parse_ok_flag(val: &serde_json::Value) -> bool {
+    val.get("ok").and_then(|v| v.as_bool()).unwrap_or(false)
 }
 
 // ── Tasks ───────────────────────────────────────────────────────────────────
@@ -223,16 +260,7 @@ pub async fn harness_claim_task(
     )
     .await
     .map_err(|e| StudioError::Other(e))?;
-    Ok(HarnessClaimResult {
-        success: result
-            .get("success")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        owner: result
-            .get("owner")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
-    })
+    Ok(parse_claim_result(&result))
 }
 
 #[tauri::command]
@@ -247,7 +275,7 @@ pub async fn harness_complete_task(
     )
     .await
     .map_err(|e| StudioError::Other(e))?;
-    Ok(result.get("ok").and_then(|v| v.as_bool()).unwrap_or(false))
+    Ok(parse_ok_flag(&result))
 }
 
 #[tauri::command]
@@ -262,7 +290,7 @@ pub async fn harness_release_task(
     )
     .await
     .map_err(|e| StudioError::Other(e))?;
-    Ok(result.get("ok").and_then(|v| v.as_bool()).unwrap_or(false))
+    Ok(parse_ok_flag(&result))
 }
 
 // ── File Reservations ───────────────────────────────────────────────────────
@@ -302,18 +330,7 @@ pub async fn harness_reserve_file(
     .await
     .map_err(|e| StudioError::Other(e))?;
 
-    let success = result
-        .get("success")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let holder = result
-        .get("conflicts")
-        .and_then(|v| v.as_array())
-        .and_then(|arr| arr.first())
-        .and_then(|o| o.get("holder"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
-    Ok(HarnessReserveResult { success, holder })
+    Ok(parse_reserve_result(&result))
 }
 
 #[tauri::command]
@@ -336,5 +353,156 @@ pub async fn harness_check_file(
         Some(row) => serde_json::from_value(row)
             .map(Some)
             .map_err(|e| StudioError::Other(e.to_string())),
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // parse_claim_result ------------------------------------------------------
+
+    #[test]
+    fn parse_claim_result_missing_fields_defaults_to_false_and_none() {
+        let r = parse_claim_result(&json!({}));
+        assert!(!r.success);
+        assert!(r.owner.is_none());
+    }
+
+    #[test]
+    fn parse_claim_result_extracts_success_and_owner() {
+        let r = parse_claim_result(&json!({
+            "success": true,
+            "owner": "agent-alice",
+        }));
+        assert!(r.success);
+        assert_eq!(r.owner.as_deref(), Some("agent-alice"));
+    }
+
+    #[test]
+    fn parse_claim_result_ignores_non_string_owner() {
+        // Daemon contract says owner is a string; a numeric value should fall
+        // back to None rather than panic or stringify the number.
+        let r = parse_claim_result(&json!({
+            "success": false,
+            "owner": 42,
+        }));
+        assert!(!r.success);
+        assert!(r.owner.is_none());
+    }
+
+    // parse_reserve_result ----------------------------------------------------
+
+    #[test]
+    fn parse_reserve_result_no_conflicts_yields_none_holder() {
+        let r = parse_reserve_result(&json!({
+            "success": true,
+            "conflicts": [],
+        }));
+        assert!(r.success);
+        assert!(r.holder.is_none());
+    }
+
+    #[test]
+    fn parse_reserve_result_extracts_first_conflict_holder() {
+        let r = parse_reserve_result(&json!({
+            "success": false,
+            "conflicts": [
+                { "path": "/x.ts", "holder": "agent-alice" },
+                { "path": "/y.ts", "holder": "agent-bob" },
+            ],
+        }));
+        assert!(!r.success);
+        assert_eq!(r.holder.as_deref(), Some("agent-alice"));
+    }
+
+    #[test]
+    fn parse_reserve_result_missing_fields_defaults_cleanly() {
+        let r = parse_reserve_result(&json!({}));
+        assert!(!r.success);
+        assert!(r.holder.is_none());
+    }
+
+    // parse_broadcast_sent ----------------------------------------------------
+
+    #[test]
+    fn parse_broadcast_sent_missing_is_zero() {
+        assert_eq!(parse_broadcast_sent(&json!({})), 0);
+    }
+
+    #[test]
+    fn parse_broadcast_sent_reads_integer() {
+        assert_eq!(parse_broadcast_sent(&json!({ "sent": 7 })), 7);
+    }
+
+    #[test]
+    fn parse_broadcast_sent_ignores_non_integer() {
+        // String or null should not crash — contract violation → 0.
+        assert_eq!(parse_broadcast_sent(&json!({ "sent": "seven" })), 0);
+        assert_eq!(parse_broadcast_sent(&json!({ "sent": null })), 0);
+    }
+
+    // parse_ok_flag -----------------------------------------------------------
+
+    #[test]
+    fn parse_ok_flag_missing_is_false() {
+        assert!(!parse_ok_flag(&json!({})));
+    }
+
+    #[test]
+    fn parse_ok_flag_reads_true_and_false() {
+        assert!(parse_ok_flag(&json!({ "ok": true })));
+        assert!(!parse_ok_flag(&json!({ "ok": false })));
+    }
+
+    #[test]
+    fn parse_ok_flag_ignores_non_bool() {
+        assert!(!parse_ok_flag(&json!({ "ok": 1 })));
+        assert!(!parse_ok_flag(&json!({ "ok": "true" })));
+    }
+
+    // Serde round-trip for wire types ----------------------------------------
+
+    #[test]
+    fn harness_session_serde_roundtrip() {
+        let s = HarnessSession {
+            id: "s1".into(),
+            env: "claude:alice".into(),
+            task: "ship feature".into(),
+            files: Some("src/a.ts".into()),
+            pid: Some(12345),
+            started_at: "2026-04-18T00:00:00Z".into(),
+            updated_at: "2026-04-18T00:05:00Z".into(),
+            ended_at: None,
+            exit_summary: None,
+        };
+        let wire = serde_json::to_value(&s).unwrap();
+        let back: HarnessSession = serde_json::from_value(wire).unwrap();
+        assert_eq!(back.id, s.id);
+        assert_eq!(back.env, s.env);
+        assert_eq!(back.task, s.task);
+        assert_eq!(back.pid, s.pid);
+        assert_eq!(back.ended_at, s.ended_at);
+    }
+
+    #[test]
+    fn harness_task_serde_roundtrip() {
+        let t = HarnessTask {
+            id: "t1".into(),
+            description: "do the thing".into(),
+            status: "open".into(),
+            owner: None,
+            claimed_at: None,
+            completed_at: None,
+            created_at: "2026-04-18T00:00:00Z".into(),
+        };
+        let wire = serde_json::to_value(&t).unwrap();
+        let back: HarnessTask = serde_json::from_value(wire).unwrap();
+        assert_eq!(back.id, t.id);
+        assert_eq!(back.status, t.status);
+        assert_eq!(back.owner, t.owner);
     }
 }

--- a/apps/studio/src-tauri/src/spawner.rs
+++ b/apps/studio/src-tauri/src/spawner.rs
@@ -291,3 +291,127 @@ pub fn remove(
         .ok_or_else(|| format!("No agent session with id {session_id}"))?;
     Ok(())
 }
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Serde contract for AgentBackend — the frontend relies on exact
+    // string tags for Snap/Ollama when configuring an agent spawn call.
+    #[test]
+    fn agent_backend_serializes_to_expected_tag() {
+        let snap = serde_json::to_string(&AgentBackend::Snap).unwrap();
+        let ollama = serde_json::to_string(&AgentBackend::Ollama).unwrap();
+        assert_eq!(snap, "\"Snap\"");
+        assert_eq!(ollama, "\"Ollama\"");
+    }
+
+    #[test]
+    fn agent_backend_deserializes_from_tag() {
+        let snap: AgentBackend = serde_json::from_str("\"Snap\"").unwrap();
+        let ollama: AgentBackend = serde_json::from_str("\"Ollama\"").unwrap();
+        assert!(matches!(snap, AgentBackend::Snap));
+        assert!(matches!(ollama, AgentBackend::Ollama));
+    }
+
+    // For state-machine tests we need real `Child` instances. The tests are
+    // gated on `unix` because constructing a portable short-lived child
+    // cross-platform is more trouble than it's worth; Studio's primary dev
+    // and CI targets are macOS and Linux.
+    #[cfg(unix)]
+    fn make_exited_process(name: &str, status: &str) -> AgentProcess {
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("exit 0")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .stdin(Stdio::null())
+            .spawn()
+            .expect("spawn exit 0");
+        // Wait so the child becomes a zombie that's already reaped; state tests
+        // don't actually touch the Child unless `stop` is called.
+        let _ = child.wait();
+        AgentProcess {
+            name: name.into(),
+            model: "test-model".into(),
+            backend: AgentBackend::Ollama,
+            prompt: "hi".into(),
+            child,
+            status: status.into(),
+        }
+    }
+
+    #[cfg(unix)]
+    fn state_with(procs: Vec<(String, AgentProcess)>) -> Arc<Mutex<HashMap<String, AgentProcess>>> {
+        let mut map = HashMap::new();
+        for (id, proc) in procs {
+            map.insert(id, proc);
+        }
+        Arc::new(Mutex::new(map))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn list_returns_empty_for_no_sessions() {
+        let state = state_with(vec![]);
+        let out = list(state).unwrap();
+        assert_eq!(out.len(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn list_projects_sessions_to_info() {
+        let state = state_with(vec![
+            ("s1".into(), make_exited_process("alice", "stopped")),
+            ("s2".into(), make_exited_process("bob", "errored")),
+        ]);
+        let mut out = list(state).unwrap();
+        out.sort_by(|a, b| a.id.cmp(&b.id));
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].id, "s1");
+        assert_eq!(out[0].name, "alice");
+        assert_eq!(out[0].status, "stopped");
+        assert_eq!(out[1].id, "s2");
+        assert_eq!(out[1].name, "bob");
+        assert_eq!(out[1].status, "errored");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_rejects_running_session() {
+        let state = state_with(vec![("s1".into(), make_exited_process("a", "running"))]);
+        let err = remove("s1", state.clone()).unwrap_err();
+        assert!(
+            err.contains("running"),
+            "error should mention 'running', got: {err}"
+        );
+        // Session must still be present.
+        assert_eq!(list(state).unwrap().len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_succeeds_on_stopped_session() {
+        let state = state_with(vec![("s1".into(), make_exited_process("a", "stopped"))]);
+        remove("s1", state.clone()).unwrap();
+        assert_eq!(list(state).unwrap().len(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_errors_on_unknown_session() {
+        let state = state_with(vec![]);
+        let err = remove("nope", state).unwrap_err();
+        assert!(err.contains("nope"), "error should mention the id: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stop_errors_on_unknown_session() {
+        let state = state_with(vec![]);
+        let err = stop("nope", state).unwrap_err();
+        assert!(err.contains("nope"), "error should mention the id: {err}");
+    }
+}


### PR DESCRIPTION
## Summary

Add 22 unit tests covering the Tauri command-layer bridge between Studio's frontend and the harness daemon + revvault. Before this PR, the only Rust tests were auto-generated ts-rs binding smoke tests (45 of them) — zero coverage of parsing, state-machine, or contract logic.

## What's covered

### `packages/commands/harness.rs` — 14 tests
Four pure parsers extracted from inline closures, each with missing-field / happy-path / contract-violation coverage:
- `parse_claim_result` — unwraps `{success, owner}` from `tasks.claim` responses, defaults to `{false, None}`
- `parse_reserve_result` — extracts first conflict's `holder` from `files.reserve`, handles empty or missing `conflicts`
- `parse_broadcast_sent` — reads `sent` integer from `mail.broadcast`, ignores non-integer values
- `parse_ok_flag` — reads `ok` bool from `tasks.complete` / `tasks.release`, ignores non-bool

Plus serde round-trips for the `HarnessSession` and `HarnessTask` wire types — catches accidental field rename or type drift before the frontend bindings regenerate.

### `src/spawner.rs` — 8 tests
State-machine tests directly against `list`, `remove`, `stop` — no mocks, uses real `Child` handles from short-lived `sh -c 'exit 0'` subprocesses (`#[cfg(unix)]`-gated for portability):
- `list` empty + populated
- `remove` rejects `running`, succeeds on `stopped`, errors on unknown id
- `stop` errors on unknown id

Plus `AgentBackend` serde contract tests — the frontend relies on exact `"Snap"` / `"Ollama"` tag strings when sending agent-spawn calls, so any accidental rename would break the TS bindings.

## Refactor

Extracted four tiny pure helper functions in `harness.rs` (`parse_claim_result`, `parse_reserve_result`, `parse_broadcast_sent`, `parse_ok_flag`) so the parsing logic is testable without standing up a mock daemon socket. The `#[tauri::command]` functions now delegate to those helpers — behavior unchanged, but each response-shape invariant is pinned by a test.

## Test plan

- [x] `cargo test --lib` — 67/67 pass (45 pre-existing bindings + 22 new)
- [x] `cargo clippy --lib --tests` — clean on the three modified files
- [x] `cargo check` — clean (1 pre-existing `dead_code` warning on `RepoEntry` is unrelated)
- [ ] Follow-up: vault.rs tests (attempted but hit an rustc ICE via a guessed `Namespace` enum shape; SecretInfo::from is a 4-line conversion, low-value to pursue separately)
- [ ] Follow-up: spawner `spawn()` integration test — requires a real `tauri::AppHandle`, would need `tauri::test::mock_builder()` scaffolding

## What's deliberately not covered

- `#[tauri::command]` invocation through the Tauri runtime — that's Tauri's job, not ours
- Actual daemon socket I/O — integration tests already exist in `packages/daemon/src/__tests__/coordination.test.ts`
- Every Tauri command wrapper individually — many are 3-line pass-throughs to tested modules; adding "does this forward its argument" tests adds noise without signal
