### PR TITLE
fix(studio): visible scrollbars on Linux webkit2gtk (WSLg)

### DIFF
--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -20,3 +20,38 @@
 .cm-mergeView-gutter {
   flex-shrink: 0;
 }
+
+/* ── Visible scrollbars on Linux WebKit (WSLg + webkit2gtk) ──────────────── */
+/* webkit2gtk's default overlay scrollbars are nearly invisible on Linux,    */
+/* especially under WSLg. Force a visible custom scrollbar across all        */
+/* WebKit/Blink. Tailwind `overflow-y-auto` provides the scroll behavior;    */
+/* this just makes the indicator visible.                                     */
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgb(23 23 23 / 0.5); /* neutral-900/50 */
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgb(64 64 64); /* neutral-700 */
+  border-radius: 5px;
+  border: 2px solid rgb(23 23 23); /* neutral-900 — creates inset look */
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgb(82 82 82); /* neutral-600 */
+}
+
+::-webkit-scrollbar-corner {
+  background: rgb(23 23 23); /* neutral-900 */
+}
+
+/* Firefox fallback (if Studio ever ships in non-WebKit context) */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(64 64 64) rgb(23 23 23 / 0.5);
+}


### PR DESCRIPTION
## Summary

Visible scrollbars on Linux webkit2gtk (WSLg) for Studio.

webkit2gtk's default overlay scrollbars are nearly invisible on Linux —
especially under WSLg — making it impossible to tell that content is
scrollable or where in a list you are. Owner reported "no scrollbar,
can't see full UI" during 2026-05-07 dev-env Tier 2 evaluation.
HMR-confirmed working in that session.

CSS-only change in `apps/studio/src/styles.css`:
- `::-webkit-scrollbar` (10px width/height)
- `::-webkit-scrollbar-track` (neutral-900/50, matches dark theme)
- `::-webkit-scrollbar-thumb` (neutral-700, rounded, 2px neutral-900 inset border)
- `::-webkit-scrollbar-thumb:hover` (neutral-600)
- `::-webkit-scrollbar-corner` (neutral-900)
- Firefox fallback: `scrollbar-width: thin` + `scrollbar-color`

No JS, no DOM, no behavior change — Tailwind `overflow-y-auto` already
handles scroll behavior; this just makes the indicator visible.

## Why now

Studio is the Pillar 3 daily-drive target. Owner is running Phase A.2
of dev-env Tier 2 migration (dev-env-tier-2-migration spec)
which depends on Studio being usable inside WSLg. Invisible scrollbars
block "Studio daily-driveable" verification.

## Test plan

- [x] Owner-verified HMR working during 2026-05-07 session — scrollbar
      appears + behaves on the affected panels
- [ ] Reviewer: pull branch, run `pnpm --filter studio tauri:dev`, verify
      visible scrollbar appears on a long content panel (Vault list,
      Setup wizard steps, etc.)
- [ ] Reviewer: confirm scrollbar palette reads as part of dark theme
      (not bolted-on)
- [ ] Reviewer: optionally test on macOS — `::-webkit-scrollbar` rules
      apply there too but should be harmless (macOS already has visible
      scrollbars; the custom styling will replace the system style)

## Refs

- Spec: dev-environment-tier-2-migration.md §Phase A.6 (daily-drive verification)
- Handoff: HANDOFF-2026-05-07-security-rotation-zt-onboarding-arc.md §Arc 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
