### PR TITLE
fix(daemon/vcs): bound git child-process spawns + propagate daemon shutdown to children

### DIFF
--- a/packages/daemon/src/__tests__/vcs.test.ts
+++ b/packages/daemon/src/__tests__/vcs.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for vcs.ts runChild — timeout + abort + shutdown propagation.
+ *
+ * runChild is the testable core under runGit; we exercise it via `node -e`
+ * commands so the tests are self-contained (no git binary needed beyond
+ * what already runs in CI) and deterministic.
+ */
+
+import { tmpdir } from 'node:os';
+import { describe, expect, it, vi } from 'vitest';
+import { runChild } from '../vcs.js';
+
+vi.setConfig({ testTimeout: 10_000, hookTimeout: 10_000 });
+
+const NODE = process.execPath;
+const CWD = tmpdir();
+
+describe('runChild', () => {
+  it('returns ok:true with stdout for a successful child', async () => {
+    const result = await runChild(NODE, ['-e', 'process.stdout.write("hello")'], {
+      cwd: CWD,
+      timeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.stdout).toBe('hello');
+    expect(result.code).toBe(0);
+    expect(result.aborted).toBeUndefined();
+  });
+
+  it('returns ok:false with non-zero exit code for a failing child', async () => {
+    const result = await runChild(NODE, ['-e', 'process.exit(7)'], {
+      cwd: CWD,
+      timeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe(7);
+    expect(result.aborted).toBeUndefined();
+  });
+
+  it('SIGTERMs and reports abortReason="timeout" when the child exceeds timeoutMs', async () => {
+    // setInterval keeps the process alive; only an external signal can
+    // bring it down.
+    const result = await runChild(NODE, ['-e', 'setInterval(() => {}, 1000)'], {
+      cwd: CWD,
+      timeoutMs: 100,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.aborted).toBe(true);
+    expect(result.abortReason).toBe('timeout');
+    expect(result.stderr).toContain('timed out after 100ms');
+  });
+
+  it('SIGTERMs and reports abortReason="shutdown" when the externalSignal aborts', async () => {
+    const ctrl = new AbortController();
+    // Abort 50ms after spawn — give the child time to start up.
+    setTimeout(() => ctrl.abort(), 50);
+    const result = await runChild(NODE, ['-e', 'setInterval(() => {}, 1000)'], {
+      cwd: CWD,
+      timeoutMs: 5_000,
+      externalSignal: ctrl.signal,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.aborted).toBe(true);
+    expect(result.abortReason).toBe('shutdown');
+    expect(result.stderr).toContain('aborted by daemon shutdown');
+  });
+
+  it('treats a pre-aborted externalSignal as immediate shutdown abort', async () => {
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const result = await runChild(NODE, ['-e', 'setInterval(() => {}, 1000)'], {
+      cwd: CWD,
+      timeoutMs: 5_000,
+      externalSignal: ctrl.signal,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.aborted).toBe(true);
+    expect(result.abortReason).toBe('shutdown');
+  });
+
+  it('returns ok:false with stderr.message for a non-existent command', async () => {
+    const result = await runChild('/nonexistent-binary-revdev-test', [], {
+      cwd: CWD,
+      timeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.aborted).toBeUndefined();
+    expect(result.code).toBe(-1);
+    // The exact error message varies (ENOENT on Linux, etc.) — just
+    // confirm we got an error string back rather than crashing.
+    expect(result.stderr.length).toBeGreaterThan(0);
+  });
+
+  it('captures stderr from a child that prints to stderr and exits non-zero', async () => {
+    const result = await runChild(NODE, ['-e', 'process.stderr.write("oops"); process.exit(1)'], {
+      cwd: CWD,
+      timeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toBe('oops');
+    expect(result.aborted).toBeUndefined();
+  });
+
+  it('honors timeout precedence over external signal when timeout fires first', async () => {
+    const ctrl = new AbortController();
+    setTimeout(() => ctrl.abort(), 5_000); // would-be later abort
+    const result = await runChild(NODE, ['-e', 'setInterval(() => {}, 1000)'], {
+      cwd: CWD,
+      timeoutMs: 100,
+      externalSignal: ctrl.signal,
+    });
+    expect(result.aborted).toBe(true);
+    expect(result.abortReason).toBe('timeout');
+  });
+});

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -15,6 +15,7 @@
  *   REVDEV_DAEMON_PID        # Override PID file path
  *   REVDEV_DAEMON_LOG        # Where stdout/stderr go in --detach mode (default: /tmp/revdev-daemon.log)
  *   REVDEV_DAEMON_MAX_LINE_BYTES  # Max bytes per JSON-RPC frame (default: 1_048_576 = 1 MiB)
+ *   REVDEV_DAEMON_GIT_TIMEOUT_MS  # Max wall-clock per git spawn (default: 60_000 = 60 s)
  */
 
 import { spawn } from 'node:child_process';
@@ -60,6 +61,7 @@ Environment:
   REVDEV_DAEMON_PID           PID file path (default: ${DAEMON_DEFAULTS.pidFile})
   REVDEV_DAEMON_LOG           Log file for --detach mode (default: ~/.local/share/revealui/daemon.log)
   REVDEV_DAEMON_MAX_LINE_BYTES  Max bytes per JSON-RPC frame (default: ${DAEMON_DEFAULTS.maxLineBytes}, ~1 MiB)
+  REVDEV_DAEMON_GIT_TIMEOUT_MS  Max wall-clock per git spawn (default: ${DAEMON_DEFAULTS.gitTimeoutMs} ms = ${DAEMON_DEFAULTS.gitTimeoutMs / 1000} s)
 
 License tiers:
   free         Session management only
@@ -103,6 +105,7 @@ const config = {
   socketPath: process.env.REVDEV_DAEMON_SOCKET ?? DAEMON_DEFAULTS.socketPath,
   dataDir: process.env.REVDEV_DAEMON_DATA ?? DAEMON_DEFAULTS.dataDir,
   maxLineBytes: parsePositiveInt('REVDEV_DAEMON_MAX_LINE_BYTES', DAEMON_DEFAULTS.maxLineBytes),
+  gitTimeoutMs: parsePositiveInt('REVDEV_DAEMON_GIT_TIMEOUT_MS', DAEMON_DEFAULTS.gitTimeoutMs),
 };
 
 const pidFile = process.env.REVDEV_DAEMON_PID ?? DAEMON_DEFAULTS.pidFile;

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -48,6 +48,25 @@ export interface DaemonConfig {
    * 250k-token prompt fits) and tight enough to defeat unbounded growth.
    */
   maxLineBytes: number;
+  /**
+   * Maximum wall-clock time (in ms) for a single git child-process spawn
+   * inside the daemon (worktree.create / worktree.remove). Without this,
+   * a runaway git command (credential prompt on a private base branch,
+   * a corrupt object DB requiring fsck, a giant repo, a hung remote)
+   * holds the daemon socket forever — SIGTERM to the daemon does not
+   * propagate to the orphaned git child.
+   *
+   * On timeout, the daemon SIGTERMs the child via the per-call
+   * AbortSignal passed to spawn(), waits briefly for clean exit, and
+   * returns a structured error response. On daemon shutdown, all
+   * in-flight git children get SIGTERM via a shared AbortController
+   * aborted from server.close().
+   *
+   * 60 s default covers any healthy worktree create/remove against a
+   * reasonable repo. Override via REVDEV_DAEMON_GIT_TIMEOUT_MS for
+   * deployers with very large repos or slow filesystems.
+   */
+  gitTimeoutMs: number;
 }
 
 const homeDir = process.env.HOME ?? '/tmp';
@@ -64,4 +83,5 @@ export const DAEMON_DEFAULTS: DaemonConfig = {
   hardDeleteDays: 30,
   pruneIntervalMs: 60 * 60 * 1000, // 1 hour
   maxLineBytes: 1_048_576, // 1 MiB
+  gitTimeoutMs: 60_000, // 60 s
 };

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -185,6 +185,27 @@ export function registerHandler(method: string, handler: RpcHandler): void {
 }
 
 // ---------------------------------------------------------------------------
+// Shutdown signal — module-level AbortController whose `.signal` aborts when
+// the daemon is closing. Long-running helpers (e.g. git child-process spawn
+// in vcs.ts) listen to this so they get SIGTERM'd before the daemon exits,
+// rather than orphaning. Reset to a fresh controller on every startDaemon()
+// so multiple sequential lifecycles in the same process (e.g. test setup +
+// teardown loops) get independent shutdown windows.
+// ---------------------------------------------------------------------------
+
+let _shutdownController: AbortController | null = null;
+
+/**
+ * Returns the daemon's current shutdown AbortSignal, or `undefined` if the
+ * daemon has not started (or has fully shut down). Helpers that spawn
+ * child processes or hold long-running async work should pass this signal
+ * to their abort-aware APIs.
+ */
+export function getShutdownSignal(): AbortSignal | undefined {
+  return _shutdownController?.signal;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -824,6 +845,9 @@ export async function startDaemon(
 ): Promise<{ close: () => Promise<void> }> {
   const cfg = { ...DAEMON_DEFAULTS, ...config };
 
+  // Reset shutdown signal for this daemon lifecycle. Aborted in close().
+  _shutdownController = new AbortController();
+
   // Initialize license guard (logs banner)
   initLicenseGuard();
 
@@ -1073,6 +1097,13 @@ export async function startDaemon(
 
       resolve({
         close: async () => {
+          // Abort first so in-flight child processes (git spawn in vcs.ts)
+          // get SIGTERM before db.close() — otherwise they orphan and the
+          // socket can race with active queries. Then clear the prune
+          // timer, stop accepting new connections, close PGlite, and
+          // unlink the Unix socket.
+          _shutdownController?.abort();
+          _shutdownController = null;
           if (pruneTimer) clearInterval(pruneTimer);
           server.close();
           await db.close();

--- a/packages/daemon/src/vcs.ts
+++ b/packages/daemon/src/vcs.ts
@@ -5,30 +5,123 @@
  * agent's working directory. Merge requests are tracked in the
  * `merge_requests` table; actual PR creation is left to the client
  * (agents call `gh pr create` themselves and then update status here).
+ *
+ * Reliability: every git spawn is bounded by `DAEMON_DEFAULTS.gitTimeoutMs`
+ * (default 60 s, env-overridable via REVDEV_DAEMON_GIT_TIMEOUT_MS) AND
+ * aborted on daemon shutdown via the shared shutdown signal from
+ * server.ts. Without this, a runaway git command (credential prompt on
+ * a private base branch, corrupt object DB, hung remote) would hold
+ * the daemon socket forever — SIGTERM to the daemon does not propagate
+ * to orphaned children. On timeout or shutdown abort, the child receives
+ * SIGTERM via spawn's native AbortSignal handling and the handler
+ * returns a structured error response.
  */
 
 import { spawn } from 'node:child_process';
-import { registerHandler } from './server.js';
+import { DAEMON_DEFAULTS } from './config.js';
+import { getShutdownSignal, registerHandler } from './server.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-interface ShellResult {
+export interface ShellResult {
   ok: boolean;
   stdout: string;
   stderr: string;
   code: number;
+  /** True if the child was aborted before clean exit (timeout or shutdown). */
+  aborted?: boolean;
+  /** Disambiguates timeout vs caller/shutdown abort. Only set when aborted. */
+  abortReason?: 'timeout' | 'shutdown';
 }
 
-function runGit(args: string[], cwd: string): Promise<ShellResult> {
+export interface RunChildOptions {
+  cwd: string;
+  /** Per-call timeout. Defaults to DAEMON_DEFAULTS.gitTimeoutMs (60 s). */
+  timeoutMs?: number;
+  /**
+   * Optional external signal — combined with the daemon shutdown signal
+   * and the timeout via `AbortSignal.any` so the spawned child gets
+   * SIGTERM if any source aborts.
+   */
+  externalSignal?: AbortSignal;
+}
+
+/**
+ * Spawn a child process with timeout + shutdown awareness. Returns a
+ * structured ShellResult; never throws. On abort, the spawned child is
+ * SIGTERM'd via Node's native AbortSignal handling on the spawn options.
+ *
+ * Exported for testing — production code uses `runGit` below.
+ */
+export function runChild(
+  command: string,
+  args: string[],
+  opts: RunChildOptions,
+): Promise<ShellResult> {
   return new Promise((resolve) => {
-    const child = spawn('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    const timeoutMs = opts.timeoutMs ?? DAEMON_DEFAULTS.gitTimeoutMs;
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    const shutdownSignal = getShutdownSignal();
+
+    const sources: AbortSignal[] = [timeoutSignal];
+    if (shutdownSignal) sources.push(shutdownSignal);
+    if (opts.externalSignal) sources.push(opts.externalSignal);
+    // sources always contains at least timeoutSignal, so AbortSignal.any
+    // is well-defined; the single-source branch avoids one allocation.
+    const signal = sources.length > 1 ? AbortSignal.any(sources) : timeoutSignal;
+
+    let aborted = false;
+    let abortReason: 'timeout' | 'shutdown' | undefined;
+    const onAbort = () => {
+      if (aborted) return;
+      aborted = true;
+      // Timeout takes precedence in disambiguation. External signals are
+      // reported as "shutdown" — caller-driven cancellation semantically
+      // matches shutdown for our purposes (the child gets SIGTERM either
+      // way; the disambiguation is only for the human-readable message).
+      abortReason = timeoutSignal.aborted ? 'timeout' : 'shutdown';
+    };
+    if (signal.aborted) onAbort();
+    else signal.addEventListener('abort', onAbort, { once: true });
+
+    const child = spawn(command, args, {
+      cwd: opts.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      signal,
+    });
+
     let stdout = '';
     let stderr = '';
-    child.stdout.on('data', (d) => (stdout += d.toString()));
-    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.stdout.on('data', (d) => {
+      stdout += d.toString();
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d.toString();
+    });
+
+    const buildAbortedResult = (code: number): ShellResult => {
+      const reason = abortReason ?? 'shutdown';
+      const message =
+        reason === 'timeout'
+          ? `${command} timed out after ${timeoutMs}ms`
+          : `${command} aborted by daemon shutdown`;
+      return {
+        ok: false,
+        stdout: stdout.trim(),
+        stderr: stderr.trim() || message,
+        code,
+        aborted: true,
+        abortReason: reason,
+      };
+    };
+
     child.on('close', (code) => {
+      if (aborted) {
+        resolve(buildAbortedResult(code ?? -1));
+        return;
+      }
       resolve({
         ok: code === 0,
         stdout: stdout.trim(),
@@ -36,10 +129,27 @@ function runGit(args: string[], cwd: string): Promise<ShellResult> {
         code: code ?? -1,
       });
     });
+
     child.on('error', (err) => {
+      // spawn() emits AbortError on signal abort; the close handler may or
+      // may not also fire depending on whether the child started. Resolve
+      // here for the abort-before-spawn case; close handler is no-op'd
+      // because Promises only resolve once.
+      if (aborted || (err as NodeJS.ErrnoException).name === 'AbortError') {
+        resolve(buildAbortedResult(-1));
+        return;
+      }
       resolve({ ok: false, stdout: '', stderr: err.message, code: -1 });
     });
   });
+}
+
+function runGit(
+  args: string[],
+  cwd: string,
+  opts?: Partial<RunChildOptions>,
+): Promise<ShellResult> {
+  return runChild('git', args, { cwd, ...opts });
 }
 
 function str(v: unknown, fallback = ''): string {


### PR DESCRIPTION
## Summary

- Bounds every `git` child-process spawn in `packages/daemon/src/vcs.ts` with a per-call timeout AND a daemon-shutdown signal so runaway children no longer hold the daemon socket forever and graceful daemon shutdown SIGTERMs in-flight git children before PGlite tears down.
- New `getShutdownSignal()` export from `server.ts` — module-level `AbortController` initialized in `startDaemon`, aborted at the top of `close()`. Designed to be reused by future helpers (e.g. §C-4 in-flight RPC drain).
- New `DaemonConfig.gitTimeoutMs` (default 60 s) wired through CLI env override `REVDEV_DAEMON_GIT_TIMEOUT_MS`.
- Refactor: `runGit` now wraps a generic `runChild(command, args, opts)` helper — `runChild` exported for testing (so we can exercise timeout/abort against `node -e '...'` deterministically without needing real git hangs).
- 8 new tests (182/182 daemon total).

Closes the **MEDIUM-priority** §C-3 fix from `pillar-1-stability-2026-05-05.md`.

## Why

Pre-fix, [`vcs.ts:24-43`](https://github.com/RevealUIStudio/revdev/blob/test/packages/daemon/src/vcs.ts#L24) ran `spawn('git', args, { cwd, stdio })` with no `signal`, no timeout. Three failure modes the audit identified:

1. **Credential prompt on a private base branch** — `git worktree add -b foo bar private/main` against a remote requiring auth hangs reading from stdin (we use `stdio: ['ignore', ...]` so the prompt never gets answered).
2. **Corrupt object DB** — `git worktree add` triggers an internal fsck that loops or hangs.
3. **Hung remote during fetch** — slow ref negotiation never completes.

In any of these, the `worktree.create` / `worktree.remove` RPC stays mid-flight forever, holding the dispatching socket. Compounding: SIGTERM to the daemon does not propagate to the orphaned git child; the child outlives the daemon.

## Design

Three abort sources combined via `AbortSignal.any`:

```ts
const sources: AbortSignal[] = [AbortSignal.timeout(cfg.gitTimeoutMs)];
if (shutdownSignal) sources.push(shutdownSignal);
if (opts.externalSignal) sources.push(opts.externalSignal);
const signal = sources.length > 1 ? AbortSignal.any(sources) : sources[0];

const child = spawn(command, args, { cwd, stdio, signal });
```

Node's spawn handles SIGTERM-on-abort natively. On abort, the handler distinguishes `'timeout'` vs `'shutdown'` for the human-readable error message. `ShellResult` gains optional `aborted` and `abortReason` fields so calling code can route cleanly without parsing strings.

The shutdown signal is exposed as a module export from `server.ts` so future helpers (e.g. §C-4 graceful-shutdown in-flight RPC drain) can reuse the same lifecycle without retrofitting plumbing.

## Test plan

- [x] `pnpm --filter "@revdev/daemon" build` clean (41ms ESM)
- [x] `pnpm --filter "@revdev/daemon" test` → 182/182 (8 new in `vcs.test.ts`)
- [x] `pnpm --filter "@revdev/daemon" typecheck` clean
- [x] `pnpm exec biome check` no errors (2 pre-existing warnings in `cli.ts:87` + `server.ts:985`, neither in code touched by this PR)
- [ ] CI green on `fix/daemon-worktree-git-timeout`
- [ ] Post-merge: fast-forward `~/suite/revdev` to test branch and re-run daemon test suite (verify-twice)

## Out of scope (queued in audit, separate PRs)

| PR | Surface |
|---|---|
| §C-4 | Graceful-shutdown in-flight RPC drain — note: simpler now that the shutdown signal exists; drain code can wait on the same `_shutdownController`'s pending callers |
| §C-5 | `mail.broadcast` transaction + batched Neon insert |
| §C-6 | internal docs gap-files for `memory.*` / `merge.*` Neon mirror + `file_reservations` TTL drift + `mail.markRead` atomicity |

Related: [#43](https://github.com/RevealUIStudio/revdev/pull/43) (Pillar 1 warm-up), [#44](https://github.com/RevealUIStudio/revdev/pull/44) (§C-1 inference timeouts), [#45](https://github.com/RevealUIStudio/revdev/pull/45) (§C-2 socket buffer bound).
