### PR TITLE
chore(daemon): remove unused z import (clears CodeQL alert blocking #37)

### DIFF
--- a/packages/daemon/src/validation/index.ts
+++ b/packages/daemon/src/validation/index.ts
@@ -6,7 +6,6 @@
  * JSON-RPC -32602 (Invalid params) on failure.
  */
 
-import { z } from 'zod';
 import { schemas } from './schemas.js';
 
 export * from './limits.js';


### PR DESCRIPTION
## Summary

Removes the single unused `import { z } from 'zod';` in `packages/daemon/src/validation/index.ts:9`.

CodeQL surfaced as **alert #1** on [#37](https://github.com/RevealUIStudio/revdev/pull/37) (test→main promote): `js/unused-local-variable`, severity `note`. Required-conversation-resolution branch protection on `main` was blocking #37's merge until this single CodeQL comment resolved. Fixing at source rather than skipping via web-UI conversation-resolve.

The `z` namespace is imported but never referenced — `validateParams()` delegates to `schemas[method].safeParse(params)` and `schemas` is imported separately from `./schemas.js`. No behavior change.

## Test plan

- [x] Local Read confirmed only the import line uses `z`; no `z.<X>` references in the file
- [ ] CI Test (vitest) — should pass; daemon tests don't exercise the unused import
- [ ] CI Typecheck — should pass; removing an unused import never breaks TS
- [ ] CI Build, Quality, CodeQL ×3, Submodule Audit, Secret Scanning, Console (Go), Dependency Review

## Why a separate PR (not amend in #37)

#37 is a `head=test` promote PR — its diff is `test ^main`, not edits to test. Modifying #37 means modifying test directly via PR. This is that PR. Once merged, #37 picks up the fix automatically (head re-evaluates) and CodeQL re-runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
