### PR TITLE
test(studio): mock health-api in Dashboard.test to eliminate jsdom-teardown flake

### DIFF
--- a/apps/studio/src/__tests__/components/Dashboard.test.tsx
+++ b/apps/studio/src/__tests__/components/Dashboard.test.tsx
@@ -7,6 +7,16 @@ import { SettingsContext } from '../../hooks/use-settings';
 import type { StatusContextValue } from '../../hooks/use-status';
 import { StatusContext } from '../../hooks/use-status';
 
+// Mock health API to prevent fetch calls from useHealth.
+// Without this mock the initial poll() fires a real fetch that hangs on
+// AbortSignal.timeout(5_000) in CI runners; when the abort resolves after
+// the synchronous tests complete and jsdom has been torn down, the
+// setReachable() call hits a missing `window` and Vitest reports it as an
+// unhandled error. See revdev CI run 25296294717 attempt 1 (2026-05-04).
+vi.mock('../../lib/health-api', () => ({
+  fetchHealth: vi.fn().mockResolvedValue(null),
+}));
+
 // Mock billing API to prevent fetch calls from useSubscription
 vi.mock('../../lib/billing-api', () => ({
   fetchSubscription: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary

- Adds `vi.mock('../../lib/health-api', ...)` to `apps/studio/src/__tests__/components/Dashboard.test.tsx`, mirroring the existing `billing-api` mock pattern.
- Eliminates a jsdom-teardown unhandled-error flake that surfaces in CI when the unmocked `useHealth` initial poll resolves after the test file has already completed.
- Production `useHealth` is untouched.

## Root cause

The Dashboard test renders the full Dashboard tree, which mounts `HealthCard → useHealth → poll()`. `poll()` calls `fetchHealth('http://localhost:3004/health/ready')` with `AbortSignal.timeout(5_000)`. In CI runners, the fetch sits until the abort fires (~5 s), which is long after the synchronous tests have completed (~270 ms) and jsdom has been torn down. When `setReachable(false)` runs at that point, React 19's `dispatchSetState → resolveUpdatePriority` reads `window`, which no longer exists, and Vitest reports the resulting `ReferenceError: window is not defined` as an unhandled error.

The "polling cleanup race" framing in prior workboard logs was inaccurate — the `setInterval` cleanup runs fine; the leak is the *initial* `poll()`'s pending promise, not the interval callback. The `pollingIntervalMs: 30_000` fixture is a red herring (the interval never fires; tests run for <300 ms).

## Evidence

revdev CI run [25296294717 attempt 1](https://github.com/RevealUIStudio/revdev/actions/runs/25296294717) (2026-05-04T01:14Z, `fix/validation-schema-reconcile@f0056c43`):

```
Vitest caught 5 unhandled errors during the test run.
This error originated in "src/__tests__/components/Dashboard.test.tsx"
ReferenceError: window is not defined
  at resolveUpdatePriority (react-dom-client.development.js:1308:7)
  at dispatchSetState (...:9126:14)
  at poll src/hooks/use-health.ts:33:7
```

Local repro fails because dev `fetch` returns `ECONNREFUSED` immediately on `localhost:3004`; the GitHub Actions network namespace lets the connection sit until abort.

## Fix scope

- Test-only change. `useHealth` itself is unchanged.
- The mock returns `null` (HealthCard's unreachable path); none of the 9 tests assert on health content, so a null payload is sufficient.

## Verification

- `pnpm --filter studio test src/__tests__/components/Dashboard.test.tsx --run` × 10 — 9/9 pass each, **zero** unhandled errors (vs. 5 unhandled errors in the affected CI run).
- Full studio suite: `pnpm --filter studio test --run` → 522/522 pass.
- `pnpm typecheck:studio` clean.
- `pnpm exec biome check apps/studio/src/__tests__/components/Dashboard.test.tsx` clean.

## Out of scope (separate Pillar 1 follow-up)

`useHealth`, `useStatus`, `useSubscription`, `useRvuiBalance`, and ~10 other studio polling hooks lack an `isMounted` ref or `AbortController` guard against post-unmount `setState`. A broader hook-hygiene sweep belongs in the planned Pillar 1 flaky-test classification track, not bundled here.

## Test plan

- [x] Local 10× isolation runs (zero unhandled errors)
- [x] Local full studio suite (522/522)
- [x] Local typecheck
- [x] Local biome
- [ ] CI green on `fix/dashboard-test-health-api-mock`
