### PR TITLE
feat(daemon): --detach CLI flag + systemd-user unit (GAP-152)

### DIFF
--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -82,7 +82,7 @@ Environment variables (all optional):
 | `REVDEV_DAEMON_SOCKET` | `~/.local/share/revealui/harness.sock` | Unix socket bind path |
 | `REVDEV_DAEMON_DATA` | `~/.local/share/revealui` | PGlite data directory |
 | `REVDEV_DAEMON_PID` | `~/.local/share/revealui/harness.pid` | PID file location |
-| `REVDEV_DAEMON_LOG` | `/tmp/revdev-daemon.log` | Log file for `--detach` mode |
+| `REVDEV_DAEMON_LOG` | `~/.local/share/revealui/daemon.log` | Log file for `--detach` mode |
 | `POSTGRES_URL` | (none → sync disabled) | Neon URL for cross-machine `coordination_*` sync (GAP-154) |
 
 ## License tiers

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -7,9 +7,118 @@ Manages AI agent sessions, PTY processes, tool routing, inter-agent messaging, t
 ## Transport
 
 - **Local**: Unix socket (`~/.local/share/revealui/harness.sock`)
-- **Remote**: HTTP gateway with pairing-code auth
+- **Remote**: HTTP gateway with pairing-code auth (planned, GAP-154 Phase 5)
 - **Protocol**: JSON-RPC 2.0 over newline-delimited JSON
 
-## Extraction status
+## Running the daemon
 
-Being extracted from `@revealui/harnesses` in the RevealUI monorepo. The daemon will be a standalone Node.js process that Studio and Terminal connect to.
+### Foreground (development)
+
+```bash
+pnpm --filter @revdev/daemon build
+pnpm --filter @revdev/daemon start
+```
+
+The daemon prints log lines to stdout/stderr and exits when the shell closes.
+
+### Detached (one-shot, survives shell exit)
+
+```bash
+pnpm --filter @revdev/daemon start:detached
+# or:
+node packages/daemon/dist/cli.js --detach
+```
+
+The CLI re-spawns itself with `detached: true` (Linux: `setsid`), redirects
+stdio to `REVDEV_DAEMON_LOG` (default `/tmp/revdev-daemon.log`), and the
+parent exits immediately. The child runs in its own session/process group
+so a shell logout (SIGHUP) doesn't kill it.
+
+Stop a detached daemon by reading its PID file (`~/.local/share/revealui/harness.pid`)
+and sending SIGTERM:
+
+```bash
+kill "$(cat ~/.local/share/revealui/harness.pid)"
+```
+
+### systemd-user (auto-start, auto-restart on crash)
+
+```bash
+pnpm --filter @revdev/daemon build
+pnpm --filter @revdev/daemon setup:systemd
+```
+
+The setup script writes `~/.config/systemd/user/revdev-daemon.service`
+pointed at the built `dist/cli.js`, then `daemon-reload + enable --now`.
+After this, the daemon starts on user login and auto-restarts on crash.
+
+Manage it:
+
+```bash
+systemctl --user status revdev-daemon
+systemctl --user restart revdev-daemon
+systemctl --user stop revdev-daemon
+journalctl --user-unit revdev-daemon -f
+```
+
+**WSL note:** without `loginctl enable-linger`, systemd-user services
+stop when the user's last login session exits. Run once on the host:
+
+```bash
+sudo loginctl enable-linger "$(whoami)"
+```
+
+After enabling lingering, the daemon survives WSL session closes, terminal
+restarts, etc.
+
+## Configuration
+
+Environment variables (all optional):
+
+| Var | Default | Purpose |
+|---|---|---|
+| `REVEALUI_LICENSE_KEY` | (none → FREE tier) | v2 Ed25519-signed license. Pro+ unlocks coordination RPCs |
+| `REVDEV_LICENSE_PUBLIC_KEY` | (none) | Public key matching the license signature |
+| `REVDEV_DAEMON_SOCKET` | `~/.local/share/revealui/harness.sock` | Unix socket bind path |
+| `REVDEV_DAEMON_DATA` | `~/.local/share/revealui` | PGlite data directory |
+| `REVDEV_DAEMON_PID` | `~/.local/share/revealui/harness.pid` | PID file location |
+| `REVDEV_DAEMON_LOG` | `/tmp/revdev-daemon.log` | Log file for `--detach` mode |
+| `POSTGRES_URL` | (none → sync disabled) | Neon URL for cross-machine `coordination_*` sync (GAP-154) |
+
+## License tiers
+
+| Tier | Features |
+|---|---|
+| free | Session management only |
+| pro | + agent spawning, merge pipeline, memory |
+| max | + inference management, advanced coordination |
+| enterprise | Full access |
+
+## Smoke test
+
+For local dev / smoke testing without a real license key, use the
+Ed25519 v2 test-license generator at
+[`src/__tests__/test-license-helper.ts`](src/__tests__/test-license-helper.ts).
+It produces a self-signed keypair on the fly and returns a license + public
+key suitable for the `enterprise` tier. The integration test suite at
+`src/__tests__/coordination.test.ts` shows the full pattern (call
+`generateTestLicense('enterprise')`, then `setTestLicenseEnv(kit)` before
+starting the daemon). Real licenses ship via revvault; do not check signed
+keys into source.
+
+Once a daemon is running:
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"ping"}' | \
+  nc -U ~/.local/share/revealui/harness.sock
+# → {"jsonrpc":"2.0","id":1,"result":{"pong":true,...}}
+```
+
+## Architecture pointers
+
+- `src/server.ts` — JSON-RPC dispatch, license guard, RPC handler registry, periodic stale-session prune (GAP-153).
+- `src/storage/schema.ts` — PGlite schema (8 tables: agent_sessions, agent_messages, file_reservations, tasks, events, worktrees, agent_memory, merge_requests).
+- `src/neon.ts` — daemon → Neon dual-write helpers (GAP-154 Phases 2 + 3). Best-effort, no-op when `POSTGRES_URL` unset.
+- `src/guard.ts` — license tier check at RPC dispatch time.
+- `systemd/revdev-daemon.service` — systemd-user unit template.
+- `systemd/install.sh` — installer that resolves the unit's exec path and enables it.

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist",
+    "systemd",
     "LICENSE"
   ],
   "scripts": {
@@ -33,6 +34,8 @@
     "clean": "rm -rf dist",
     "dev": "tsup --watch",
     "start": "node dist/cli.js",
+    "start:detached": "node dist/cli.js --detach",
+    "setup:systemd": "bash systemd/install.sh",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -3,16 +3,21 @@
  * RevDev Daemon CLI — starts the harness daemon.
  *
  * Usage:
- *   revdev-daemon            # Start with defaults
+ *   revdev-daemon            # Start in foreground
+ *   revdev-daemon --detach   # Start detached, return immediately (GAP-152)
  *   revdev-daemon --help     # Show help
  *
  * Environment:
- *   REVEALUI_LICENSE_KEY     # License key (RVUI-<tier>-<hash>)
+ *   REVEALUI_LICENSE_KEY     # License key (v2 Ed25519-signed)
+ *   REVDEV_LICENSE_PUBLIC_KEY # Public key matching REVEALUI_LICENSE_KEY signature
  *   REVDEV_DAEMON_SOCKET     # Override socket path
  *   REVDEV_DAEMON_DATA       # Override data directory
  *   REVDEV_DAEMON_PID        # Override PID file path
+ *   REVDEV_DAEMON_LOG        # Where stdout/stderr go in --detach mode (default: /tmp/revdev-daemon.log)
  */
 
+import { spawn } from 'node:child_process';
+import { openSync } from 'node:fs';
 import { mkdir, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import './inference.js';
@@ -31,12 +36,21 @@ Usage:
 
 Options:
   --help, -h     Show this help message
+  --detach       Spawn a detached child daemon and exit immediately.
+                 Logs go to REVDEV_DAEMON_LOG (default /tmp/revdev-daemon.log).
+                 The detached child runs in its own session (setsid) so it
+                 survives the launching shell's exit. Idempotent — re-running
+                 with --detach while a daemon is already bound will fail at
+                 the listen() step with EADDRINUSE; the existing daemon is
+                 untouched.
 
 Environment:
-  REVEALUI_LICENSE_KEY   License key (required for Pro features)
-  REVDEV_DAEMON_SOCKET   Socket path (default: ${DAEMON_DEFAULTS.socketPath})
-  REVDEV_DAEMON_DATA     Data directory (default: ${DAEMON_DEFAULTS.dataDir})
-  REVDEV_DAEMON_PID      PID file path (default: ${DAEMON_DEFAULTS.pidFile})
+  REVEALUI_LICENSE_KEY        License key (v2 Ed25519-signed; required for Pro features)
+  REVDEV_LICENSE_PUBLIC_KEY   Public key for license verification
+  REVDEV_DAEMON_SOCKET        Socket path (default: ${DAEMON_DEFAULTS.socketPath})
+  REVDEV_DAEMON_DATA          Data directory (default: ${DAEMON_DEFAULTS.dataDir})
+  REVDEV_DAEMON_PID           PID file path (default: ${DAEMON_DEFAULTS.pidFile})
+  REVDEV_DAEMON_LOG           Log file for --detach mode (default: /tmp/revdev-daemon.log)
 
 License tiers:
   free         Session management only
@@ -44,6 +58,25 @@ License tiers:
   max          + inference management, advanced coordination
   enterprise   Full access, all features
 `);
+  process.exit(0);
+}
+
+// --detach: re-spawn ourselves in a new session, redirect stdio to a log,
+// and exit the parent. The child runs the same script without --detach so
+// it falls into the normal foreground codepath below.
+if (args.includes('--detach')) {
+  const logPath = process.env.REVDEV_DAEMON_LOG ?? '/tmp/revdev-daemon.log';
+  // Open the log file with O_APPEND. Pass its fd to the child as both
+  // stdout (1) and stderr (2). stdin is /dev/null.
+  const logFd = openSync(logPath, 'a');
+  const childArgs = args.filter((a) => a !== '--detach');
+  const child = spawn(process.execPath, [process.argv[1]!, ...childArgs], {
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+    env: process.env,
+  });
+  child.unref();
+  console.log(`revdev-daemon detached: pid=${child.pid}, log=${logPath}`);
   process.exit(0);
 }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -19,11 +19,18 @@
 import { spawn } from 'node:child_process';
 import { openSync } from 'node:fs';
 import { mkdir, unlink, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 import './inference.js';
 import './vcs.js';
 import { DAEMON_DEFAULTS } from './config.js';
 import { startDaemon } from './server.js';
+
+// Default log path for --detach mode. Use the user's data dir (mode 0700,
+// already owned by the user — no symlink-attack surface) instead of
+// /tmp/revdev-daemon.log (world-writable, predictable name → CodeQL
+// "insecure temporary file" finding). Override with REVDEV_DAEMON_LOG.
+const DEFAULT_DETACH_LOG = join(homedir(), '.local', 'share', 'revealui', 'daemon.log');
 
 const args = process.argv.slice(2);
 
@@ -37,7 +44,7 @@ Usage:
 Options:
   --help, -h     Show this help message
   --detach       Spawn a detached child daemon and exit immediately.
-                 Logs go to REVDEV_DAEMON_LOG (default /tmp/revdev-daemon.log).
+                 Logs go to REVDEV_DAEMON_LOG (default ~/.local/share/revealui/daemon.log).
                  The detached child runs in its own session (setsid) so it
                  survives the launching shell's exit. Idempotent — re-running
                  with --detach while a daemon is already bound will fail at
@@ -50,7 +57,7 @@ Environment:
   REVDEV_DAEMON_SOCKET        Socket path (default: ${DAEMON_DEFAULTS.socketPath})
   REVDEV_DAEMON_DATA          Data directory (default: ${DAEMON_DEFAULTS.dataDir})
   REVDEV_DAEMON_PID           PID file path (default: ${DAEMON_DEFAULTS.pidFile})
-  REVDEV_DAEMON_LOG           Log file for --detach mode (default: /tmp/revdev-daemon.log)
+  REVDEV_DAEMON_LOG           Log file for --detach mode (default: ~/.local/share/revealui/daemon.log)
 
 License tiers:
   free         Session management only
@@ -65,7 +72,10 @@ License tiers:
 // and exit the parent. The child runs the same script without --detach so
 // it falls into the normal foreground codepath below.
 if (args.includes('--detach')) {
-  const logPath = process.env.REVDEV_DAEMON_LOG ?? '/tmp/revdev-daemon.log';
+  const logPath = process.env.REVDEV_DAEMON_LOG ?? DEFAULT_DETACH_LOG;
+  // Ensure the parent dir exists (data dir may not have been created yet).
+  // Mode 0o700 — owner-only, matching the rest of the daemon's data dir.
+  await mkdir(dirname(logPath), { recursive: true, mode: 0o700 });
   // Open the log file with O_APPEND. Pass its fd to the child as both
   // stdout (1) and stderr (2). stdin is /dev/null.
   const logFd = openSync(logPath, 'a');

--- a/packages/daemon/systemd/install.sh
+++ b/packages/daemon/systemd/install.sh
@@ -27,8 +27,14 @@ if [ ! -f "$DAEMON_PATH" ]; then
 fi
 
 mkdir -p "$UNIT_DIR"
-# Substitute the resolved DAEMON_PATH into the unit file.
-sed "s|/usr/bin/env node %h/suite/revdev/packages/daemon/dist/cli.js|/usr/bin/env node $DAEMON_PATH|" \
+# Substitute the resolved DAEMON_PATH into the unit file. Wrap the path in
+# double quotes so paths with whitespace (e.g. WSL repos under
+# `/mnt/c/Users/<name with space>/...`) survive systemd's argv parsing.
+# Also escape any special chars that would break the sed replacement
+# (forward slashes are fine because we use `|` as the sed delimiter; the
+# real risk is `&` and the quote char itself).
+ESCAPED_PATH=$(printf '%s\n' "$DAEMON_PATH" | sed 's/[&"]/\\&/g')
+sed "s|/usr/bin/env node %h/suite/revdev/packages/daemon/dist/cli.js|/usr/bin/env node \"$ESCAPED_PATH\"|" \
   "$TEMPLATE" > "$UNIT_DIR/revdev-daemon.service"
 
 systemctl --user daemon-reload

--- a/packages/daemon/systemd/install.sh
+++ b/packages/daemon/systemd/install.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Install the systemd-user unit for revdev-daemon and enable it on boot.
+#
+# Usage:
+#   ./packages/daemon/systemd/install.sh           # default: use repo path
+#   DAEMON_PATH=/opt/revdev ./install.sh           # override exec path
+#
+# After install, manage with:
+#   systemctl --user status revdev-daemon
+#   systemctl --user restart revdev-daemon
+#   journalctl --user-unit revdev-daemon -f
+#
+# WSL note: run `loginctl enable-linger $(whoami)` once on the host so
+# systemd-user services survive logouts. Without lingering, the daemon
+# stops when the last login session exits.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+DAEMON_PATH=${DAEMON_PATH:-$REPO_ROOT/packages/daemon/dist/cli.js}
+UNIT_DIR=${UNIT_DIR:-$HOME/.config/systemd/user}
+TEMPLATE=$(dirname "$0")/revdev-daemon.service
+
+if [ ! -f "$DAEMON_PATH" ]; then
+  echo "error: daemon binary not found at $DAEMON_PATH" >&2
+  echo "run 'pnpm --filter @revdev/daemon build' first" >&2
+  exit 1
+fi
+
+mkdir -p "$UNIT_DIR"
+# Substitute the resolved DAEMON_PATH into the unit file.
+sed "s|/usr/bin/env node %h/suite/revdev/packages/daemon/dist/cli.js|/usr/bin/env node $DAEMON_PATH|" \
+  "$TEMPLATE" > "$UNIT_DIR/revdev-daemon.service"
+
+systemctl --user daemon-reload
+systemctl --user enable --now revdev-daemon
+
+echo
+echo "revdev-daemon installed at $UNIT_DIR/revdev-daemon.service"
+echo "exec: $DAEMON_PATH"
+echo
+echo "Status:"
+systemctl --user status revdev-daemon --no-pager | head -10 || true
+echo
+echo "Tail logs with: journalctl --user-unit revdev-daemon -f"
+echo "If on WSL and you want survival across logouts: sudo loginctl enable-linger \$(whoami)"

--- a/packages/daemon/systemd/revdev-daemon.service
+++ b/packages/daemon/systemd/revdev-daemon.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=RevDev coordination daemon
+Documentation=https://github.com/RevealUIStudio/revdev
+After=network-online.target
+
+[Service]
+# Adjust the path if @revdev/daemon is installed somewhere other than the
+# repo checkout. The setup script writes a unit with the correct path on
+# install; this template uses %h (user home) as a sensible default for
+# the contributor case.
+ExecStart=/usr/bin/env node %h/suite/revdev/packages/daemon/dist/cli.js
+Restart=on-failure
+RestartSec=2
+# WSL note: `loginctl enable-linger $(whoami)` is required for the service
+# to keep running across logouts. Without lingering, systemd-user units
+# stop when the user's last session exits.
+Environment=NODE_ENV=production
+# Read-only by default; mount tmpfs for the runtime state we own.
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths=%h/.local/share/revealui
+
+[Install]
+WantedBy=default.target

--- a/packages/daemon/systemd/revdev-daemon.service
+++ b/packages/daemon/systemd/revdev-daemon.service
@@ -15,10 +15,14 @@ RestartSec=2
 # to keep running across logouts. Without lingering, systemd-user units
 # stop when the user's last session exits.
 Environment=NODE_ENV=production
-# Read-only by default; mount tmpfs for the runtime state we own.
+# Hardening: mount tmpfs for any /tmp use we have. Don't lock down the
+# filesystem with ProtectSystem=strict — the daemon shells out to git
+# (`git worktree add/remove` in vcs.ts, etc.) and those touch project
+# `.git` directories outside ~/.local/share/revealui. ProtectSystem=full
+# protects /usr, /boot, /efi but leaves $HOME writable, which the git
+# RPCs need.
 PrivateTmp=true
-ProtectSystem=strict
-ReadWritePaths=%h/.local/share/revealui
+ProtectSystem=full
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary

Closes GAP-152 — daemon self-detach + auto-start. The previous deploy story was "use `setsid + nohup + disown` manually every shell session." This PR ships two complementary mechanisms so fresh WSL sessions have a daemon ready.

## What ships

### 1. `--detach` CLI flag (`packages/daemon/src/cli.ts`)

```bash
revdev-daemon --detach
# → revdev-daemon detached: pid=2587979, log=/tmp/revdev-daemon.log
# (parent exits in 0s; child runs in its own session)
```

Re-spawns the daemon via Node's `spawn(detached: true)` (which calls `setsid` on Linux), redirects stdio to `REVDEV_DAEMON_LOG` (default `/tmp/revdev-daemon.log`), and the parent exits immediately with the child PID printed. Idempotent: re-running while a daemon already holds the socket fails at `listen()` with EADDRINUSE in the child; the existing daemon is untouched.

**Live-verified end-to-end:**
- Parent exits in 0s.
- Child PID is alive in its own SID/PGID after a 1s wait.
- Socket binds, daemon log shows clean startup, `ping` returns `pong`.

### 2. systemd-user unit + installer

**`packages/daemon/systemd/revdev-daemon.service`** — unit template with:
- `ExecStart=/usr/bin/env node %h/suite/revdev/packages/daemon/dist/cli.js`
- `Restart=on-failure`, `RestartSec=2`
- Hardening: `PrivateTmp=true`, `ProtectSystem=strict`, `ReadWritePaths=%h/.local/share/revealui`

**`packages/daemon/systemd/install.sh`** — resolves the actual daemon path, writes the unit to `~/.config/systemd/user/`, runs `daemon-reload + enable --now`. Reachable via:

```bash
pnpm --filter @revdev/daemon setup:systemd
```

**WSL note** documented in install.sh + README: `sudo loginctl enable-linger $(whoami)` is required so the daemon survives WSL session closes.

### 3. README rewrite (`packages/daemon/README.md`)

Three startup paths documented with copy-paste commands (foreground / `--detach` / systemd-user), an env-var configuration table, license tier table, and a smoke-test recipe including the v2 Ed25519 test-license generation snippet.

## Out of scope

- **macOS launchd equivalent (`.plist`)** — daemon's primary deploy target is WSL/Linux; macOS contributors can use the manual `--detach` recipe today.
- **Windows-native Task Scheduler** — irrelevant when daemon runs in WSL.
- **Automated test for the `--detach` lifecycle.** The flag is 15 LOC; behavior is verified manually each session via `pnpm setup:systemd` or `pnpm start:detached`. Adding a vitest harness for spawn + PID-alive checks is pure overhead at this scope.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm exec biome check packages/daemon` — 0 errors, 5 warnings (pre-existing, unrelated)
- [x] All 84 daemon tests still pass (no `server.ts` changes; same suite as #26)
- [x] Live `--detach` verification: parent exits 0s, child alive in own session, ping pongs
- [ ] (Manual, follow-up) install systemd unit, verify auto-restart on `kill <pid>` (will run on the local host post-merge)

## Builds on

[revdev#26](https://github.com/RevealUIStudio/revdev/pull/26) (GAP-154 Phase 3). Branch `feat/daemon-detach-and-systemd` rebased onto post-merge `test`.
