### PR TITLE
docs(readmes): surface shipped-vs-planned state in Studio + Console READMEs

### DIFF
--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -15,9 +15,13 @@ Built with the [Charm](https://charm.sh/) ecosystem:
 
 ## Usage
 
+The intended entry point — once hosted deployment ships — is a single SSH command:
+
 ```bash
-ssh console.revealui.com
+ssh console.revealui.com    # planned — hosted endpoint not yet live
 ```
+
+Until then, run locally via the [Development](#development) section.
 
 ## Development
 

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -1,5 +1,7 @@
 # RevealUI Studio
 
+> **Status:** Functional in dev — connects to the harness daemon, 506 frontend tests passing. Prebuilt binary release is **not** yet shipped (Tauri `studio-release.yml` CI in progress). Run locally via `pnpm tauri:dev` for now.
+
 Native AI experience — agent coordination hub, local inference management, visual agent dashboard, DevPod manager, and secret vault.
 
 Built with Tauri 2 + React 19 + Tailwind CSS v4.


### PR DESCRIPTION
## Summary

Make the **shipped-vs-planned** state of Studio and Console visible from the README header, instead of implicit in the feature prose or buried mid-body.

## Changes (two files, docs-only)

### `apps/studio/README.md`
Added a header-badge status line. The previous README jumped straight from title → feature list, which read as if a downloadable binary was available. Ground truth: Studio is functional in `pnpm tauri:dev` with 506 frontend tests passing, but the prebuilt binary release is still being wired up (`studio-release.yml` CI is in progress per MASTER_PLAN §Studio Release).

New header:
> **Status:** Functional in dev — connects to the harness daemon, 506 frontend tests passing. Prebuilt binary release is **not** yet shipped (Tauri `studio-release.yml` CI in progress). Run locally via `pnpm tauri:dev` for now.

### `apps/console/README.md`
The file already had a top-of-file status line (`> **Status: Experimental** — Not production-deployed. Functional prototype.`). But the Usage block underneath then showed `ssh console.revealui.com` as if it were a working endpoint. A reader could easily copy that line, try it, and conclude the project is broken — when in fact the endpoint just isn't live yet.

Change: qualify the usage example as planned (`# planned — hosted endpoint not yet live`) and add a one-liner pointing first-time users at the Development section for current access.

## Why this matches CR9-P1-07 intent

The CR9-P1-07 item called for moving "experimental / preview quality" language from buried body to header badge. Verified state-on-disk was slightly different from the item's description:

- **Console** already had a top-of-file status line (not buried) — but its Usage example was aspirational without being labeled as such. That's the same framing problem the CR item targets, just in a different column of the doc.
- **Studio** had no status line at all — features were listed as if fully shipped; the binary-release gap is genuinely in-flight per MASTER_PLAN but wasn't visible to a README reader.

Rather than edit a phantom "experimental" flag, this PR surfaces the real state in each file's header and adjacent prose, which is the CR item's underlying goal.

## Non-goals

- No changes to Studio's feature list. The listed features (Dashboard, Vault, Infrastructure, Sync, Tunnel, Setup) are all shipped; no "Roadmap" restructure needed for features themselves. The only aspirational piece is the release-artifact path, which the status line now names.
- No changes to Console's capability prose. The existing "SSH-delivered TUI ops cockpit" description matches the shipped-in-dev state.

## Verification

- `git diff --cached --stat`: 2 files, 7 insertions, 1 deletion
- Rendered markdown preview: status line and qualified usage-command render cleanly
- No impact on any build, test, or CI pipeline (docs-only)
