### PR TITLE
chore(ci): unbreak test branch — default-tab assertion + pnpm version conflict

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -57,11 +57,13 @@ jobs:
           queries: security-and-quality
           config-file: ./.github/codeql/codeql-config.yml
 
-      # JS/TS-specific setup: install deps so CodeQL sees the full module graph
+      # JS/TS-specific setup: install deps so CodeQL sees the full module graph.
+      # Don't pin a version on pnpm/action-setup — the root package.json's
+      # `packageManager` field already specifies `pnpm@10.12.1`, and the
+      # action errors with "Multiple versions of pnpm specified" if both
+      # are set.
       - if: matrix.language == 'javascript-typescript'
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - if: matrix.language == 'javascript-typescript'
         uses: actions/setup-node@v4

--- a/apps/studio/src/__tests__/components/InfrastructurePanel.test.tsx
+++ b/apps/studio/src/__tests__/components/InfrastructurePanel.test.tsx
@@ -67,8 +67,12 @@ describe('InfrastructurePanel', () => {
 
   it('highlights active tab', () => {
     render(<InfrastructurePanel />);
-    const appTab = screen.getAllByText('App Launcher')[0].closest('button');
-    expect(appTab?.className).toContain('border-orange-500');
+    // The Daemon tab is active by default (per InfrastructurePanel's
+    // useState<InfraTab>('daemon') initial value). Earlier this test
+    // asserted on App Launcher, which silently went stale when the
+    // default flipped — tracked under the chore that fixed it.
+    const daemonTab = screen.getAllByText('Daemon')[0].closest('button');
+    expect(daemonTab?.className).toContain('border-orange-500');
   });
 
   it('switches tab highlight when clicking DevPod', () => {


### PR DESCRIPTION
## Summary

Two pre-existing CI failures on the `test` branch that were silently red for at least a week (every CI run since 2026-04-20). Both block any PR merging into `test` and were surfaced when [revdev#23](https://github.com/RevealUIStudio/revdev/pull/23) went up. Neither is a regression from #23; both pre-date it.

### Fix 1 — InfrastructurePanel default tab assertion

`apps/studio/src/__tests__/components/InfrastructurePanel.test.tsx > highlights active tab` was asserting that the **App Launcher** tab carries `border-orange-500`. But [`InfrastructurePanel.tsx`](https://github.com/RevealUIStudio/revdev/blob/test/apps/studio/src/components/infrastructure/InfrastructurePanel.tsx) was changed in commit `697e62c` (`feat(studio): add Daemon control panel + license issuing script`, 2026-04-20) to default to `'daemon'`:

```tsx
const [tab, setTab] = useState<InfraTab>('daemon');
```

The test wasn't updated when the default flipped. Fixed by asserting on **Daemon** — the new default — and leaving an inline comment explaining the relationship so the next default-flip doesn't silently re-break.

### Fix 2 — CodeQL "Multiple versions of pnpm specified"

`.github/workflows/security.yml` had `pnpm/action-setup@v4` configured with `with: version: 10`, AND root `package.json` declares `packageManager: "pnpm@10.12.1"`. The action errors with "Multiple versions of pnpm specified" because both are set. Removed `version: 10` and let the `packageManager` field govern (correct precedence: lockfile-pinned, single source of truth).

## Test plan

- [x] `pnpm test --run src/__tests__/components/InfrastructurePanel.test.tsx` — 6/6 pass (was 1 failing)
- [ ] CI on this PR — verifying both fixes land green

## Out of scope

The other tests in `InfrastructurePanel.test.tsx` (lines 40, 52: "renders App Launcher tab by default", "shows AppsPanel content by default") have stale descriptions but assert only that "App Launcher" appears at all — vacuously true since it's always rendered as a tab button regardless of which tab is active. Leaving the descriptions as-is to keep this PR scope-tight. A follow-up cleanup PR can rewrite them.

## Why this exists as its own PR

Bundling these into [#23](https://github.com/RevealUIStudio/revdev/pull/23) would mix a daemon feature commit with infrastructure cleanup. Keeping them separate so each PR's commit history reflects what it actually does.
