### PR TITLE
fix(ci): resolve pnpm/action-setup version conflict in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -58,10 +58,11 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       # JS/TS-specific setup: install deps so CodeQL sees the full module graph
+      # (pnpm version sourced from package.json "packageManager" field; don't set
+      # `version:` here — pnpm/action-setup@v4 rejects the combination since
+      # late 2026 with ERR_PNPM_BAD_PM_VERSION)
       - if: matrix.language == 'javascript-typescript'
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - if: matrix.language == 'javascript-typescript'
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

`CodeQL (javascript-typescript)` job in `security.yml` has been hard-failing on every PR because `pnpm/action-setup@v4` now rejects the combination of `version:` in the workflow step + `packageManager` in package.json:

```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.12.1 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

Fix: drop the redundant `version: 10` from the workflow step. The action reads the pinned version from `package.json` `"packageManager"` field — same pattern `ci.yml` and `studio-release.yml` already use.

## Blocks

- [revdev#17](https://github.com/RevealUIStudio/revdev/pull/17) Studio/Console README status badges
- [revdev#21](https://github.com/RevealUIStudio/revdev/pull/21) Ed25519 license label + StepEmail honesty

Both were cleared on Dependency Review after Joshua toggled Dependency Graph in repo settings just now; CodeQL (js-ts) was the remaining blocker.

## Test plan

- [ ] Full CI green on this PR (CodeQL js-ts now runs cleanly)
- [ ] After merge, rebase #17 + #21 onto new main → Security workflow goes green → both mergeable
