### PR TITLE
chore(deps): bump rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -5118,9 +5118,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Patch-bumps `rustls-webpki` from 0.103.12 → 0.103.13 in `apps/studio/src-tauri/Cargo.lock`. Closes [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) (CRL parsing panic, medium severity).

This is owner action item A from HANDOFF-2026-05-03-1830Z-revdev-merge-train-and-daemon-hardening, surfaced by `dependency-review-action` on the closed [#34](https://github.com/RevealUIStudio/revdev/pull/34) test→main PR. Smaller scope than the russh chain (item B, upstream-blocked).

## Diff

Single 4-line lockfile change:

```diff
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
```

`cargo update -p rustls-webpki` produces only this change — 57 other dependencies unchanged.

## Audit-first verification

- `cargo update -p rustls-webpki --dry-run`: clean single-package bump, patch-compatible.
- `cargo audit` (pre-fix): rustls-webpki 0.103.12 listed as vulnerable.
- `cargo audit` (post-fix): rustls-webpki **no longer in findings**; 3 remaining vulnerabilities are unchanged and tracked separately:
  - `libcrux-sha3 0.0.4` ([RUSTSEC-2026-0074](https://rustsec.org/advisories/RUSTSEC-2026-0074), HIGH) — blocks test→main per HANDOFF-2026-05-03-1830Z item B; russh chain upstream-blocked.
  - `rsa 0.9.10` + `rsa 0.10.0-rc.12` ([RUSTSEC-2023-0071](https://rustsec.org/advisories/RUSTSEC-2023-0071), MEDIUM) — Marvin Attack, no upstream fix available.
- `dep-review-action` should pass: this PR removes a CVE, doesn't add one.

## Test plan

- [x] `cargo update -p rustls-webpki --dry-run` shows single-package bump
- [x] `cargo update -p rustls-webpki` applied; `git diff --stat` confirms 1 file / +2 / -2
- [x] `cargo audit` confirms rustls-webpki removed from findings (3 remain, unchanged)
- [ ] CI: Build + Typecheck + Test + CodeQL + Dependency Review + Secret Scanning + Submodule Audit + Quality + Console (Go) all green
- [ ] Manual `gh pr merge --squash --delete-branch` after CI green (no `--auto`)

## Companion to

- [#31](https://github.com/RevealUIStudio/revdev/pull/31) (fnm-PATH fix) and [#32](https://github.com/RevealUIStudio/revdev/pull/32) (MemoryHigh/MemoryMax) shipped earlier today.
- Does NOT close out item B from the handoff — that needs upstream russh to ship a libcrux-sha3 ≥0.0.8 chain.
