### PR TITLE
chore(daemon/validation): add harness.* + inference.status schemas (GAP-173 follow-on)

### DIFF
--- a/packages/daemon/src/__tests__/validation.test.ts
+++ b/packages/daemon/src/__tests__/validation.test.ts
@@ -329,6 +329,58 @@ describe('merge.list validation', () => {
   });
 });
 
+describe('harness.health validation', () => {
+  it('accepts empty payload', () => {
+    expect(validateParams('harness.health', {}).valid).toBe(true);
+  });
+
+  it('accepts actorAgentId', () => {
+    expect(validateParams('harness.health', { actorAgentId: 'agent-1' }).valid).toBe(true);
+  });
+
+  it('passes through extra fields (passthrough)', () => {
+    expect(validateParams('harness.health', { extra: 'ignored' }).valid).toBe(true);
+  });
+});
+
+describe('harness.prune validation', () => {
+  it('accepts empty payload (handler defaults apply)', () => {
+    expect(validateParams('harness.prune', {}).valid).toBe(true);
+  });
+
+  it('accepts integer staleDays + hardDeleteDays', () => {
+    expect(validateParams('harness.prune', { staleDays: 7, hardDeleteDays: 30 }).valid).toBe(true);
+  });
+
+  it('accepts fractional days (test helpers use these to avoid long sleeps)', () => {
+    expect(validateParams('harness.prune', { staleDays: 0.00001 }).valid).toBe(true);
+  });
+
+  it('accepts negative days (handler defensive clamp is the safety net)', () => {
+    expect(validateParams('harness.prune', { staleDays: -1, hardDeleteDays: -7 }).valid).toBe(true);
+  });
+
+  it('rejects non-numeric staleDays', () => {
+    const result = validateParams('harness.prune', { staleDays: 'forever' });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects non-numeric hardDeleteDays', () => {
+    const result = validateParams('harness.prune', { hardDeleteDays: { days: 30 } });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('inference.status validation', () => {
+  it('accepts empty payload', () => {
+    expect(validateParams('inference.status', {}).valid).toBe(true);
+  });
+
+  it('accepts actorAgentId', () => {
+    expect(validateParams('inference.status', { actorAgentId: 'agent-1' }).valid).toBe(true);
+  });
+});
+
 describe('No-schema methods (pass-through)', () => {
   it('ping passes through with empty payload', () => {
     expect(validateParams('ping', {}).valid).toBe(true);

--- a/packages/daemon/src/validation/index.ts
+++ b/packages/daemon/src/validation/index.ts
@@ -1,9 +1,11 @@
 /**
  * RPC input validation — validates params before handler dispatch.
  *
- * Methods without a schema pass through unchecked (ping, harness.health,
- * inference.status). Methods with a schema are validated and rejected with
- * JSON-RPC -32602 (Invalid params) on failure.
+ * The only registered method without a schema is `ping` (intentional —
+ * no params). Methods with a schema are validated and rejected with
+ * JSON-RPC -32602 (Invalid params) on failure. Unknown methods also
+ * pass through here (the registry only validates known methods; the
+ * dispatcher surfaces -32601 Method not found later).
  */
 
 import { schemas } from './schemas.js';

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -291,7 +291,45 @@ export const schemas: Record<string, z.ZodType> = {
     })
     .passthrough(),
 
+  // -- Health -----------------------------------------------------------------
+  // Both handlers (`server.ts:registerHandler('harness.health', ...)` and
+  // `harness.prune`) previously bypassed `validateParams` because no
+  // schema existed in the registry. Adding them here completes the
+  // Option A direction (schemas as canonical) shipped by GAP-173 —
+  // every live handler should have a schema entry. Schemas are
+  // intentionally TYPE-ONLY (no integer / non-negative / upper-bound
+  // constraints on `staleDays` / `hardDeleteDays`): the prune handler
+  // already runs a defensive clamp via `Number.isFinite` + `Math.max(0,
+  // ...)`, AND the integration tests legitimately pass fractional days
+  // (e.g. `staleDays: 0.00001` ≈ 0.86s) to exercise the prune logic
+  // without 24h sleeps + negative days to verify the defensive clamp.
+  // Adding `int()` / `min(0)` here would break those tests and move
+  // safety enforcement away from the handler where it belongs.
+  'harness.health': z
+    .object({
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'harness.prune': z
+    .object({
+      staleDays: z.number().optional(),
+      hardDeleteDays: z.number().optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
   // -- Inference --------------------------------------------------------------
+  // `inference.status` takes no required params (handler signature is
+  // `async ()` — no params destructured). Schema added for symmetry with
+  // the rest of the inference.* methods + so the only remaining bare
+  // method in the registry is `ping` (intentional, no params).
+  'inference.status': z
+    .object({
+      actorAgentId,
+    })
+    .passthrough(),
+
   'inference.pull': z
     .object({
       model: z.string().max(256),


### PR DESCRIPTION
## Summary

Follow-on to [#39](https://github.com/RevealUIStudio/revdev/pull/39) (closed GAP-173). Adds schemas for the 3 remaining live handlers that were bypassing `validateParams()` because no schema entry existed in the registry.

After this PR, the only registered method without a schema is `ping` (intentional — no params).

## Net change

| File | Change |
|---|---|
| `packages/daemon/src/validation/schemas.ts` | +`harness.health` + `harness.prune` + `inference.status` schemas (3 new entries, +section comment) |
| `packages/daemon/src/validation/index.ts` | Updated stale doc comment (was: "ping, harness.health, inference.status" pass-through; now: "only `ping` — intentional, no params") |
| `packages/daemon/src/__tests__/validation.test.ts` | +11 new tests (3 for `harness.health`, 6 for `harness.prune`, 2 for `inference.status`) |

3 files / +95 / −3.

## `harness.prune` design note

Schema is intentionally TYPE-ONLY (no `int()`, no `min(0)`, no `max(...)` bounds on `staleDays` / `hardDeleteDays`):

1. The handler already runs a defensive clamp via `Number.isFinite` + `Math.max(0, ...)` (`server.ts:142-143`).
2. The `coordination.test.ts` integration tests legitimately pass fractional days (e.g. `staleDays: 0.00001` ≈ 0.86s) to exercise the prune logic without 24h sleeps, AND negative days to verify the handler's defensive clamp.

Adding `int()` / `min(0)` to the schema would break those tests + move safety enforcement away from the handler where it belongs. Schema's job here is type-narrowing (rejects `staleDays: "forever"` / `hardDeleteDays: { days: 30 }`), not bound-checking.

## Verification

Local:
- `pnpm --filter @revdev/daemon test` → **146/146 pass** (135 baseline post-#39 + 11 new)
- `pnpm --filter @revdev/daemon exec tsc --noEmit` → clean
- `pnpm exec biome check` → clean (auto-formatted one collapsed test assertion)

## Audit context

This PR closes the follow-up flagged in my 2026-05-04 ~02:05Z GAP-173 audit pass-along (an internal repo coord note). The pass-along's headline finding ("3 dead handler schemas") was wrong — the handlers exist in `inference.ts` + `vcs.ts` via side-effect imports in `cli.ts:24-25`. Correction notes posted in an internal repo `b19c5e458` (GAP-173.yml work-field amended with the methodology correction so future agents don't repeat the error).

## Test plan

- [x] `pnpm --filter @revdev/daemon test` passes locally (146/146)
- [x] `pnpm --filter @revdev/daemon exec tsc --noEmit` clean
- [x] `pnpm exec biome check` clean
- [ ] All CI checks green
- [ ] Codex review (if invoked) does not flag new P1s in `validation/`
