### PR TITLE
fix(daemon/inference): per-operation fetch timeouts + structured error envelope

### DIFF
--- a/packages/daemon/src/__tests__/inference.test.ts
+++ b/packages/daemon/src/__tests__/inference.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('inference module — timeout configuration', () => {
+  const TIMEOUT_ENV_VARS = [
+    'REVDEV_OLLAMA_STATUS_TIMEOUT_MS',
+    'REVDEV_OLLAMA_STOP_TIMEOUT_MS',
+    'REVDEV_OLLAMA_START_TIMEOUT_MS',
+    'REVDEV_OLLAMA_CHAT_TIMEOUT_MS',
+    'REVDEV_OLLAMA_GENERATE_TIMEOUT_MS',
+    'REVDEV_OLLAMA_PULL_TIMEOUT_MS',
+  ] as const;
+
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const k of TIMEOUT_ENV_VARS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of TIMEOUT_ENV_VARS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('uses defaults when no env vars are set', async () => {
+    const { OLLAMA_TIMEOUTS } = await import('../inference.js');
+    expect(OLLAMA_TIMEOUTS.status).toBe(5_000);
+    expect(OLLAMA_TIMEOUTS.stop).toBe(5_000);
+    expect(OLLAMA_TIMEOUTS.start).toBe(60_000);
+    expect(OLLAMA_TIMEOUTS.chat).toBe(300_000);
+    expect(OLLAMA_TIMEOUTS.generate).toBe(300_000);
+    expect(OLLAMA_TIMEOUTS.pull).toBe(1_800_000);
+  });
+
+  it('honors env-var overrides per operation', async () => {
+    process.env.REVDEV_OLLAMA_STATUS_TIMEOUT_MS = '1000';
+    process.env.REVDEV_OLLAMA_CHAT_TIMEOUT_MS = '120000';
+    process.env.REVDEV_OLLAMA_PULL_TIMEOUT_MS = '900000';
+
+    const { OLLAMA_TIMEOUTS } = await import('../inference.js');
+    expect(OLLAMA_TIMEOUTS.status).toBe(1_000);
+    expect(OLLAMA_TIMEOUTS.chat).toBe(120_000);
+    expect(OLLAMA_TIMEOUTS.pull).toBe(900_000);
+    // Unset ones still default
+    expect(OLLAMA_TIMEOUTS.stop).toBe(5_000);
+    expect(OLLAMA_TIMEOUTS.generate).toBe(300_000);
+  });
+
+  it('falls back to default when env var is non-numeric', async () => {
+    process.env.REVDEV_OLLAMA_STATUS_TIMEOUT_MS = 'not-a-number';
+    const { OLLAMA_TIMEOUTS } = await import('../inference.js');
+    expect(OLLAMA_TIMEOUTS.status).toBe(5_000);
+  });
+
+  it('falls back to default when env var is zero or negative', async () => {
+    process.env.REVDEV_OLLAMA_STATUS_TIMEOUT_MS = '0';
+    process.env.REVDEV_OLLAMA_STOP_TIMEOUT_MS = '-1';
+    const { OLLAMA_TIMEOUTS } = await import('../inference.js');
+    expect(OLLAMA_TIMEOUTS.status).toBe(5_000);
+    expect(OLLAMA_TIMEOUTS.stop).toBe(5_000);
+  });
+});
+
+describe('inference module — isTimeoutError', () => {
+  it('identifies TimeoutError (Node 20+ AbortSignal.timeout shape)', async () => {
+    const { isTimeoutError } = await import('../inference.js');
+    const err = new Error('timed out');
+    err.name = 'TimeoutError';
+    expect(isTimeoutError(err)).toBe(true);
+  });
+
+  it('identifies AbortError (older runtime shape)', async () => {
+    const { isTimeoutError } = await import('../inference.js');
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    expect(isTimeoutError(err)).toBe(true);
+  });
+
+  it('identifies DOMException-shaped TimeoutError when AbortSignal.timeout fires for real', async () => {
+    const { isTimeoutError } = await import('../inference.js');
+    const signal = AbortSignal.timeout(1);
+    await new Promise<void>((resolve) => {
+      signal.addEventListener('abort', () => resolve(), { once: true });
+    });
+    expect(signal.aborted).toBe(true);
+    expect(isTimeoutError(signal.reason)).toBe(true);
+  });
+
+  it('rejects non-abort errors', async () => {
+    const { isTimeoutError } = await import('../inference.js');
+    expect(isTimeoutError(new Error('connection refused'))).toBe(false);
+    expect(isTimeoutError(new TypeError('fetch failed'))).toBe(false);
+  });
+
+  it('rejects non-Error values', async () => {
+    const { isTimeoutError } = await import('../inference.js');
+    expect(isTimeoutError(undefined)).toBe(false);
+    expect(isTimeoutError(null)).toBe(false);
+    expect(isTimeoutError('AbortError')).toBe(false);
+    expect(isTimeoutError({ name: 'TimeoutError' })).toBe(false);
+  });
+});

--- a/packages/daemon/src/inference.ts
+++ b/packages/daemon/src/inference.ts
@@ -4,18 +4,62 @@
  * These handlers provide model management and chat completion through
  * the daemon's license-gated RPC surface. Free tier gets local inference
  * if Ollama is running; Pro+ gets full management (pull, start, stop).
+ *
+ * Every handler enforces a per-operation timeout via AbortSignal. Without
+ * this, a stuck Ollama (accepts the connection but never responds) would
+ * hold the daemon socket indefinitely — any caller could DoS the daemon
+ * with a single inference.status call. Timeouts are env-overridable so
+ * deployers can tune for slow hardware, large models, and slow networks.
+ *
+ * Error envelope: every handler returns a structured response on timeout
+ * or connection failure rather than throwing to the daemon's central
+ * error path. This matches the existing inference.status precedent and
+ * gives callers a consistent error shape they can render.
  */
 
 import { registerHandler } from './server.js';
 
 const OLLAMA_URL = process.env.OLLAMA_BASE_URL ?? 'http://localhost:11434';
 
-async function ollamaFetch(path: string, options?: RequestInit): Promise<Response> {
+function readTimeoutMs(envName: string, defaultMs: number): number {
+  const raw = process.env[envName];
+  if (!raw) return defaultMs;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultMs;
+}
+
+export const OLLAMA_TIMEOUTS = {
+  status: readTimeoutMs('REVDEV_OLLAMA_STATUS_TIMEOUT_MS', 5_000),
+  stop: readTimeoutMs('REVDEV_OLLAMA_STOP_TIMEOUT_MS', 5_000),
+  start: readTimeoutMs('REVDEV_OLLAMA_START_TIMEOUT_MS', 60_000),
+  chat: readTimeoutMs('REVDEV_OLLAMA_CHAT_TIMEOUT_MS', 300_000),
+  generate: readTimeoutMs('REVDEV_OLLAMA_GENERATE_TIMEOUT_MS', 300_000),
+  pull: readTimeoutMs('REVDEV_OLLAMA_PULL_TIMEOUT_MS', 1_800_000),
+} as const;
+
+interface OllamaFetchOptions extends Omit<RequestInit, 'signal'> {
+  timeoutMs: number;
+}
+
+async function ollamaFetch(path: string, opts: OllamaFetchOptions): Promise<Response> {
+  const { timeoutMs, headers, ...rest } = opts;
   return fetch(`${OLLAMA_URL}${path}`, {
-    ...options,
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    ...rest,
+    signal: AbortSignal.timeout(timeoutMs),
+    headers: { 'Content-Type': 'application/json', ...headers },
   });
 }
+
+export function isTimeoutError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === 'TimeoutError' || err.name === 'AbortError';
+}
+
+function timeoutMessage(op: keyof typeof OLLAMA_TIMEOUTS): string {
+  return `Ollama did not respond within ${OLLAMA_TIMEOUTS[op]}ms`;
+}
+
+const CONNECT_ERROR = 'Cannot connect to Ollama. Run: ollama serve';
 
 // ---------------------------------------------------------------------------
 // inference.status — check Ollama health + loaded models
@@ -24,12 +68,12 @@ async function ollamaFetch(path: string, options?: RequestInit): Promise<Respons
 registerHandler('inference.status', async () => {
   try {
     const [versionRes, modelsRes] = await Promise.all([
-      ollamaFetch('/api/version'),
-      ollamaFetch('/api/tags'),
+      ollamaFetch('/api/version', { timeoutMs: OLLAMA_TIMEOUTS.status }),
+      ollamaFetch('/api/tags', { timeoutMs: OLLAMA_TIMEOUTS.status }),
     ]);
 
     if (!versionRes.ok) {
-      return { running: false, error: 'Ollama not responding' };
+      return { running: false, error: 'Ollama not responding', url: OLLAMA_URL };
     }
 
     const version = (await versionRes.json()) as { version: string };
@@ -47,12 +91,11 @@ registerHandler('inference.status', async () => {
         modified: m.modified_at,
       })),
     };
-  } catch {
-    return {
-      running: false,
-      error: 'Cannot connect to Ollama. Run: ollama serve',
-      url: OLLAMA_URL,
-    };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return { running: false, error: timeoutMessage('status'), url: OLLAMA_URL };
+    }
+    return { running: false, error: CONNECT_ERROR, url: OLLAMA_URL };
   }
 });
 
@@ -63,18 +106,26 @@ registerHandler('inference.status', async () => {
 registerHandler('inference.pull', async (params) => {
   const { model } = params as { model: string };
 
-  const res = await ollamaFetch('/api/pull', {
-    method: 'POST',
-    body: JSON.stringify({ name: model, stream: false }),
-  });
+  try {
+    const res = await ollamaFetch('/api/pull', {
+      method: 'POST',
+      body: JSON.stringify({ name: model, stream: false }),
+      timeoutMs: OLLAMA_TIMEOUTS.pull,
+    });
 
-  if (!res.ok) {
-    const text = await res.text();
-    return { success: false, error: `Pull failed (${res.status}): ${text}` };
+    if (!res.ok) {
+      const text = await res.text();
+      return { success: false, error: `Pull failed (${res.status}): ${text}` };
+    }
+
+    const result = (await res.json()) as { status: string };
+    return { success: true, model, status: result.status };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return { success: false, error: timeoutMessage('pull') };
+    }
+    return { success: false, error: CONNECT_ERROR };
   }
-
-  const result = (await res.json()) as { status: string };
-  return { success: true, model, status: result.status };
 });
 
 // ---------------------------------------------------------------------------
@@ -84,18 +135,26 @@ registerHandler('inference.pull', async (params) => {
 registerHandler('inference.start', async (params) => {
   const { model } = params as { model: string };
 
-  // Ollama loads models on first request — send empty generate to warm up
-  const res = await ollamaFetch('/api/generate', {
-    method: 'POST',
-    body: JSON.stringify({ model, prompt: '', stream: false }),
-  });
+  try {
+    // Ollama loads models on first request — send empty generate to warm up
+    const res = await ollamaFetch('/api/generate', {
+      method: 'POST',
+      body: JSON.stringify({ model, prompt: '', stream: false }),
+      timeoutMs: OLLAMA_TIMEOUTS.start,
+    });
 
-  if (!res.ok) {
-    const text = await res.text();
-    return { loaded: false, error: `Load failed (${res.status}): ${text}` };
+    if (!res.ok) {
+      const text = await res.text();
+      return { loaded: false, error: `Load failed (${res.status}): ${text}` };
+    }
+
+    return { loaded: true, model };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return { loaded: false, error: timeoutMessage('start') };
+    }
+    return { loaded: false, error: CONNECT_ERROR };
   }
-
-  return { loaded: true, model };
 });
 
 // ---------------------------------------------------------------------------
@@ -105,17 +164,25 @@ registerHandler('inference.start', async (params) => {
 registerHandler('inference.stop', async (params) => {
   const { model } = params as { model: string };
 
-  // Ollama uses keep_alive: 0 to immediately unload
-  const res = await ollamaFetch('/api/generate', {
-    method: 'POST',
-    body: JSON.stringify({ model, prompt: '', keep_alive: 0, stream: false }),
-  });
+  try {
+    // Ollama uses keep_alive: 0 to immediately unload
+    const res = await ollamaFetch('/api/generate', {
+      method: 'POST',
+      body: JSON.stringify({ model, prompt: '', keep_alive: 0, stream: false }),
+      timeoutMs: OLLAMA_TIMEOUTS.stop,
+    });
 
-  if (!res.ok) {
-    return { unloaded: false, error: `Unload failed (${res.status})` };
+    if (!res.ok) {
+      return { unloaded: false, error: `Unload failed (${res.status})` };
+    }
+
+    return { unloaded: true, model };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return { unloaded: false, error: timeoutMessage('stop') };
+    }
+    return { unloaded: false, error: CONNECT_ERROR };
   }
-
-  return { unloaded: true, model };
 });
 
 // ---------------------------------------------------------------------------
@@ -130,41 +197,49 @@ registerHandler('inference.chat', async (params) => {
     maxTokens?: number;
   };
 
-  const res = await ollamaFetch('/api/chat', {
-    method: 'POST',
-    body: JSON.stringify({
-      model,
-      messages,
-      stream: false,
-      options: {
-        ...(temperature !== undefined && { temperature }),
-        ...(maxTokens !== undefined && { num_predict: maxTokens }),
+  try {
+    const res = await ollamaFetch('/api/chat', {
+      method: 'POST',
+      body: JSON.stringify({
+        model,
+        messages,
+        stream: false,
+        options: {
+          ...(temperature !== undefined && { temperature }),
+          ...(maxTokens !== undefined && { num_predict: maxTokens }),
+        },
+      }),
+      timeoutMs: OLLAMA_TIMEOUTS.chat,
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      return { error: `Chat failed (${res.status}): ${text}` };
+    }
+
+    const result = (await res.json()) as {
+      message: { role: string; content: string };
+      total_duration: number;
+      eval_count: number;
+      eval_duration: number;
+    };
+
+    return {
+      message: result.message,
+      stats: {
+        totalMs: Math.round(result.total_duration / 1_000_000),
+        tokens: result.eval_count,
+        tokensPerSecond: result.eval_duration
+          ? Math.round((result.eval_count / result.eval_duration) * 1_000_000_000)
+          : 0,
       },
-    }),
-  });
-
-  if (!res.ok) {
-    const text = await res.text();
-    return { error: `Chat failed (${res.status}): ${text}` };
+    };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return { error: timeoutMessage('chat') };
+    }
+    return { error: CONNECT_ERROR };
   }
-
-  const result = (await res.json()) as {
-    message: { role: string; content: string };
-    total_duration: number;
-    eval_count: number;
-    eval_duration: number;
-  };
-
-  return {
-    message: result.message,
-    stats: {
-      totalMs: Math.round(result.total_duration / 1_000_000),
-      tokens: result.eval_count,
-      tokensPerSecond: result.eval_duration
-        ? Math.round((result.eval_count / result.eval_duration) * 1_000_000_000)
-        : 0,
-    },
-  };
 });
 
 // ---------------------------------------------------------------------------
@@ -180,40 +255,48 @@ registerHandler('inference.generate', async (params) => {
     maxTokens?: number;
   };
 
-  const res = await ollamaFetch('/api/generate', {
-    method: 'POST',
-    body: JSON.stringify({
-      model,
-      prompt,
-      system,
-      stream: false,
-      options: {
-        ...(temperature !== undefined && { temperature }),
-        ...(maxTokens !== undefined && { num_predict: maxTokens }),
+  try {
+    const res = await ollamaFetch('/api/generate', {
+      method: 'POST',
+      body: JSON.stringify({
+        model,
+        prompt,
+        system,
+        stream: false,
+        options: {
+          ...(temperature !== undefined && { temperature }),
+          ...(maxTokens !== undefined && { num_predict: maxTokens }),
+        },
+      }),
+      timeoutMs: OLLAMA_TIMEOUTS.generate,
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      return { error: `Generate failed (${res.status}): ${text}` };
+    }
+
+    const result = (await res.json()) as {
+      response: string;
+      total_duration: number;
+      eval_count: number;
+      eval_duration: number;
+    };
+
+    return {
+      response: result.response,
+      stats: {
+        totalMs: Math.round(result.total_duration / 1_000_000),
+        tokens: result.eval_count,
+        tokensPerSecond: result.eval_duration
+          ? Math.round((result.eval_count / result.eval_duration) * 1_000_000_000)
+          : 0,
       },
-    }),
-  });
-
-  if (!res.ok) {
-    const text = await res.text();
-    return { error: `Generate failed (${res.status}): ${text}` };
+    };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return { error: timeoutMessage('generate') };
+    }
+    return { error: CONNECT_ERROR };
   }
-
-  const result = (await res.json()) as {
-    response: string;
-    total_duration: number;
-    eval_count: number;
-    eval_duration: number;
-  };
-
-  return {
-    response: result.response,
-    stats: {
-      totalMs: Math.round(result.total_duration / 1_000_000),
-      tokens: result.eval_count,
-      tokensPerSecond: result.eval_duration
-        ? Math.round((result.eval_count / result.eval_duration) * 1_000_000_000)
-        : 0,
-    },
-  };
 });


### PR DESCRIPTION
## Summary

- Adds per-operation fetch timeouts + AbortController to all 6 `inference.*` handlers in `packages/daemon/src/inference.ts`.
- Aligns the connection-failure path of `pull/start/stop/chat/generate` with the existing structured-error precedent in `inference.status` (no more throws to the daemon's central error path on connection issues).
- 9 new unit tests covering env-override behavior + `isTimeoutError` shape detection across `TimeoutError`, `AbortError`, and the real `AbortSignal.timeout()` `DOMException` reason.

Closes the **HIGH-severity** §C-1 fix from `pillar-1-stability-2026-05-05.md`.

## Why

Pre-fix, every `inference.*` handler called `fetch(...)` against Ollama with no `AbortSignal`. A stuck Ollama (accepts the connection but never responds) holds the daemon socket indefinitely — any caller can DoS the daemon with a single `inference.status` call. The audit walked the live production daemon and confirmed 6 of 6 handlers had no timeout, no AbortController, no structured error envelope.

This is the contained-module HIGH-priority fix from the §5.27 Phase 1 audit. The other 13 Phase 2 PRs are queued in the audit doc.

## Defaults

| Env var | Default | Reasoning |
|---|---|---|
| `REVDEV_OLLAMA_STATUS_TIMEOUT_MS` | `5_000` (5 s) | health probe; long hang = stuck Ollama |
| `REVDEV_OLLAMA_STOP_TIMEOUT_MS` | `5_000` (5 s) | unload should be near-instant |
| `REVDEV_OLLAMA_START_TIMEOUT_MS` | `60_000` (60 s) | cold model warm-up (large weights) |
| `REVDEV_OLLAMA_CHAT_TIMEOUT_MS` | `300_000` (5 min) | long generations |
| `REVDEV_OLLAMA_GENERATE_TIMEOUT_MS` | `300_000` (5 min) | same |
| `REVDEV_OLLAMA_PULL_TIMEOUT_MS` | `1_800_000` (30 min) | multi-GB model download on residential link |

Each is independently overridable. `readTimeoutMs` falls back to default on missing / non-numeric / zero / negative values.

## Behavior change (intentional)

`pull / start / stop / chat / generate` previously **threw** on connection failure (uncaught). The thrown error became a JSON-RPC error response from the daemon's central error path, but the caller-side error UX was inconsistent across the inference surface (some methods returned structured errors, some surfaced as JSON-RPC `-32000`).

After this PR, all six methods return structured errors with the existing per-method shape (`{running:false}` / `{success:false}` / `{loaded:false}` / `{unloaded:false}` / `{error}`). This matches the precedent set by `inference.status` and gives callers a uniform error envelope they can render.

## Test plan

- [x] `pnpm --filter "@revdev/daemon" build` clean (43ms ESM, no errors)
- [x] `pnpm --filter "@revdev/daemon" test` → 166/166 pass (9 new)
- [x] `pnpm --filter "@revdev/daemon" typecheck` clean
- [x] `pnpm exec biome check` clean on changed files
- [ ] CI green on `fix/daemon-inference-fetch-timeout`
- [ ] Post-merge fast-forward of `~/suite/revdev` to test branch and re-run daemon test suite (verify-twice)

## Out of scope (queued in audit, separate PRs)

| PR | Lane |
|---|---|
| §C-2 | Bound per-socket buffer (DoS surface, `server.ts:874-879`) |
| §C-3 | `worktree.*` git child-process timeout (`vcs.ts`) |
| §C-4 | Graceful-shutdown in-flight RPC drain (`server.ts:1021-1028`) |
| §C-5 | `mail.broadcast` transaction + batched Neon insert |
| §C-6 | File follow-up gaps for memory.*/merge.* Neon mirror + file_reservations TTL + mail.markRead atomicity |

Related: [revdev#43](https://github.com/RevealUIStudio/revdev/pull/43) (the Pillar 1 warm-up that surfaced the audit) closed the test-side leak from the same lesson — this PR closes the production-side reliability gap on a different surface.
