### PR TITLE
chore(gitignore): ignore .claude/ and .agents/ local tooling dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ coverage/
 
 # opensrc context (fetched on demand)
 opensrc/
+.claude/
+.agents/


### PR DESCRIPTION
Match the convention already in `revealui`: add `.claude/` and `.agents/` to `.gitignore`.

These directories hold AI-assistant local state (session transcripts, agent scratch files, generated plans) that is machine-local and should never be committed.
