### PR TITLE
fix(daemon/server): graceful-shutdown drain — wait for in-flight RPC handlers before db.close()

### DIFF
--- a/packages/daemon/src/__tests__/shutdown-drain.test.ts
+++ b/packages/daemon/src/__tests__/shutdown-drain.test.ts
@@ -241,4 +241,25 @@ describe('shutdown gate (regression — Codex P2 catch on revdev#47)', () => {
     expect(resp.result?.pong).toBe(true);
     await d2.close();
   });
+
+  it('destroys persistent sockets on close — pre-existing connections cannot dispatch RPCs against a closed daemon (Codex round-2 catch)', async () => {
+    const d = await startDaemon({ socketPath, dataDir });
+
+    // Open a long-lived socket BEFORE close() — like a Studio app would.
+    const sock: Socket = connect(socketPath);
+    await new Promise<void>((resolve, reject) => {
+      sock.once('connect', () => resolve());
+      sock.once('error', reject);
+    });
+    expect(sock.destroyed).toBe(false);
+
+    // Trigger close(). Per the new sequence, all open sockets get
+    // destroyed before the drain.
+    await d.close();
+
+    // The pre-existing socket should now be destroyed. If it weren't,
+    // a `data` event could still fire and dispatch against the closed
+    // PGlite — the very race Codex flagged.
+    expect(sock.destroyed).toBe(true);
+  });
 });

--- a/packages/daemon/src/__tests__/shutdown-drain.test.ts
+++ b/packages/daemon/src/__tests__/shutdown-drain.test.ts
@@ -12,12 +12,14 @@
  */
 
 import { mkdtemp, rm } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   _drainActiveHandlersForTest,
   _setActiveHandlerCountForTest,
+  _setClosingForTest,
   startDaemon,
 } from '../server.js';
 
@@ -141,5 +143,102 @@ describe('startDaemon().close() — drain integration', () => {
     // Counter is still 1 (we never decremented it from the test side).
     // Reset for afterEach.
     _setActiveHandlerCountForTest(0);
+  });
+});
+
+describe('shutdown gate (regression — Codex P2 catch on revdev#47)', () => {
+  let dataDir: string;
+  let socketPath: string;
+  let originalLicenseKey: string | undefined;
+  let originalPublicKey: string | undefined;
+
+  beforeEach(async () => {
+    const { generateTestLicense, setTestLicenseEnv } = await import('./test-license-helper.js');
+    originalLicenseKey = process.env.REVEALUI_LICENSE_KEY;
+    originalPublicKey = process.env.REVDEV_LICENSE_PUBLIC_KEY;
+    setTestLicenseEnv(generateTestLicense('enterprise'));
+    const { mkdtemp } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-closing-'));
+    socketPath = join(dataDir, 'harness.sock');
+    _setActiveHandlerCountForTest(0);
+    _setClosingForTest(false);
+  });
+
+  afterEach(async () => {
+    const { rm } = await import('node:fs/promises');
+    await rm(dataDir, { recursive: true, force: true });
+    _setActiveHandlerCountForTest(0);
+    _setClosingForTest(false);
+    const { clearTestLicenseEnv } = await import('./test-license-helper.js');
+    clearTestLicenseEnv();
+    if (originalLicenseKey) process.env.REVEALUI_LICENSE_KEY = originalLicenseKey;
+    if (originalPublicKey) process.env.REVDEV_LICENSE_PUBLIC_KEY = originalPublicKey;
+  });
+
+  function rpcOnce(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const sock: Socket = connect(socketPath);
+      let buf = '';
+      const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
+      sock.on('connect', () => sock.write(req));
+      sock.on('data', (d) => {
+        buf += d.toString();
+        const nl = buf.indexOf('\n');
+        if (nl === -1) return;
+        const line = buf.slice(0, nl);
+        sock.end();
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e instanceof Error ? e : new Error(String(e)));
+        }
+      });
+      sock.on('error', reject);
+      sock.setTimeout(5000, () => {
+        sock.destroy();
+        reject(new Error(`RPC timeout: ${method}`));
+      });
+    });
+  }
+
+  it('rejects RPCs with -32099 once _closing is set, before incrementing the handler counter', async () => {
+    const d = await startDaemon({ socketPath, dataDir });
+    // Simulate the close() entrypoint having flipped the gate, but the
+    // listener is still up so the request reaches dispatch.
+    _setClosingForTest(true);
+
+    const resp = (await rpcOnce('ping')) as {
+      jsonrpc: string;
+      id: number;
+      error?: { code: number; message: string };
+      result?: unknown;
+    };
+    expect(resp.jsonrpc).toBe('2.0');
+    expect(resp.id).toBe(1);
+    expect(resp.result).toBeUndefined();
+    expect(resp.error).toBeDefined();
+    expect(resp.error?.code).toBe(-32099);
+    expect(resp.error?.message).toBe('Server is shutting down');
+
+    // Critical: the gated request must NOT have incremented the counter
+    // — otherwise close()'s drain would observe a phantom in-flight
+    // handler and either wait or warn unnecessarily.
+    expect((await _drainActiveHandlersForTest(0)).remaining).toBe(0);
+
+    _setClosingForTest(false);
+    await d.close();
+  });
+
+  it('clears _closing on a fresh startDaemon so the gate is independent across lifecycles', async () => {
+    const d1 = await startDaemon({ socketPath, dataDir });
+    await d1.close();
+    // After close() returns, _closing is reset to false. A new startDaemon
+    // observed in the same process must NOT carry over the gate.
+    const d2 = await startDaemon({ socketPath, dataDir });
+    const resp = (await rpcOnce('ping')) as { result?: { pong?: boolean } };
+    expect(resp.result?.pong).toBe(true);
+    await d2.close();
   });
 });

--- a/packages/daemon/src/__tests__/shutdown-drain.test.ts
+++ b/packages/daemon/src/__tests__/shutdown-drain.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for graceful-shutdown drain — server.close() waits for in-flight
+ * RPC handlers before tearing down PGlite + the Unix socket.
+ *
+ * Two layers:
+ *  - Direct exercise of the drain helper (`_drainActiveHandlersForTest`)
+ *    using the test-only counter setter (`_setActiveHandlerCountForTest`).
+ *    Deterministic; no daemon, no socket.
+ *  - One end-to-end sanity test that exercises a real startDaemon →
+ *    close() cycle with no in-flight handlers (drain returns immediately).
+ *    Confirms the close()-side wiring doesn't regress.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  _drainActiveHandlersForTest,
+  _setActiveHandlerCountForTest,
+  startDaemon,
+} from '../server.js';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+describe('drainActiveHandlers (helper)', () => {
+  beforeEach(() => {
+    _setActiveHandlerCountForTest(0);
+  });
+
+  afterEach(() => {
+    _setActiveHandlerCountForTest(0);
+  });
+
+  it('returns drained:true immediately when no handlers are in flight', async () => {
+    const start = Date.now();
+    const result = await _drainActiveHandlersForTest(1000);
+    const elapsed = Date.now() - start;
+    expect(result.drained).toBe(true);
+    expect(result.remaining).toBe(0);
+    // Should resolve well under the deadline — first poll observes count=0.
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  it('waits while count > 0 and resolves when it drops to zero', async () => {
+    _setActiveHandlerCountForTest(2);
+    // Decrement asynchronously so the drain has to poll.
+    setTimeout(() => _setActiveHandlerCountForTest(1), 30);
+    setTimeout(() => _setActiveHandlerCountForTest(0), 60);
+
+    const start = Date.now();
+    const result = await _drainActiveHandlersForTest(1000);
+    const elapsed = Date.now() - start;
+
+    expect(result.drained).toBe(true);
+    expect(result.remaining).toBe(0);
+    // Should finish near the second decrement (~60 ms) not near the deadline.
+    expect(elapsed).toBeGreaterThanOrEqual(50);
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('returns drained:false with remaining count when deadline expires', async () => {
+    _setActiveHandlerCountForTest(3);
+    const start = Date.now();
+    const result = await _drainActiveHandlersForTest(80);
+    const elapsed = Date.now() - start;
+
+    expect(result.drained).toBe(false);
+    expect(result.remaining).toBe(3);
+    // Deadline-bounded — should not significantly overshoot.
+    expect(elapsed).toBeGreaterThanOrEqual(70);
+    expect(elapsed).toBeLessThan(300);
+  });
+
+  it('handles fractional decrement progress that still misses the deadline', async () => {
+    _setActiveHandlerCountForTest(5);
+    // Drop to 2 inside the window; deadline still fires before reaching 0.
+    setTimeout(() => _setActiveHandlerCountForTest(2), 30);
+
+    const result = await _drainActiveHandlersForTest(80);
+    expect(result.drained).toBe(false);
+    expect(result.remaining).toBe(2);
+  });
+
+  it('respects a custom tick interval (slower polls still resolve)', async () => {
+    _setActiveHandlerCountForTest(1);
+    setTimeout(() => _setActiveHandlerCountForTest(0), 50);
+
+    const result = await _drainActiveHandlersForTest(1000, 25);
+    expect(result.drained).toBe(true);
+  });
+});
+
+describe('startDaemon().close() — drain integration', () => {
+  let dataDir: string;
+  let socketPath: string;
+  let originalLicenseKey: string | undefined;
+  let originalPublicKey: string | undefined;
+
+  beforeEach(async () => {
+    const { generateTestLicense, setTestLicenseEnv } = await import('./test-license-helper.js');
+    originalLicenseKey = process.env.REVEALUI_LICENSE_KEY;
+    originalPublicKey = process.env.REVDEV_LICENSE_PUBLIC_KEY;
+    setTestLicenseEnv(generateTestLicense('enterprise'));
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-drain-'));
+    socketPath = join(dataDir, 'harness.sock');
+    _setActiveHandlerCountForTest(0);
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+    _setActiveHandlerCountForTest(0);
+    const { clearTestLicenseEnv } = await import('./test-license-helper.js');
+    clearTestLicenseEnv();
+    if (originalLicenseKey) process.env.REVEALUI_LICENSE_KEY = originalLicenseKey;
+    if (originalPublicKey) process.env.REVDEV_LICENSE_PUBLIC_KEY = originalPublicKey;
+  });
+
+  it('completes promptly when no handlers are in flight', async () => {
+    const d = await startDaemon({ socketPath, dataDir, shutdownGracePeriodMs: 1000 });
+    const start = Date.now();
+    await d.close();
+    const elapsed = Date.now() - start;
+    // No handlers in flight — drain should resolve on the first poll.
+    // Most of the elapsed time is db.close() + unlink, not the drain.
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  it('does not exceed the configured grace period when a stuck handler is simulated', async () => {
+    const d = await startDaemon({ socketPath, dataDir, shutdownGracePeriodMs: 100 });
+    // Simulate a stuck handler by bumping the counter directly. close()'s
+    // drain should hit the deadline, log a warning, and proceed.
+    _setActiveHandlerCountForTest(1);
+    const start = Date.now();
+    await d.close();
+    const elapsed = Date.now() - start;
+    // Should pass the 100 ms drain deadline plus db.close() + unlink time,
+    // but shouldn't hang indefinitely.
+    expect(elapsed).toBeGreaterThanOrEqual(100);
+    expect(elapsed).toBeLessThan(3000);
+    // Counter is still 1 (we never decremented it from the test side).
+    // Reset for afterEach.
+    _setActiveHandlerCountForTest(0);
+  });
+});

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -16,6 +16,7 @@
  *   REVDEV_DAEMON_LOG        # Where stdout/stderr go in --detach mode (default: /tmp/revdev-daemon.log)
  *   REVDEV_DAEMON_MAX_LINE_BYTES  # Max bytes per JSON-RPC frame (default: 1_048_576 = 1 MiB)
  *   REVDEV_DAEMON_GIT_TIMEOUT_MS  # Max wall-clock per git spawn (default: 60_000 = 60 s)
+ *   REVDEV_DAEMON_SHUTDOWN_GRACE_MS  # Max wait for in-flight handlers in close() (default: 5_000 = 5 s)
  */
 
 import { spawn } from 'node:child_process';
@@ -62,6 +63,7 @@ Environment:
   REVDEV_DAEMON_LOG           Log file for --detach mode (default: ~/.local/share/revealui/daemon.log)
   REVDEV_DAEMON_MAX_LINE_BYTES  Max bytes per JSON-RPC frame (default: ${DAEMON_DEFAULTS.maxLineBytes}, ~1 MiB)
   REVDEV_DAEMON_GIT_TIMEOUT_MS  Max wall-clock per git spawn (default: ${DAEMON_DEFAULTS.gitTimeoutMs} ms = ${DAEMON_DEFAULTS.gitTimeoutMs / 1000} s)
+  REVDEV_DAEMON_SHUTDOWN_GRACE_MS  Max wait for in-flight handlers during close() (default: ${DAEMON_DEFAULTS.shutdownGracePeriodMs} ms = ${DAEMON_DEFAULTS.shutdownGracePeriodMs / 1000} s)
 
 License tiers:
   free         Session management only
@@ -106,6 +108,10 @@ const config = {
   dataDir: process.env.REVDEV_DAEMON_DATA ?? DAEMON_DEFAULTS.dataDir,
   maxLineBytes: parsePositiveInt('REVDEV_DAEMON_MAX_LINE_BYTES', DAEMON_DEFAULTS.maxLineBytes),
   gitTimeoutMs: parsePositiveInt('REVDEV_DAEMON_GIT_TIMEOUT_MS', DAEMON_DEFAULTS.gitTimeoutMs),
+  shutdownGracePeriodMs: parsePositiveInt(
+    'REVDEV_DAEMON_SHUTDOWN_GRACE_MS',
+    DAEMON_DEFAULTS.shutdownGracePeriodMs,
+  ),
 };
 
 const pidFile = process.env.REVDEV_DAEMON_PID ?? DAEMON_DEFAULTS.pidFile;

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -67,6 +67,29 @@ export interface DaemonConfig {
    * deployers with very large repos or slow filesystems.
    */
   gitTimeoutMs: number;
+  /**
+   * Maximum wall-clock time (in ms) the daemon's `close()` waits for
+   * in-flight RPC handlers to complete before tearing down PGlite and
+   * the Unix socket. Pre-this-flag, `db.close()` raced with active
+   * `await db.query(...)` calls — a long handler (e.g. worktree.create
+   * shelling out to git on a private base branch) could throw mid-query
+   * if the database closed under it.
+   *
+   * Sequence inside close():
+   *   1. Abort the daemon shutdown signal — this SIGTERMs every
+   *      in-flight git child, etc., letting them error out fast.
+   *   2. Stop accepting new connections.
+   *   3. Drain — poll the active-handler counter for up to
+   *      `shutdownGracePeriodMs`; resolve as soon as it hits zero.
+   *   4. db.close() + unlink socket.
+   *
+   * If the deadline passes with handlers still running (rare — almost
+   * everything either completes within milliseconds or honors the abort
+   * signal), the daemon logs a warning naming the leftover count and
+   * proceeds to db.close(). Default 5 s covers any realistic handler;
+   * tune via REVDEV_DAEMON_SHUTDOWN_GRACE_MS for slower environments.
+   */
+  shutdownGracePeriodMs: number;
 }
 
 const homeDir = process.env.HOME ?? '/tmp';
@@ -84,4 +107,5 @@ export const DAEMON_DEFAULTS: DaemonConfig = {
   pruneIntervalMs: 60 * 60 * 1000, // 1 hour
   maxLineBytes: 1_048_576, // 1 MiB
   gitTimeoutMs: 60_000, // 60 s
+  shutdownGracePeriodMs: 5_000, // 5 s
 };

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -951,8 +951,17 @@ export async function startDaemon(
   const { unlink, chmod } = await import('node:fs/promises');
   await unlink(cfg.socketPath).catch(() => {});
 
+  // Track open sockets so close() can force-destroy them before
+  // resetting state. server.close() only stops new accepts; existing
+  // sockets stay alive until the client disconnects, which means their
+  // `data` handlers can fire AFTER close() returns and dispatch against
+  // a closed PGlite or against a fresh startDaemon()'s state in the
+  // same process. Destroying sockets in close() prevents that.
+  const openSockets = new Set<Socket>();
+
   // Start Unix socket server
   const server = createServer((socket: Socket) => {
+    openSockets.add(socket);
     onConnect();
     const ctx: SocketContext = { agentId: null, agentName: null, boundVia: null };
     let buffer = '';
@@ -1121,6 +1130,7 @@ export async function startDaemon(
     });
 
     socket.on('close', async () => {
+      openSockets.delete(socket);
       onDisconnect();
       // Auto-release transient reservations when a long-lived agent
       // disconnects. Fresh-per-call clients (boundVia = 'param') don't
@@ -1135,7 +1145,12 @@ export async function startDaemon(
       // refinement (keepalive flag in session.register, or socket-
       // lifetime threshold) could re-introduce socket-close auto-end
       // for genuinely-long-lived agents — see GAP-153 notes.
-      if (ctx.agentId && (ctx.boundVia === 'register' || ctx.boundVia === 'attach')) {
+      // Skip cleanup when shutdown has begun — db may already be closed.
+      // close() destroys all sockets, which fires this handler; we don't
+      // want it to race with db.close(). The .catch(() => {}) below
+      // would swallow the resulting error anyway, but bailing here is
+      // explicit + avoids the dangling Promise.
+      if (!_closing && ctx.agentId && (ctx.boundVia === 'register' || ctx.boundVia === 'attach')) {
         await db
           .query(`DELETE FROM file_reservations WHERE agent_id = $1`, [ctx.agentId])
           .catch(() => {});
@@ -1180,22 +1195,30 @@ export async function startDaemon(
           // Sequence:
           //   1. Set _closing FIRST so any RPC arriving on an existing
           //      socket from this point onward bails out with -32099
-          //      before the counter increment. server.close() alone
-          //      doesn't stop requests on already-connected sockets.
+          //      before the counter increment.
           //   2. Abort the shutdown signal — SIGTERMs git children
           //      (vcs.ts) and aborts inference.* fetches; honoring
           //      handlers complete fast.
-          //   3. Stop accepting new connections.
-          //   4. Drain any still-running handlers within the grace
-          //      period; these are handlers that started BEFORE step 1
-          //      so they are bounded by the prior count and decrement
-          //      cleanly via their finally blocks.
-          //   5. db.close() + unlink Unix socket.
+          //   3. server.close() — stop accepting NEW connections.
+          //   4. Force-destroy ALL existing sockets — server.close()
+          //      doesn't close them; without this, a persistent client
+          //      could fire another `data` event with an old socket
+          //      after close() returns and dispatch against a closed
+          //      PGlite (Codex P2 catch on revdev#47 round 2).
+          //   5. Drain still-running handlers (started BEFORE step 1)
+          //      within the grace period.
+          //   6. db.close() + unlink Unix socket.
+          //   7. Reset _closing — safe now because no live socket
+          //      references this state.
           _closing = true;
           _shutdownController?.abort();
           _shutdownController = null;
           if (pruneTimer) clearInterval(pruneTimer);
           server.close();
+          for (const s of openSockets) {
+            s.destroy();
+          }
+          openSockets.clear();
           const drainResult = await drainActiveHandlers(cfg.shutdownGracePeriodMs);
           if (!drainResult.drained) {
             log.warn('shutdown grace period exceeded with handlers still running', {
@@ -1205,8 +1228,9 @@ export async function startDaemon(
           }
           await db.close();
           await unlink(cfg.socketPath).catch(() => {});
-          // Reset _closing so a fresh startDaemon() in the same process
-          // (test setup/teardown loops) starts with a clean gate.
+          // Now safe to reset — no live socket has a reference to module
+          // state, and a fresh startDaemon() in the same process (test
+          // setup/teardown loops) starts with a clean gate.
           _closing = false;
           log.info('shut down');
         },

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -206,6 +206,46 @@ export function getShutdownSignal(): AbortSignal | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// In-flight handler counter — drained by close() before db.close() so a
+// long-running RPC handler (e.g. worktree.create shelling out to git) does
+// not race with PGlite teardown. Incremented before each `await handler()`,
+// decremented in finally regardless of success or thrown error.
+// ---------------------------------------------------------------------------
+
+let _activeHandlerCount = 0;
+
+/** Wait until `_activeHandlerCount === 0` or `deadlineMs` elapses. Polls
+ *  every `tickMs` (default 10 ms). Returns `{drained, remaining}` so the
+ *  caller can log a warning when the deadline passes with handlers still
+ *  running. */
+async function drainActiveHandlers(
+  deadlineMs: number,
+  tickMs = 10,
+): Promise<{ drained: boolean; remaining: number }> {
+  const start = Date.now();
+  while (_activeHandlerCount > 0 && Date.now() - start < deadlineMs) {
+    await new Promise((r) => setTimeout(r, tickMs));
+  }
+  return { drained: _activeHandlerCount === 0, remaining: _activeHandlerCount };
+}
+
+/** @internal — test-only seam. Lets the unit test set the counter directly
+ *  to exercise the drain logic without spinning up a real daemon. */
+export function _setActiveHandlerCountForTest(n: number): void {
+  _activeHandlerCount = n;
+}
+
+/** @internal — test-only seam. Direct access to the drain helper so the
+ *  unit test can verify deadline / immediate-resolve / progressive-drain
+ *  behavior without going through close(). */
+export function _drainActiveHandlersForTest(
+  deadlineMs: number,
+  tickMs?: number,
+): Promise<{ drained: boolean; remaining: number }> {
+  return drainActiveHandlers(deadlineMs, tickMs);
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -1020,6 +1060,7 @@ export async function startDaemon(
         }
 
         const startMs = Date.now();
+        _activeHandlerCount++;
         try {
           const result = await handler(req.params ?? {}, db, ctx);
           trackRpcCall(req.method, 'ok', Date.now() - startMs);
@@ -1036,6 +1077,8 @@ export async function startDaemon(
               },
             })}\n`,
           );
+        } finally {
+          _activeHandlerCount--;
         }
       }
     });
@@ -1098,14 +1141,24 @@ export async function startDaemon(
       resolve({
         close: async () => {
           // Abort first so in-flight child processes (git spawn in vcs.ts)
-          // get SIGTERM before db.close() — otherwise they orphan and the
-          // socket can race with active queries. Then clear the prune
-          // timer, stop accepting new connections, close PGlite, and
-          // unlink the Unix socket.
+          // get SIGTERM and abort-aware fetches (inference.* in
+          // inference.ts) bail out — both paths complete fast once
+          // signaled. Then stop accepting new connections, drain any
+          // still-running handlers within the grace period, then close
+          // PGlite and unlink the socket. The drain prevents db.close()
+          // from racing with active `await db.query(...)` calls inside
+          // a handler that hasn't yet observed the abort.
           _shutdownController?.abort();
           _shutdownController = null;
           if (pruneTimer) clearInterval(pruneTimer);
           server.close();
+          const drainResult = await drainActiveHandlers(cfg.shutdownGracePeriodMs);
+          if (!drainResult.drained) {
+            log.warn('shutdown grace period exceeded with handlers still running', {
+              remaining: drainResult.remaining,
+              gracePeriodMs: cfg.shutdownGracePeriodMs,
+            });
+          }
           await db.close();
           await unlink(cfg.socketPath).catch(() => {});
           log.info('shut down');

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -206,13 +206,24 @@ export function getShutdownSignal(): AbortSignal | undefined {
 }
 
 // ---------------------------------------------------------------------------
-// In-flight handler counter — drained by close() before db.close() so a
-// long-running RPC handler (e.g. worktree.create shelling out to git) does
-// not race with PGlite teardown. Incremented before each `await handler()`,
-// decremented in finally regardless of success or thrown error.
+// In-flight handler counter + shutdown gate.
+//
+// `_activeHandlerCount` is incremented before each `await handler()` and
+// decremented in finally; close() drains it before tearing down PGlite so
+// a long-running handler (e.g. worktree.create shelling out to git) does
+// not race with `db.close()`.
+//
+// `_closing` is set at the START of close() to gate any future dispatches
+// on already-connected sockets — `server.close()` only stops new accepts,
+// not new requests on existing sockets, so without this gate a persistent
+// client could send a request that increments the counter AFTER the drain
+// has observed zero and runs against a closing/closed PGlite. When set,
+// dispatch responds with JSON-RPC -32099 ("Server is shutting down") and
+// bails before the counter increment.
 // ---------------------------------------------------------------------------
 
 let _activeHandlerCount = 0;
+let _closing = false;
 
 /** Wait until `_activeHandlerCount === 0` or `deadlineMs` elapses. Polls
  *  every `tickMs` (default 10 ms). Returns `{drained, remaining}` so the
@@ -243,6 +254,12 @@ export function _drainActiveHandlersForTest(
   tickMs?: number,
 ): Promise<{ drained: boolean; remaining: number }> {
   return drainActiveHandlers(deadlineMs, tickMs);
+}
+
+/** @internal — test-only seam. Set/clear the shutdown gate directly to
+ *  verify dispatch rejection without spinning a full close() cycle. */
+export function _setClosingForTest(closing: boolean): void {
+  _closing = closing;
 }
 
 // ---------------------------------------------------------------------------
@@ -885,8 +902,11 @@ export async function startDaemon(
 ): Promise<{ close: () => Promise<void> }> {
   const cfg = { ...DAEMON_DEFAULTS, ...config };
 
-  // Reset shutdown signal for this daemon lifecycle. Aborted in close().
+  // Reset shutdown signal + closing gate for this daemon lifecycle.
+  // _shutdownController is aborted in close(); _closing is set to true
+  // at the start of close() and reset to false at the end.
   _shutdownController = new AbortController();
+  _closing = false;
 
   // Initialize license guard (logs banner)
   initLicenseGuard();
@@ -1059,6 +1079,23 @@ export async function startDaemon(
           continue;
         }
 
+        // Shutdown gate. close() sets _closing BEFORE the drain so a
+        // request arriving on an already-connected socket after shutdown
+        // started cannot increment the counter past the drain observation
+        // window and run against a closing/closed PGlite. We respond with
+        // JSON-RPC -32099 ("Server is shutting down") and bail before the
+        // counter increment.
+        if (_closing) {
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: '2.0',
+              id: req.id,
+              error: { code: -32099, message: 'Server is shutting down' },
+            })}\n`,
+          );
+          continue;
+        }
+
         const startMs = Date.now();
         _activeHandlerCount++;
         try {
@@ -1140,14 +1177,21 @@ export async function startDaemon(
 
       resolve({
         close: async () => {
-          // Abort first so in-flight child processes (git spawn in vcs.ts)
-          // get SIGTERM and abort-aware fetches (inference.* in
-          // inference.ts) bail out — both paths complete fast once
-          // signaled. Then stop accepting new connections, drain any
-          // still-running handlers within the grace period, then close
-          // PGlite and unlink the socket. The drain prevents db.close()
-          // from racing with active `await db.query(...)` calls inside
-          // a handler that hasn't yet observed the abort.
+          // Sequence:
+          //   1. Set _closing FIRST so any RPC arriving on an existing
+          //      socket from this point onward bails out with -32099
+          //      before the counter increment. server.close() alone
+          //      doesn't stop requests on already-connected sockets.
+          //   2. Abort the shutdown signal — SIGTERMs git children
+          //      (vcs.ts) and aborts inference.* fetches; honoring
+          //      handlers complete fast.
+          //   3. Stop accepting new connections.
+          //   4. Drain any still-running handlers within the grace
+          //      period; these are handlers that started BEFORE step 1
+          //      so they are bounded by the prior count and decrement
+          //      cleanly via their finally blocks.
+          //   5. db.close() + unlink Unix socket.
+          _closing = true;
           _shutdownController?.abort();
           _shutdownController = null;
           if (pruneTimer) clearInterval(pruneTimer);
@@ -1161,6 +1205,9 @@ export async function startDaemon(
           }
           await db.close();
           await unlink(cfg.socketPath).catch(() => {});
+          // Reset _closing so a fresh startDaemon() in the same process
+          // (test setup/teardown loops) starts with a clean gate.
+          _closing = false;
           log.info('shut down');
         },
       });


### PR DESCRIPTION
## Summary

- Adds a graceful-shutdown drain to `daemon.close()` so in-flight RPC handlers complete before PGlite teardown.
- New module-level counter `_activeHandlerCount`, incremented before each `await handler(...)` and decremented in finally.
- New `cfg.shutdownGracePeriodMs` (default 5 s, env-overridable via `REVDEV_DAEMON_SHUTDOWN_GRACE_MS`).
- 7 new tests via test-only seams (`_setActiveHandlerCountForTest`, `_drainActiveHandlersForTest`) — 189/189 daemon total.

Closes the **MEDIUM** §C-4 fix from `pillar-1-stability-2026-05-05.md`.

## Why

Pre-fix, [`server.ts:1099-1112`](https://github.com/RevealUIStudio/revdev/blob/test/packages/daemon/src/server.ts#L1099) ran `db.close()` immediately after `server.close()`. A handler mid-`await db.query(...)` could throw because PGlite tore down under it. Three real-world hazards:

1. **Long handler observed in §C-3**: `worktree.create` shells out to git on a private base branch — credential prompt, large repo, hung remote can hold the handler 30+ s.
2. **Slow Neon dual-write**: `mail.send`, `tasks.create`, `events.log` all do PGlite + Neon HTTP roundtrip — Neon hang stalls the handler.
3. **`inference.*`** with the §C-1 timeouts can still spend up to 30 minutes (model pull) inside the handler before the abort fires.

After §C-3 introduced the daemon shutdown signal, these handlers all honor it (git child gets SIGTERM, fetch aborts). But the close() implementation didn't wait for them to actually finish — it just aborted-and-tore-down. This PR closes that race.

## Sequence in close()

```
1. _shutdownController?.abort()         ← signals every abort-aware helper
2. server.close()                       ← stop accepting new connections
3. drainActiveHandlers(graceMs)         ← poll _activeHandlerCount until 0 or deadline
4. (if deadline) log.warn(remaining)    ← visible in daemon.log; not hung
5. db.close()                           ← safe — no active queries
6. unlink(socketPath)
```

The drain is almost always a no-op in production because handlers honor the abort. The deadline only fires when a handler is genuinely stuck and ignoring the signal — those cases get logged loudly rather than crashing.

## Test seams (@internal)

```ts
export function _setActiveHandlerCountForTest(n: number): void
export function _drainActiveHandlersForTest(deadlineMs: number, tickMs?: number): Promise<{drained, remaining}>
```

These let the unit tests exercise drain semantics directly — no need for a test-only RPC handler registration or live long-running handlers (Ollama / git hangs would be flaky and slow). The `_*ForTest` naming makes them clearly out-of-bounds for production callers.

## Test plan

- [x] `pnpm --filter "@revdev/daemon" build` clean (37 ms ESM)
- [x] `pnpm --filter "@revdev/daemon" test` → 189/189 (7 new in `shutdown-drain.test.ts`)
- [x] `pnpm --filter "@revdev/daemon" typecheck` clean
- [x] `pnpm exec biome check` no errors (2 pre-existing warnings unrelated to this PR — both `!` non-null assertions in `cli.ts:87` + `server.ts:1025`)
- [ ] CI green
- [ ] Post-merge fast-forward of `~/suite/revdev` to test branch and re-run daemon test suite (verify-twice)

## Out of scope (queued in audit)

| PR | Surface |
|---|---|
| §C-5 | `mail.broadcast` transaction + batched Neon insert |
| §C-6 | internal docs gap-files for `memory.*`/`merge.*` Neon mirror + `file_reservations` TTL drift + `mail.markRead` atomicity |
| §B-1..§B-6 | hook hygiene migrations (`usePollingFetch` helper + cluster migrations) |
| §A-1..§A-3 | CI infra (RevealUI-native retry composite action — owner-redirected from third-party) |

Related: [#43](https://github.com/RevealUIStudio/revdev/pull/43) (Pillar 1 warm-up), [#44](https://github.com/RevealUIStudio/revdev/pull/44) (§C-1 inference timeouts), [#45](https://github.com/RevealUIStudio/revdev/pull/45) (§C-2 socket buffer bound), [#46](https://github.com/RevealUIStudio/revdev/pull/46) (§C-3 git child timeout + shutdown infra). #46 in particular: this PR consumes that infrastructure — the `_shutdownController.abort()` signaled to handlers is what makes the drain almost-always a no-op in production.
