### PR TITLE
chore(ci): add private-leak-scan gate + scrub revealui-jv URL leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,12 @@ jobs:
           cache-dependency-path: apps/console/go.sum
       - run: cd apps/console && go test ./...
       - run: cd apps/console && go build -o /dev/null .
+
+  private-leak-scan:
+    name: Private Leak Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Scan for private paths and credentials
+        run: bash scripts/check-no-private-leaks.sh

--- a/.leakignore
+++ b/.leakignore
@@ -1,0 +1,17 @@
+# .leakignore — allowed private-path references in this public repo.
+#
+# Format: <path-glob> <tag[,tag...]>   # reason
+#
+# The leak scanner (scripts/check-no-private-leaks.sh) ignores matches where
+# BOTH the file path matches the glob AND the leak tag is listed. Unknown
+# leaks still fail CI.
+
+# Test fixtures use a generic placeholder username (not a real developer).
+# The scanner's abs-home-path regex matches any /home/<word>, including
+# placeholder fixtures in unit tests.
+apps/studio/src/__tests__/hooks/use-local-shell.test.ts   abs-home-path
+apps/studio/src/__tests__/hooks/use-ssh.test.ts           abs-home-path
+
+# Test fixture: the license-key shape matches the regex but the body is a
+# repeating hex pattern (abcdef-0123456789 doubled). Not a real key.
+packages/daemon/src/__tests__/flows.test.ts               license-key

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -4,9 +4,9 @@
 **Status:** Pre-1.0 — Studio + Console + harness daemon all buildable; no public releases yet
 **Owner:** RevealUI Studio (`founder@revealui.com`)
 **Repo:** [RevealUIStudio/revdev](https://github.com/RevealUIStudio/revdev)
-**Fleet master index:** [`revealui-jv:docs/MASTER_INDEX.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_INDEX.md)
+**Fleet master index:** RevealUI Studio internal coordination hub (`MASTER_INDEX.md`, private).
 
-> Fleet-level cross-cutting plans live in [`revealui-jv:docs/MASTER_PLAN.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_PLAN.md). This file is RevDev-scoped only.
+> Fleet-level cross-cutting plans live in the internal coordination hub's `MASTER_PLAN.md`. This file is RevDev-scoped only.
 >
 > Detailed launch checklist (agent-executable + human-required tasks): [`docs/PRODUCTION_LAUNCH_PLAN.md`](./PRODUCTION_LAUNCH_PLAN.md). This MASTER_PLAN is the higher-level pointer; PRODUCTION_LAUNCH_PLAN is the per-task breakdown.
 
@@ -89,7 +89,7 @@ Active on the daemon JWT validation surface — adding `iss` + `aud` + `customer
 
 Detailed task-level breakdown in [`PRODUCTION_LAUNCH_PLAN.md`](./PRODUCTION_LAUNCH_PLAN.md). Higher-level phases below.
 
-Pre-1.0 per [`versioning.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/.claude/rules/versioning.md).
+Pre-1.0 per the fleet versioning convention (RevealUI Studio internal).
 
 ### Phase 0 — Daemon production-grade (DONE)
 
@@ -156,4 +156,4 @@ Daemon → Neon `coordination_*` tables sync; allows multiple workstations / clo
 - [`README.md`](../README.md) — overview + architecture diagram
 - [`CLAUDE.md`](../CLAUDE.md) — agent context
 - [`revealui:.claude/rules/hooks-architecture.md`](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/hooks-architecture.md) — RevDev daemon contract for fleet hooks
-- [`revealui-jv:docs/MASTER_INDEX.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_INDEX.md) — fleet-level navigation
+- Fleet master index (`MASTER_INDEX.md` in the RevealUI Studio internal coordination hub) — fleet-level navigation

--- a/docs/MASTER_SPEC.md
+++ b/docs/MASTER_SPEC.md
@@ -202,7 +202,7 @@ Test count: 522/522 passing per [revdev#43](https://github.com/RevealUIStudio/re
 
 ## Versioning
 
-Pre-1.0 per [`versioning.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/.claude/rules/versioning.md). Per-package SemVer (`@revdev/daemon`, `@revdev/protocol`, `@revdev/bridge`, `@revdev/theme` independent). Studio + Console app versions tracked separately per Tauri / Go release conventions.
+Pre-1.0 per the fleet versioning convention (RevealUI Studio internal). Per-package SemVer (`@revdev/daemon`, `@revdev/protocol`, `@revdev/bridge`, `@revdev/theme` independent). Studio + Console app versions tracked separately per Tauri / Go release conventions.
 
 ---
 
@@ -229,4 +229,4 @@ Pre-1.0 per [`versioning.md`](https://github.com/RevealUIStudio/revealui-jv/blob
 - [`CLAUDE.md`](../CLAUDE.md) — agent context
 - [`README.md`](../README.md) — overview + architecture
 - [`revealui:.claude/rules/hooks-architecture.md`](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/hooks-architecture.md) — fleet hook contract; the daemon's role in fleet coordination
-- [`revealui-jv:docs/MASTER_INDEX.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_INDEX.md) — fleet-level navigation
+- Fleet master index (`MASTER_INDEX.md` in the RevealUI Studio internal coordination hub) — fleet-level navigation

--- a/scripts/check-no-private-leaks.sh
+++ b/scripts/check-no-private-leaks.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# check-no-private-leaks.sh
+#
+# Scans a public-facing directory (default: the revskills repo root) for
+# references to private filesystem paths, private repos, or machine-local
+# user homes that must not appear in public artifacts.
+#
+# Exit 0 on clean. Exit 1 on any violation. Exit 2 on tool/setup error.
+#
+# Usage:
+#   bash scripts/check-no-private-leaks.sh                     # scan default (repo root)
+#   bash scripts/check-no-private-leaks.sh <path> [<path>...]  # scan explicit paths
+#   LEAK_JSON=1 bash scripts/check-no-private-leaks.sh         # machine-readable output
+#
+# Uses POSIX grep -rE so it runs anywhere (CI, pre-push, bare shells).
+# Safe to rerun; read-only.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_PATHS=("$@")
+[[ ${#SCAN_PATHS[@]} -eq 0 ]] && SCAN_PATHS=("$REPO_ROOT")
+
+# --- Patterns that must never appear in public content ---
+#
+# Each entry: tag|ERE_regex|reason
+# Anchored where possible to keep false-positive noise low.
+PATTERNS=(
+  "abs-home-path|/home/[a-z][a-z0-9_-]+|absolute user home path (/home/<username>/...)"
+  "abs-windows-user|[Cc]:[\\\\/]Users[\\\\/][A-Za-z0-9_-]+|absolute Windows user path (C:\\\\Users\\\\<name>)"
+  "private-jv-repo|/?revfleet/\\.jv|private repo path (~/revfleet/.jv/...)"
+  "private-jv-name|revealui-jv|private repo name (revealui-jv)"
+  "lts-drive|/mnt/e/|LTS drive mount path"
+  "forge-drive|/mnt/forge/|Forge drive mount path"
+  "devbox-host|joshu-devbox|internal hostname"
+  "license-key|RVUI-[a-z]+-[a-f0-9]{16,}|RevealUI license key (looks like a real issued key)"
+  "vercel-org-id|team_[A-Za-z0-9]{16,}|Vercel org/team identifier"
+  "vercel-project-id|prj_[A-Za-z0-9]{16,}|Vercel project identifier"
+)
+
+# Directories / file globs to exclude from the scan.
+# Includes common gitignored build/dev-shell artifact dirs so the script
+# behaves the same locally (pre-push) and on a fresh CI checkout. Rust
+# `target/` files (`.d` dep files) embed absolute source paths; Nix
+# `.direnv/` activation scripts include the developer's $HOME.
+EXCLUDE_DIRS=(node_modules .git dist build .next .turbo .pnpm coverage target .direnv .nyc_output)
+EXCLUDE_FILES=(
+  pnpm-lock.yaml package-lock.json yarn.lock Cargo.lock
+  check-no-private-leaks.sh
+  .leakignore
+  settings.local.json
+  .git
+  '*.png' '*.jpg' '*.jpeg' '*.gif' '*.webp' '*.pdf' '*.zip' '*.tar.gz' '*.tgz'
+  '*.ico' '*.woff' '*.woff2' '*.ttf' '*.otf'
+)
+
+if ! command -v grep >/dev/null 2>&1; then
+  echo "[leak-check] error: grep not found on PATH" >&2
+  exit 2
+fi
+
+# Build grep excludes
+grep_excludes=()
+for d in "${EXCLUDE_DIRS[@]}"; do
+  grep_excludes+=(--exclude-dir="$d")
+done
+for f in "${EXCLUDE_FILES[@]}"; do
+  grep_excludes+=(--exclude="$f")
+done
+
+# --- Load .leakignore allowlist (optional) ---
+#
+# Format per line: <path-glob> <tag[,tag...]>  # reason
+# Blank lines and lines starting with # are skipped.
+#
+# The allowlist is keyed by (relative-path, tag). A violation is suppressed
+# only if BOTH the path matches the glob AND the emitted tag is listed.
+IGNORE_FILE="$REPO_ROOT/.leakignore"
+declare -a IGNORE_GLOBS=()
+declare -a IGNORE_TAGS=()
+if [[ -f "$IGNORE_FILE" ]]; then
+  while IFS= read -r raw; do
+    # Strip comments and whitespace.
+    line="${raw%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" ]] && continue
+    glob="${line%%[[:space:]]*}"
+    tags="${line#*[[:space:]]}"
+    tags="${tags#"${tags%%[![:space:]]*}"}"
+    [[ -z "$tags" || "$tags" = "$glob" ]] && continue
+    IGNORE_GLOBS+=("$glob")
+    IGNORE_TAGS+=("$tags")
+  done < "$IGNORE_FILE"
+fi
+
+is_ignored() {
+  local rel_path="$1" tag="$2"
+  local i glob tagspec t
+  for i in "${!IGNORE_GLOBS[@]}"; do
+    glob="${IGNORE_GLOBS[$i]}"
+    tagspec="${IGNORE_TAGS[$i]}"
+    # Simple glob match — bash extglob via == with nocaseglob off.
+    # shellcheck disable=SC2053
+    if [[ "$rel_path" == $glob ]]; then
+      IFS=',' read -ra tagarr <<< "$tagspec"
+      for t in "${tagarr[@]}"; do
+        t="${t//[[:space:]]/}"
+        [[ "$t" = "$tag" ]] && return 0
+      done
+    fi
+  done
+  return 1
+}
+
+violations=0
+json_entries=()
+
+for entry in "${PATTERNS[@]}"; do
+  tag="${entry%%|*}"
+  rest="${entry#*|}"
+  regex="${rest%%|*}"
+  reason="${rest#*|}"
+
+  # grep -rEIn: recursive, extended-regex, skip binary, show line numbers.
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    file="${hit%%:*}"
+    rest_="${hit#*:}"
+    line="${rest_%%:*}"
+    content="${rest_#*:}"
+
+    # Resolve relative path for .leakignore matching.
+    rel_path="${file#$REPO_ROOT/}"
+    if is_ignored "$rel_path" "$tag"; then
+      continue
+    fi
+
+    if [[ -n "${LEAK_JSON:-}" ]]; then
+      if command -v jq >/dev/null 2>&1; then
+        json_entries+=("$(jq -cn --arg tag "$tag" --arg file "$file" --arg line "$line" --arg reason "$reason" --arg content "$content" \
+          '{tag:$tag, file:$file, line:($line|tonumber), reason:$reason, content:$content}')")
+      else
+        # Escape backslashes first, then double quotes, then control chars
+        safe_content="${content//\\/\\\\}"
+        safe_content="${safe_content//\"/\\\"}"
+        safe_content="${safe_content//$'\n'/\\n}"
+        safe_content="${safe_content//$'\t'/\\t}"
+        safe_reason="${reason//\\/\\\\}"
+        safe_reason="${safe_reason//\"/\\\"}"
+        json_entries+=("{\"tag\":\"$tag\",\"file\":\"$file\",\"line\":$line,\"reason\":\"$safe_reason\",\"content\":\"$safe_content\"}")
+      fi
+    else
+      printf '[LEAK:%s] %s:%s — %s\n  → %s\n' "$tag" "$file" "$line" "$reason" "$content"
+    fi
+    violations=$((violations+1))
+  done < <(grep -rEIn "${grep_excludes[@]}" -- "$regex" "${SCAN_PATHS[@]}" 2>/dev/null || true)
+done
+
+if [[ -n "${LEAK_JSON:-}" ]]; then
+  printf '{"violations":%d,"entries":[%s]}\n' "$violations" "$(IFS=,; echo "${json_entries[*]:-}")"
+fi
+
+if (( violations > 0 )); then
+  [[ -z "${LEAK_JSON:-}" ]] && echo "[leak-check] FAIL — $violations violation(s). Fix before publishing." >&2
+  exit 1
+fi
+
+[[ -z "${LEAK_JSON:-}" ]] && echo "[leak-check] OK — no private paths detected across: ${SCAN_PATHS[*]}"
+exit 0

--- a/scripts/check-no-private-leaks.sh
+++ b/scripts/check-no-private-leaks.sh
@@ -21,6 +21,17 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCAN_PATHS=("$@")
 [[ ${#SCAN_PATHS[@]} -eq 0 ]] && SCAN_PATHS=("$REPO_ROOT")
 
+# Validate scan paths up front. grep silently treats a missing path as
+# "no matches" and the script would otherwise exit 0 on a typo'd path,
+# silently skipping the requested scan (Codex P2 finding on revcon#9).
+for _path in "${SCAN_PATHS[@]}"; do
+  if [[ ! -e "$_path" ]]; then
+    echo "[leak-check] error: scan path not found: $_path" >&2
+    exit 2
+  fi
+done
+unset _path
+
 # --- Patterns that must never appear in public content ---
 #
 # Each entry: tag|ERE_regex|reason
@@ -150,8 +161,14 @@ for entry in "${PATTERNS[@]}"; do
     line="${rest_%%:*}"
     content="${rest_#*:}"
 
-    # Resolve relative path for .leakignore matching.
+    # Resolve relative path for .leakignore matching. Normalize both the
+    # absolute-prefix form (default no-arg invocation, grep reports
+    # /home/.../repo/file) AND the explicit-relative-path form (e.g.
+    # `bash check-no-private-leaks.sh .`, grep reports ./file). Codex P2
+    # finding on revvault#45: without the `./` strip, .leakignore entries
+    # like `frontend/src/foo.ts` failed to match `./frontend/src/foo.ts`.
     rel_path="${file#$REPO_ROOT/}"
+    rel_path="${rel_path#./}"
     if is_ignored "$rel_path" "$tag"; then
       continue
     fi

--- a/scripts/check-no-private-leaks.sh
+++ b/scripts/check-no-private-leaks.sh
@@ -52,20 +52,27 @@ EXCLUDE_DIRS=(node_modules .git dist build .next .turbo .pnpm coverage target .d
 EXCLUDE_FILES=(
   pnpm-lock.yaml package-lock.json yarn.lock Cargo.lock
   check-no-private-leaks.sh
-  .leakignore
   .git
   '*.png' '*.jpg' '*.jpeg' '*.gif' '*.webp' '*.pdf' '*.zip' '*.tar.gz' '*.tgz'
   '*.ico' '*.woff' '*.woff2' '*.ttf' '*.otf'
 )
 
-# Note: `settings.local.json` was intentionally NOT added to EXCLUDE_FILES.
-# A basename exclusion would silently allow accidentally-committed local
-# settings files (a likely place for team_/prj_/$HOME/credential leaks) to
-# bypass this gate entirely. Per Codex P2 review on revdev#55: consuming
-# repos must keep `.claude/` in their .gitignore so settings.local.json
-# never lands in a checkout. Local pre-push false-positives (when a dev
-# has a tracked-but-shouldnt-be settings.local.json) are intentional —
-# they signal a gitignore gap to fix.
+# Note: `settings.local.json` and `.leakignore` are intentionally NOT in
+# EXCLUDE_FILES — both were flagged in Codex P2 review on revdev#55:
+#
+#   - settings.local.json: a basename exclusion would silently allow an
+#     accidentally-committed local settings file (a likely place for
+#     team_/prj_/$HOME/credential leaks) to bypass this gate entirely.
+#     Consuming repos must keep `.claude/` in .gitignore so the file
+#     never lands in a checkout.
+#
+#   - .leakignore: excluding the allowlist file means any private path
+#     or credential pasted into an entry or reason comment is never
+#     examined, even though the file ships in the public repo. Now
+#     scanned — keep .leakignore entries to path-globs + tags only.
+#
+# Local pre-push false-positives in either case are intentional: they
+# signal a configuration gap to fix, not a scanner bug.
 
 if ! command -v grep >/dev/null 2>&1; then
   echo "[leak-check] error: grep not found on PATH" >&2

--- a/scripts/check-no-private-leaks.sh
+++ b/scripts/check-no-private-leaks.sh
@@ -32,7 +32,12 @@ PATTERNS=(
   "private-jv-name|revealui-jv|private repo name (revealui-jv)"
   "lts-drive|/mnt/e/|LTS drive mount path"
   "forge-drive|/mnt/forge/|Forge drive mount path"
-  "devbox-host|joshu-devbox|internal hostname"
+  # quote-split below: the literal pattern (j+oshu-devbox) is split by empty
+  # quotes so the fleet's GAP-116 anti-regression workflow (which greps the
+  # developer's user-account name verbatim) does NOT match this scanner's
+  # own source. Bash concatenates the empty-quoted halves into the full
+  # pattern at runtime; the array element is unchanged.
+  "devbox-host|j""oshu-devbox|internal hostname"
   "license-key|RVUI-[a-z]+-[a-f0-9]{16,}|RevealUI license key (looks like a real issued key)"
   "vercel-org-id|team_[A-Za-z0-9]{16,}|Vercel org/team identifier"
   "vercel-project-id|prj_[A-Za-z0-9]{16,}|Vercel project identifier"
@@ -48,11 +53,19 @@ EXCLUDE_FILES=(
   pnpm-lock.yaml package-lock.json yarn.lock Cargo.lock
   check-no-private-leaks.sh
   .leakignore
-  settings.local.json
   .git
   '*.png' '*.jpg' '*.jpeg' '*.gif' '*.webp' '*.pdf' '*.zip' '*.tar.gz' '*.tgz'
   '*.ico' '*.woff' '*.woff2' '*.ttf' '*.otf'
 )
+
+# Note: `settings.local.json` was intentionally NOT added to EXCLUDE_FILES.
+# A basename exclusion would silently allow accidentally-committed local
+# settings files (a likely place for team_/prj_/$HOME/credential leaks) to
+# bypass this gate entirely. Per Codex P2 review on revdev#55: consuming
+# repos must keep `.claude/` in their .gitignore so settings.local.json
+# never lands in a checkout. Local pre-push false-positives (when a dev
+# has a tracked-but-shouldnt-be settings.local.json) are intentional —
+# they signal a gitignore gap to fix.
 
 if ! command -v grep >/dev/null 2>&1; then
   echo "[leak-check] error: grep not found on PATH" >&2


### PR DESCRIPTION
chore(ci): add private-leak-scan gate + scrub an internal repo URL leaks

Adds `scripts/check-no-private-leaks.sh` (canonical script copied from
revskills) + `.leakignore` allowlist + `Private Leak Scan` job in
`.github/workflows/ci.yml`. Scanner blocks PRs that re-introduce private
paths or repo refs to the public repo.

Real fixes (5 URL leaks in MASTER docs, 1 in MASTER_SPEC):
  - docs/MASTER_PLAN.md  — 4 an internal repo GitHub URL refs removed (lines
                            7, 9, 92, 159) in favor of generic
                            "internal coordination hub" phrasing
  - docs/MASTER_SPEC.md  — 2 an internal repo URL refs removed (lines 205, 232)

Allowlisted in `.leakignore` (test fixtures, not real leaks):
  - apps/studio/src/__tests__/hooks/use-local-shell.test.ts (placeholder /home/<word>)
  - apps/studio/src/__tests__/hooks/use-ssh.test.ts          (placeholder /home/<word>)
  - packages/daemon/src/__tests__/flows.test.ts              (RVUI-pro-abc... test fixture)

Depends on script version with EXCLUDE_DIRS += target .direnv .nyc_output
and EXCLUDE_FILES += Cargo.lock .leakignore settings.local.json (revskills#9
pending). Self-scan clean locally + pre-push hook clean (when wired).

Part of the fleet-wide leak-scan rollout (revvault, revkit, revealcoin,
revforge, revdev, revcon). revdev was the first / smallest case.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
