### PR TITLE
docs: fix Console go run/build commands in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,9 @@ pnpm --filter studio tauri:dev    # Start Studio in dev mode
 pnpm --filter studio tauri build  # Build desktop binary
 pnpm typecheck:studio             # Typecheck Studio frontend
 
-# Console
-go run ./apps/console             # Run Console
-go build -o rvui ./apps/console   # Build Console binary
+# Console (no root go.mod; module lives under apps/console/ per CI ci.yml:78-79)
+cd apps/console && go run .                    # Run Console
+cd apps/console && go build -o ../../rvui .    # Build Console binary
 
 # Workspace
 pnpm -r --filter=!studio build    # Build all packages (skip Tauri)


### PR DESCRIPTION
Codex finding from PR #53 follow-up. Repo has no root go.mod; the console module lives under apps/console/. Documented commands fail from repo root with . Fix uses cd apps/console pattern matching CI at .github/workflows/ci.yml:78-79.