### PR TITLE
chore(docs): rename + state refresh per Phase D-2 audit

### DIFF
--- a/docs/KEY_GENERATION.md
+++ b/docs/KEY_GENERATION.md
@@ -11,7 +11,7 @@ Signs Studio desktop binaries for auto-update verification.
 
 ```bash
 # Generate keypair (prompts for a password)
-cd ~/suite/revdev/apps/studio/src-tauri
+cd ~/revfleet/revdev/apps/studio/src-tauri
 npx @tauri-apps/cli signer generate -w ~/.tauri/revdev-studio.key
 
 # Store in revvault
@@ -35,7 +35,7 @@ Signs customer license keys (RVUI.v2 format) so the daemon can verify them.
 # Mint Ed25519 keypair; auto-stores both halves in revvault at
 # revdev/license-signing-{private,public}-key and prints the public PEM.
 # No plaintext key files ever land on disk.
-cd ~/suite/revdev
+cd ~/revfleet/revdev
 npx tsx scripts/issue-license.ts --generate-keypair
 
 # Wire the public key into the local daemon's environment.
@@ -50,7 +50,7 @@ export REVDEV_LICENSE_PUBLIC_KEY="$(revvault get --full revdev/license-signing-p
 Verify the key works by issuing yourself an enterprise license:
 
 ```bash
-cd ~/suite/revdev
+cd ~/revfleet/revdev
 npx tsx scripts/issue-license.ts --tier enterprise --perpetual
 ```
 

--- a/docs/PRODUCTION_LAUNCH_PLAN.md
+++ b/docs/PRODUCTION_LAUNCH_PLAN.md
@@ -3,7 +3,7 @@
 Complete spec for remaining work to ship RevDev as a commercial product.
 Covers both agent-executable (code) and human-required (secrets, accounts, infrastructure) tasks.
 
-Last updated: 2026-04-20
+Last updated: 2026-05-08
 
 ---
 
@@ -212,7 +212,7 @@ Tasks that require the founder's credentials, physical access, or business decis
 **Who**: Founder
 
 ```bash
-cd ~/suite/revdev/apps/studio/src-tauri
+cd ~/revfleet/revdev/apps/studio/src-tauri
 pnpm tauri signer generate -w ~/.tauri/revdev-studio.key
 ```
 
@@ -313,7 +313,7 @@ Add these secrets to `RevealUIStudio/revdev` → Settings → Secrets:
 **Who**: Founder
 
 ```bash
-cd ~/suite/revdev
+cd ~/revfleet/revdev
 
 # Build daemon
 pnpm --filter @revdev/daemon build
@@ -328,6 +328,8 @@ bash packages/daemon/service/install.sh
 # Verify
 systemctl --user status revdev-daemon
 ```
+
+✅ **DONE** — closed via [revdev#27](https://github.com/RevealUIStudio/revdev/pull/27) 2026-04-28 (GAP-152) + [revdev#23](https://github.com/RevealUIStudio/revdev/pull/23) 2026-04-28 (GAP-153)
 
 ---
 


### PR DESCRIPTION
## Summary

Phase D-2 doc-quality sweep:
- Path rename `~/suite/revdev` → `~/revfleet/revdev` in `docs/KEY_GENERATION.md` (3 lines).
- Path sweep + state refresh in `docs/PRODUCTION_LAUNCH_PLAN.md`: H6 daemon-install task marked DONE (closed via [#27](https://github.com/RevealUIStudio/revdev/pull/27) + [#23](https://github.com/RevealUIStudio/revdev/pull/23) on 2026-04-28 → GAP-152 + GAP-153 closed). "Last updated" date bumped (2026-04-20 → 2026-05-08).

Per fleet doc-quality audit at internal docs (committed `e0a59018c` on an internal repo:main).

## Audit context

Audit-flagged finding: PRODUCTION_LAUNCH_PLAN.md still listed H6 as a P1 todo and "Status After PRs #18 + #19" header implies a 24-PR-old cutoff. H6 daemon-install task is now marked DONE (closed via #27 + #23 on 2026-04-28, shipping GAP-152 daemon self-detach + GAP-153 stale-session prune). "Last updated" timestamp refreshed to indicate current audit cut.

Defining-of-done sections may need separate refresh; this PR fixes only the H6 obsolescence + paths. Flag for owner: launch plan deeper refresh is recommended in a follow-up PR if you want the Phase 5 list fully reconciled.

## Test plan

- [ ] Doc-only change
- [ ] All revdev CI gates green expected (no code touched)
- [ ] Path examples now resolve correctly post-rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)