### PR TITLE
chore(ci): SHA-pin all 41 actions across 6 workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     name: Quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: quality
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: quality
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -56,9 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [typecheck, test]
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -70,8 +70,8 @@ jobs:
     name: Console (Go)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.23'
           cache-dependency-path: apps/console/go.sum

--- a/.github/workflows/console-release.yml
+++ b/.github/workflows/console-release.yml
@@ -47,9 +47,9 @@ jobs:
       BINARY: rvui-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: apps/console/go.mod
           cache-dependency-path: apps/console/go.sum
@@ -73,7 +73,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.BINARY }}
           path: |
@@ -84,13 +84,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
           merge-multiple: true
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           draft: ${{ github.event.inputs.draft || true }}
           generate_release_notes: true

--- a/.github/workflows/no-submodules.yml
+++ b/.github/workflows/no-submodules.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run no-submodules audit
         run: bash scripts/audit-no-submodules.sh

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -49,9 +49,9 @@ jobs:
       matrix:
         language: [javascript-typescript, go]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
@@ -62,10 +62,10 @@ jobs:
       # `version:` here — pnpm/action-setup@v4 rejects the combination since
       # late 2026 with ERR_PNPM_BAD_PM_VERSION)
       - if: matrix.language == 'javascript-typescript'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - if: matrix.language == 'javascript-typescript'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -75,12 +75,12 @@ jobs:
 
       # Go-specific setup
       - if: matrix.language == 'go'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.23'
           cache-dependency-path: apps/terminal/go.sum
 
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
         with:
           category: /language:${{ matrix.language }}
 
@@ -90,7 +90,7 @@ jobs:
     timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high

--- a/.github/workflows/studio-release.yml
+++ b/.github/workflows/studio-release.yml
@@ -36,7 +36,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Linux system dependencies
         if: matrix.platform == 'ubuntu-latest'
@@ -49,19 +49,19 @@ jobs:
             patchelf \
             libssl-dev
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.rust_target }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: apps/studio/src-tauri -> target
 
@@ -73,7 +73,7 @@ jobs:
 
 
       - name: Build Studio (Tauri)
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}

--- a/.github/workflows/terminal-release.yml
+++ b/.github/workflows/terminal-release.yml
@@ -47,9 +47,9 @@ jobs:
       BINARY: rvui-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: apps/terminal/go.mod
           cache-dependency-path: apps/terminal/go.sum
@@ -73,7 +73,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.BINARY }}
           path: |
@@ -84,13 +84,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
           merge-multiple: true
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           draft: ${{ github.event.inputs.draft || true }}
           generate_release_notes: true


### PR DESCRIPTION
## Summary

Pin all 41 unpinned `uses:` references across 6 workflow files to specific commit SHAs.

## Per-file changes

| File | Replacements |
|---|---|
| `.github/workflows/ci.yml` | 14 |
| `.github/workflows/console-release.yml` | 5 |
| `.github/workflows/no-submodules.yml` | 1 |
| `.github/workflows/security.yml` | 10 |
| `.github/workflows/studio-release.yml` | 6 |
| `.github/workflows/terminal-release.yml` | 5 |
| **Total** | **41** |

## Action+version pins

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@34e11487... # v4` |
| `actions/dependency-review-action` | `@v4` | `@2031cfc0... # v4` |
| `actions/download-artifact` | `@v4` | `@d3f86a10... # v4` |
| `actions/setup-go` | `@v5` | `@40f1582b... # v5` |
| `actions/setup-node` | `@v4` | `@49933ea5... # v4` |
| `actions/upload-artifact` | `@v4` | `@ea165f8d... # v4` |
| `dtolnay/rust-toolchain` | `@stable` | `@29eef336... # stable` |
| `github/codeql-action/analyze` | `@v4` | `@e46ed2cb... # v4` |
| `github/codeql-action/init` | `@v4` | `@e46ed2cb... # v4` |
| `gitleaks/gitleaks-action` | `@v2` | `@ff98106e... # v2` |
| `pnpm/action-setup` | `@v4` | `@b906affc... # v4` |
| `softprops/action-gh-release` | `@v2` | `@3bb12739... # v2` |
| `swatinem/rust-cache` | `@v2` | `@e18b4977... # v2` |
| `tauri-apps/tauri-action` | `@v0` | `@84b9d35b... # v0` |

41 ins / 41 del clean replacement. No version bumps. No functional change.

## Why

GitHub Actions tag references (`@v4`, `@v2`, `@stable`) are mutable: an action repo owner — or an attacker who compromises one — can move the tag to a malicious commit. SHA pinning makes the reference content-addressed; a malicious update would have to ship a new SHA, which Dependabot then proposes as an explicit, reviewable PR rather than a silent re-target. Reference: [`tj-actions/changed-files` 2025-03 incident](https://github.com/tj-actions/changed-files/issues/2464).

## Note on `dtolnay/rust-toolchain@stable`

The `stable` ref in `dtolnay/rust-toolchain` is a branch that the maintainer force-pushes when Rust stable advances. By pinning to a specific SHA, this workflow no longer auto-tracks Rust stable releases — Dependabot will propose explicit bumps as new SHAs ship at `stable`. This is the correct security posture (explicit > silent), but the workflow's effective Rust version will not advance until Dependabot's update PRs are merged. If the project wants automatic Rust stable tracking, leave this single ref unpinned (revert just that line in each file using it).

## Suite-wide context

Part of a suite-wide SHA-pin sweep started 2026-05-02:
- `revealui#718` MERGED `7f354d197` (2 workflows, 7 references pinned)
- `revvault#34` MERGED `60c29120` (1 workflow, 37 references pinned)
- `revealcoin#7`, `revcon#5`, `revskills#2`, `revkit#15`, `forge#11` sister PRs in flight
- This PR brings revdev to 0 unpinned references

SHAs resolved live via `gh api repos/{owner}/{repo}/commits/{ref}` (no hand-typed). All applied via Python script (`/tmp/pin-revdev.py`) — anchored regex `(uses:\s+)([\w./-]+@[\w.-]+)(\s|$)` to avoid touching anything other than action references.

## Test plan

- [x] Audit confirmed zero remaining unpinned `uses:` after edits
- [x] `git diff --stat` shows 41 ins / 41 del across 6 files (clean replacement)
- [ ] CI green on this PR (all 6 workflow files trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
