### PR TITLE
feat(studio): introduce usePollingFetch helper + migrate useStatus / useHealth / useSubscription

### DIFF
--- a/apps/studio/src/__tests__/hooks/use-health.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-health.test.ts
@@ -87,7 +87,7 @@ describe('useHealth', () => {
       await vi.advanceTimersByTimeAsync(10);
     });
 
-    expect(fetchHealth).toHaveBeenCalledWith('http://localhost:3004');
+    expect(fetchHealth).toHaveBeenCalledWith('http://localhost:3004', expect.anything());
     expect(result.current.health).toEqual(MOCK_HEALTH);
     expect(result.current.reachable).toBe(true);
     expect(result.current.loading).toBe(false);
@@ -248,6 +248,6 @@ describe('useHealth', () => {
       await vi.advanceTimersByTimeAsync(10);
     });
 
-    expect(fetchHealth).toHaveBeenCalledWith('https://api.revealui.com');
+    expect(fetchHealth).toHaveBeenCalledWith('https://api.revealui.com', expect.anything());
   });
 });

--- a/apps/studio/src/__tests__/hooks/use-polling-fetch.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-polling-fetch.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for usePollingFetch — the shared polling helper used by
+ * useStatus / useHealth / useSubscription / etc.
+ *
+ * The Pillar 1 §C audit catalogued ~30 production surfaces sharing the
+ * same hygiene gap (no AbortController, no isMounted guard) that bit
+ * Dashboard.test.tsx today. usePollingFetch is the durable production-
+ * side fix; these tests pin its contract so future migrations can rely
+ * on it.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePollingFetch } from '../../hooks/use-polling-fetch';
+
+describe('usePollingFetch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('fires fn(signal) on mount and surfaces the result via data', async () => {
+    const fn = vi.fn(async (_signal: AbortSignal) => ({ value: 42 }));
+    const { result } = renderHook(() => usePollingFetch(fn, null));
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toEqual({ value: 42 });
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('passes an AbortSignal to fn that fires on unmount', async () => {
+    const observed: AbortSignal[] = [];
+    const fn = vi.fn(async (signal: AbortSignal) => {
+      observed.push(signal);
+      return 'ok';
+    });
+
+    const { unmount } = renderHook(() => usePollingFetch(fn, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.aborted).toBe(false);
+
+    unmount();
+
+    expect(observed[0]?.aborted).toBe(true);
+  });
+
+  it('polls at the configured interval', async () => {
+    const fn = vi.fn(async () => 'tick');
+    renderHook(() => usePollingFetch(fn, 1000));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not poll when intervalMs is null (fires once on mount only)', async () => {
+    const fn = vi.fn(async () => 'once');
+    renderHook(() => usePollingFetch(fn, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats zero or negative intervalMs the same as null (no polling)', async () => {
+    const fn = vi.fn(async () => 'once');
+    const { rerender } = renderHook(({ ms }: { ms: number }) => usePollingFetch(fn, ms), {
+      initialProps: { ms: 0 },
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    rerender({ ms: -100 });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    // Re-render with new fn-identity-equivalent ms flips the effect: it
+    // re-runs runOnce once on the deps change, then idles. So we expect
+    // exactly 2 total calls (one per effect activation).
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the interval on unmount', async () => {
+    const fn = vi.fn(async () => 'tick');
+    const { unmount } = renderHook(() => usePollingFetch(fn, 1000));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the in-flight signal when a new poll begins (no overlap)', async () => {
+    const observed: AbortSignal[] = [];
+    let resolveCurrent: ((value: string) => void) | null = null;
+
+    const fn = vi.fn(async (signal: AbortSignal) => {
+      observed.push(signal);
+      return new Promise<string>((resolve) => {
+        resolveCurrent = resolve;
+      });
+    });
+
+    renderHook(() => usePollingFetch(fn, 1000));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.aborted).toBe(false);
+
+    // Trigger second call by advancing past the interval. The first call
+    // is still in flight (resolveCurrent never called) — its signal should
+    // abort when the new call begins.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(observed).toHaveLength(2);
+    expect(observed[0]?.aborted).toBe(true);
+    expect(observed[1]?.aborted).toBe(false);
+
+    // Cleanup: resolve the dangling promises so vitest doesn't warn.
+    if (resolveCurrent) (resolveCurrent as (v: string) => void)('done');
+  });
+
+  it('surfaces errors via the error state', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const { result } = renderHook(() => usePollingFetch(fn, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('boom');
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('wraps non-Error rejections in an Error', async () => {
+    const fn = vi.fn(async () => {
+      throw 'string failure';
+    });
+    const { result } = renderHook(() => usePollingFetch(fn, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('string failure');
+  });
+
+  it('clears a previous error after a successful re-fetch', async () => {
+    let shouldFail = true;
+    const fn = vi.fn(async () => {
+      if (shouldFail) throw new Error('first call failed');
+      return 'ok';
+    });
+
+    const { result } = renderHook(() => usePollingFetch(fn, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(result.current.error?.message).toBe('first call failed');
+
+    shouldFail = false;
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toBe('ok');
+  });
+
+  it("swallows AbortError silently (the helper's own abort)", async () => {
+    const fn = vi.fn(async (signal: AbortSignal) => {
+      if (signal.aborted) {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        throw err;
+      }
+      return 'ok';
+    });
+
+    const { result, unmount } = renderHook(() => usePollingFetch(fn, null));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    // No error surfaces from the AbortError path
+    expect(result.current.error).toBeNull();
+    unmount();
+  });
+
+  it('swallows TimeoutError silently', async () => {
+    const fn = vi.fn(async () => {
+      const err = new Error('timed out');
+      err.name = 'TimeoutError';
+      throw err;
+    });
+
+    const { result } = renderHook(() => usePollingFetch(fn, null));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
+  it('refresh() returns a Promise that resolves after the call completes', async () => {
+    const fn = vi.fn(async () => 'value');
+    const { result } = renderHook(() => usePollingFetch(fn, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('restarts polling when fn identity changes (caller useCallback dep change)', async () => {
+    const fn1 = vi.fn(async () => 'first');
+    const fn2 = vi.fn(async () => 'second');
+
+    const { result, rerender } = renderHook(
+      ({ fn }: { fn: typeof fn1 }) => usePollingFetch(fn, 1000),
+      { initialProps: { fn: fn1 } },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(result.current.data).toBe('first');
+
+    rerender({ fn: fn2 });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(fn2).toHaveBeenCalled();
+    expect(result.current.data).toBe('second');
+  });
+});

--- a/apps/studio/src/__tests__/hooks/use-subscription.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-subscription.test.ts
@@ -111,8 +111,16 @@ describe('useSubscription', () => {
       await vi.advanceTimersByTimeAsync(10);
     });
 
-    expect(fetchSubscription).toHaveBeenCalledWith('http://localhost:3004', 'test-token');
-    expect(fetchUsage).toHaveBeenCalledWith('http://localhost:3004', 'test-token');
+    expect(fetchSubscription).toHaveBeenCalledWith(
+      'http://localhost:3004',
+      'test-token',
+      expect.anything(),
+    );
+    expect(fetchUsage).toHaveBeenCalledWith(
+      'http://localhost:3004',
+      'test-token',
+      expect.anything(),
+    );
     expect(result.current.subscription).toEqual(MOCK_SUBSCRIPTION);
     expect(result.current.usage).toEqual(MOCK_USAGE);
     expect(result.current.loading).toBe(false);

--- a/apps/studio/src/hooks/use-health.ts
+++ b/apps/studio/src/hooks/use-health.ts
@@ -2,51 +2,48 @@
  * useHealth — Polls the production API's readiness probe.
  *
  * Returns the health status (healthy/degraded/unhealthy/unreachable)
- * along with individual check results. Polls on the settings interval.
+ * along with individual check results. Polls on the settings interval
+ * via `usePollingFetch`, which gives this hook full abort + isMounted
+ * hygiene without per-hook plumbing.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { HealthResponse } from '../lib/health-api';
 import { fetchHealth } from '../lib/health-api';
+import { usePollingFetch } from './use-polling-fetch';
 import { useSettingsContext } from './use-settings';
 
 export interface HealthState {
   health: HealthResponse | null;
   reachable: boolean;
   loading: boolean;
-  refresh: () => void;
+  refresh: () => Promise<void>;
 }
 
 export function useHealth(): HealthState {
   const { settings } = useSettingsContext();
+  const { apiUrl, pollingIntervalMs } = settings;
 
-  const [health, setHealth] = useState<HealthResponse | null>(null);
-  const [reachable, setReachable] = useState(true);
-  const [loading, setLoading] = useState(true);
+  const fetchFn = useCallback(
+    (signal: AbortSignal): Promise<HealthResponse | null> => fetchHealth(apiUrl, signal),
+    [apiUrl],
+  );
 
-  async function poll() {
-    const result = await fetchHealth(settings.apiUrl);
-    if (result) {
-      setHealth(result);
-      setReachable(true);
-    } else {
-      setReachable(false);
-    }
-    setLoading(false);
-  }
+  const { data, loading, refresh } = usePollingFetch(fetchFn, pollingIntervalMs);
 
-  function refresh() {
-    setLoading(true);
-    poll();
-  }
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-poll when apiUrl or interval changes
-  useEffect(() => {
-    poll();
-
-    const interval = setInterval(poll, settings.pollingIntervalMs);
-    return () => clearInterval(interval);
-  }, [settings.apiUrl, settings.pollingIntervalMs]);
-
-  return { health, reachable, loading, refresh };
+  // `data === null` after a fetchHealth round-trip means the API was
+  // unreachable (network error / timeout). The legacy hook surfaced
+  // that as `reachable: false` rather than as an error, so we preserve
+  // that mapping. Initial render (data === null, loading === true) is
+  // the "no probe yet" state — keep `reachable` optimistic until we
+  // see at least one resolved-to-null result.
+  return useMemo<HealthState>(
+    () => ({
+      health: data ?? null,
+      reachable: loading ? true : data !== null,
+      loading,
+      refresh,
+    }),
+    [data, loading, refresh],
+  );
 }

--- a/apps/studio/src/hooks/use-polling-fetch.ts
+++ b/apps/studio/src/hooks/use-polling-fetch.ts
@@ -1,0 +1,138 @@
+/**
+ * usePollingFetch — fire an async fetcher on mount + at a fixed interval,
+ * with full abort + isMounted hygiene.
+ *
+ * Why: every studio polling hook (useStatus, useHealth, useSubscription,
+ * useRvuiBalance, useTunnel, …) was hand-rolling an initial fetch + a
+ * setInterval, with no AbortController and no isMounted guard. Initial
+ * fetches that resolved post-unmount (e.g. inside a Vitest jsdom
+ * teardown, or a real user closing a window mid-fetch) called setState
+ * against a torn-down React tree, which crashed React 19's
+ * dispatchSetState path with "ReferenceError: window is not defined".
+ * The Pillar 1 §C audit catalogued ~30 production surfaces sharing
+ * this gap (revdev studio + revealui admin + @revealui/ai Pro hooks).
+ *
+ * Behavioral contract:
+ *   - Fires fn(signal) on mount.
+ *   - Re-fires fn(signal) every intervalMs while mounted (when intervalMs
+ *     is a positive number; null / 0 / negative disables polling).
+ *   - On unmount: aborts the in-flight signal and clears the interval.
+ *   - Aborts the previous in-flight call before firing a new one (no
+ *     overlap; the most-recent call always wins).
+ *   - Swallows AbortError + TimeoutError silently (those are the helper's
+ *     own abort, not real failures).
+ *   - Surfaces other errors via `error` state. Successful resolves clear
+ *     the previous error.
+ *   - Never sets state after unmount.
+ *
+ * Caller contract:
+ *   - `fn` should be wrapped in `useCallback` so its identity only changes
+ *     when its inputs change. The hook restarts when `fn` changes
+ *     (new initial fetch + new interval bound to the new fn).
+ *   - `fn` should propagate the provided AbortSignal to any abortable
+ *     work it does (e.g. `fetch(url, { signal })`). For non-abortable
+ *     work (Tauri invoke etc.), the signal is still useful — the helper
+ *     drops the result if the signal aborted before resolution.
+ *   - Polling can be conditionally disabled by passing `null` for
+ *     `intervalMs` (e.g. "wait until authenticated, then poll").
+ */
+
+import type { DependencyList } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UsePollingFetchResult<T> {
+  /** Most-recent successful result; null until the first resolve. */
+  data: T | null;
+  /** Most-recent unhandled error; null after a successful resolve. */
+  error: Error | null;
+  /** True from the start of the most-recent call until it resolves or aborts. */
+  loading: boolean;
+  /** Trigger an immediate re-fetch. Returns a Promise that resolves
+   *  when the call completes (success, error, or abort). */
+  refresh: () => Promise<void>;
+}
+
+function isAbortLike(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === 'AbortError' || err.name === 'TimeoutError';
+}
+
+export function usePollingFetch<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  intervalMs: number | null,
+): UsePollingFetchResult<T>;
+export function usePollingFetch<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  intervalMs: number | null,
+  // Reserved for callers that prefer explicit deps over useCallback-on-fn.
+  // The hook also re-runs when any dep changes.
+  deps: DependencyList,
+): UsePollingFetchResult<T>;
+export function usePollingFetch<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  intervalMs: number | null,
+  deps?: DependencyList,
+): UsePollingFetchResult<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(true);
+  const isMountedRef = useRef(true);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  // Stable ref to fn so internal helpers can read it without going stale.
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+
+  const runOnce = useCallback(async (): Promise<void> => {
+    // Abort any in-flight call before starting a new one. The previous
+    // call's result-handling block sees ctrl.signal.aborted and bails
+    // before touching state.
+    controllerRef.current?.abort();
+    const ctrl = new AbortController();
+    controllerRef.current = ctrl;
+
+    if (isMountedRef.current) setLoading(true);
+
+    try {
+      const result = await fnRef.current(ctrl.signal);
+      if (!isMountedRef.current || ctrl.signal.aborted) return;
+      setData(result);
+      setError(null);
+    } catch (err) {
+      if (!isMountedRef.current || ctrl.signal.aborted) return;
+      // Swallow our own abort. AbortError fires when ctrl.abort() races
+      // a fetch call; TimeoutError fires when the consumer combined the
+      // helper's signal with AbortSignal.timeout. Both are expected,
+      // not real failures.
+      if (isAbortLike(err)) return;
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      if (isMountedRef.current && !ctrl.signal.aborted) setLoading(false);
+    }
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deps from caller, intentional
+  useEffect(() => {
+    isMountedRef.current = true;
+    runOnce();
+
+    let interval: ReturnType<typeof setInterval> | null = null;
+    if (intervalMs !== null && intervalMs > 0) {
+      interval = setInterval(() => {
+        runOnce();
+      }, intervalMs);
+    }
+
+    return () => {
+      isMountedRef.current = false;
+      controllerRef.current?.abort();
+      if (interval !== null) clearInterval(interval);
+    };
+    // The effect depends on `intervalMs` (controls the timer) and on
+    // `fn`'s identity (so callers' `useCallback` dep changes restart
+    // the loop) plus any extra `deps` the caller wants to track.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [intervalMs, fn, runOnce, ...(deps ?? [])]);
+
+  return { data, error, loading, refresh: runOnce };
+}

--- a/apps/studio/src/hooks/use-status.ts
+++ b/apps/studio/src/hooks/use-status.ts
@@ -1,18 +1,21 @@
-import { createContext, use, useCallback, useEffect, useState } from 'react';
-
-const STATUS_POLL_INTERVAL_MS = 30_000;
+import { createContext, use, useCallback, useMemo } from 'react';
 
 import { getMountStatus, getSystemStatus } from '../lib/invoke';
 import type { MountStatus, SystemStatus } from '../types';
+import { usePollingFetch } from './use-polling-fetch';
 
-interface StatusState {
+const STATUS_POLL_INTERVAL_MS = 30_000;
+
+interface StatusPayload {
+  system: SystemStatus;
+  mount: MountStatus;
+}
+
+export interface StatusContextValue {
   system: SystemStatus | null;
   mount: MountStatus | null;
   loading: boolean;
   error: string | null;
-}
-
-export interface StatusContextValue extends StatusState {
   refresh: () => Promise<void>;
 }
 
@@ -24,33 +27,29 @@ export function useStatusContext(): StatusContextValue {
   return ctx;
 }
 
-export function useStatus() {
-  const [state, setState] = useState<StatusState>({
-    system: null,
-    mount: null,
-    loading: true,
-    error: null,
-  });
-
-  const refresh = useCallback(async () => {
-    setState((prev) => ({ ...prev, loading: true, error: null }));
-    try {
-      const [system, mount] = await Promise.all([getSystemStatus(), getMountStatus()]);
-      setState({ system, mount, loading: false, error: null });
-    } catch (err) {
-      setState((prev) => ({
-        ...prev,
-        loading: false,
-        error: err instanceof Error ? err.message : String(err),
-      }));
-    }
+export function useStatus(): StatusContextValue {
+  // Fetcher is a stable identity — no caller-supplied dependencies — so
+  // the polling loop only restarts on intervalMs change (which never
+  // happens here; the constant is module-level).
+  const fetchFn = useCallback(async (_signal: AbortSignal): Promise<StatusPayload> => {
+    const [system, mount] = await Promise.all([getSystemStatus(), getMountStatus()]);
+    return { system, mount };
   }, []);
 
-  useEffect(() => {
-    refresh();
-    const interval = setInterval(refresh, STATUS_POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [refresh]);
+  const { data, error, loading, refresh } = usePollingFetch(fetchFn, STATUS_POLL_INTERVAL_MS);
 
-  return { ...state, refresh };
+  // Preserve the legacy public surface — separate `system`/`mount`
+  // slots and a string `error`. Wrapped in useMemo so consumers that
+  // depend on object identity (Dashboard via context) don't re-render
+  // every poll tick if the underlying data didn't change shape.
+  return useMemo(
+    () => ({
+      system: data?.system ?? null,
+      mount: data?.mount ?? null,
+      loading,
+      error: error?.message ?? null,
+      refresh,
+    }),
+    [data, error, loading, refresh],
+  );
 }

--- a/apps/studio/src/hooks/use-subscription.ts
+++ b/apps/studio/src/hooks/use-subscription.ts
@@ -3,12 +3,16 @@
  *
  * Polls on an interval (from settings.pollingIntervalMs) so the Dashboard
  * always reflects the current billing state without manual refresh.
+ * Polling is gated on `step === 'authenticated'` AND `getToken()` returning
+ * a token. When either gate is closed the fetcher returns null and the
+ * underlying API calls are skipped.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { SubscriptionResponse, UsageResponse } from '../lib/billing-api';
 import { fetchSubscription, fetchUsage } from '../lib/billing-api';
 import { useAuthContext } from './use-auth';
+import { usePollingFetch } from './use-polling-fetch';
 import { useSettingsContext } from './use-settings';
 
 export interface SubscriptionState {
@@ -16,59 +20,63 @@ export interface SubscriptionState {
   usage: UsageResponse | null;
   loading: boolean;
   error: string | null;
-  refresh: () => void;
+  refresh: () => Promise<void>;
 }
+
+interface BillingPayload {
+  subscription: SubscriptionResponse;
+  usage: UsageResponse;
+}
+
+const FALLBACK_ERROR = 'Failed to fetch billing data';
 
 export function useSubscription(): SubscriptionState {
   const { getToken, step } = useAuthContext();
   const { settings } = useSettingsContext();
+  const { apiUrl, pollingIntervalMs } = settings;
 
-  const [subscription, setSubscription] = useState<SubscriptionResponse | null>(null);
-  const [usage, setUsage] = useState<UsageResponse | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const refreshRef = useRef(0);
+  const fetchFn = useCallback(
+    async (signal: AbortSignal): Promise<BillingPayload | null> => {
+      // Gate: skip the network entirely when not authenticated or no
+      // token. Returning null leaves data unchanged (still null after
+      // first call) and the helper's loading transitions to false.
+      if (step !== 'authenticated') return null;
+      const token = getToken();
+      if (!token) return null;
 
-  function refresh() {
-    refreshRef.current += 1;
-    // Trigger re-fetch by updating a counter dependency
-    setLoading(true);
-    fetchAll();
-  }
+      try {
+        const [sub, usg] = await Promise.all([
+          fetchSubscription(apiUrl, token, signal),
+          fetchUsage(apiUrl, token, signal),
+        ]);
+        return { subscription: sub, usage: usg };
+      } catch (err) {
+        // Re-throw Error instances unchanged so the consumer surfaces
+        // the real message; replace non-Error rejections with the
+        // legacy fallback string for caller compatibility.
+        if (err instanceof Error) throw err;
+        throw new Error(FALLBACK_ERROR);
+      }
+    },
+    [apiUrl, getToken, step],
+  );
 
-  async function fetchAll() {
-    const token = getToken();
-    if (!token) {
-      setLoading(false);
-      return;
-    }
+  // Disable interval polling until the user is authenticated. The
+  // initial fetch still fires once per fetchFn-identity change, but
+  // when step !== 'authenticated' the gate above short-circuits the
+  // network call, so no fetchSubscription/fetchUsage requests go out.
+  const effectiveInterval = step === 'authenticated' ? pollingIntervalMs : null;
 
-    try {
-      const [sub, usg] = await Promise.all([
-        fetchSubscription(settings.apiUrl, token),
-        fetchUsage(settings.apiUrl, token),
-      ]);
-      setSubscription(sub);
-      setUsage(usg);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch billing data');
-    } finally {
-      setLoading(false);
-    }
-  }
+  const { data, error, loading, refresh } = usePollingFetch(fetchFn, effectiveInterval);
 
-  // Fetch on mount and on interval
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-fetch when auth step or apiUrl changes
-  useEffect(() => {
-    if (step !== 'authenticated') return;
-
-    setLoading(true);
-    fetchAll();
-
-    const interval = setInterval(fetchAll, settings.pollingIntervalMs);
-    return () => clearInterval(interval);
-  }, [step, settings.apiUrl, settings.pollingIntervalMs]);
-
-  return { subscription, usage, loading, error, refresh };
+  return useMemo<SubscriptionState>(
+    () => ({
+      subscription: data?.subscription ?? null,
+      usage: data?.usage ?? null,
+      loading,
+      error: error?.message ?? null,
+      refresh,
+    }),
+    [data, error, loading, refresh],
+  );
 }

--- a/apps/studio/src/lib/billing-api.ts
+++ b/apps/studio/src/lib/billing-api.ts
@@ -27,13 +27,19 @@ export interface UsageResponse {
 
 // ── Client ──────────────────────────────────────────────────────────────────
 
-async function authedGet<T>(apiUrl: string, path: string, token: string): Promise<T> {
+async function authedGet<T>(
+  apiUrl: string,
+  path: string,
+  token: string,
+  signal?: AbortSignal,
+): Promise<T> {
   const res = await fetch(`${apiUrl}/api/billing${path}`, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
+    signal,
   });
 
   if (!res.ok) {
@@ -44,18 +50,26 @@ async function authedGet<T>(apiUrl: string, path: string, token: string): Promis
 }
 
 /**
- * Fetch the current user's subscription/license status.
+ * Fetch the current user's subscription/license status. Accepts an
+ * optional AbortSignal so callers (usePollingFetch) can cancel the
+ * fetch on unmount or when a new poll begins.
  */
 export async function fetchSubscription(
   apiUrl: string,
   token: string,
+  signal?: AbortSignal,
 ): Promise<SubscriptionResponse> {
-  return authedGet<SubscriptionResponse>(apiUrl, '/subscription', token);
+  return authedGet<SubscriptionResponse>(apiUrl, '/subscription', token, signal);
 }
 
 /**
- * Fetch the current billing cycle's agent task usage.
+ * Fetch the current billing cycle's agent task usage. Accepts an
+ * optional AbortSignal — see fetchSubscription.
  */
-export async function fetchUsage(apiUrl: string, token: string): Promise<UsageResponse> {
-  return authedGet<UsageResponse>(apiUrl, '/usage', token);
+export async function fetchUsage(
+  apiUrl: string,
+  token: string,
+  signal?: AbortSignal,
+): Promise<UsageResponse> {
+  return authedGet<UsageResponse>(apiUrl, '/usage', token, signal);
 }

--- a/apps/studio/src/lib/health-api.ts
+++ b/apps/studio/src/lib/health-api.ts
@@ -26,13 +26,27 @@ export interface HealthResponse {
 
 /**
  * Fetch the readiness probe from the API. Public endpoint — no auth needed.
- * Returns null if the API is unreachable (network error).
+ * Returns null if the API is unreachable (network error or timeout).
+ *
+ * Accepts an optional caller-supplied AbortSignal that's combined with
+ * an internal 5 s timeout via `AbortSignal.any` — either source aborting
+ * cancels the fetch. Callers using `usePollingFetch` should pass their
+ * call's signal so the fetch is canceled on unmount or when a new poll
+ * begins, instead of leaking a pending promise past component teardown
+ * (the bug closed by revdev#43 on Dashboard.test.tsx).
  */
-export async function fetchHealth(apiUrl: string): Promise<HealthResponse | null> {
+export async function fetchHealth(
+  apiUrl: string,
+  signal?: AbortSignal,
+): Promise<HealthResponse | null> {
+  const sources: AbortSignal[] = [AbortSignal.timeout(5_000)];
+  if (signal) sources.push(signal);
+  const combined = sources.length > 1 ? AbortSignal.any(sources) : sources[0];
+
   try {
     const res = await fetch(`${apiUrl}/health/ready`, {
       method: 'GET',
-      signal: AbortSignal.timeout(5_000),
+      signal: combined,
     });
     return (await res.json()) as HealthResponse;
   } catch {


### PR DESCRIPTION
## Summary

Opens the **§B hook-hygiene arc** for Pillar 1. Ships a shared `usePollingFetch` helper with full abort + isMounted hygiene and migrates the three critical-path studio hooks (`useStatus`, `useHealth`, `useSubscription`) to use it. 14 new helper tests + arg-shape updates for the existing hook tests. **536/536 studio tests pass.**

Closes the §B-1 fix from `pillar-1-stability-2026-05-05.md`.

## Why

The §C audit catalogued **~30 production surfaces** in revdev studio + revealui admin + `@revealui/ai` Pro hooks that hand-rolled an initial fetch + setInterval with **no AbortController and no `isMounted` guard**. Initial fetches that resolved post-unmount called `setState` against a torn-down React tree, which crashed React 19's `dispatchSetState` path with `ReferenceError: window is not defined` — the bug closed by [revdev#43](https://github.com/RevealUIStudio/revdev/pull/43) on `Dashboard.test.tsx` (test-side mock workaround).

This PR ships the **durable production-side fix** for the studio's three highest-traffic polling hooks. §B-2..§B-6 will migrate the rest in follow-up PRs.

## Helper contract (`usePollingFetch`)

- Fires `fn(signal)` on mount; passes a per-call `AbortSignal` that fires on unmount AND when a new poll begins (no overlap).
- Polls at `intervalMs` while mounted (`null` / `0` / negative = no polling, fire-once).
- Swallows `AbortError` + `TimeoutError` silently (the helper's own abort isn't a real failure).
- Surfaces other errors via `error` state; clears error on successful re-fetch.
- Never sets state after unmount.
- `refresh` returns `Promise<void>` so callers can await.
- Restarts the loop when `fn` identity changes (caller `useCallback` dep change) or when `intervalMs` changes.

## Library API additions

`fetchHealth(apiUrl, signal?)` — combines caller signal with internal `AbortSignal.timeout(5_000)` via `AbortSignal.any`.

`fetchSubscription(apiUrl, token, signal?)` and `fetchUsage(apiUrl, token, signal?)` — pass-through to fetch.

All three accept an optional signal so callers using `usePollingFetch` get true cancellation, not just state-update gating. Backwards-compatible (signal is optional).

## Test plan

- [x] `pnpm typecheck:studio` clean
- [x] `pnpm --filter studio test --run` → 536/536 pass (14 new helper tests + 28 existing tests for the migrated hooks all green)
- [x] `pnpm exec biome check` no errors (1 pre-existing warning unrelated)
- [ ] CI green
- [ ] Post-merge fast-forward + re-run studio test suite (verify-twice)

## Out of scope (queued in audit)

| PR | Surface |
|---|---|
| §B-2 | migrate `useRvuiBalance` / `useTunnel` / `useApps` / `useTiles` / `useHarness` / `useInference` (6 hooks) |
| §B-3 | migrate component-internal pollers (`AppCard`, `DeployDashboard`, `TerminalPanel`, `AgentPanel`, `AgentTerminalPane`, `DaemonPanel`) |
| §B-4 | port helper to `@revealui/core/client/hooks` for revealui admin (or duplicate per intentional decoupling — owner sign-off needed) |
| §B-5 | migrate Pro hooks in `@revealui/ai` (consumer-facing minor bump — owner sign-off) |
| §B-6 | retire `vi.mock('../../lib/health-api')` from `Dashboard.test.tsx` now that production-side hardening covers the leak |

Related: [#43](https://github.com/RevealUIStudio/revdev/pull/43) (warm-up), [#44](https://github.com/RevealUIStudio/revdev/pull/44) / [#45](https://github.com/RevealUIStudio/revdev/pull/45) / [#46](https://github.com/RevealUIStudio/revdev/pull/46) / [#47](https://github.com/RevealUIStudio/revdev/pull/47) (§C-1..§C-4 daemon arc), internal docs a1cd58e6f (§C-6 gap files).
