### PR TITLE
feat(daemon): periodic stale-session prune + harness.prune RPC (GAP-153)

### DIFF
--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -309,3 +309,120 @@ describe('two-agent coordination', () => {
     expect(bobInbox.messages.some((m) => m.subject === 'all-hands')).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GAP-153 — periodic prune of stale + old-completed sessions.
+//
+// We use `harness.prune` (the on-demand RPC) with very small thresholds
+// (fractional days, ≈ a few seconds) so the test doesn't have to wait for
+// the periodic timer or the 7-day production threshold. The runPrune
+// helper accepts fractional days because the SQL uses
+// `INTERVAL '1 day' * $param`.
+// ---------------------------------------------------------------------------
+
+describe('GAP-153: stale-session prune', () => {
+  it('harness.health includes prune state (initially zeroed)', async () => {
+    const health = (await rpc(socketPath, 'harness.health')) as {
+      prune?: { lastRunAt: string | null; lastAgedCount: number; lastDeletedCount: number };
+    };
+    expect(health.prune).toBeDefined();
+    // lastRunAt may or may not have run by now (the 5s startup setTimeout
+    // is unref'd but might fire); but the shape must be correct.
+    expect(typeof health.prune?.lastAgedCount).toBe('number');
+    expect(typeof health.prune?.lastDeletedCount).toBe('number');
+  });
+
+  it('ages out a session whose age exceeds the stale threshold', async () => {
+    // Register a stable-id session, then wait briefly so its started_at
+    // is older than the threshold we'll pass to prune.
+    await rpc(socketPath, 'session.register', {
+      agentId: 'stale-test',
+      agentName: 'stale-test',
+      backend: 'test',
+    });
+
+    // Sanity: row is currently active in session.list (which filters
+    // to ended_at IS NULL).
+    const before = (await rpc(socketPath, 'session.list')) as {
+      sessions: Array<{ id: string }>;
+    };
+    expect(before.sessions.find((s) => s.id === 'stale-test')).toBeDefined();
+
+    await new Promise((r) => setTimeout(r, 1100));
+
+    // staleDays = 0.00001 → ≈ 0.86s. With the 1.1s sleep above, the
+    // session is past the threshold.
+    const result = (await rpc(socketPath, 'harness.prune', {
+      staleDays: 0.00001,
+      hardDeleteDays: 365,
+    })) as { aged: number; deleted: number };
+    expect(result.aged).toBeGreaterThanOrEqual(1);
+    expect(result.deleted).toBe(0);
+
+    // After prune, the row is no longer in session.list (proof its
+    // ended_at + exit_summary were populated by runPrune; session.list
+    // hides any row with ended_at IS NOT NULL).
+    const after = (await rpc(socketPath, 'session.list')) as {
+      sessions: Array<{ id: string }>;
+    };
+    expect(after.sessions.find((s) => s.id === 'stale-test')).toBeUndefined();
+  });
+
+  it('hard-deletes a session ended longer than hardDeleteDays', async () => {
+    // Register, end, then prune with a tiny hardDeleteDays.
+    await rpc(socketPath, 'session.register', {
+      agentId: 'hard-delete-test',
+      agentName: 'hard-delete-test',
+      backend: 'test',
+    });
+    await rpc(socketPath, 'session.end', {
+      actorAgentId: 'hard-delete-test',
+      sessionId: 'hard-delete-test',
+      summary: 'test end',
+    });
+    await new Promise((r) => setTimeout(r, 1100));
+
+    const result = (await rpc(socketPath, 'harness.prune', {
+      staleDays: 365,
+      hardDeleteDays: 0.00001,
+    })) as { aged: number; deleted: number };
+
+    expect(result.deleted).toBeGreaterThanOrEqual(1);
+
+    const listing = (await rpc(socketPath, 'session.list')) as {
+      sessions: Array<{ id: string }>;
+    };
+    expect(listing.sessions.find((s) => s.id === 'hard-delete-test')).toBeUndefined();
+  });
+
+  it('harness.health reports prune state after a prune run', async () => {
+    await rpc(socketPath, 'harness.prune', { staleDays: 365, hardDeleteDays: 365 });
+    const health = (await rpc(socketPath, 'harness.health')) as {
+      prune: { lastRunAt: string | null; lastAgedCount: number; lastDeletedCount: number };
+    };
+    expect(health.prune.lastRunAt).not.toBeNull();
+    // The aged/deleted counts reflect the LAST prune, which used very
+    // permissive thresholds — should be 0 for both.
+    expect(health.prune.lastAgedCount).toBe(0);
+    expect(health.prune.lastDeletedCount).toBe(0);
+  });
+
+  it('clamps negative thresholds to zero (defensive)', async () => {
+    // staleDays=0 → "older than NOW" → matches every session with
+    // ended_at IS NULL. We need at least one such session to verify
+    // the clamp is wider than negative-would-be (which Postgres
+    // semantics handle the same way as 0 here, but the explicit
+    // clamp is what we're checking the call doesn't error on).
+    await rpc(socketPath, 'session.register', {
+      agentId: 'clamp-test',
+      agentName: 'clamp-test',
+      backend: 'test',
+    });
+    const result = (await rpc(socketPath, 'harness.prune', {
+      staleDays: -100,
+      hardDeleteDays: 365,
+    })) as { aged: number };
+    // Negative was clamped to 0 → matches all unended sessions.
+    expect(result.aged).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -17,6 +17,12 @@ export interface DaemonConfig {
   pidFile: string;
   /** Maximum memory for PGlite (in MB) */
   maxMemoryMb: number;
+  /** Sessions older than this with no `ended_at` are auto-ended on each prune pass. */
+  staleSessionDays: number;
+  /** Sessions ended longer than this are hard-deleted on each prune pass. */
+  hardDeleteDays: number;
+  /** How often to run the periodic prune (ms). Set to 0 to disable. */
+  pruneIntervalMs: number;
 }
 
 const homeDir = process.env.HOME ?? '/tmp';
@@ -29,4 +35,7 @@ export const DAEMON_DEFAULTS: DaemonConfig = {
   httpStaticDir: null,
   pidFile: `${homeDir}/.local/share/revealui/harness.pid`,
   maxMemoryMb: 512,
+  staleSessionDays: 7,
+  hardDeleteDays: 30,
+  pruneIntervalMs: 60 * 60 * 1000, // 1 hour
 };

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -74,6 +74,7 @@ const IDENTITY_EXEMPT = new Set([
   'session.attach',
   'session.list',
   'harness.health',
+  'harness.prune',
   'inference.status',
   'inference.pull',
   'inference.start',
@@ -81,6 +82,85 @@ const IDENTITY_EXEMPT = new Set([
   'inference.chat',
   'inference.generate',
 ]);
+
+// ---------------------------------------------------------------------------
+// Stale-session pruning state (GAP-153)
+//
+// Module-level by design — each daemon process is a singleton, so a single
+// state object suffices. The integration test suite at coordination.test.ts
+// runs daemons sequentially, not concurrently, so cross-test contamination
+// is not a concern. If the test pattern ever changes to spawn concurrent
+// daemons in the same process, this needs to become a per-db Map.
+// ---------------------------------------------------------------------------
+
+interface PruneState {
+  lastRunAt: Date | null;
+  lastAgedCount: number;
+  lastDeletedCount: number;
+}
+
+const pruneState: PruneState = {
+  lastRunAt: null,
+  lastAgedCount: 0,
+  lastDeletedCount: 0,
+};
+
+/**
+ * Run a single prune pass against the daemon database.
+ *
+ * Two-phase cleanup:
+ *   1. Sessions older than `staleDays` with no `ended_at` are marked ended
+ *      with `exit_summary = 'pruned-stale'`. Models cases where the daemon
+ *      itself crashed (or was SIGKILL'd) before the per-socket auto-end
+ *      had a chance to fire.
+ *   2. Sessions ended longer than `hardDeleteDays` are hard-deleted to keep
+ *      `agent_sessions` from growing without bound.
+ *
+ * Idempotent — running twice in a row produces the same end state. Safe to
+ * invoke on demand via the `harness.prune` RPC for ops use, in addition to
+ * the periodic timer set up in `startDaemon`.
+ */
+async function runPrune(
+  db: PGlite,
+  staleDays: number,
+  hardDeleteDays: number,
+): Promise<{ aged: number; deleted: number }> {
+  // Clamp non-negative + finite. Defends against bad caller input — a
+  // negative or NaN threshold would otherwise widen the WHERE clause to
+  // include all-or-no rows depending on Postgres semantics.
+  const stale = Number.isFinite(staleDays) ? Math.max(0, staleDays) : 7;
+  const hard = Number.isFinite(hardDeleteDays) ? Math.max(0, hardDeleteDays) : 30;
+
+  // Parameterized interval avoids SQL injection on the days value.
+  const aged = await db.query<{ id: string }>(
+    `UPDATE agent_sessions
+        SET ended_at = NOW(),
+            exit_summary = COALESCE(exit_summary, 'pruned-stale')
+      WHERE ended_at IS NULL
+        AND started_at < NOW() - INTERVAL '1 day' * $1
+      RETURNING id`,
+    [stale],
+  );
+  const deleted = await db.query<{ id: string }>(
+    `DELETE FROM agent_sessions
+      WHERE ended_at IS NOT NULL
+        AND ended_at < NOW() - INTERVAL '1 day' * $1
+      RETURNING id`,
+    [hard],
+  );
+  pruneState.lastRunAt = new Date();
+  pruneState.lastAgedCount = aged.rows.length;
+  pruneState.lastDeletedCount = deleted.rows.length;
+  if (pruneState.lastAgedCount > 0 || pruneState.lastDeletedCount > 0) {
+    log.info('prune complete', {
+      aged: pruneState.lastAgedCount,
+      deleted: pruneState.lastDeletedCount,
+      staleDays: stale,
+      hardDeleteDays: hard,
+    });
+  }
+  return { aged: pruneState.lastAgedCount, deleted: pruneState.lastDeletedCount };
+}
 
 // ---------------------------------------------------------------------------
 // Handler registry
@@ -555,6 +635,26 @@ registerHandler('harness.health', async (_params, db) => {
     activeSessions: Number(sessions.rows[0]?.count ?? 0),
     openTasks: Number(tasks.rows[0]?.count ?? 0),
     uptime: process.uptime(),
+    prune: {
+      lastRunAt: pruneState.lastRunAt?.toISOString() ?? null,
+      lastAgedCount: pruneState.lastAgedCount,
+      lastDeletedCount: pruneState.lastDeletedCount,
+    },
+  };
+});
+
+registerHandler('harness.prune', async (params, db) => {
+  // Allow ops / tests to run a prune pass on demand. Defaults match
+  // DAEMON_DEFAULTS so callers can invoke with no params.
+  const staleDays = num(params.staleDays, DAEMON_DEFAULTS.staleSessionDays);
+  const hardDeleteDays = num(params.hardDeleteDays, DAEMON_DEFAULTS.hardDeleteDays);
+  const result = await runPrune(db, staleDays, hardDeleteDays);
+  return {
+    aged: result.aged,
+    deleted: result.deleted,
+    runAt: pruneState.lastRunAt?.toISOString() ?? null,
+    staleDays,
+    hardDeleteDays,
   };
 });
 
@@ -615,6 +715,25 @@ export async function startDaemon(
 
   // Initialize observability (metrics + health checks)
   initObservability(db);
+
+  // Periodic prune of stale + old-completed sessions (GAP-153). Disabled
+  // when pruneIntervalMs is 0. unref() so the timer doesn't keep the
+  // process alive on its own. The startup prune runs after a short delay
+  // so it doesn't block the listen call.
+  let pruneTimer: NodeJS.Timeout | null = null;
+  if (cfg.pruneIntervalMs > 0) {
+    pruneTimer = setInterval(() => {
+      runPrune(db, cfg.staleSessionDays, cfg.hardDeleteDays).catch((err) =>
+        log.warn('periodic prune failed', { error: String(err) }),
+      );
+    }, cfg.pruneIntervalMs);
+    pruneTimer.unref();
+    setTimeout(() => {
+      runPrune(db, cfg.staleSessionDays, cfg.hardDeleteDays).catch((err) =>
+        log.warn('startup prune failed', { error: String(err) }),
+      );
+    }, 5000).unref();
+  }
 
   // Remove stale socket
   const { unlink, chmod } = await import('node:fs/promises');
@@ -721,6 +840,16 @@ export async function startDaemon(
       // Auto-release transient reservations when a long-lived agent
       // disconnects. Fresh-per-call clients (boundVia = 'param') don't
       // trigger cleanup — their identity outlives this socket.
+      //
+      // Note: we do NOT auto-end the session row on socket close. The
+      // daemon's session model is LOGICAL agent identity (not socket
+      // lifetime): hooks open-call-close in <100ms per RPC and bind to
+      // existing sessions via `actorAgentId` params; Studio etc. may
+      // disconnect and reattach. The only end triggers are explicit
+      // session.end and the periodic prune (GAP-153). A future
+      // refinement (keepalive flag in session.register, or socket-
+      // lifetime threshold) could re-introduce socket-close auto-end
+      // for genuinely-long-lived agents — see GAP-153 notes.
       if (ctx.agentId && (ctx.boundVia === 'register' || ctx.boundVia === 'attach')) {
         await db
           .query(`DELETE FROM file_reservations WHERE agent_id = $1`, [ctx.agentId])
@@ -763,6 +892,7 @@ export async function startDaemon(
 
       resolve({
         close: async () => {
+          if (pruneTimer) clearInterval(pruneTimer);
           server.close();
           await db.close();
           await unlink(cfg.socketPath).catch(() => {});

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -17,6 +17,7 @@ export const RPC_METHODS = {
   'harness.syncConfig': 'harness.syncConfig',
   'harness.diffConfig': 'harness.diffConfig',
   'harness.health': 'harness.health',
+  'harness.prune': 'harness.prune',
 
   // Agent sessions
   'session.register': 'session.register',


### PR DESCRIPTION
## Summary

Adds periodic stale-session pruning to the daemon. Closes the residual cleanup work from GAP-153 — the smoke test on 2026-04-27 (during the GAP-150 daemon audit) surfaced a 14-day-stale `agent-system` row from 2026-04-14 that had been "active" because no `session.end` ever fired. Now there's a time-based mechanism to clean those up.

## What ships

- `runPrune(db, staleDays, hardDeleteDays)` helper — two-phase: ages unended sessions past `staleDays`, hard-deletes ended sessions past `hardDeleteDays`. Parameterized SQL; thresholds clamped to non-negative finite numbers.
- Periodic timer in `startDaemon` (default every 1h, `unref()`'d). Initial prune ~5s after listen completes. Cleared on `daemon.close()`.
- `harness.prune` RPC method — runs prune on demand with overrideable thresholds. Identity-exempt (admin tool).
- `harness.health` response includes a `prune: { lastRunAt, lastAgedCount, lastDeletedCount }` field.
- Three config knobs in `DaemonConfig`: `staleSessionDays` (7), `hardDeleteDays` (30), `pruneIntervalMs` (1h). Set `pruneIntervalMs: 0` to disable.
- `harness.prune` added to `RPC_METHODS` in `@revdev/protocol`.

## What's intentionally NOT in this PR

- **Socket-close auto-end was investigated and rejected.** The daemon's session model is logical agent identity, not socket lifetime. Hooks open-call-close in <100ms per RPC and bind to existing sessions via `actorAgentId` params; `session.attach` requires `ended_at IS NULL`. Auto-ending on register's socket close would mark every hook session as ended within milliseconds, breaking the entire flow. (See GAP-153.yml Phase 1 for the full reasoning.)
- A future `keepalive` flag in `session.register` (or a socket-lifetime threshold) could re-introduce socket-close auto-end for genuinely-long-lived agents (Studio/Tauri) without affecting hooks. Filed in GAP-153 notes for future work.
- Daemon → Neon coordination_* sync — GAP-154, separate PR.
- Daemon self-detach / systemd-user unit — GAP-152, separate PR.

## Test plan

- [x] `pnpm --filter @revdev/daemon typecheck` — passes
- [x] `pnpm --filter @revdev/daemon test` — 66/66 tests pass
- [x] 5 new tests in `coordination.test.ts` cover: prune-state shape, age-out via `staleDays=0.00001`, hard-delete via `hardDeleteDays=0.00001`, health surface after a prune run, negative-threshold clamping
- [ ] Live smoke test on the running daemon (PID from prior session): kill, rebuild, restart, verify the 14-day-stale `agent-system` row gets pruned on first cycle. Reviewer can confirm or this lands and the next prune cycle handles it.

## Related

- Builds on GAP-150 (closed) — the audit that surfaced this work.
- Companion docs reconciliation already in `~/.claude/rules/hooks-architecture.md` (local) + internal docs (commit `0ae54e38a`).
