### PR TITLE
fix(daemon,bridge,studio): reconcile validation schemas with handlers + bridge (closes GAP-173)

### DIFF
--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -116,7 +116,10 @@ pub async fn daemon_start() -> Result<u32, String> {
 
         let pid = child.id();
 
-        // Wait for socket to become reachable (up to 5s)
+        // Wait for socket to become reachable (up to 5s).
+        // If the daemon never becomes reachable, return an error rather than
+        // a false-success Ok(pid) — the child may have exited (bind/startup
+        // failure, missing dependencies, etc.) and reporting Ok hides that.
         for _ in 0..50 {
             sleep(Duration::from_millis(100)).await;
             if crate::harness::rpc_call("ping", serde_json::json!({}))
@@ -127,7 +130,9 @@ pub async fn daemon_start() -> Result<u32, String> {
             }
         }
 
-        Ok(pid)
+        Err(format!(
+            "Daemon spawned (PID {pid}) but did not become reachable within 5s — likely exited or failed to bind socket"
+        ))
     }
 
     #[cfg(not(unix))]

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -155,10 +155,10 @@ server.tool(
   'session_attach',
   'Re-bind an existing session ID to this connection (used by UIs that reconnect per call)',
   {
-    agentId: z.string().describe('Previously-registered session/agent ID'),
+    sessionId: z.string().describe('Previously-registered session ID (a.k.a. agentId)'),
   },
-  async ({ agentId }) => {
-    const result = await daemon.call(RPC_METHODS['session.attach'], { agentId });
+  async ({ sessionId }) => {
+    const result = await daemon.call(RPC_METHODS['session.attach'], { sessionId });
     return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
   },
 );
@@ -340,14 +340,26 @@ server.tool(
 
 server.tool(
   'memory_store',
-  'Store a memory for cross-session agent knowledge',
+  'Store a typed memory record for cross-session agent knowledge',
   {
-    key: z.string().describe('Memory key'),
-    value: z.string().describe('Memory content'),
-    tags: z.array(z.string()).optional().describe('Tags for filtering'),
+    memoryType: z
+      .string()
+      .describe('Memory category (e.g. "fact", "preference", "decision", or any agent-defined type)'),
+    content: z.string().describe('Memory content body'),
+    tags: z.array(z.string()).optional().describe('Tags filed under metadata.tags for filtering'),
+    metadata: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe('Free-form metadata; tags are merged in if both are provided'),
   },
-  async ({ key, value, tags }) => {
-    const result = await daemon.call(RPC_METHODS['memory.store'], { key, value, tags });
+  async ({ memoryType, content, tags, metadata }) => {
+    // Merge tags into metadata so the daemon stores a single JSONB blob.
+    const mergedMetadata = tags && tags.length > 0 ? { ...(metadata ?? {}), tags } : metadata;
+    const result = await daemon.call(RPC_METHODS['memory.store'], {
+      memoryType,
+      content,
+      metadata: mergedMetadata,
+    });
     return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
   },
 );
@@ -356,12 +368,14 @@ server.tool(
   'memory_query',
   'Query stored agent memories',
   {
-    query: z.string().optional().describe('Search query'),
-    tags: z.array(z.string()).optional().describe('Filter by tags'),
+    memoryType: z.string().optional().describe('Filter by memory category (exact match)'),
+    query: z.string().optional().describe('Full-text search filter on content'),
+    tags: z.array(z.string()).optional().describe('Filter by metadata tags (any-of match)'),
     limit: z.number().optional().describe('Max results (default: 10)'),
   },
-  async ({ query, tags, limit }) => {
+  async ({ memoryType, query, tags, limit }) => {
     const result = await daemon.call(RPC_METHODS['memory.query'], {
+      memoryType,
       query,
       tags,
       limit: limit ?? 10,
@@ -376,14 +390,14 @@ server.tool(
   'merge_request',
   'Request a merge review from the daemon merge pipeline',
   {
-    branch: z.string().describe('Branch to merge'),
-    targetBranch: z.string().optional().describe('Target branch (default: main)'),
+    sourceBranch: z.string().describe('Branch to merge (head)'),
+    baseBranch: z.string().optional().describe('Branch to merge into (default: main)'),
     description: z.string().optional().describe('Merge description'),
   },
-  async ({ branch, targetBranch, description }) => {
+  async ({ sourceBranch, baseBranch, description }) => {
     const result = await daemon.call(RPC_METHODS['merge.request'], {
-      branch,
-      targetBranch: targetBranch ?? 'main',
+      sourceBranch,
+      baseBranch: baseBranch ?? 'main',
       description,
     });
     return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -344,7 +344,9 @@ server.tool(
   {
     memoryType: z
       .string()
-      .describe('Memory category (e.g. "fact", "preference", "decision", or any agent-defined type)'),
+      .describe(
+        'Memory category (e.g. "fact", "preference", "decision", or any agent-defined type)',
+      ),
     content: z.string().describe('Memory content body'),
     tags: z.array(z.string()).optional().describe('Tags filed under metadata.tags for filtering'),
     metadata: z

--- a/packages/daemon/src/__tests__/validation.test.ts
+++ b/packages/daemon/src/__tests__/validation.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Validation tests covering the schema/handler/bridge reconcile.
+ *
+ * Verifies each schema accepts the canonical payload shape that the
+ * handler reads + the bridge sends. See GAP-173 for the audit context.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { validateParams } from '../validation/index.js';
+
+describe('session.attach validation', () => {
+  it('accepts canonical sessionId payload', () => {
+    expect(validateParams('session.attach', { sessionId: 'agent-1' }).valid).toBe(true);
+  });
+
+  it('accepts agentId alias (compat)', () => {
+    expect(validateParams('session.attach', { agentId: 'agent-1' }).valid).toBe(true);
+  });
+
+  it('accepts both sessionId and agentId together', () => {
+    expect(
+      validateParams('session.attach', { sessionId: 'agent-1', agentId: 'agent-1' }).valid,
+    ).toBe(true);
+  });
+
+  it('rejects payload missing both sessionId and agentId', () => {
+    const result = validateParams('session.attach', {});
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('sessionId or agentId');
+  });
+});
+
+describe('session.end validation', () => {
+  it('accepts exitSummary (canonical)', () => {
+    expect(validateParams('session.end', { exitSummary: 'done' }).valid).toBe(true);
+  });
+
+  it('accepts summary alias (compat)', () => {
+    expect(validateParams('session.end', { summary: 'done' }).valid).toBe(true);
+  });
+
+  it('accepts sessionId override (admin cleanup)', () => {
+    expect(
+      validateParams('session.end', { sessionId: 'agent-1', exitSummary: 'done' }).valid,
+    ).toBe(true);
+  });
+
+  it('accepts agentId override alias', () => {
+    expect(validateParams('session.end', { agentId: 'agent-1' }).valid).toBe(true);
+  });
+
+  it('accepts empty payload (ends caller session, no summary)', () => {
+    expect(validateParams('session.end', {}).valid).toBe(true);
+  });
+});
+
+describe('session.update validation', () => {
+  it('accepts canonical task + files', () => {
+    expect(validateParams('session.update', { task: 'work', files: 'a.ts' }).valid).toBe(true);
+  });
+
+  it('accepts sessionId/agentId for cross-session targeting', () => {
+    expect(
+      validateParams('session.update', {
+        sessionId: 'agent-1',
+        task: 'admin',
+      }).valid,
+    ).toBe(true);
+  });
+});
+
+describe('session.list validation', () => {
+  it('accepts default (no scope)', () => {
+    expect(validateParams('session.list', {}).valid).toBe(true);
+  });
+
+  it("accepts scope='local'", () => {
+    expect(validateParams('session.list', { scope: 'local' }).valid).toBe(true);
+  });
+
+  it("accepts scope='fleet'", () => {
+    expect(validateParams('session.list', { scope: 'fleet' }).valid).toBe(true);
+  });
+
+  it('rejects invalid scope value', () => {
+    expect(validateParams('session.list', { scope: 'galaxy' }).valid).toBe(false);
+  });
+});
+
+describe('session.register validation', () => {
+  it('accepts handler compat aliases (task, env, pid)', () => {
+    expect(
+      validateParams('session.register', {
+        agentId: 'a',
+        task: '/work',
+        env: 'tmux:1',
+        pid: 12345,
+      }).valid,
+    ).toBe(true);
+  });
+
+  it('rejects negative pid', () => {
+    expect(validateParams('session.register', { pid: -1 }).valid).toBe(false);
+  });
+});
+
+describe('mail.send validation', () => {
+  it('accepts canonical to', () => {
+    expect(
+      validateParams('mail.send', { to: 'agent-2', subject: 's', body: 'b' }).valid,
+    ).toBe(true);
+  });
+
+  it('accepts toAgent alias (compat)', () => {
+    expect(
+      validateParams('mail.send', { toAgent: 'agent-2', subject: 's', body: 'b' }).valid,
+    ).toBe(true);
+  });
+
+  it('rejects payload missing both to and toAgent', () => {
+    const result = validateParams('mail.send', { subject: 's', body: 'b' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('to or toAgent');
+  });
+
+  it('accepts priority enum', () => {
+    expect(
+      validateParams('mail.send', {
+        to: 'a',
+        subject: 's',
+        body: 'b',
+        priority: 'high',
+      }).valid,
+    ).toBe(true);
+  });
+
+  it('rejects invalid priority value', () => {
+    expect(
+      validateParams('mail.send', {
+        to: 'a',
+        subject: 's',
+        body: 'b',
+        priority: 'urgent',
+      }).valid,
+    ).toBe(false);
+  });
+});
+
+describe('memory.store validation', () => {
+  it('accepts canonical typed-record payload (memoryType + content)', () => {
+    expect(
+      validateParams('memory.store', {
+        memoryType: 'fact',
+        content: 'The sky is blue',
+      }).valid,
+    ).toBe(true);
+  });
+
+  it('accepts metadata as an object', () => {
+    expect(
+      validateParams('memory.store', {
+        memoryType: 'preference',
+        content: 'dark mode',
+        metadata: { tags: ['ui', 'theme'] },
+      }).valid,
+    ).toBe(true);
+  });
+
+  it('rejects payload missing memoryType', () => {
+    expect(validateParams('memory.store', { content: 'no type' }).valid).toBe(false);
+  });
+
+  it('rejects payload missing content', () => {
+    expect(validateParams('memory.store', { memoryType: 'fact' }).valid).toBe(false);
+  });
+
+  it('rejects pre-#20 colloquial key/value/tags shape (no longer accepted)', () => {
+    // The schema now requires memoryType + content; bare key/value won't satisfy.
+    expect(
+      validateParams('memory.store', {
+        key: 'old-style',
+        value: 'colloquial',
+        tags: ['legacy'],
+      }).valid,
+    ).toBe(false);
+  });
+});
+
+describe('memory.query validation', () => {
+  it('accepts memoryType filter', () => {
+    expect(validateParams('memory.query', { memoryType: 'fact' }).valid).toBe(true);
+  });
+
+  it('accepts query (full-text)', () => {
+    expect(validateParams('memory.query', { query: 'sky' }).valid).toBe(true);
+  });
+
+  it('accepts tags filter', () => {
+    expect(validateParams('memory.query', { tags: ['ui', 'theme'] }).valid).toBe(true);
+  });
+
+  it('accepts all filters together', () => {
+    expect(
+      validateParams('memory.query', {
+        memoryType: 'preference',
+        query: 'dark',
+        tags: ['ui'],
+        limit: 5,
+      }).valid,
+    ).toBe(true);
+  });
+
+  it('accepts empty payload (returns recent memories)', () => {
+    expect(validateParams('memory.query', {}).valid).toBe(true);
+  });
+});
+
+describe('tasks.create validation', () => {
+  it('accepts canonical priority enum', () => {
+    expect(
+      validateParams('tasks.create', {
+        title: 'Do thing',
+        priority: 'high',
+      }).valid,
+    ).toBe(true);
+  });
+
+  it('accepts all 4 priority values', () => {
+    for (const p of ['low', 'medium', 'high', 'critical']) {
+      expect(
+        validateParams('tasks.create', { title: 't', priority: p }).valid,
+      ).toBe(true);
+    }
+  });
+
+  it('rejects invalid priority value', () => {
+    expect(
+      validateParams('tasks.create', { title: 't', priority: 'urgent' }).valid,
+    ).toBe(false);
+  });
+
+  it('accepts payload without priority (optional)', () => {
+    expect(validateParams('tasks.create', { title: 't' }).valid).toBe(true);
+  });
+});
+
+describe('tasks.complete validation', () => {
+  it('accepts taskId + summary', () => {
+    expect(
+      validateParams('tasks.complete', { taskId: 't1', summary: 'done' }).valid,
+    ).toBe(true);
+  });
+
+  it('rejects payload missing taskId', () => {
+    expect(validateParams('tasks.complete', { summary: 'done' }).valid).toBe(false);
+  });
+});
+
+describe('events.log validation', () => {
+  it('accepts canonical eventType', () => {
+    expect(
+      validateParams('events.log', { eventType: 'agent.start', payload: {} }).valid,
+    ).toBe(true);
+  });
+
+  it('accepts agentId override (handler reads it)', () => {
+    expect(
+      validateParams('events.log', {
+        eventType: 'admin.action',
+        agentId: 'admin-1',
+      }).valid,
+    ).toBe(true);
+  });
+});
+
+describe('worktree.remove validation', () => {
+  it('accepts required branch', () => {
+    expect(validateParams('worktree.remove', { branch: 'feat/x' }).valid).toBe(true);
+  });
+
+  it('rejects payload missing branch (handler throws otherwise)', () => {
+    expect(validateParams('worktree.remove', {}).valid).toBe(false);
+  });
+});
+
+describe('worktree.create validation', () => {
+  it('accepts branch + baseBranch + path override', () => {
+    expect(
+      validateParams('worktree.create', {
+        branch: 'feat/x',
+        baseBranch: 'test',
+        path: '/tmp/wt-feat-x',
+      }).valid,
+    ).toBe(true);
+  });
+});
+
+describe('worktree.list validation', () => {
+  it('accepts agentId filter', () => {
+    expect(validateParams('worktree.list', { agentId: 'agent-1' }).valid).toBe(true);
+  });
+
+  it('accepts empty payload', () => {
+    expect(validateParams('worktree.list', {}).valid).toBe(true);
+  });
+});
+
+describe('merge.request validation', () => {
+  it('accepts canonical sourceBranch', () => {
+    expect(
+      validateParams('merge.request', {
+        sourceBranch: 'feat/x',
+        baseBranch: 'main',
+        description: 'd',
+      }).valid,
+    ).toBe(true);
+  });
+
+  it('accepts branch alias (compat — handler reads either)', () => {
+    expect(
+      validateParams('merge.request', { branch: 'feat/x', targetBranch: 'main' }).valid,
+    ).toBe(true);
+  });
+
+  it('rejects payload missing both sourceBranch and branch', () => {
+    const result = validateParams('merge.request', { description: 'no branch' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('sourceBranch or branch');
+  });
+});
+
+describe('merge.list validation', () => {
+  it('accepts agentId filter', () => {
+    expect(validateParams('merge.list', { agentId: 'agent-1' }).valid).toBe(true);
+  });
+});
+
+describe('No-schema methods (pass-through)', () => {
+  it('ping passes through with empty payload', () => {
+    expect(validateParams('ping', {}).valid).toBe(true);
+  });
+
+  it('unknown method passes through (schemas only validate known methods)', () => {
+    expect(validateParams('not.a.method', { foo: 'bar' }).valid).toBe(true);
+  });
+});

--- a/packages/daemon/src/__tests__/validation.test.ts
+++ b/packages/daemon/src/__tests__/validation.test.ts
@@ -40,9 +40,9 @@ describe('session.end validation', () => {
   });
 
   it('accepts sessionId override (admin cleanup)', () => {
-    expect(
-      validateParams('session.end', { sessionId: 'agent-1', exitSummary: 'done' }).valid,
-    ).toBe(true);
+    expect(validateParams('session.end', { sessionId: 'agent-1', exitSummary: 'done' }).valid).toBe(
+      true,
+    );
   });
 
   it('accepts agentId override alias', () => {
@@ -106,15 +106,15 @@ describe('session.register validation', () => {
 
 describe('mail.send validation', () => {
   it('accepts canonical to', () => {
-    expect(
-      validateParams('mail.send', { to: 'agent-2', subject: 's', body: 'b' }).valid,
-    ).toBe(true);
+    expect(validateParams('mail.send', { to: 'agent-2', subject: 's', body: 'b' }).valid).toBe(
+      true,
+    );
   });
 
   it('accepts toAgent alias (compat)', () => {
-    expect(
-      validateParams('mail.send', { toAgent: 'agent-2', subject: 's', body: 'b' }).valid,
-    ).toBe(true);
+    expect(validateParams('mail.send', { toAgent: 'agent-2', subject: 's', body: 'b' }).valid).toBe(
+      true,
+    );
   });
 
   it('rejects payload missing both to and toAgent', () => {
@@ -227,16 +227,12 @@ describe('tasks.create validation', () => {
 
   it('accepts all 4 priority values', () => {
     for (const p of ['low', 'medium', 'high', 'critical']) {
-      expect(
-        validateParams('tasks.create', { title: 't', priority: p }).valid,
-      ).toBe(true);
+      expect(validateParams('tasks.create', { title: 't', priority: p }).valid).toBe(true);
     }
   });
 
   it('rejects invalid priority value', () => {
-    expect(
-      validateParams('tasks.create', { title: 't', priority: 'urgent' }).valid,
-    ).toBe(false);
+    expect(validateParams('tasks.create', { title: 't', priority: 'urgent' }).valid).toBe(false);
   });
 
   it('accepts payload without priority (optional)', () => {
@@ -246,9 +242,7 @@ describe('tasks.create validation', () => {
 
 describe('tasks.complete validation', () => {
   it('accepts taskId + summary', () => {
-    expect(
-      validateParams('tasks.complete', { taskId: 't1', summary: 'done' }).valid,
-    ).toBe(true);
+    expect(validateParams('tasks.complete', { taskId: 't1', summary: 'done' }).valid).toBe(true);
   });
 
   it('rejects payload missing taskId', () => {
@@ -258,9 +252,9 @@ describe('tasks.complete validation', () => {
 
 describe('events.log validation', () => {
   it('accepts canonical eventType', () => {
-    expect(
-      validateParams('events.log', { eventType: 'agent.start', payload: {} }).valid,
-    ).toBe(true);
+    expect(validateParams('events.log', { eventType: 'agent.start', payload: {} }).valid).toBe(
+      true,
+    );
   });
 
   it('accepts agentId override (handler reads it)', () => {
@@ -317,9 +311,9 @@ describe('merge.request validation', () => {
   });
 
   it('accepts branch alias (compat — handler reads either)', () => {
-    expect(
-      validateParams('merge.request', { branch: 'feat/x', targetBranch: 'main' }).valid,
-    ).toBe(true);
+    expect(validateParams('merge.request', { branch: 'feat/x', targetBranch: 'main' }).valid).toBe(
+      true,
+    );
   });
 
   it('rejects payload missing both sourceBranch and branch', () => {

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -296,19 +296,22 @@ registerHandler('session.register', async (params, db, ctx) => {
 });
 
 registerHandler('session.attach', async (params, db, ctx) => {
-  const agentId = strOrNull(params.agentId);
-  if (!agentId) throw new Error('session.attach: missing agentId');
+  // Accept canonical sessionId, fall back to agentId alias (in this codebase
+  // the session row's `id` column IS the agentId — they're the same value
+  // bound at session.register time).
+  const sessionId = strOrNull(params.sessionId) ?? strOrNull(params.agentId);
+  if (!sessionId) throw new Error('session.attach: missing sessionId or agentId');
   const r = await db.query<{ id: string; env: string }>(
     `SELECT id, env FROM agent_sessions WHERE id = $1 AND ended_at IS NULL`,
-    [agentId],
+    [sessionId],
   );
   if (r.rows.length === 0) {
-    throw new Error(`session.attach: unknown or ended session ${agentId}`);
+    throw new Error(`session.attach: unknown or ended session ${sessionId}`);
   }
-  ctx.agentId = agentId;
+  ctx.agentId = sessionId;
   ctx.agentName = r.rows[0]?.env.split(':')[1] ?? null;
   ctx.boundVia = 'attach';
-  return { attached: true, agentId };
+  return { attached: true, sessionId, agentId: sessionId };
 });
 
 registerHandler('session.list', async (params, db) => {
@@ -334,20 +337,22 @@ registerHandler('session.end', async (params, db, ctx) => {
   // Prefer caller's own session, but allow explicit override (e.g. admin cleanup).
   const target = strOrNull(params.sessionId) ?? strOrNull(params.agentId) ?? ctx.agentId;
   if (!target) throw new Error('No session to end');
-  const summary = strOrNull(params.summary);
+  // Canonical: exitSummary (matches DB column `exit_summary`).
+  // Compat alias: summary (for callers using shorter name).
+  const exitSummary = strOrNull(params.exitSummary) ?? strOrNull(params.summary);
   await db.query(
     `UPDATE agent_sessions
         SET ended_at = NOW(),
             exit_summary = COALESCE($2, exit_summary)
       WHERE id = $1`,
-    [target, summary],
+    [target, exitSummary],
   );
   if (ctx.agentId === target) {
     ctx.agentId = null;
     ctx.agentName = null;
   }
   // Best-effort dual-write — see GAP-154 §E.
-  await syncSessionEnd({ sessionId: target, summary });
+  await syncSessionEnd({ sessionId: target, summary: exitSummary });
   return { ended: target };
 });
 
@@ -763,32 +768,50 @@ registerHandler('harness.prune', async (params, db) => {
 
 registerHandler('memory.store', async (params, db, ctx) => {
   const agentId = requireAgent(ctx, params);
-  const key = str(params.key);
-  const value = str(params.value);
-  const tags = asStringArray(params.tags);
+  const memoryType = str(params.memoryType);
+  const content = str(params.content);
+  const metadataInput =
+    params.metadata && typeof params.metadata === 'object' && !Array.isArray(params.metadata)
+      ? (params.metadata as Record<string, unknown>)
+      : {};
   await db.query(
     `INSERT INTO agent_memory (agent_id, memory_type, content, metadata)
      VALUES ($1, $2, $3, $4::jsonb)`,
-    [agentId, key, value, JSON.stringify({ tags })],
+    [agentId, memoryType, content, JSON.stringify(metadataInput)],
   );
-  return { stored: key };
+  return { stored: memoryType };
 });
 
 registerHandler('memory.query', async (params, db, ctx) => {
   const agentId = requireAgent(ctx, params);
+  const memoryType = strOrNull(params.memoryType);
   const query = strOrNull(params.query);
+  const tags = asStringArray(params.tags);
   const limit = Math.min(num(params.limit, 10), 200);
-  const sql = query
-    ? `SELECT * FROM agent_memory
-       WHERE agent_id = $1 AND content ILIKE $2
-       ORDER BY created_at DESC LIMIT $3`
-    : `SELECT * FROM agent_memory
-       WHERE agent_id = $1
-       ORDER BY created_at DESC LIMIT $2`;
-  const result = await db.query<Record<string, unknown>>(
-    sql,
-    query ? [agentId, `%${query}%`, limit] : [agentId, limit],
-  );
+
+  // Build WHERE clause dynamically based on which filters are present.
+  const where: string[] = ['agent_id = $1'];
+  const args: unknown[] = [agentId];
+  let p = 2;
+  if (memoryType) {
+    where.push(`memory_type = $${p++}`);
+    args.push(memoryType);
+  }
+  if (query) {
+    where.push(`content ILIKE $${p++}`);
+    args.push(`%${query}%`);
+  }
+  if (tags && tags.length > 0) {
+    // PG ?| operator: any tag in the array matches a tag in metadata->'tags'.
+    where.push(`metadata->'tags' ?| $${p++}::text[]`);
+    args.push(tags);
+  }
+  args.push(limit);
+  const sql = `SELECT * FROM agent_memory
+     WHERE ${where.join(' AND ')}
+     ORDER BY created_at DESC LIMIT $${p}`;
+
+  const result = await db.query<Record<string, unknown>>(sql, args);
   return { memories: result.rows };
 });
 

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -2,7 +2,18 @@
  * Zod schemas for all daemon RPC method params.
  *
  * Each schema validates + constrains the input for one RPC method.
- * Uses @revealui/contracts where shared schemas exist.
+ * Field names are derived from the underlying DB columns (in
+ * `storage/schema.ts`) and align with the RevealUI fleet's
+ * agent-memory + agent-coordination contracts (see
+ * `revealui/packages/contracts/src/agents`,
+ * `revealui/packages/db/src/schema/agents.ts`,
+ * `revealui/packages/mcp/src/servers/revealui-memory.ts`,
+ * `revealui/packages/harnesses/src/server/rpc-server.ts` —
+ * all use the typed-record framing
+ * `memoryType`/`content`/`metadata`, not KV-store `key`/`value`).
+ *
+ * Drift between schemas and handler/bridge param names was tracked
+ * in GAP-173 and reconciled in `fix/validation-schema-reconcile`.
  */
 
 import { z } from 'zod';
@@ -35,6 +46,18 @@ const safePath = z
 const agentId = z.string().max(MAX_NAME_LENGTH).optional();
 const actorAgentId = z.string().max(MAX_NAME_LENGTH).optional();
 
+/**
+ * Task priority enum — canonical naming used by bridge MCP tool +
+ * handler. Matches RevealUI contracts naming convention.
+ */
+const taskPriority = z.enum(['low', 'medium', 'high', 'critical']).optional();
+
+/**
+ * Mail priority enum — kept narrow (3 values) since mail is
+ * coordination-tier, not the full task priority spectrum.
+ */
+const mailPriority = z.enum(['low', 'normal', 'high']).optional();
+
 // ---------------------------------------------------------------------------
 // Method schemas
 // ---------------------------------------------------------------------------
@@ -47,26 +70,46 @@ export const schemas: Record<string, z.ZodType> = {
       agentName: z.string().max(MAX_NAME_LENGTH).optional(),
       workDir: z.string().max(MAX_PATH_LENGTH).optional(),
       backend: z.string().max(64).optional(),
+      // Compat aliases — handler reads workDir||task and backend||env.
+      task: z.string().max(MAX_PATH_LENGTH).optional(),
+      env: z.string().max(64).optional(),
+      pid: z.number().int().nonnegative().optional(),
       actorAgentId,
     })
     .passthrough(),
 
   'session.attach': z
     .object({
-      sessionId: z.string().max(MAX_NAME_LENGTH),
+      // Canonical: sessionId (matches DB column `agent_sessions.id` and
+      // session.register's response field). Handler accepts agentId as
+      // alias since in this codebase sessionId == agentId.
+      sessionId: z.string().max(MAX_NAME_LENGTH).optional(),
+      agentId: z.string().max(MAX_NAME_LENGTH).optional(),
       actorAgentId,
     })
-    .passthrough(),
+    .passthrough()
+    .refine((v) => v.sessionId || v.agentId, {
+      message: 'session.attach requires sessionId or agentId',
+    }),
 
   'session.list': z
     .object({
+      // 'local' (default) queries the in-process PGlite; 'fleet' queries
+      // Neon's coordination_sessions table for cross-machine peers.
+      scope: z.enum(['local', 'fleet']).optional(),
       actorAgentId,
     })
     .passthrough(),
 
   'session.end': z
     .object({
+      // Canonical: exitSummary (matches DB column `exit_summary`).
+      // Handler accepts `summary` as alias.
       exitSummary: z.string().max(MAX_BODY_LENGTH).optional(),
+      summary: z.string().max(MAX_BODY_LENGTH).optional(),
+      // Compat: handler accepts sessionId or agentId for cross-session targeting.
+      sessionId: z.string().max(MAX_NAME_LENGTH).optional(),
+      agentId: z.string().max(MAX_NAME_LENGTH).optional(),
       actorAgentId,
     })
     .passthrough(),
@@ -75,6 +118,9 @@ export const schemas: Record<string, z.ZodType> = {
     .object({
       task: z.string().max(MAX_BODY_LENGTH).optional(),
       files: z.string().max(MAX_BODY_LENGTH).optional(),
+      // Compat: handler accepts sessionId or agentId for cross-session targeting.
+      sessionId: z.string().max(MAX_NAME_LENGTH).optional(),
+      agentId: z.string().max(MAX_NAME_LENGTH).optional(),
       actorAgentId,
     })
     .passthrough(),
@@ -82,12 +128,18 @@ export const schemas: Record<string, z.ZodType> = {
   // -- Mail -------------------------------------------------------------------
   'mail.send': z
     .object({
-      to: z.string().max(MAX_NAME_LENGTH),
+      to: z.string().max(MAX_NAME_LENGTH).optional(),
+      // Compat alias: handler accepts toAgent.
+      toAgent: z.string().max(MAX_NAME_LENGTH).optional(),
       subject: z.string().max(MAX_SUBJECT_LENGTH),
       body: z.string().max(MAX_BODY_LENGTH),
+      priority: mailPriority,
       actorAgentId,
     })
-    .passthrough(),
+    .passthrough()
+    .refine((v) => v.to || v.toAgent, {
+      message: 'mail.send requires to or toAgent',
+    }),
 
   'mail.inbox': z
     .object({
@@ -152,6 +204,7 @@ export const schemas: Record<string, z.ZodType> = {
       taskId: z.string().max(MAX_NAME_LENGTH).optional(),
       title: z.string().max(MAX_SUBJECT_LENGTH).optional(),
       description: z.string().max(MAX_BODY_LENGTH).optional(),
+      priority: taskPriority,
       full: z.string().max(MAX_BODY_LENGTH).optional(),
       actorAgentId,
     })
@@ -175,6 +228,7 @@ export const schemas: Record<string, z.ZodType> = {
   'tasks.complete': z
     .object({
       taskId: z.string().max(MAX_NAME_LENGTH),
+      summary: z.string().max(MAX_BODY_LENGTH).optional(),
       actorAgentId,
     })
     .passthrough(),
@@ -196,6 +250,8 @@ export const schemas: Record<string, z.ZodType> = {
           message: `Event payload exceeds ${MAX_PAYLOAD_SIZE} bytes`,
         })
         .optional(),
+      // Handler accepts agentId override; falls back to ctx.agentId.
+      agentId: z.string().max(MAX_NAME_LENGTH).optional(),
       actorAgentId,
     })
     .passthrough(),
@@ -209,6 +265,11 @@ export const schemas: Record<string, z.ZodType> = {
     .passthrough(),
 
   // -- Memory -----------------------------------------------------------------
+  // Field names match DB columns (`agent_memory.memory_type`, `.content`,
+  // `.metadata`) and the RevealUI fleet's typed-record framing
+  // (contracts/agents, db/schema/agents, mcp/servers/revealui-memory,
+  // harnesses/server/rpc-server). Pre-#20 colloquial `key`/`value`/`tags`
+  // names were retired in fix/validation-schema-reconcile (GAP-173).
   'memory.store': z
     .object({
       memoryType: z.string().max(64),
@@ -221,6 +282,10 @@ export const schemas: Record<string, z.ZodType> = {
   'memory.query': z
     .object({
       memoryType: z.string().max(64).optional(),
+      // Full-text content filter — distinct from memoryType (categorical).
+      query: z.string().max(MAX_NAME_LENGTH).optional(),
+      // Tag filter — searches metadata.tags JSONB.
+      tags: z.array(z.string().max(64)).max(MAX_IDS_BATCH).optional(),
       limit: z.number().int().min(1).max(MAX_QUERY_LIMIT).optional(),
       actorAgentId,
     })
@@ -276,18 +341,24 @@ export const schemas: Record<string, z.ZodType> = {
     .object({
       branch: z.string().max(256),
       baseBranch: z.string().max(256).optional(),
+      // Optional override for derived worktree path.
+      path: z.string().max(MAX_PATH_LENGTH).optional(),
       actorAgentId,
     })
     .passthrough(),
 
   'worktree.list': z
     .object({
+      // Filter by owning agent; handler defaults to all when omitted.
+      agentId: z.string().max(MAX_NAME_LENGTH).optional(),
       actorAgentId,
     })
     .passthrough(),
 
   'worktree.remove': z
     .object({
+      // Required: worktree.remove handler throws when branch is absent.
+      branch: z.string().max(256),
       actorAgentId,
     })
     .passthrough(),
@@ -296,11 +367,21 @@ export const schemas: Record<string, z.ZodType> = {
   'merge.request': z
     .object({
       taskId: z.string().max(MAX_NAME_LENGTH).optional(),
-      sourceBranch: z.string().max(256),
+      // Canonical: sourceBranch (matches DB column `merge_requests.source_branch`).
+      sourceBranch: z.string().max(256).optional(),
+      // Compat alias — handler accepts `branch` as alias for sourceBranch.
+      branch: z.string().max(256).optional(),
+      // Canonical: baseBranch (matches DB column `merge_requests.base_branch`).
       baseBranch: z.string().max(256).optional(),
+      // Compat alias — handler accepts `targetBranch` as alias for baseBranch.
+      targetBranch: z.string().max(256).optional(),
+      description: z.string().max(MAX_BODY_LENGTH).optional(),
       actorAgentId,
     })
-    .passthrough(),
+    .passthrough()
+    .refine((v) => v.sourceBranch || v.branch, {
+      message: 'merge.request requires sourceBranch or branch',
+    }),
 
   'merge.status': z
     .object({
@@ -312,6 +393,8 @@ export const schemas: Record<string, z.ZodType> = {
   'merge.list': z
     .object({
       status: z.string().max(32).optional(),
+      // Filter by owning agent; handler defaults to all when omitted.
+      agentId: z.string().max(MAX_NAME_LENGTH).optional(),
       actorAgentId,
     })
     .passthrough(),


### PR DESCRIPTION
## Summary

Closes GAP-173 — reconciles daemon validation schemas with handler/bridge param names. Comprehensive sweep — covers ~7 P1s + several P2s, not just the 2 Codex caught on closed [#37](https://github.com/RevealUIStudio/revdev/pull/37).

## Direction picked: (A) — match handlers/bridge to canonical schemas

Pre-fix research showed the daemon's `key`/`value`/`tags` framing was the **lone outlier** across 5+ agreeing surfaces in the suite: `revealui/packages/contracts/agents`, `revealui/packages/db/schema/agents`, `revealui/packages/mcp/servers/revealui-memory`, `revealui/packages/harnesses/server/rpc-server` — all use typed-record framing (`memoryType`/`content`/`metadata` or equivalent). The schemas in `validation/schemas.ts` are derived from DB columns (`agent_memory.memory_type`, `.content`, `.metadata`); GAP-173's "schemas drafted speculatively" premise was wrong.

Per-method reconciliation:

| method | direction | change |
|---|---|---|
| `session.attach` | (A) | Schema `sessionId` canonical, accepts `agentId` alias via refine. Handler reads either. Bridge sends `sessionId`. |
| `session.end` | (A) | Schema `exitSummary` canonical, accepts `summary` alias. Handler reads either. |
| `session.update`, `session.list`, `session.register` | P2 | Add missing optional fields handler already reads (sessionId/agentId, scope, task/env/pid). |
| `memory.store` | (A) | Schema unchanged (canonical). Handler renamed `key`/`value`/`tags` → `memoryType`/`content`/`metadata`. Bridge MCP tool + RPC payload renamed. |
| `memory.query` | (A) | Schema adds `query` + `tags` filters (handler/bridge use them). Handler now supports `memoryType` + `query` + `tags` filtering via PG `?|` operator on `metadata->'tags'`. Bridge MCP tool exposes `memoryType` filter. |
| `tasks.create` | P2 | Add `priority` enum (matches bridge: `low|medium|high|critical`). |
| `tasks.complete` | P2 | Add `summary` (handler reads it). |
| `mail.send` | P2 | Add `toAgent` alias + `priority` enum, refine `to | toAgent`. |
| `events.log` | P2 | Add `agentId` override (handler reads it). |
| `worktree.create` | P2 | Add `path` override (handler reads it). |
| `worktree.list` | P2 | Add `agentId` filter (handler reads it). |
| `worktree.remove` | (A) | **Add required `branch`** — was a schema gap; handler throws if missing. |
| `merge.request` | (A) | Schema `sourceBranch`/`baseBranch` canonical, accepts `branch`/`targetBranch` aliases via refine. Bridge MCP tool + RPC payload renamed canonical. Handler unchanged (already accepted both). |
| `merge.list` | P2 | Add `agentId` filter (handler reads it). |

## Studio P2 fix

`apps/studio/src-tauri/src/daemon_ctl.rs` `daemon_start` now returns `Err` when readiness ping times out instead of `Ok(pid)` — false-success was hiding bind/startup failures.

## Tests

51 new tests in `packages/daemon/src/__tests__/validation.test.ts` covering schema acceptance/rejection per method (canonical payloads accepted, alias accepted, refine constraints enforced, invalid enum values rejected, etc.).

**135/135 daemon tests pass** (84 baseline + 51 new). Bridge typecheck clean. Build clean.

## Audit-first SDLC

Per internal docs:

1. **AUDIT** — comprehensive subagent research read all of `validation/schemas.ts`, every handler in `server.ts` + `vcs.ts`, every bridge call site, the DB schema in `storage/schema.ts`, plus 4 cross-fleet memory naming surfaces.
2. **REVIEW** — surfaced 5 additional P1s beyond Codex's 2 (memory.query drift, merge.request bridge naming, worktree.remove schema gap, tasks.create priority gap+enum mismatch, session.end summary alias).
3. **PLAN** — direction (A) decision per cross-fleet evidence; expanded scope from 2 P1s to comprehensive sweep.
4. **COMMIT** — 2 commits: WIP-skeleton (schemas.ts) + reconcile (server.ts + vcs.ts handlers + bridge + studio + tests).

## Test plan

- [x] `pnpm --filter @revdev/daemon test` → 135/135
- [x] `pnpm --filter @revdev/daemon --filter @revdev/bridge typecheck` → clean post-build
- [x] `pnpm -r --filter='!studio' build` → clean
- [x] Pre-push gate PASS (signaled by successful push)
- [ ] CI passes on `test` (Quality, Typecheck, Test, Build, CodeQL ×3, Console (Go), Dependency Review, Secret Scanning, Submodule Audit)
- [ ] After merge: fresh test→main promotion PR (replacement for closed #37) for Codex re-review

## Coordination

Lane registered on internal docs workboard at 23:30Z. No active peer conflicts. Worktree `~/suite/.wt/revdev-validation-schema-reconcile` removed cleanly post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
