### PR TITLE
feat(daemon): replace dotted-v2 with Ed25519 JWT acceptor — Phase B (CR8-P0-01)

### DIFF
--- a/packages/daemon/src/__tests__/flows.test.ts
+++ b/packages/daemon/src/__tests__/flows.test.ts
@@ -1,6 +1,8 @@
+import { generateKeyPairSync, sign } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { DAEMON_DEFAULTS } from '../config.js';
 import { checkLicense, isExemptMethod, LICENSE_TIERS } from '../license.js';
+import { verifyLicenseJWT } from '../license-crypto.js';
 import { SCHEMA_SQL } from '../storage/schema.js';
 import {
   clearTestLicenseEnv,
@@ -20,11 +22,43 @@ describe('license', () => {
     if (original) process.env.REVEALUI_LICENSE_KEY = original;
   });
 
-  it('validates a pro v2 license key', () => {
+  it('validates a pro JWT license key', () => {
     setTestLicenseEnv(generateTestLicense('pro'));
     const result = checkLicense();
     expect(result.tier).toBe('pro');
     expect(result.valid).toBe(true);
+    clearTestLicenseEnv();
+  });
+
+  it('validates a max JWT license key', () => {
+    setTestLicenseEnv(generateTestLicense('max'));
+    const result = checkLicense();
+    expect(result.tier).toBe('max');
+    expect(result.valid).toBe(true);
+    clearTestLicenseEnv();
+  });
+
+  it('validates an enterprise JWT license key', () => {
+    setTestLicenseEnv(generateTestLicense('enterprise'));
+    const result = checkLicense();
+    expect(result.tier).toBe('enterprise');
+    expect(result.valid).toBe(true);
+    clearTestLicenseEnv();
+  });
+
+  it('validates a non-perpetual JWT license key (with exp)', () => {
+    setTestLicenseEnv(generateTestLicense('pro', false, { daysUntilExpiry: 30 }));
+    const result = checkLicense();
+    expect(result.tier).toBe('pro');
+    expect(result.valid).toBe(true);
+    clearTestLicenseEnv();
+  });
+
+  it('rejects a dotted-v2 format license (legacy)', () => {
+    process.env.REVEALUI_LICENSE_KEY = 'RVUI.v2.pro.0.somesig';
+    const result = checkLicense();
+    expect(result.tier).toBe('free');
+    expect(result.valid).toBe(false);
     clearTestLicenseEnv();
   });
 
@@ -53,6 +87,131 @@ describe('license', () => {
     expect(isExemptMethod('session.register')).toBe(true);
     expect(isExemptMethod('agent.spawn')).toBe(false);
     expect(isExemptMethod('merge.request')).toBe(false);
+  });
+});
+
+describe('verifyLicenseJWT — negative cases', () => {
+  it('rejects an RS256-signed JWT (algorithm mismatch)', () => {
+    const { privateKey: rsaPriv, publicKey: edPub } = (() => {
+      const { privateKey } = generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      });
+      const { publicKey } = generateKeyPairSync('ed25519', {
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      });
+      return { privateKey, publicKey };
+    })();
+
+    const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+    const payload = Buffer.from(JSON.stringify({ tier: 'pro' })).toString('base64url');
+    const sig = sign('sha256', Buffer.from(`${header}.${payload}`), rsaPriv).toString('base64url');
+    const rs256Jwt = `${header}.${payload}.${sig}`;
+
+    const result = verifyLicenseJWT(rs256Jwt, edPub as string);
+    expect(result.valid).toBe(false);
+    expect('reason' in result && result.reason).toBe('unsupported algorithm');
+  });
+
+  it('rejects a JWT signed with the wrong Ed25519 key', () => {
+    const kit = generateTestLicense('pro');
+    const { publicKey: wrongPub } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const result = verifyLicenseJWT(kit.licenseKey, wrongPub as string);
+    expect(result.valid).toBe(false);
+    expect('reason' in result && result.reason).toBe('invalid signature');
+  });
+
+  it('rejects a JWT with non-JSON payload', () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
+    const payloadB64 = Buffer.from('not-json-at-all!!!').toString('base64url');
+    const message = `${header}.${payloadB64}`;
+    const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');
+
+    const result = verifyLicenseJWT(`${message}.${sig}`, publicKey as string);
+    expect(result.valid).toBe(false);
+    expect('reason' in result && result.reason).toBe('invalid format');
+  });
+
+  it('rejects a JWT with an unrecognized tier', () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
+    const payloadB64 = Buffer.from(
+      JSON.stringify({ tier: 'gold', iat: Math.floor(Date.now() / 1000) }),
+    ).toString('base64url');
+    const message = `${header}.${payloadB64}`;
+    const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');
+
+    const result = verifyLicenseJWT(`${message}.${sig}`, publicKey as string);
+    expect(result.valid).toBe(false);
+    expect('reason' in result && result.reason).toContain('invalid tier');
+  });
+
+  it('rejects an expired JWT', () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const now = Math.floor(Date.now() / 1000);
+    const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
+    const payloadB64 = Buffer.from(
+      JSON.stringify({ tier: 'pro', iat: now - 7200, exp: now - 3600 }),
+    ).toString('base64url');
+    const message = `${header}.${payloadB64}`;
+    const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');
+
+    const result = verifyLicenseJWT(`${message}.${sig}`, publicKey as string);
+    expect(result.valid).toBe(false);
+    expect('reason' in result && result.reason).toBe('license expired');
+  });
+
+  it('accepts a perpetual JWT (no exp claim)', () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const now = Math.floor(Date.now() / 1000);
+    const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
+    // No exp claim
+    const payloadB64 = Buffer.from(
+      JSON.stringify({ tier: 'enterprise', iat: now }),
+    ).toString('base64url');
+    const message = `${header}.${payloadB64}`;
+    const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');
+
+    const result = verifyLicenseJWT(`${message}.${sig}`, publicKey as string);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.tier).toBe('enterprise');
+      expect(result.expiresAt).toBe(0);
+    }
+  });
+
+  it('rejects a JWT with only two parts (malformed)', () => {
+    const { publicKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const result = verifyLicenseJWT('header.payload', publicKey as string);
+    expect(result.valid).toBe(false);
+    expect('reason' in result && result.reason).toBe('invalid format');
   });
 });
 

--- a/packages/daemon/src/__tests__/flows.test.ts
+++ b/packages/daemon/src/__tests__/flows.test.ts
@@ -189,9 +189,9 @@ describe('verifyLicenseJWT — negative cases', () => {
     const now = Math.floor(Date.now() / 1000);
     const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
     // No exp claim
-    const payloadB64 = Buffer.from(
-      JSON.stringify({ tier: 'enterprise', iat: now }),
-    ).toString('base64url');
+    const payloadB64 = Buffer.from(JSON.stringify({ tier: 'enterprise', iat: now })).toString(
+      'base64url',
+    );
     const message = `${header}.${payloadB64}`;
     const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');
 

--- a/packages/daemon/src/__tests__/test-license-helper.ts
+++ b/packages/daemon/src/__tests__/test-license-helper.ts
@@ -1,5 +1,5 @@
 /**
- * Test helper: generates Ed25519-signed v2 license keys for tests.
+ * Test helper: generates Ed25519-signed JWT license keys for tests.
  * Creates a fresh keypair per call — no secrets needed.
  */
 
@@ -10,28 +10,53 @@ export interface TestLicenseKit {
   licenseKey: string;
   /** Set as REVDEV_LICENSE_PUBLIC_KEY */
   publicKey: string;
+  /** The private key PEM — available for constructing adversarial fixtures */
+  privateKey: string;
 }
 
 /**
- * Generate a real Ed25519-signed v2 license key for testing.
+ * Generate a real Ed25519-signed JWT license key for testing.
  * Returns both the key and the public key to set in env.
+ *
+ * opts.daysUntilExpiry: if set, JWT includes an exp claim that far in the future.
+ * perpetual (default true): JWT omits exp claim.
  */
 export function generateTestLicense(
   tier: 'pro' | 'max' | 'enterprise' = 'enterprise',
   perpetual = true,
+  opts: { daysUntilExpiry?: number; customerId?: string } = {},
 ): TestLicenseKit {
   const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
     publicKeyEncoding: { type: 'spki', format: 'pem' },
     privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
   });
 
-  const expiresAt = perpetual ? '0' : String(Math.floor(Date.now() / 1000) + 86400);
-  const message = `${tier}.${expiresAt}`;
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'EdDSA', typ: 'JWT' };
+  const payload: Record<string, unknown> = {
+    tier,
+    iat: now,
+    iss: 'https://revealui.com',
+    aud: 'revealui-license',
+  };
+
+  if (opts.customerId) {
+    payload['customerId'] = opts.customerId;
+  }
+
+  if (!perpetual) {
+    payload['exp'] = now + (opts.daysUntilExpiry ?? 1) * 86400;
+  }
+
+  const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const message = `${headerB64}.${payloadB64}`;
   const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');
 
   return {
-    licenseKey: `RVUI.v2.${tier}.${expiresAt}.${sig}`,
+    licenseKey: `${message}.${sig}`,
     publicKey: publicKey as string,
+    privateKey: privateKey as string,
   };
 }
 

--- a/packages/daemon/src/__tests__/test-license-helper.ts
+++ b/packages/daemon/src/__tests__/test-license-helper.ts
@@ -41,11 +41,11 @@ export function generateTestLicense(
   };
 
   if (opts.customerId) {
-    payload['customerId'] = opts.customerId;
+    payload.customerId = opts.customerId;
   }
 
   if (!perpetual) {
-    payload['exp'] = now + (opts.daysUntilExpiry ?? 1) * 86400;
+    payload.exp = now + (opts.daysUntilExpiry ?? 1) * 86400;
   }
 
   const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');

--- a/packages/daemon/src/license-crypto.ts
+++ b/packages/daemon/src/license-crypto.ts
@@ -80,15 +80,12 @@ export function verifyLicenseJWT(
     // Decode + parse header
     let header: Record<string, unknown>;
     try {
-      header = JSON.parse(decodeBase64url(headerB64).toString('utf-8')) as Record<
-        string,
-        unknown
-      >;
+      header = JSON.parse(decodeBase64url(headerB64).toString('utf-8')) as Record<string, unknown>;
     } catch {
       return { tier: 'free', valid: false, reason: 'invalid format' };
     }
 
-    if (header['alg'] !== 'EdDSA') {
+    if (header.alg !== 'EdDSA') {
       return { tier: 'free', valid: false, reason: 'unsupported algorithm' };
     }
 
@@ -104,13 +101,13 @@ export function verifyLicenseJWT(
     }
 
     // Validate tier
-    const tier = payload['tier'];
+    const tier = payload.tier;
     if (typeof tier !== 'string' || !VALID_TIERS.has(tier)) {
       return { tier: 'free', valid: false, reason: `invalid tier: ${String(tier)}` };
     }
 
     // Validate exp (absent = perpetual; present = must be a number)
-    const exp = payload['exp'];
+    const exp = payload.exp;
     if (exp !== undefined && typeof exp !== 'number') {
       return { tier: 'free', valid: false, reason: 'invalid exp claim' };
     }

--- a/packages/daemon/src/license-crypto.ts
+++ b/packages/daemon/src/license-crypto.ts
@@ -1,11 +1,14 @@
 /**
- * Ed25519 license key cryptography for RevDev.
+ * Ed25519 JWT license key cryptography for RevDev.
  *
- * License format: RVUI.v2.<tier>.<expiresAt>.<signature-base64url>
+ * License format: Ed25519-signed JWT (RFC 7519)
+ *   Header: { "alg": "EdDSA", "typ": "JWT" }
+ *   Payload: { tier, iat, iss, aud, customerId?, exp? }
  *
- * - <tier>: pro | max | enterprise
- * - <expiresAt>: unix timestamp (seconds), or "0" for perpetual
- * - <signature>: Ed25519 signature over "<tier>.<expiresAt>" in base64url
+ * - tier: "pro" | "max" | "enterprise"
+ * - exp: unix timestamp (seconds); absent = perpetual
+ * - iss: "https://revealui.com"
+ * - aud: "revealui-license"
  *
  * The vendor public key is read from the REVDEV_LICENSE_PUBLIC_KEY env var
  * (also stored in revvault at `revdev/license-signing-public-key`). The
@@ -13,8 +16,14 @@
  * and is only used by the key issuing CLI (`scripts/issue-license.ts`,
  * which also has a `--generate-keypair` mode for first-time setup).
  *
+ * Verification is hand-decoded (no jose dep): split on ".", base64url-decode
+ * header+payload, assert alg=EdDSA, verify Ed25519 signature over the raw
+ * "<headerB64url>.<payloadB64url>" bytes via node:crypto.verify(null, ...).
+ *
  * Threat model: blocks casual forgery. Determined attackers can patch
  * the binary, but that's a separate concern from tier-gate enforcement.
+ *
+ * Per CR8-P0-01 spec (Phase B), ships after Phase A revealui#735.
  */
 
 import { verify } from 'node:crypto';
@@ -28,86 +37,120 @@ import { verify } from 'node:crypto';
  * That writes both halves to revvault and prints the PEM-formatted public
  * key to copy into the daemon's environment / Studio bundle.
  */
-function getVendorPublicKey(): string {
+export function getVendorPublicKey(): string {
   return process.env.REVDEV_LICENSE_PUBLIC_KEY ?? '';
 }
 
 const VALID_TIERS = new Set(['pro', 'max', 'enterprise']);
 
-export interface LicenseV2Result {
+export interface LicenseJWTResult {
   tier: 'pro' | 'max' | 'enterprise';
   expiresAt: number; // unix seconds, 0 = perpetual
   valid: true;
 }
 
-export interface LicenseV2Failure {
+export interface LicenseJWTFailure {
   tier: 'free';
   valid: false;
   reason: string;
 }
 
+function decodeBase64url(input: string): Buffer {
+  return Buffer.from(input, 'base64url');
+}
+
 /**
- * Verify an Ed25519-signed license key.
+ * Verify an Ed25519-signed JWT license key.
  *
  * Returns the tier + expiration if valid, or { valid: false, reason } if not.
+ * Never throws — all parse/verify errors are returned as failures.
  */
-export function verifyLicenseV2(key: string): LicenseV2Result | LicenseV2Failure {
-  // Parse format: RVUI.v2.<tier>.<expiresAt>.<signature>
-  const parts = key.split('.');
-  if (parts.length !== 5 || parts[0] !== 'RVUI' || parts[1] !== 'v2') {
-    return { tier: 'free', valid: false, reason: 'invalid format' };
-  }
-
-  const [, , tierStr, expiresAtStr, signatureB64] = parts;
-
-  if (!tierStr || !VALID_TIERS.has(tierStr)) {
-    return { tier: 'free', valid: false, reason: `invalid tier: ${tierStr}` };
-  }
-
-  if (!expiresAtStr || !signatureB64) {
-    return { tier: 'free', valid: false, reason: 'missing fields' };
-  }
-
-  const expiresAt = parseInt(expiresAtStr, 10);
-  if (Number.isNaN(expiresAt)) {
-    return { tier: 'free', valid: false, reason: 'invalid expiresAt' };
-  }
-
-  // Check expiration (0 = perpetual, never expires)
-  if (expiresAt > 0) {
-    const nowSeconds = Math.floor(Date.now() / 1000);
-    if (nowSeconds > expiresAt) {
-      return { tier: 'free', valid: false, reason: 'license expired' };
-    }
-  }
-
-  // Verify Ed25519 signature
-  const vendorKey = getVendorPublicKey();
-  if (!vendorKey) {
-    return {
-      tier: 'free',
-      valid: false,
-      reason: 'REVDEV_LICENSE_PUBLIC_KEY not set — cannot verify signature',
-    };
-  }
-
-  const message = `${tierStr}.${expiresAtStr}`;
-  const signature = Buffer.from(signatureB64, 'base64url');
-
+export function verifyLicenseJWT(
+  token: string,
+  publicKey: string,
+): LicenseJWTResult | LicenseJWTFailure {
   try {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return { tier: 'free', valid: false, reason: 'invalid format' };
+    }
+
+    const [headerB64, payloadB64, signatureB64] = parts as [string, string, string];
+
+    // Decode + parse header
+    let header: Record<string, unknown>;
+    try {
+      header = JSON.parse(decodeBase64url(headerB64).toString('utf-8')) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      return { tier: 'free', valid: false, reason: 'invalid format' };
+    }
+
+    if (header['alg'] !== 'EdDSA') {
+      return { tier: 'free', valid: false, reason: 'unsupported algorithm' };
+    }
+
+    // Decode + parse payload
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(decodeBase64url(payloadB64).toString('utf-8')) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      return { tier: 'free', valid: false, reason: 'invalid format' };
+    }
+
+    // Validate tier
+    const tier = payload['tier'];
+    if (typeof tier !== 'string' || !VALID_TIERS.has(tier)) {
+      return { tier: 'free', valid: false, reason: `invalid tier: ${String(tier)}` };
+    }
+
+    // Validate exp (absent = perpetual; present = must be a number)
+    const exp = payload['exp'];
+    if (exp !== undefined && typeof exp !== 'number') {
+      return { tier: 'free', valid: false, reason: 'invalid exp claim' };
+    }
+
+    // Check expiration if exp is present
+    if (typeof exp === 'number') {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      if (nowSeconds > exp) {
+        return { tier: 'free', valid: false, reason: 'license expired' };
+      }
+    }
+
+    if (!publicKey) {
+      return {
+        tier: 'free',
+        valid: false,
+        reason: 'REVDEV_LICENSE_PUBLIC_KEY not set — cannot verify signature',
+      };
+    }
+
+    // The signed message is the literal "<headerB64url>.<payloadB64url>" string
+    const message = `${headerB64}.${payloadB64}`;
+    const signatureBuffer = decodeBase64url(signatureB64);
+
     // Ed25519 doesn't use a separate digest — pass null as algorithm
-    const isValid = verify(null, Buffer.from(message), vendorKey, signature);
+    const isValid = verify(null, Buffer.from(message, 'utf-8'), publicKey, signatureBuffer);
 
     if (!isValid) {
       return { tier: 'free', valid: false, reason: 'invalid signature' };
     }
-  } catch {
-    return { tier: 'free', valid: false, reason: 'signature verification failed' };
-  }
 
-  return {
-    tier: tierStr as 'pro' | 'max' | 'enterprise',
-    expiresAt,
-    valid: true,
-  };
+    // expiresAt: 0 = perpetual (mirrors dotted-v2 semantics)
+    const expiresAt = typeof exp === 'number' ? exp : 0;
+
+    return {
+      tier: tier as 'pro' | 'max' | 'enterprise',
+      expiresAt,
+      valid: true,
+    };
+  } catch {
+    return { tier: 'free', valid: false, reason: 'invalid format' };
+  }
 }

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -7,7 +7,16 @@
  *
  * When running as a standalone daemon (outside the RevealUI monorepo),
  * license validation is done via the REVEALUI_LICENSE_KEY env var.
+ *
+ * License format: Ed25519-signed JWT (RFC 7519) — keys start with "eyJ".
+ * Issued by the RevealUI license API or `revdev/scripts/issue-license.ts`.
+ *
+ * Legacy formats (RVUI.v2.*, RVUI-*) are rejected per CR8-P0-01 Q2
+ * (immediate dotted-v2 removal, no deprecation window, 2026-05-04).
  */
+
+// Import statically — same ESM module, no circular risk.
+import { getVendorPublicKey, verifyLicenseJWT } from './license-crypto.js';
 
 export const LICENSE_TIERS = ['free', 'pro', 'max', 'enterprise'] as const;
 export type LicenseTier = (typeof LICENSE_TIERS)[number];
@@ -26,17 +35,7 @@ const EXEMPT_METHODS = new Set([
  * Returns the detected tier, or 'free' if no valid license is found.
  * The daemon runs in degraded mode on free tier: session management
  * works, but spawning, inference, and merge pipeline are gated.
- *
- * License format:
- *   v2 (Ed25519): RVUI.v2.<tier>.<expiresAt>.<ed25519-sig-base64url>
- *   v1 (legacy):  RVUI-<tier>-<32 hex chars> — DEPRECATED, rejected
- *
- * v1 keys are no longer accepted. If you have a v1 key, contact
- * support@revealui.com for a v2 replacement.
  */
-// Import verifyLicenseV2 statically — same ESM module, no circular risk.
-import { verifyLicenseV2 } from './license-crypto.js';
-
 export function checkLicense(): { tier: LicenseTier; valid: boolean } {
   const key = process.env.REVEALUI_LICENSE_KEY;
 
@@ -44,9 +43,9 @@ export function checkLicense(): { tier: LicenseTier; valid: boolean } {
     return { tier: 'free', valid: false };
   }
 
-  // v2 format: RVUI.v2.<tier>.<expiresAt>.<signature>
-  if (key.startsWith('RVUI.v2.')) {
-    const result = verifyLicenseV2(key);
+  // JWT format (Ed25519-signed): header starts with base64url-encoded "{"
+  if (key.startsWith('eyJ')) {
+    const result = verifyLicenseJWT(key, getVendorPublicKey());
     if (result.valid) {
       return { tier: result.tier, valid: true };
     }
@@ -56,11 +55,12 @@ export function checkLicense(): { tier: LicenseTier; valid: boolean } {
     return { tier: 'free', valid: false };
   }
 
-  // v1 format: RVUI-<tier>-<hash> — REJECTED (not cryptographically bound)
-  if (key.match(/^RVUI-/i)) {
+  // Legacy formats — REJECTED outright per CR8-P0-01 Q2
+  if (key.startsWith('RVUI.v2.') || key.match(/^RVUI-/i)) {
     process.stderr.write(
-      '[revdev] v1 license keys (RVUI-<tier>-<hash>) are no longer accepted. ' +
-        'Contact support@revealui.com for a v2 Ed25519-signed key.\n',
+      '[revdev] Legacy license formats (RVUI.v2.*, RVUI-*) are no longer accepted. ' +
+        'Mint an Ed25519-signed JWT via the RevealUI license API or ' +
+        '`revdev/scripts/issue-license.ts`.\n',
     );
     return { tier: 'free', valid: false };
   }

--- a/scripts/issue-license.ts
+++ b/scripts/issue-license.ts
@@ -124,11 +124,11 @@ function issueLicense(opts: Options): string {
   };
 
   if (opts.customer) {
-    payload['customerId'] = opts.customer;
+    payload.customerId = opts.customer;
   }
 
   if (!opts.perpetual) {
-    payload['exp'] = now + (opts.days ?? 365) * 86400;
+    payload.exp = now + (opts.days ?? 365) * 86400;
   }
 
   const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');

--- a/scripts/issue-license.ts
+++ b/scripts/issue-license.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --import=tsx
 
 /**
- * Issue a RevDev license key (Ed25519-signed v2 format), or generate the
+ * Issue a RevDev license key (Ed25519-signed JWT), or generate the
  * Ed25519 keypair the daemon uses to verify those keys.
  *
  * Usage:
@@ -15,6 +15,10 @@
  *
  * Signing private key is read from revvault at revdev/license-signing-private-key
  * (or REVDEV_LICENSE_PRIVATE_KEY env, or ~/.revealui/license-private.pem).
+ *
+ * Output: Ed25519-signed JWT (RFC 7519). Header: { alg: "EdDSA", typ: "JWT" }.
+ * Payload: { tier, iat, iss, aud, customerId?, exp? }.
+ * Format matches the RevealUI license API issuer (revealui#735, Phase A).
  */
 
 import { execSync } from 'node:child_process';
@@ -49,7 +53,7 @@ function parseArgs(): Options {
       case '--help':
       case '-h':
         console.log(`
-Issue RevDev License Key (Ed25519 v2)
+Issue RevDev License Key (Ed25519-signed JWT)
 
 Usage:
   npx tsx scripts/issue-license.ts --generate-keypair
@@ -60,10 +64,12 @@ Options:
                                 (revdev/license-signing-{private,public}-key).
                                 Exits before signing.
   --tier <pro|max|enterprise>   License tier (required for signing)
-  --customer <name>             Customer identifier (informational; not signed)
+  --customer <name>             Customer identifier (embedded in JWT payload)
   --days <n>                    Expiry in days (default: 365)
-  --perpetual                   Never expires
+  --perpetual                   Never expires (omits exp claim)
   --help                        Show this help
+
+Output format: Ed25519-signed JWT (RFC 7519). Set as REVEALUI_LICENSE_KEY on the daemon.
 `);
         process.exit(0);
     }
@@ -108,14 +114,29 @@ function issueLicense(opts: Options): string {
   const privateKeyPem = getPrivateKey();
   const privateKey = createPrivateKey(privateKeyPem);
 
-  const expiresAt = opts.perpetual
-    ? '0'
-    : String(Math.floor(Date.now() / 1000) + (opts.days ?? 365) * 86400);
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'EdDSA', typ: 'JWT' };
+  const payload: Record<string, unknown> = {
+    tier: opts.tier,
+    iat: now,
+    iss: 'https://revealui.com',
+    aud: 'revealui-license',
+  };
 
-  const message = `${opts.tier}.${expiresAt}`;
+  if (opts.customer) {
+    payload['customerId'] = opts.customer;
+  }
+
+  if (!opts.perpetual) {
+    payload['exp'] = now + (opts.days ?? 365) * 86400;
+  }
+
+  const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const message = `${headerB64}.${payloadB64}`;
   const signature = sign(null, Buffer.from(message), privateKey).toString('base64url');
 
-  return `RVUI.v2.${opts.tier}.${expiresAt}.${signature}`;
+  return `${message}.${signature}`;
 }
 
 function revvaultSet(path: string, value: string): void {
@@ -174,6 +195,7 @@ console.log('  ──────────────────');
 console.log(`  Tier:     ${opts.tier.toUpperCase()}`);
 console.log(`  Customer: ${opts.customer ?? '(not specified)'}`);
 console.log(`  Expires:  ${opts.perpetual ? 'Never (perpetual)' : `${opts.days ?? 365} days`}`);
+console.log(`  Format:   Ed25519-signed JWT (RFC 7519)`);
 console.log('');
 console.log('  Key:');
 console.log(`  ${key}`);


### PR DESCRIPTION
## Summary

Phase B of the CR8-P0-01 charge-readiness P0 migration. Replaces the daemon's dotted-v2 license verifier with Ed25519-signed JWT acceptance — pairs with the API issuer shipped in [revealui#735](https://github.com/RevealUIStudio/revealui/pull/735) (commit `6c728d582` on revealui:test).

Per owner direction 2026-05-04 (Q1+Q2): hand-decode JWT verifier (zero new daemon deps, ~50 LOC) + immediate dotted-v2 removal (no deprecation window — no live customers depend on out-of-band dotted-v2 keys per owner).

**Audit:** internal docs (private, commit `47a05c287`)
**Spec:** internal docs (private, commit `9d4df4baf`)

## Why this matters

After Phase A, `POST /api/license/generate` returns Ed25519-signed JWTs (`alg: EdDSA`). Without Phase B, the daemon at `packages/daemon/src/license.ts` still strictly accepted only the `RVUI.v2.<tier>.<expiresAt>.<sig>` dotted format — JWTs from the API would be rejected silently and the customer would fall back to free-tier despite paying for Pro. Phase B closes that gap so a customer's `REVEALUI_LICENSE_KEY` env paste works whether the JWT comes from the API issuer or the CLI issuer.

## Scope

### Daemon verifier (`packages/daemon/src/license-crypto.ts`)

REPLACED `verifyLicenseV2()` with `verifyLicenseJWT(token, publicKey)`:
- Hand-decode JWT (no `jose` dep) — split on `.`, base64url-decode header+payload, JSON.parse
- Assert `header.alg === 'EdDSA'` (rejects RS256 and any other algorithm with clean error)
- Validate payload tier against `pro|max|enterprise` whitelist
- Check `exp` if present (absent = perpetual, mirrors dotted-v2 semantics with `expiresAt: 0`)
- Verify Ed25519 signature over `<headerB64url>.<payloadB64url>` UTF-8 bytes via `node:crypto.verify(null, ...)`
- Wraps everything in try/catch with explicit failure reasons (`invalid format`, `unsupported algorithm`, `invalid tier`, `invalid exp claim`, `license expired`, `invalid signature`, missing public key)

### Daemon dispatcher (`packages/daemon/src/license.ts`)

REPLACED dotted-v2 branch with JWT branch (`if (key.startsWith('eyJ'))`). Legacy formats (`RVUI.v2.*`, `RVUI-*`) get a clear stderr rejection message pointing customer at the API or CLI for a fresh JWT.

### CLI issuer (`scripts/issue-license.ts`)

REPLACED dotted-v2 emission with JWT emission. Output now matches Phase A's `generateLicenseKey()` shape exactly:
- Header: `{ alg: 'EdDSA', typ: 'JWT' }`
- Payload: `{ tier, iat, iss: 'https://revealui.com', aud: 'revealui-license', customerId?, exp? }`
- Signature: Ed25519 over `<headerB64url>.<payloadB64url>` UTF-8 bytes

CLI args (`--tier`, `--customer`, `--days`, `--perpetual`, `--generate-keypair`) preserved. `--generate-keypair` mode unchanged (still mints Ed25519 keypair via `generateKeyPairSync('ed25519', ...)`).

### Tests (`packages/daemon/src/__tests__/`)

- `test-license-helper.ts` — REPLACED `generateV2Key()` with JWT generator that mints fixtures matching the CLI's shape
- `flows.test.ts` — existing positive-path fixtures regenerated as JWTs; 11 new negative + edge tests added:
  - rejects dotted-v2 format (legacy)
  - rejects v1 (`RVUI-*`) keys
  - rejects invalid license-key formats
  - rejects RS256-signed JWT (algorithm mismatch — explicit pre-Phase-A regression test)
  - rejects JWT signed with wrong Ed25519 key
  - rejects JWT with non-JSON payload
  - rejects JWT with unrecognized tier
  - rejects expired JWT
  - accepts perpetual JWT (no `exp` claim)
  - rejects 2-part malformed JWT
  - validates non-perpetual JWT with `exp` (positive)

**Daemon test count: 146 baseline → 157 (+11)**

## Verification

- `pnpm --filter @revdev/daemon test` — 157/157 pass
- `pnpm --filter @revdev/daemon typecheck` — clean
- `pnpm lint` — 0 errors (8 pre-existing warnings unrelated to this PR)
- Cross-repo parity: CLI-issued JWT verifies via daemon's new verifier (same algorithm, same payload schema, same signature scheme as `revealui/packages/core/src/license.ts`'s `generateLicenseKey()`)

## Explicitly NOT in this PR

- ❌ Anything in `revealui/...` — separate repo, Phase A already shipped
- ❌ Daemon files unrelated to license (RPC handlers, validation/schemas, server.ts — out of scope)
- ❌ Studio / Console / Bridge license UI — Phase A's runtime verifier covers what these need; daemon is the only consumer of the `RVUI.v2.*` format that needed format migration

## Phase chain

- ✅ **Phase A** — revealui issuer + verifier swap + C1 internal docs ([revealui#735](https://github.com/RevealUIStudio/revealui/pull/735) MERGED `6c728d582`)
- 🔨 **Phase B (this PR)** — daemon JWT-acceptor + CLI JWT issuer + negative test suite
- **Phase C2** (deferred) — customer-facing copy sweep on revealui repo (gated on Phase D smoke green per Q3 split)
- **Phase D** (owner action) — Vercel env rotation (RSA → Ed25519 PEM) on revealui-server + revealui-admin Production scope; redeploy; smoke test; close CR8-P0-01

## Locked posture preserved

- `core.fileMode=false` on every commit
- Branched from `origin/test`, will merge to `test`
- `-F /tmp/cmsg-*-2026-05-04.txt` for multi-line commit messages
- `--body-file` for this PR body (no bash heredoc)
- Worktree-isolation pattern (`~/suite/.wt/license-ed25519-phase-b`)
- Manual `gh pr merge --squash --delete-branch` will follow CI green (no `--auto` per `feedback_no_auto_merge`)
- WIP commit `ad10f7a` is squashed away by `--squash` merge

## Implementer-flagged deviation

`useLiteralKeys` Biome unsafe-fixes were applied during cleanup. Per `feedback_biome_unsafe_typecheck`, `--unsafe` can change types — implementer re-ran `pnpm --filter @revdev/daemon typecheck` + 157/157 tests after the fix to confirm no behavior changes. Main-thread verify-twice on the diff confirmed scope is bounded to the 5 spec-listed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
