### PR TITLE
fix(studio,docs): Ed25519 license label + retire misleading test-email button

### DIFF
--- a/apps/studio/src/__tests__/components/StepEmail.test.tsx
+++ b/apps/studio/src/__tests__/components/StepEmail.test.tsx
@@ -57,11 +57,10 @@ describe('StepEmail', () => {
     expect(screen.getByPlaceholderText('noreply@yourdomain.com')).toBeInTheDocument();
   });
 
-  it('renders test email input and send button', () => {
+  it('surfaces an honest note that in-wizard test send is not wired', () => {
     renderStep();
 
-    expect(screen.getByPlaceholderText('you@example.com')).toBeInTheDocument();
-    expect(screen.getByText('Send Test Email')).toBeInTheDocument();
+    expect(screen.getByText(/test send is not wired/i)).toBeInTheDocument();
   });
 
   it('disables Next until credentials are configured', () => {
@@ -70,13 +69,13 @@ describe('StepEmail', () => {
     expect(screen.getByText('Next')).toBeDisabled();
   });
 
-  it('disables Send Test Email when fields are empty', () => {
+  it('disables Save Config when credentials are empty', () => {
     renderStep();
 
-    expect(screen.getByText('Send Test Email')).toBeDisabled();
+    expect(screen.getByText('Save Config')).toBeDisabled();
   });
 
-  it('enables Send Test Email when all required fields are filled', () => {
+  it('enables Save Config when service account email + private key are filled', () => {
     renderStep();
 
     fireEvent.change(
@@ -87,14 +86,11 @@ describe('StepEmail', () => {
       // gitleaks:allow
       target: { value: 'test-private-key-fixture' },
     });
-    fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
-      target: { value: 'test@example.com' },
-    });
 
-    expect(screen.getByText('Send Test Email')).not.toBeDisabled();
+    expect(screen.getByText('Save Config')).not.toBeDisabled();
   });
 
-  it('shows honest error and saves config when test email is attempted', async () => {
+  it('persists credentials when Save Config is clicked', async () => {
     const { onUpdateData, onUpdateConfig } = renderStep();
 
     fireEvent.change(
@@ -105,36 +101,20 @@ describe('StepEmail', () => {
       // gitleaks:allow
       target: { value: 'test-private-key-fixture' },
     });
-    fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
-      target: { value: 'test@example.com' },
-    });
-    fireEvent.click(screen.getByText('Send Test Email'));
+    fireEvent.click(screen.getByText('Save Config'));
 
     await waitFor(() => {
-      expect(screen.getByText(/not yet implemented/)).toBeInTheDocument();
-    });
-
-    // Config still saved even though test send isn't wired
-    expect(onUpdateData).toHaveBeenCalledWith({
-      emailProvider: 'gmail',
-      googleServiceAccountEmail: 'sa@project.iam.gserviceaccount.com',
-      googlePrivateKey: 'test-private-key-fixture',
-      emailFrom: '',
+      expect(onUpdateData).toHaveBeenCalledWith({
+        emailProvider: 'gmail',
+        googleServiceAccountEmail: 'sa@project.iam.gserviceaccount.com',
+        googlePrivateKey: 'test-private-key-fixture',
+        emailFrom: '',
+      });
     });
     expect(onUpdateConfig).toHaveBeenCalled();
   });
 
-  it('disables Send Test Email when service account fields are missing', () => {
-    renderStep();
-
-    fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
-      target: { value: 'test@example.com' },
-    });
-
-    expect(screen.getByText('Send Test Email')).toBeDisabled();
-  });
-
-  it('updates from address in wizard data', async () => {
+  it('includes the from-address in the saved config', async () => {
     const { onUpdateData } = renderStep();
 
     fireEvent.change(
@@ -148,20 +128,15 @@ describe('StepEmail', () => {
     fireEvent.change(screen.getByPlaceholderText('noreply@yourdomain.com'), {
       target: { value: 'noreply@example.com' },
     });
-    fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
-      target: { value: 'test@example.com' },
-    });
-    fireEvent.click(screen.getByText('Send Test Email'));
+    fireEvent.click(screen.getByText('Save Config'));
 
     await waitFor(() => {
-      expect(screen.getByText(/not yet implemented/)).toBeInTheDocument();
+      expect(onUpdateData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emailFrom: 'noreply@example.com',
+        }),
+      );
     });
-
-    expect(onUpdateData).toHaveBeenCalledWith(
-      expect.objectContaining({
-        emailFrom: 'noreply@example.com',
-      }),
-    );
   });
 
   it('pre-fills from existing wizard data', () => {

--- a/apps/studio/src/components/deploy/StepEmail.tsx
+++ b/apps/studio/src/components/deploy/StepEmail.tsx
@@ -24,16 +24,12 @@ export default function StepEmail({
   );
   const [privateKey, setPrivateKey] = useState(data.googlePrivateKey || '');
   const [emailFrom, setEmailFrom] = useState(data.emailFrom || '');
-  const [testEmail, setTestEmail] = useState('');
   const [loading, setLoading] = useState(false);
-  const [testSent, setTestSent] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const isConfigured = serviceAccountEmail.trim().length > 0 && privateKey.trim().length > 0;
 
-  async function handleSendTest() {
-    if (!testEmail.trim()) return;
-
+  async function handleSaveConfig() {
     setLoading(true);
     setError(null);
 
@@ -43,7 +39,6 @@ export default function StepEmail({
         return;
       }
 
-      // Save credentials even though test send isn't wired yet
       onUpdateData({
         emailProvider: 'gmail',
         googleServiceAccountEmail: serviceAccountEmail.trim(),
@@ -60,16 +55,8 @@ export default function StepEmail({
           emailProvider: 'gmail',
         },
       });
-
-      // Email test send not yet wired to a real SMTP probe.
-      // Rather than faking success, inform the user honestly.
-      setError(
-        'Email test send is not yet implemented. Config saved — verify ' +
-          'email delivery manually after deployment.',
-      );
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to send test email');
-      setTestSent(false);
+      setError(err instanceof Error ? err.message : 'Failed to save email config');
     } finally {
       setLoading(false);
     }
@@ -117,38 +104,24 @@ export default function StepEmail({
           />
         </div>
 
-        <div className="flex items-end gap-3">
-          <div className="flex-1">
-            <Input
-              id="test-email"
-              label="Test Email Address"
-              type="email"
-              placeholder="you@example.com"
-              value={testEmail}
-              onChange={(e) => setTestEmail(e.target.value)}
-              disabled={loading}
-            />
-          </div>
+        <p className="text-xs text-neutral-400">
+          In-wizard test send is not wired yet — verify delivery from the Admin app after
+          deployment.
+        </p>
+
+        <div className="flex gap-3 self-end">
           <Button
-            variant="primary"
-            onClick={handleSendTest}
+            variant="secondary"
+            onClick={handleSaveConfig}
             loading={loading}
-            disabled={!(testEmail.trim() && isConfigured) || loading}
+            disabled={!isConfigured || loading}
           >
-            Send Test Email
+            Save Config
+          </Button>
+          <Button variant="primary" onClick={onNext} disabled={!isConfigured}>
+            Next
           </Button>
         </div>
-
-        {testSent && <p className="text-sm text-green-400">Test email sent — check your inbox.</p>}
-
-        <Button
-          variant="primary"
-          onClick={onNext}
-          disabled={!isConfigured}
-          className="mt-2 self-end"
-        >
-          Next
-        </Button>
       </div>
     </WizardStep>
   );

--- a/docs/PRODUCTION_LAUNCH_PLAN.md
+++ b/docs/PRODUCTION_LAUNCH_PLAN.md
@@ -11,7 +11,7 @@ Last updated: 2026-04-20
 
 | Capability | Status |
 |---|---|
-| RS256 JWT license validation | Integrated (needs keypair) |
+| Ed25519 license validation | Integrated (needs keypair) |
 | Feature-based method gating | Done |
 | Structured JSON logging | Done |
 | Prometheus metrics + health checks | Done |


### PR DESCRIPTION
## Summary

Two related honesty fixes from the 2026-04-23 suite-wide messaging audit.

### 1. `PRODUCTION_LAUNCH_PLAN.md`: license label RS256 → Ed25519

The status table claimed "RS256 JWT license validation". The daemon actually implements **Ed25519** signature verification — see `packages/daemon/src/license-crypto.ts` (`verifyLicenseV2`, `Vendor Ed25519 public key (PEM)`, signature format `RVUI.v2.<tier>.<expiresAt>.<ed25519-sig-base64url>`). Label fixed to match code.

### 2. `StepEmail.tsx`: remove dishonest "Send Test Email" button

The deploy wizard's email step had a "Send Test Email" button that accepted a test address and looked functional. Under the hood it silently wrote the config and then set `error = 'Email test send is not yet implemented. Config saved — verify email delivery manually after deployment.'` — nothing was ever actually sent. The `testSent` state that would have rendered the green success banner was never set to `true`, making the branch unreachable dead code.

The 2026-04-18 re-audit flagged this as a UX honesty regression. Fix:

- Remove the test-send affordance entirely (input + button + unreachable green-success branch).
- Rename the remaining action from "Send Test Email" → "Save Config" (now actually describes what it does).
- Add an inline note: "In-wizard test send is not wired yet — verify delivery from the Admin app after deployment."

No API surface change. No daemon/config-shape change. 61 → 20 lines in the component; 43 lines removed.

**Source:** internal docs § revdev` + 2026-04-18 re-audit.

## Test plan
- [ ] `pnpm --filter studio typecheck` green
- [ ] `pnpm --filter studio test` green (any StepEmail snapshot/test needs updating — audit for `testSent` / `handleSendTest` references)
- [ ] Manual: open the deploy wizard, reach the email step, confirm only Service Account + Private Key + From Address inputs render plus Save Config / Next buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
