### PR TITLE
ci: port revealui security + no-submodules workflows

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,28 @@
+name: "RevDev CodeQL config"
+
+# Exclude test files from analysis. CodeQL on test code is high-noise /
+# low-signal: taint-tracking rules fire on test fixtures, mock inputs, and
+# assertion helpers that never run in production. Real exploit surface
+# lives in source files, which are still analysed.
+paths-ignore:
+  - "**/__tests__/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/*_test.go"
+  - "**/e2e/**"
+  - "**/*.e2e.ts"
+  - "**/test-fixtures/**"
+  - "**/*-corpus/**"
+  - "**/target/**"
+  - "**/node_modules/**"
+
+# Dismissals for alerts in source files should use the GitHub UI/API with
+# a "false positive" + rationale comment, not path exclusions. The only
+# reason to add a rule-level exclusion here is if a sanitiser implementation
+# is persistently flagged by a rule that cannot model the sanitisation —
+# which is rare enough that per-alert dismissal is preferable.
+
+queries:
+  - uses: security-and-quality

--- a/.github/workflows/no-submodules.yml
+++ b/.github/workflows/no-submodules.yml
@@ -1,0 +1,31 @@
+name: No Submodules
+
+# Mirrors RevealUI's policy: cross-repo deps publish via workspace packages,
+# npm, Cargo, or Go modules — never .gitmodules. This workflow fails if any
+# submodule artifact appears in the repo.
+
+on:
+  push:
+    branches: [main, test]
+  pull_request:
+    branches: [main, test]
+  schedule:
+    - cron: '0 6 * * 0' # weekly Sunday 6 AM UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: no-submodules-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  audit:
+    name: Submodule Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run no-submodules audit
+        run: bash scripts/audit-no-submodules.sh

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,95 @@
+name: Security
+
+# Ports the portable jobs from RevealUI's Security workflow:
+#   gitleaks       — full-history secret scanning
+#   codeql         — TypeScript + Go static analysis (Rust uses clippy in ci.yml)
+#   dependency-review — blocks PRs that introduce high-severity CVEs
+#
+# The revealui-specific `security-gate` job (which runs `pnpm gate:security`)
+# is not ported because its underlying scripts live in the revealui repo.
+
+on:
+  push:
+    branches: [main, test]
+  pull_request:
+    branches: [main, test]
+  schedule:
+    - cron: '0 9 * * 1' # weekly Monday 9 AM UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  gitleaks:
+    name: Secret Scanning (Gitleaks)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, go]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
+
+      # JS/TS-specific setup: install deps so CodeQL sees the full module graph
+      - if: matrix.language == 'javascript-typescript'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - if: matrix.language == 'javascript-typescript'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - if: matrix.language == 'javascript-typescript'
+        run: pnpm install --frozen-lockfile
+
+      # Go-specific setup
+      - if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache-dependency-path: apps/terminal/go.sum
+
+      - uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}
+
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,79 @@
+# gitleaks config for RevDev
+#
+# Layered defense:
+#   1. .gitignore already keeps build artifacts out of git.
+#   2. This file narrows gitleaks scans so working-tree and history
+#      scans don't produce noise from Rust .rmeta docstrings,
+#      test fixtures, and generated code.
+#   3. Historical fingerprints pinned in .gitleaksignore.
+#
+# Docs: https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
+# Extends the default ruleset; base rules still apply unless overridden.
+
+[extend]
+useDefault = true
+
+# ----------------------------------------------------------------------
+# Global allowlist — paths that never contain genuine secrets.
+# ----------------------------------------------------------------------
+[allowlist]
+description = "Paths with no real secrets: build output, generated code, lockfiles, fixtures"
+paths = [
+  # Rust build output — .rmeta files embed crate docstrings that often show
+  # PEM examples ("-----BEGIN PRIVATE KEY-----...") as documentation.
+  '''^(?:.*/)?target/''',
+  # Node / pnpm build output
+  '''^(?:.*/)?node_modules/''',
+  '''^(?:.*/)?dist/''',
+  '''^(?:.*/)?build/''',
+  '''^(?:.*/)?\.next/''',
+  # Go build cache
+  '''^(?:.*/)?\.cache/''',
+  # ts-rs generated bindings
+  '''^(?:.*/)?bindings/''',
+  # Test snapshot directories
+  '''^(?:.*/)?__snapshots__/''',
+  '''^(?:.*/)?test-fixtures/''',
+  # This file itself
+  '''^\.gitleaks\.toml$''',
+  # Dependency lock files — secrets do not belong in them, and noisy
+  # entropy heuristics can false-positive.
+  '''^(?:.*/)?Cargo\.lock$''',
+  '''^(?:.*/)?pnpm-lock\.yaml$''',
+  '''^(?:.*/)?package-lock\.json$''',
+  '''^(?:.*/)?go\.sum$''',
+]
+
+# Forward-looking regex allowlist.
+regexes = [
+  # Documentation placeholders (README examples, etc.)
+  '''<(your[_-]?(secret|token|key|password)|redacted|placeholder)>''',
+  # Unix socket paths the daemon uses as config defaults (not secrets).
+  '''~?/\.local/share/(revealui|revdev)/harness\.sock''',
+]
+
+# ----------------------------------------------------------------------
+# Custom rule: brand the RVUI license key format.
+#
+# This rule matches the daemon's regex (RVUI-<tier>-<32 hex>) so real
+# keys get flagged anywhere they appear. The rule's own allowlist
+# excludes test files by path — any fixture key in a test file is
+# presumed intentional. A real key leaking into production code (or
+# docs, or config examples) would fire immediately.
+# ----------------------------------------------------------------------
+[[rules]]
+id = "revealui-license-key"
+description = "RevealUI / RevDev license key (format: RVUI-<tier>-<32 hex>)"
+regex = '''RVUI-(pro|max|enterprise)-[a-f0-9]{32}'''
+tags = ["key", "revealui"]
+
+[[rules.allowlists]]
+description = "Test files may hardcode fixture keys — they match the format but are not issued credentials"
+paths = [
+  '''^(?:.*/)?__tests__/''',
+  '''^(?:.*/)?.*\.test\.(ts|tsx|js|jsx|rs)$''',
+  '''^(?:.*/)?.*\.spec\.(ts|tsx|js|jsx|rs)$''',
+  '''^(?:.*/)?tests/''',
+  # License regex docstring in the daemon itself documents the format.
+  '''^packages/daemon/src/license\.ts$''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -63,17 +63,24 @@ regexes = [
 # ----------------------------------------------------------------------
 [[rules]]
 id = "revealui-license-key"
-description = "RevealUI / RevDev license key (format: RVUI-<tier>-<32 hex>)"
-regex = '''RVUI-(pro|max|enterprise)-[a-f0-9]{32}'''
+description = "RevealUI / RevDev license key (format: RVUI-<tier>-<32 hex>, case-insensitive)"
+regex = '''(?i)RVUI-(pro|max|enterprise)-[a-f0-9]{32}'''
 tags = ["key", "revealui"]
 
-[[rules.allowlists]]
-description = "Test files may hardcode fixture keys — they match the format but are not issued credentials"
-paths = [
-  '''^(?:.*/)?__tests__/''',
-  '''^(?:.*/)?.*\.test\.(ts|tsx|js|jsx|rs)$''',
-  '''^(?:.*/)?.*\.spec\.(ts|tsx|js|jsx|rs)$''',
-  '''^(?:.*/)?tests/''',
-  # License regex docstring in the daemon itself documents the format.
-  '''^packages/daemon/src/license\.ts$''',
-]
+  [rules.allowlist]
+  description = "Test files + the daemon's own format documentation — fixture keys, not issued credentials"
+  paths = [
+    '''__tests__''',
+    '''\.test\.(ts|tsx|js|jsx|rs)$''',
+    '''\.spec\.(ts|tsx|js|jsx|rs)$''',
+    '''(^|/)tests/''',
+    '''packages/daemon/src/license\.ts$''',
+  ]
+  regexes = [
+    # Obvious fixture patterns — repeating / placeholder hex
+    '''(?i)RVUI-[a-z]+-(0123456789abcdef){2}''',
+    '''(?i)RVUI-[a-z]+-(a1b2c3d4e5f6){2}.{8}''',
+    '''(?i)RVUI-[a-z]+-(abcdef0123456789){2}''',
+    '''(?i)RVUI-[a-z]+-0{32}''',
+    '''(?i)RVUI-[a-z]+-f{32}''',
+  ]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,21 @@
+# Suppress false positives for gitleaks secret scanning.
+#
+# Each line below suppresses a specific finding by its fingerprint:
+#   <commit>:<path>:<rule>:<line>
+#
+# These are test-fixture license keys in unit tests. They match the
+# RevDev license regex (`^RVUI-(pro|max|enterprise)-[a-f0-9]{32}$`)
+# but the format is regex-validated only — no cryptographic binding
+# (tracked for upgrade to Ed25519 signatures in packages/daemon/src/license.ts).
+# So the test strings cannot unlock anything a forged string couldn't
+# also unlock, by design. They exist in history from two commits.
+
+# guard.test.ts — test license keys for max/enterprise tier paths
+5afa81cc5e5a4614ce9b1748172caaa9ab4e7752:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:102
+5afa81cc5e5a4614ce9b1748172caaa9ab4e7752:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:109
+173d460359d0378cd2b6d2aeb6526c5149437b31:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:102
+173d460359d0378cd2b6d2aeb6526c5149437b31:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:109
+
+# coordination.test.ts — test license key required for license-gated coordination RPCs
+173d460359d0378cd2b6d2aeb6526c5149437b31:packages/daemon/src/__tests__/coordination.test.ts:generic-api-key:69
+5afa81cc5e5a4614ce9b1748172caaa9ab4e7752:packages/daemon/src/__tests__/coordination.test.ts:generic-api-key:69

--- a/scripts/audit-no-submodules.sh
+++ b/scripts/audit-no-submodules.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# =============================================================================
+# No-Submodules Audit
+#
+# Verifies zero git submodules exist in this repository.
+# RevDev policy (mirrors RevealUI): cross-repo deps publish to npm / Cargo /
+# Go modules, never .gitmodules.
+#
+# Checks:
+#   1. No .gitmodules file at repo root
+#   2. No .git/modules/ directory (stale submodule artifacts)
+#   3. No submodule entries in git config
+#   4. No tree-object gitlinks (mode 160000) in HEAD
+#
+# Exit codes:
+#   0 — all checks pass (no submodules found)
+#   1 — one or more checks failed (submodules detected)
+#
+# Usage:
+#   bash scripts/audit-no-submodules.sh
+# =============================================================================
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  ✓ $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  ✗ $1"
+  FAIL=$((FAIL + 1))
+}
+
+echo "========================================"
+echo "  No-Submodules Audit"
+echo "========================================"
+echo ""
+
+# Check 1: .gitmodules file
+if [ -f .gitmodules ]; then
+  fail ".gitmodules file exists at repo root"
+else
+  pass "No .gitmodules file"
+fi
+
+# Check 2: .git/modules/ directory
+if [ -d .git/modules ] && [ "$(ls -A .git/modules/ 2>/dev/null)" ]; then
+  fail ".git/modules/ directory contains stale submodule data"
+else
+  pass "No .git/modules/ artifacts"
+fi
+
+# Check 3: git config submodule entries
+if git config --list 2>/dev/null | grep -q "^submodule\."; then
+  fail "git config contains submodule entries"
+else
+  pass "No submodule entries in git config"
+fi
+
+# Check 4: tree-object gitlinks (mode 160000)
+if git ls-tree -r HEAD 2>/dev/null | grep -q "^160000 "; then
+  fail "Tree contains gitlinks (mode 160000) — submodule references in HEAD"
+else
+  pass "No gitlinks in HEAD tree"
+fi
+
+echo ""
+echo "----------------------------------------"
+echo "  Results: $PASS passed, $FAIL failed"
+echo "----------------------------------------"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "FAIL: Submodule artifacts detected."
+  echo "Policy: use workspace packages, published crates/npm modules, or Go modules."
+  exit 1
+fi
+
+echo ""
+echo "PASS: No submodules found."
+exit 0


### PR DESCRIPTION
Port the three portable jobs from RevealUI's `security.yml` plus the no-submodules audit to RevDev. Brings RevDev's CI surface closer to RevealUI's.

## What runs

**`.github/workflows/security.yml`** (3 jobs, push/PR + weekly cron):

- **Gitleaks** — full-history secret scanning
- **CodeQL** — matrix over `javascript-typescript` + `go`; Rust is covered by `cargo clippy` (CodeQL doesn't officially support Rust)
- **Dependency Review** — blocks PRs that introduce high-severity CVEs

**`.github/workflows/no-submodules.yml`** — fails the build if any submodule artifacts appear.

## What's deliberately not ported

- **`security-gate` job** from RevealUI's security.yml — that one runs `pnpm gate:security` which depends on scripts that live in the revealui repo. Not portable without also porting the scripts.

## Supporting files

- `scripts/audit-no-submodules.sh` — self-contained bash audit. Passes locally.
- `.github/codeql/codeql-config.yml` — excludes tests / e2e / fixtures / target / node_modules so CodeQL focuses on production code.

## Note on quota

This PR's workflows will only run once **either** the org's private-repo Actions quota resets **or** the repo visibility flips to public. Until then, the files are staged and ready. The logic is verified locally (`bash scripts/audit-no-submodules.sh` → 4/4 pass).

## Test plan

- [x] `bash scripts/audit-no-submodules.sh` passes locally
- [ ] After quota reset / public flip: gitleaks clean
- [ ] After quota reset / public flip: CodeQL finishes on both languages
- [ ] After quota reset / public flip: dependency-review gates PR
