### PR TITLE
fix(daemon/systemd): resolve node binary at install time (fnm-managed installs)

### DIFF
--- a/packages/daemon/systemd/install.sh
+++ b/packages/daemon/systemd/install.sh
@@ -2,8 +2,9 @@
 # Install the systemd-user unit for revdev-daemon and enable it on boot.
 #
 # Usage:
-#   ./packages/daemon/systemd/install.sh           # default: use repo path
+#   ./packages/daemon/systemd/install.sh           # default: use repo path + PATH-resolved node
 #   DAEMON_PATH=/opt/revdev ./install.sh           # override exec path
+#   NODE_PATH=/opt/node-24/bin/node ./install.sh   # override node binary
 #
 # After install, manage with:
 #   systemctl --user status revdev-daemon
@@ -17,6 +18,12 @@ set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
 DAEMON_PATH=${DAEMON_PATH:-$REPO_ROOT/packages/daemon/dist/cli.js}
+# Resolve node binary at install time. systemd-user services run with a
+# minimal PATH that typically excludes ~/.local/bin (where fnm + nvm + n
+# shims live), so the unit template's `/usr/bin/env node` lookup fails
+# at boot with exit 127. Bake the absolute path in instead.
+# Override via NODE_PATH=/path/to/node for non-PATH installs or sandboxes.
+NODE_PATH=${NODE_PATH:-$(command -v node || true)}
 UNIT_DIR=${UNIT_DIR:-$HOME/.config/systemd/user}
 TEMPLATE=$(dirname "$0")/revdev-daemon.service
 
@@ -26,15 +33,27 @@ if [ ! -f "$DAEMON_PATH" ]; then
   exit 1
 fi
 
+if [ -z "$NODE_PATH" ]; then
+  echo "error: 'node' not found on PATH (and NODE_PATH not set)" >&2
+  echo "either install node or pass NODE_PATH=/path/to/node ./install.sh" >&2
+  exit 1
+fi
+
+if [ ! -x "$NODE_PATH" ]; then
+  echo "error: NODE_PATH ($NODE_PATH) is not executable" >&2
+  exit 1
+fi
+
 mkdir -p "$UNIT_DIR"
-# Substitute the resolved DAEMON_PATH into the unit file. Wrap the path in
-# double quotes so paths with whitespace (e.g. WSL repos under
-# `/mnt/c/Users/<name with space>/...`) survive systemd's argv parsing.
-# Also escape any special chars that would break the sed replacement
+# Substitute the resolved NODE_PATH + DAEMON_PATH into the unit file. Both
+# are wrapped in double quotes so paths with whitespace (e.g. WSL repos
+# under `/mnt/c/Users/<name with space>/...`) survive systemd's argv
+# parsing. Escape any special chars that would break the sed replacement
 # (forward slashes are fine because we use `|` as the sed delimiter; the
 # real risk is `&` and the quote char itself).
+ESCAPED_NODE=$(printf '%s\n' "$NODE_PATH" | sed 's/[&"]/\\&/g')
 ESCAPED_PATH=$(printf '%s\n' "$DAEMON_PATH" | sed 's/[&"]/\\&/g')
-sed "s|/usr/bin/env node %h/suite/revdev/packages/daemon/dist/cli.js|/usr/bin/env node \"$ESCAPED_PATH\"|" \
+sed "s|/usr/bin/env node %h/suite/revdev/packages/daemon/dist/cli.js|\"$ESCAPED_NODE\" \"$ESCAPED_PATH\"|" \
   "$TEMPLATE" > "$UNIT_DIR/revdev-daemon.service"
 
 systemctl --user daemon-reload
@@ -42,6 +61,7 @@ systemctl --user enable --now revdev-daemon
 
 echo
 echo "revdev-daemon installed at $UNIT_DIR/revdev-daemon.service"
+echo "node: $NODE_PATH"
 echo "exec: $DAEMON_PATH"
 echo
 echo "Status:"


### PR DESCRIPTION
## Summary

The systemd-user unit template ships with `ExecStart=/usr/bin/env node ...`. On installs where `node` isn't on systemd-user's minimal PATH — typically fnm- / nvm- / n-managed installs whose shim lives under `~/.local/bin/` — the unit fails at boot with exit 127 (`/usr/bin/env: 'node': No such file or directory`) and enters a restart loop until systemd's start-rate-limit gives up.

Mirror the existing `DAEMON_PATH` substitution pattern: resolve `node` via `command -v node` at install time and bake the absolute path into the unit's ExecStart, alongside the daemon path. Both wrapped in double quotes so paths containing whitespace survive systemd's argv parsing.

## Changes

- `packages/daemon/systemd/install.sh`:
  - New `NODE_PATH` env var override (parallel to `DAEMON_PATH`) for non-PATH installs / sandboxes.
  - Default: `NODE_PATH=$(command -v node || true)` at install time.
  - Validate node exists and is executable; fail-fast with an actionable error message pointing at the `NODE_PATH` override if not.
  - Extend the existing single-pass `sed` substitution to also replace `/usr/bin/env node` with `"$ESCAPED_NODE"`, applying the same `&` + `"` escape pattern used for `DAEMON_PATH`.
  - Update header docstring + success-output line to surface the resolved node path.

The unit template (`revdev-daemon.service`) is unchanged — the `/usr/bin/env node` placeholder is now a substitution target, parallel to the `%h/...` daemon path placeholder it sits next to. The template still works as a documented fallback for installs where the install.sh substitution isn't run.

## Why

GAP-152's acceptance criteria say `systemctl --user enable --now revdev-daemon` should bring the daemon up. On the originally-tested host (which presumably had node on the system PATH), this worked. On a fnm v24.13.1 install (the WSL `~/.revealui` portable dev environment Joshua uses), the recipe fails — manually editing the installed unit is the workaround.

This is the upstream fix for that workaround.

## Test plan

- [x] `bash -n install.sh` — passes
- [x] Dry-run with `UNIT_DIR=/tmp/test-systemd DAEMON_PATH=$HOME/suite/revdev/packages/daemon/dist/cli.js bash install.sh` — generates `ExecStart="~/.local/bin/node" "..."` (both paths quoted, fnm shim resolved)
- [x] Verified live daemon on this host (manually-edited unit using the same node path) — running, ping returns pong, license=ENTERPRISE
- [ ] CI runs full test matrix
- [ ] Post-merge: `pnpm --filter @revdev/daemon setup:systemd` should now produce a working unit on fnm-managed installs without manual editing

## Out of scope

- Whitespace coverage for `NODE_PATH` itself (existing `DAEMON_PATH` whitespace test covers the pattern; `NODE_PATH` uses the identical escape).
- macOS launchd / Windows Task Scheduler equivalents (deferred per GAP-152 closure note — primary deploy is WSL/Linux).
- README install instructions update — minimal: the `NODE_PATH=` override line is documented inline in the install.sh header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
