### PR TITLE
chore: promote test -> main (13 commits: daemon hardening + Studio polling + MASTER_PLAN)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,9 @@ pnpm --filter studio tauri:dev    # Start Studio in dev mode
 pnpm --filter studio tauri build  # Build desktop binary
 pnpm typecheck:studio             # Typecheck Studio frontend
 
-# Console
-go run ./apps/console             # Run Console
-go build -o rvui ./apps/console   # Build Console binary
+# Console (no root go.mod; module lives under apps/console/ per CI ci.yml:78-79)
+cd apps/console && go run .                    # Run Console
+cd apps/console && go build -o ../../rvui .    # Build Console binary
 
 # Workspace
 pnpm -r --filter=!studio build    # Build all packages (skip Tauri)

--- a/apps/studio/src/__tests__/components/Dashboard.test.tsx
+++ b/apps/studio/src/__tests__/components/Dashboard.test.tsx
@@ -7,6 +7,16 @@ import { SettingsContext } from '../../hooks/use-settings';
 import type { StatusContextValue } from '../../hooks/use-status';
 import { StatusContext } from '../../hooks/use-status';
 
+// Mock health API to prevent fetch calls from useHealth.
+// Without this mock the initial poll() fires a real fetch that hangs on
+// AbortSignal.timeout(5_000) in CI runners; when the abort resolves after
+// the synchronous tests complete and jsdom has been torn down, the
+// setReachable() call hits a missing `window` and Vitest reports it as an
+// unhandled error. See revdev CI run 25296294717 attempt 1 (2026-05-04).
+vi.mock('../../lib/health-api', () => ({
+  fetchHealth: vi.fn().mockResolvedValue(null),
+}));
+
 // Mock billing API to prevent fetch calls from useSubscription
 vi.mock('../../lib/billing-api', () => ({
   fetchSubscription: vi.fn().mockResolvedValue({

--- a/apps/studio/src/__tests__/hooks/use-health.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-health.test.ts
@@ -87,7 +87,7 @@ describe('useHealth', () => {
       await vi.advanceTimersByTimeAsync(10);
     });
 
-    expect(fetchHealth).toHaveBeenCalledWith('http://localhost:3004');
+    expect(fetchHealth).toHaveBeenCalledWith('http://localhost:3004', expect.anything());
     expect(result.current.health).toEqual(MOCK_HEALTH);
     expect(result.current.reachable).toBe(true);
     expect(result.current.loading).toBe(false);
@@ -248,6 +248,6 @@ describe('useHealth', () => {
       await vi.advanceTimersByTimeAsync(10);
     });
 
-    expect(fetchHealth).toHaveBeenCalledWith('https://api.revealui.com');
+    expect(fetchHealth).toHaveBeenCalledWith('https://api.revealui.com', expect.anything());
   });
 });

--- a/apps/studio/src/__tests__/hooks/use-polling-fetch.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-polling-fetch.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for usePollingFetch — the shared polling helper used by
+ * useStatus / useHealth / useSubscription / etc.
+ *
+ * The Pillar 1 §C audit catalogued ~30 production surfaces sharing the
+ * same hygiene gap (no AbortController, no isMounted guard) that bit
+ * Dashboard.test.tsx today. usePollingFetch is the durable production-
+ * side fix; these tests pin its contract so future migrations can rely
+ * on it.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePollingFetch } from '../../hooks/use-polling-fetch';
+
+describe('usePollingFetch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('fires fn(signal) on mount and surfaces the result via data', async () => {
+    const fn = vi.fn(async (_signal: AbortSignal) => ({ value: 42 }));
+    const { result } = renderHook(() => usePollingFetch(fn, null));
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toEqual({ value: 42 });
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('passes an AbortSignal to fn that fires on unmount', async () => {
+    const observed: AbortSignal[] = [];
+    const fn = vi.fn(async (signal: AbortSignal) => {
+      observed.push(signal);
+      return 'ok';
+    });
+
+    const { unmount } = renderHook(() => usePollingFetch(fn, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.aborted).toBe(false);
+
+    unmount();
+
+    expect(observed[0]?.aborted).toBe(true);
+  });
+
+  it('polls at the configured interval', async () => {
+    const fn = vi.fn(async () => 'tick');
+    renderHook(() => usePollingFetch(fn, 1000));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not poll when intervalMs is null (fires once on mount only)', async () => {
+    const fn = vi.fn(async () => 'once');
+    renderHook(() => usePollingFetch(fn, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats zero or negative intervalMs the same as null (no polling)', async () => {
+    const fn = vi.fn(async () => 'once');
+    const { rerender } = renderHook(({ ms }: { ms: number }) => usePollingFetch(fn, ms), {
+      initialProps: { ms: 0 },
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    rerender({ ms: -100 });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    // Re-render with new fn-identity-equivalent ms flips the effect: it
+    // re-runs runOnce once on the deps change, then idles. So we expect
+    // exactly 2 total calls (one per effect activation).
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the interval on unmount', async () => {
+    const fn = vi.fn(async () => 'tick');
+    const { unmount } = renderHook(() => usePollingFetch(fn, 1000));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the in-flight signal when a new poll begins (no overlap)', async () => {
+    const observed: AbortSignal[] = [];
+    let resolveCurrent: ((value: string) => void) | null = null;
+
+    const fn = vi.fn(async (signal: AbortSignal) => {
+      observed.push(signal);
+      return new Promise<string>((resolve) => {
+        resolveCurrent = resolve;
+      });
+    });
+
+    renderHook(() => usePollingFetch(fn, 1000));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.aborted).toBe(false);
+
+    // Trigger second call by advancing past the interval. The first call
+    // is still in flight (resolveCurrent never called) — its signal should
+    // abort when the new call begins.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(observed).toHaveLength(2);
+    expect(observed[0]?.aborted).toBe(true);
+    expect(observed[1]?.aborted).toBe(false);
+
+    // Cleanup: resolve the dangling promises so vitest doesn't warn.
+    if (resolveCurrent) (resolveCurrent as (v: string) => void)('done');
+  });
+
+  it('surfaces errors via the error state', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const { result } = renderHook(() => usePollingFetch(fn, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('boom');
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('wraps non-Error rejections in an Error', async () => {
+    const fn = vi.fn(async () => {
+      throw 'string failure';
+    });
+    const { result } = renderHook(() => usePollingFetch(fn, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('string failure');
+  });
+
+  it('clears a previous error after a successful re-fetch', async () => {
+    let shouldFail = true;
+    const fn = vi.fn(async () => {
+      if (shouldFail) throw new Error('first call failed');
+      return 'ok';
+    });
+
+    const { result } = renderHook(() => usePollingFetch(fn, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(result.current.error?.message).toBe('first call failed');
+
+    shouldFail = false;
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toBe('ok');
+  });
+
+  it("swallows AbortError silently (the helper's own abort)", async () => {
+    const fn = vi.fn(async (signal: AbortSignal) => {
+      if (signal.aborted) {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        throw err;
+      }
+      return 'ok';
+    });
+
+    const { result, unmount } = renderHook(() => usePollingFetch(fn, null));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    // No error surfaces from the AbortError path
+    expect(result.current.error).toBeNull();
+    unmount();
+  });
+
+  it('swallows TimeoutError silently', async () => {
+    const fn = vi.fn(async () => {
+      const err = new Error('timed out');
+      err.name = 'TimeoutError';
+      throw err;
+    });
+
+    const { result } = renderHook(() => usePollingFetch(fn, null));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
+  it('refresh() returns a Promise that resolves after the call completes', async () => {
+    const fn = vi.fn(async () => 'value');
+    const { result } = renderHook(() => usePollingFetch(fn, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('restarts polling when fn identity changes (caller useCallback dep change)', async () => {
+    const fn1 = vi.fn(async () => 'first');
+    const fn2 = vi.fn(async () => 'second');
+
+    const { result, rerender } = renderHook(
+      ({ fn }: { fn: typeof fn1 }) => usePollingFetch(fn, 1000),
+      { initialProps: { fn: fn1 } },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(result.current.data).toBe('first');
+
+    rerender({ fn: fn2 });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(fn2).toHaveBeenCalled();
+    expect(result.current.data).toBe('second');
+  });
+});

--- a/apps/studio/src/__tests__/hooks/use-subscription.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-subscription.test.ts
@@ -111,8 +111,16 @@ describe('useSubscription', () => {
       await vi.advanceTimersByTimeAsync(10);
     });
 
-    expect(fetchSubscription).toHaveBeenCalledWith('http://localhost:3004', 'test-token');
-    expect(fetchUsage).toHaveBeenCalledWith('http://localhost:3004', 'test-token');
+    expect(fetchSubscription).toHaveBeenCalledWith(
+      'http://localhost:3004',
+      'test-token',
+      expect.anything(),
+    );
+    expect(fetchUsage).toHaveBeenCalledWith(
+      'http://localhost:3004',
+      'test-token',
+      expect.anything(),
+    );
     expect(result.current.subscription).toEqual(MOCK_SUBSCRIPTION);
     expect(result.current.usage).toEqual(MOCK_USAGE);
     expect(result.current.loading).toBe(false);

--- a/apps/studio/src/hooks/use-apps.ts
+++ b/apps/studio/src/hooks/use-apps.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { listApps, startApp, stopApp } from '../lib/invoke';
 import type { AppStatus } from '../types';
+import { usePollingFetch } from './use-polling-fetch';
 
 /** Poll listApps until the named app matches the expected running state, or timeout. */
 async function pollUntil(
@@ -21,55 +22,71 @@ async function pollUntil(
 }
 
 export function useApps() {
-  const [apps, setApps] = useState<AppStatus[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const lastResultRef = useRef<AppStatus[]>([]);
+  const [actionError, setActionError] = useState<string | null>(null);
   const [operating, setOperating] = useState<Record<string, boolean>>({});
 
-  const refresh = useCallback(async () => {
-    try {
-      const result = await listApps();
-      setApps(result);
-      setLoading(false);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-      setLoading(false);
-    }
+  const fetchFn = useCallback(async (_signal: AbortSignal) => {
+    if (document.hidden) return lastResultRef.current;
+    const result = await listApps();
+    lastResultRef.current = result;
+    return result;
   }, []);
 
-  useEffect(() => {
-    refresh();
-    const id = setInterval(() => {
-      if (!document.hidden) refresh();
-    }, 5_000);
-    return () => clearInterval(id);
-  }, [refresh]);
+  const { data, error: pollError, loading, refresh } = usePollingFetch(fetchFn, 5_000);
 
-  const start = useCallback(async (name: string) => {
-    setOperating((p) => ({ ...p, [name]: true }));
-    setError(null);
-    try {
-      await startApp(name);
-      await pollUntil(name, true, setApps, 1000, 10_000);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setOperating((p) => ({ ...p, [name]: false }));
-    }
-  }, []);
+  const apps = data ?? lastResultRef.current;
+  const error = actionError ?? pollError?.message ?? null;
 
-  const stop = useCallback(async (name: string) => {
-    setOperating((p) => ({ ...p, [name]: true }));
-    setError(null);
-    try {
-      await stopApp(name);
-      await pollUntil(name, false, setApps, 500, 5_000);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setOperating((p) => ({ ...p, [name]: false }));
-    }
-  }, []);
+  const start = useCallback(
+    async (name: string) => {
+      setOperating((p) => ({ ...p, [name]: true }));
+      setActionError(null);
+      try {
+        await startApp(name);
+        await pollUntil(
+          name,
+          true,
+          (updated) => {
+            lastResultRef.current = updated;
+          },
+          1000,
+          10_000,
+        );
+        await refresh();
+      } catch (err) {
+        setActionError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setOperating((p) => ({ ...p, [name]: false }));
+      }
+    },
+    [refresh],
+  );
+
+  const stop = useCallback(
+    async (name: string) => {
+      setOperating((p) => ({ ...p, [name]: true }));
+      setActionError(null);
+      try {
+        await stopApp(name);
+        await pollUntil(
+          name,
+          false,
+          (updated) => {
+            lastResultRef.current = updated;
+          },
+          500,
+          5_000,
+        );
+        await refresh();
+      } catch (err) {
+        setActionError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setOperating((p) => ({ ...p, [name]: false }));
+      }
+    },
+    [refresh],
+  );
 
   return { apps, loading, error, operating, refresh, start, stop };
 }

--- a/apps/studio/src/hooks/use-harness.ts
+++ b/apps/studio/src/hooks/use-harness.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   harnessCheckFile,
   harnessClaimTask,
@@ -22,6 +22,7 @@ import type {
   HarnessSession,
   HarnessTask,
 } from '../types';
+import { usePollingFetch } from './use-polling-fetch';
 
 /** Fallback poll interval for browser dev mode (no Tauri events available) */
 const BROWSER_POLL_MS = 5_000;
@@ -188,14 +189,17 @@ export function useHarness(agentId?: string): UseHarnessReturn {
     };
   }, []);
 
-  // Browser mode: fall back to polling (no Tauri event system available)
-  useEffect(() => {
-    if (isTauri()) return;
-
-    void loadAllRef.current();
-    const id = setInterval(() => void loadAllRef.current(), BROWSER_POLL_MS);
-    return () => clearInterval(id);
+  // Browser mode: fall back to polling via usePollingFetch (no Tauri
+  // event system available). Tauri mode subscribes to push events
+  // (above) and disables the helper by passing intervalMs=null. The
+  // helper returns void from this fetcher — actual state lives in the
+  // outer setState calls that loadAll() makes; we're using the helper
+  // here purely for its abort + isMounted hygiene wrapping the polled
+  // call.
+  const browserPollFn = useCallback(async (_signal: AbortSignal): Promise<void> => {
+    await loadAllRef.current();
   }, []);
+  usePollingFetch(browserPollFn, isTauri() ? null : BROWSER_POLL_MS);
 
   async function refresh(): Promise<void> {
     setLoading(true);

--- a/apps/studio/src/hooks/use-health.ts
+++ b/apps/studio/src/hooks/use-health.ts
@@ -2,51 +2,48 @@
  * useHealth — Polls the production API's readiness probe.
  *
  * Returns the health status (healthy/degraded/unhealthy/unreachable)
- * along with individual check results. Polls on the settings interval.
+ * along with individual check results. Polls on the settings interval
+ * via `usePollingFetch`, which gives this hook full abort + isMounted
+ * hygiene without per-hook plumbing.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { HealthResponse } from '../lib/health-api';
 import { fetchHealth } from '../lib/health-api';
+import { usePollingFetch } from './use-polling-fetch';
 import { useSettingsContext } from './use-settings';
 
 export interface HealthState {
   health: HealthResponse | null;
   reachable: boolean;
   loading: boolean;
-  refresh: () => void;
+  refresh: () => Promise<void>;
 }
 
 export function useHealth(): HealthState {
   const { settings } = useSettingsContext();
+  const { apiUrl, pollingIntervalMs } = settings;
 
-  const [health, setHealth] = useState<HealthResponse | null>(null);
-  const [reachable, setReachable] = useState(true);
-  const [loading, setLoading] = useState(true);
+  const fetchFn = useCallback(
+    (signal: AbortSignal): Promise<HealthResponse | null> => fetchHealth(apiUrl, signal),
+    [apiUrl],
+  );
 
-  async function poll() {
-    const result = await fetchHealth(settings.apiUrl);
-    if (result) {
-      setHealth(result);
-      setReachable(true);
-    } else {
-      setReachable(false);
-    }
-    setLoading(false);
-  }
+  const { data, loading, refresh } = usePollingFetch(fetchFn, pollingIntervalMs);
 
-  function refresh() {
-    setLoading(true);
-    poll();
-  }
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-poll when apiUrl or interval changes
-  useEffect(() => {
-    poll();
-
-    const interval = setInterval(poll, settings.pollingIntervalMs);
-    return () => clearInterval(interval);
-  }, [settings.apiUrl, settings.pollingIntervalMs]);
-
-  return { health, reachable, loading, refresh };
+  // `data === null` after a fetchHealth round-trip means the API was
+  // unreachable (network error / timeout). The legacy hook surfaced
+  // that as `reachable: false` rather than as an error, so we preserve
+  // that mapping. Initial render (data === null, loading === true) is
+  // the "no probe yet" state — keep `reachable` optimistic until we
+  // see at least one resolved-to-null result.
+  return useMemo<HealthState>(
+    () => ({
+      health: data ?? null,
+      reachable: loading ? true : data !== null,
+      loading,
+      refresh,
+    }),
+    [data, loading, refresh],
+  );
 }

--- a/apps/studio/src/hooks/use-inference.ts
+++ b/apps/studio/src/hooks/use-inference.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import {
   inferenceOllamaDelete,
   inferenceOllamaModels,
@@ -11,118 +11,115 @@ import {
   inferenceSnapRemove,
 } from '../lib/invoke';
 import type { OllamaModel, OllamaStatus, SnapModel } from '../types';
+import { usePollingFetch } from './use-polling-fetch';
+
+interface InferenceSnapshot {
+  ollama: OllamaStatus;
+  models: OllamaModel[];
+  snaps: SnapModel[];
+}
 
 export function useInference() {
-  const [ollama, setOllama] = useState<OllamaStatus | null>(null);
-  const [models, setModels] = useState<OllamaModel[]>([]);
-  const [snaps, setSnaps] = useState<SnapModel[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const lastResultRef = useRef<InferenceSnapshot | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
   const [pulling, setPulling] = useState(false);
   const [installingSnap, setInstallingSnap] = useState<string | null>(null);
 
-  async function refresh(): Promise<void> {
-    try {
-      const [ollamaResult, snapList] = await Promise.all([
-        inferenceOllamaStatus(),
-        inferenceSnapList(),
-      ]);
-      setOllama(ollamaResult);
-      setSnaps(snapList);
-
-      if (ollamaResult.running) {
-        const modelList = await inferenceOllamaModels();
-        setModels(modelList);
-      } else {
-        setModels([]);
-      }
-
-      setLoading(false);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-      setLoading(false);
+  const fetchFn = useCallback(async (_signal: AbortSignal): Promise<InferenceSnapshot> => {
+    if (document.hidden && lastResultRef.current !== null) {
+      return lastResultRef.current;
     }
-  }
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: refresh is stable, run on mount only
-  useEffect(() => {
-    refresh();
-    const id = setInterval(() => {
-      if (!document.hidden) refresh();
-    }, 30_000);
-    return () => clearInterval(id);
+    const [ollamaResult, snapList] = await Promise.all([
+      inferenceOllamaStatus(),
+      inferenceSnapList(),
+    ]);
+    const modelList = ollamaResult.running ? await inferenceOllamaModels() : [];
+    const snapshot: InferenceSnapshot = {
+      ollama: ollamaResult,
+      models: modelList,
+      snaps: snapList,
+    };
+    lastResultRef.current = snapshot;
+    return snapshot;
   }, []);
 
+  const { data, error: pollError, loading, refresh } = usePollingFetch(fetchFn, 30_000);
+
+  const ollama = data?.ollama ?? null;
+  const models = data?.models ?? [];
+  const snaps = data?.snaps ?? [];
+  const error = actionError ?? pollError?.message ?? null;
+
   async function startOllama(): Promise<void> {
-    setError(null);
+    setActionError(null);
     try {
       await inferenceOllamaStart();
       await new Promise((r) => setTimeout(r, 2000));
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setActionError(err instanceof Error ? err.message : String(err));
     }
   }
 
   async function stopOllama(): Promise<void> {
-    setError(null);
+    setActionError(null);
     try {
       await inferenceOllamaStop();
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setActionError(err instanceof Error ? err.message : String(err));
     }
   }
 
   async function pullModel(name: string): Promise<void> {
-    setError(null);
+    setActionError(null);
     setPulling(true);
     try {
       const result = await inferenceOllamaPull(name);
       if (!result.success) {
-        setError(result.message);
+        setActionError(result.message);
       }
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setActionError(err instanceof Error ? err.message : String(err));
     } finally {
       setPulling(false);
     }
   }
 
   async function deleteModel(name: string): Promise<void> {
-    setError(null);
+    setActionError(null);
     try {
       await inferenceOllamaDelete(name);
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setActionError(err instanceof Error ? err.message : String(err));
     }
   }
 
   async function installSnap(snapName: string): Promise<void> {
-    setError(null);
+    setActionError(null);
     setInstallingSnap(snapName);
     try {
       const result = await inferenceSnapInstall(snapName);
       if (!result.success) {
-        setError(result.message);
+        setActionError(result.message);
       }
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setActionError(err instanceof Error ? err.message : String(err));
     } finally {
       setInstallingSnap(null);
     }
   }
 
   async function removeSnap(snapName: string): Promise<void> {
-    setError(null);
+    setActionError(null);
     try {
       await inferenceSnapRemove(snapName);
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setActionError(err instanceof Error ? err.message : String(err));
     }
   }
 

--- a/apps/studio/src/hooks/use-polling-fetch.ts
+++ b/apps/studio/src/hooks/use-polling-fetch.ts
@@ -1,0 +1,138 @@
+/**
+ * usePollingFetch — fire an async fetcher on mount + at a fixed interval,
+ * with full abort + isMounted hygiene.
+ *
+ * Why: every studio polling hook (useStatus, useHealth, useSubscription,
+ * useRvuiBalance, useTunnel, …) was hand-rolling an initial fetch + a
+ * setInterval, with no AbortController and no isMounted guard. Initial
+ * fetches that resolved post-unmount (e.g. inside a Vitest jsdom
+ * teardown, or a real user closing a window mid-fetch) called setState
+ * against a torn-down React tree, which crashed React 19's
+ * dispatchSetState path with "ReferenceError: window is not defined".
+ * The Pillar 1 §C audit catalogued ~30 production surfaces sharing
+ * this gap (revdev studio + revealui admin + @revealui/ai Pro hooks).
+ *
+ * Behavioral contract:
+ *   - Fires fn(signal) on mount.
+ *   - Re-fires fn(signal) every intervalMs while mounted (when intervalMs
+ *     is a positive number; null / 0 / negative disables polling).
+ *   - On unmount: aborts the in-flight signal and clears the interval.
+ *   - Aborts the previous in-flight call before firing a new one (no
+ *     overlap; the most-recent call always wins).
+ *   - Swallows AbortError + TimeoutError silently (those are the helper's
+ *     own abort, not real failures).
+ *   - Surfaces other errors via `error` state. Successful resolves clear
+ *     the previous error.
+ *   - Never sets state after unmount.
+ *
+ * Caller contract:
+ *   - `fn` should be wrapped in `useCallback` so its identity only changes
+ *     when its inputs change. The hook restarts when `fn` changes
+ *     (new initial fetch + new interval bound to the new fn).
+ *   - `fn` should propagate the provided AbortSignal to any abortable
+ *     work it does (e.g. `fetch(url, { signal })`). For non-abortable
+ *     work (Tauri invoke etc.), the signal is still useful — the helper
+ *     drops the result if the signal aborted before resolution.
+ *   - Polling can be conditionally disabled by passing `null` for
+ *     `intervalMs` (e.g. "wait until authenticated, then poll").
+ */
+
+import type { DependencyList } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UsePollingFetchResult<T> {
+  /** Most-recent successful result; null until the first resolve. */
+  data: T | null;
+  /** Most-recent unhandled error; null after a successful resolve. */
+  error: Error | null;
+  /** True from the start of the most-recent call until it resolves or aborts. */
+  loading: boolean;
+  /** Trigger an immediate re-fetch. Returns a Promise that resolves
+   *  when the call completes (success, error, or abort). */
+  refresh: () => Promise<void>;
+}
+
+function isAbortLike(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === 'AbortError' || err.name === 'TimeoutError';
+}
+
+export function usePollingFetch<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  intervalMs: number | null,
+): UsePollingFetchResult<T>;
+export function usePollingFetch<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  intervalMs: number | null,
+  // Reserved for callers that prefer explicit deps over useCallback-on-fn.
+  // The hook also re-runs when any dep changes.
+  deps: DependencyList,
+): UsePollingFetchResult<T>;
+export function usePollingFetch<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  intervalMs: number | null,
+  deps?: DependencyList,
+): UsePollingFetchResult<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(true);
+  const isMountedRef = useRef(true);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  // Stable ref to fn so internal helpers can read it without going stale.
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+
+  const runOnce = useCallback(async (): Promise<void> => {
+    // Abort any in-flight call before starting a new one. The previous
+    // call's result-handling block sees ctrl.signal.aborted and bails
+    // before touching state.
+    controllerRef.current?.abort();
+    const ctrl = new AbortController();
+    controllerRef.current = ctrl;
+
+    if (isMountedRef.current) setLoading(true);
+
+    try {
+      const result = await fnRef.current(ctrl.signal);
+      if (!isMountedRef.current || ctrl.signal.aborted) return;
+      setData(result);
+      setError(null);
+    } catch (err) {
+      if (!isMountedRef.current || ctrl.signal.aborted) return;
+      // Swallow our own abort. AbortError fires when ctrl.abort() races
+      // a fetch call; TimeoutError fires when the consumer combined the
+      // helper's signal with AbortSignal.timeout. Both are expected,
+      // not real failures.
+      if (isAbortLike(err)) return;
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      if (isMountedRef.current && !ctrl.signal.aborted) setLoading(false);
+    }
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deps from caller, intentional
+  useEffect(() => {
+    isMountedRef.current = true;
+    runOnce();
+
+    let interval: ReturnType<typeof setInterval> | null = null;
+    if (intervalMs !== null && intervalMs > 0) {
+      interval = setInterval(() => {
+        runOnce();
+      }, intervalMs);
+    }
+
+    return () => {
+      isMountedRef.current = false;
+      controllerRef.current?.abort();
+      if (interval !== null) clearInterval(interval);
+    };
+    // The effect depends on `intervalMs` (controls the timer) and on
+    // `fn`'s identity (so callers' `useCallback` dep changes restart
+    // the loop) plus any extra `deps` the caller wants to track.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [intervalMs, fn, runOnce, ...(deps ?? [])]);
+
+  return { data, error, loading, refresh: runOnce };
+}

--- a/apps/studio/src/hooks/use-rvui-balance.ts
+++ b/apps/studio/src/hooks/use-rvui-balance.ts
@@ -3,12 +3,14 @@
  *
  * Reads the wallet address + network from StudioSettings (localStorage).
  * Queries the Token-2022 Associated Token Account for the RVUI mint.
- * Polls every 60 seconds. Returns zero gracefully if ATA doesn't exist.
+ * Polls every 60 seconds via `usePollingFetch`. Returns zero gracefully
+ * if the ATA doesn't exist; null when no wallet is configured.
  */
 
 import { RVUI_MINT_ADDRESSES, RVUI_TOKEN_CONFIG } from '@revealui/contracts';
 import { address, createSolanaRpc } from '@solana/kit';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useMemo } from 'react';
+import { usePollingFetch } from './use-polling-fetch';
 import { useSettingsContext } from './use-settings';
 
 const POLL_INTERVAL_MS = 60_000;
@@ -17,6 +19,11 @@ const CLUSTER_URLS: Record<string, string> = {
   devnet: 'https://api.devnet.solana.com',
   'mainnet-beta': 'https://api.mainnet-beta.solana.com',
 };
+
+interface BalancePayload {
+  balance: string;
+  uiAmount: number;
+}
 
 export interface RvuiBalanceState {
   /** Human-readable balance (e.g., "1,234.56 RVUI"). Null if not configured. */
@@ -30,34 +37,24 @@ export interface RvuiBalanceState {
   /** Whether a wallet address is configured. */
   configured: boolean;
   /** Trigger an immediate refresh. */
-  refresh: () => void;
+  refresh: () => Promise<void>;
 }
 
 export function useRvuiBalance(): RvuiBalanceState {
   const { settings } = useSettingsContext();
-  const [balance, setBalance] = useState<string | null>(null);
-  const [uiAmount, setUiAmount] = useState(0);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
   const walletAddress = settings.solanaWalletAddress;
   const network = settings.solanaNetwork;
   const configured = walletAddress.length > 0;
 
-  const fetchBalance = useCallback(async () => {
-    if (!walletAddress) return;
+  const fetchFn = useCallback(
+    async (_signal: AbortSignal): Promise<BalancePayload | null> => {
+      if (!walletAddress) return null;
 
-    const mintAddress = RVUI_MINT_ADDRESSES[network];
-    if (!mintAddress) {
-      setError(`RVUI not deployed on ${network}`);
-      return;
-    }
+      const mintAddress = RVUI_MINT_ADDRESSES[network];
+      if (!mintAddress) {
+        throw new Error(`RVUI not deployed on ${network}`);
+      }
 
-    setLoading(true);
-    setError(null);
-
-    try {
       const rpcUrl = CLUSTER_URLS[network] ?? CLUSTER_URLS.devnet;
       const rpc = createSolanaRpc(rpcUrl);
       const wallet = address(walletAddress);
@@ -72,55 +69,44 @@ export function useRvuiBalance(): RvuiBalanceState {
         .send();
 
       if (response.value.length === 0) {
-        setBalance('0');
-        setUiAmount(0);
-      } else {
-        const accountData = response.value[0].account.data as {
-          parsed: { info: { tokenAmount: { amount: string } } };
-        };
-        const raw = BigInt(accountData.parsed.info.tokenAmount.amount);
-        const divisor = 10 ** RVUI_TOKEN_CONFIG.decimals;
-        const amount = Number(raw) / divisor;
-
-        setUiAmount(amount);
-        setBalance(
-          amount.toLocaleString(undefined, {
-            minimumFractionDigits: 0,
-            maximumFractionDigits: 2,
-          }),
-        );
+        return { balance: '0', uiAmount: 0 };
       }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to fetch RVUI balance';
-      setError(msg);
-    } finally {
-      setLoading(false);
-    }
-  }, [walletAddress, network]);
 
-  // Initial fetch + polling
-  useEffect(() => {
-    if (!configured) {
-      setBalance(null);
-      setUiAmount(0);
-      setError(null);
-      return;
-    }
+      const accountData = response.value[0].account.data as {
+        parsed: { info: { tokenAmount: { amount: string } } };
+      };
+      const raw = BigInt(accountData.parsed.info.tokenAmount.amount);
+      const divisor = 10 ** RVUI_TOKEN_CONFIG.decimals;
+      const amount = Number(raw) / divisor;
 
-    void fetchBalance();
+      return {
+        balance: amount.toLocaleString(undefined, {
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 2,
+        }),
+        uiAmount: amount,
+      };
+    },
+    [walletAddress, network],
+  );
 
-    intervalRef.current = setInterval(() => {
-      void fetchBalance();
-    }, POLL_INTERVAL_MS);
+  // Disable polling entirely when no wallet is configured. The fetcher
+  // gates on walletAddress and would return null anyway, but skipping
+  // the interval avoids a no-op fetch every minute on the unconfigured
+  // path and keeps the legacy behavior of "do nothing until configured".
+  const intervalMs = configured ? POLL_INTERVAL_MS : null;
 
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [configured, fetchBalance]);
+  const { data, error, loading, refresh } = usePollingFetch(fetchFn, intervalMs);
 
-  const refresh = useCallback(() => {
-    void fetchBalance();
-  }, [fetchBalance]);
-
-  return { balance, uiAmount, loading, error, configured, refresh };
+  return useMemo<RvuiBalanceState>(
+    () => ({
+      balance: configured ? (data?.balance ?? null) : null,
+      uiAmount: configured ? (data?.uiAmount ?? 0) : 0,
+      loading,
+      error: configured ? (error?.message ?? null) : null,
+      configured,
+      refresh,
+    }),
+    [configured, data, error, loading, refresh],
+  );
 }

--- a/apps/studio/src/hooks/use-status.ts
+++ b/apps/studio/src/hooks/use-status.ts
@@ -1,18 +1,21 @@
-import { createContext, use, useCallback, useEffect, useState } from 'react';
-
-const STATUS_POLL_INTERVAL_MS = 30_000;
+import { createContext, use, useCallback, useMemo } from 'react';
 
 import { getMountStatus, getSystemStatus } from '../lib/invoke';
 import type { MountStatus, SystemStatus } from '../types';
+import { usePollingFetch } from './use-polling-fetch';
 
-interface StatusState {
+const STATUS_POLL_INTERVAL_MS = 30_000;
+
+interface StatusPayload {
+  system: SystemStatus;
+  mount: MountStatus;
+}
+
+export interface StatusContextValue {
   system: SystemStatus | null;
   mount: MountStatus | null;
   loading: boolean;
   error: string | null;
-}
-
-export interface StatusContextValue extends StatusState {
   refresh: () => Promise<void>;
 }
 
@@ -24,33 +27,29 @@ export function useStatusContext(): StatusContextValue {
   return ctx;
 }
 
-export function useStatus() {
-  const [state, setState] = useState<StatusState>({
-    system: null,
-    mount: null,
-    loading: true,
-    error: null,
-  });
-
-  const refresh = useCallback(async () => {
-    setState((prev) => ({ ...prev, loading: true, error: null }));
-    try {
-      const [system, mount] = await Promise.all([getSystemStatus(), getMountStatus()]);
-      setState({ system, mount, loading: false, error: null });
-    } catch (err) {
-      setState((prev) => ({
-        ...prev,
-        loading: false,
-        error: err instanceof Error ? err.message : String(err),
-      }));
-    }
+export function useStatus(): StatusContextValue {
+  // Fetcher is a stable identity — no caller-supplied dependencies — so
+  // the polling loop only restarts on intervalMs change (which never
+  // happens here; the constant is module-level).
+  const fetchFn = useCallback(async (_signal: AbortSignal): Promise<StatusPayload> => {
+    const [system, mount] = await Promise.all([getSystemStatus(), getMountStatus()]);
+    return { system, mount };
   }, []);
 
-  useEffect(() => {
-    refresh();
-    const interval = setInterval(refresh, STATUS_POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [refresh]);
+  const { data, error, loading, refresh } = usePollingFetch(fetchFn, STATUS_POLL_INTERVAL_MS);
 
-  return { ...state, refresh };
+  // Preserve the legacy public surface — separate `system`/`mount`
+  // slots and a string `error`. Wrapped in useMemo so consumers that
+  // depend on object identity (Dashboard via context) don't re-render
+  // every poll tick if the underlying data didn't change shape.
+  return useMemo(
+    () => ({
+      system: data?.system ?? null,
+      mount: data?.mount ?? null,
+      loading,
+      error: error?.message ?? null,
+      refresh,
+    }),
+    [data, error, loading, refresh],
+  );
 }

--- a/apps/studio/src/hooks/use-subscription.ts
+++ b/apps/studio/src/hooks/use-subscription.ts
@@ -3,12 +3,16 @@
  *
  * Polls on an interval (from settings.pollingIntervalMs) so the Dashboard
  * always reflects the current billing state without manual refresh.
+ * Polling is gated on `step === 'authenticated'` AND `getToken()` returning
+ * a token. When either gate is closed the fetcher returns null and the
+ * underlying API calls are skipped.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { SubscriptionResponse, UsageResponse } from '../lib/billing-api';
 import { fetchSubscription, fetchUsage } from '../lib/billing-api';
 import { useAuthContext } from './use-auth';
+import { usePollingFetch } from './use-polling-fetch';
 import { useSettingsContext } from './use-settings';
 
 export interface SubscriptionState {
@@ -16,59 +20,63 @@ export interface SubscriptionState {
   usage: UsageResponse | null;
   loading: boolean;
   error: string | null;
-  refresh: () => void;
+  refresh: () => Promise<void>;
 }
+
+interface BillingPayload {
+  subscription: SubscriptionResponse;
+  usage: UsageResponse;
+}
+
+const FALLBACK_ERROR = 'Failed to fetch billing data';
 
 export function useSubscription(): SubscriptionState {
   const { getToken, step } = useAuthContext();
   const { settings } = useSettingsContext();
+  const { apiUrl, pollingIntervalMs } = settings;
 
-  const [subscription, setSubscription] = useState<SubscriptionResponse | null>(null);
-  const [usage, setUsage] = useState<UsageResponse | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const refreshRef = useRef(0);
+  const fetchFn = useCallback(
+    async (signal: AbortSignal): Promise<BillingPayload | null> => {
+      // Gate: skip the network entirely when not authenticated or no
+      // token. Returning null leaves data unchanged (still null after
+      // first call) and the helper's loading transitions to false.
+      if (step !== 'authenticated') return null;
+      const token = getToken();
+      if (!token) return null;
 
-  function refresh() {
-    refreshRef.current += 1;
-    // Trigger re-fetch by updating a counter dependency
-    setLoading(true);
-    fetchAll();
-  }
+      try {
+        const [sub, usg] = await Promise.all([
+          fetchSubscription(apiUrl, token, signal),
+          fetchUsage(apiUrl, token, signal),
+        ]);
+        return { subscription: sub, usage: usg };
+      } catch (err) {
+        // Re-throw Error instances unchanged so the consumer surfaces
+        // the real message; replace non-Error rejections with the
+        // legacy fallback string for caller compatibility.
+        if (err instanceof Error) throw err;
+        throw new Error(FALLBACK_ERROR);
+      }
+    },
+    [apiUrl, getToken, step],
+  );
 
-  async function fetchAll() {
-    const token = getToken();
-    if (!token) {
-      setLoading(false);
-      return;
-    }
+  // Disable interval polling until the user is authenticated. The
+  // initial fetch still fires once per fetchFn-identity change, but
+  // when step !== 'authenticated' the gate above short-circuits the
+  // network call, so no fetchSubscription/fetchUsage requests go out.
+  const effectiveInterval = step === 'authenticated' ? pollingIntervalMs : null;
 
-    try {
-      const [sub, usg] = await Promise.all([
-        fetchSubscription(settings.apiUrl, token),
-        fetchUsage(settings.apiUrl, token),
-      ]);
-      setSubscription(sub);
-      setUsage(usg);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch billing data');
-    } finally {
-      setLoading(false);
-    }
-  }
+  const { data, error, loading, refresh } = usePollingFetch(fetchFn, effectiveInterval);
 
-  // Fetch on mount and on interval
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-fetch when auth step or apiUrl changes
-  useEffect(() => {
-    if (step !== 'authenticated') return;
-
-    setLoading(true);
-    fetchAll();
-
-    const interval = setInterval(fetchAll, settings.pollingIntervalMs);
-    return () => clearInterval(interval);
-  }, [step, settings.apiUrl, settings.pollingIntervalMs]);
-
-  return { subscription, usage, loading, error, refresh };
+  return useMemo<SubscriptionState>(
+    () => ({
+      subscription: data?.subscription ?? null,
+      usage: data?.usage ?? null,
+      loading,
+      error: error?.message ?? null,
+      refresh,
+    }),
+    [data, error, loading, refresh],
+  );
 }

--- a/apps/studio/src/hooks/use-tiles.ts
+++ b/apps/studio/src/hooks/use-tiles.ts
@@ -1,5 +1,5 @@
 import { Command } from '@tauri-apps/plugin-shell';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { focusWindow } from '../lib/invoke';
 import {
   type BrowserProfile,
@@ -16,6 +16,7 @@ import {
   type TileDefinition,
   type TilePreferences,
 } from '../lib/tiles';
+import { usePollingFetch } from './use-polling-fetch';
 
 interface UseTilesReturn {
   /** All tiles grouped by category (respects hidden/collapsed state) */
@@ -107,8 +108,20 @@ export function useTiles(): UseTilesReturn {
   const [prefs, setPrefs] = useState<TilePreferences>(loadTilePreferences);
   const [query, setQuery] = useState('');
   const [editing, setEditing] = useState(false);
-  const [runningTileIds, setRunningTileIds] = useState<Set<string>>(new Set());
   const [detectedProfiles, setDetectedProfiles] = useState<TileDefinition[]>([]);
+
+  // Poll running processes every 10 s via the shared helper. The fetcher
+  // ignores the AbortSignal because detectRunningProcesses shells out
+  // through Tauri's Command API which is one-shot, but the helper still
+  // gates state updates on isMounted so post-unmount setState is dropped.
+  const fetchRunning = useCallback(
+    async (_signal: AbortSignal): Promise<Set<string>> => detectRunningProcesses(),
+    [],
+  );
+  const { data: runningData } = usePollingFetch(fetchRunning, 10_000);
+  // Helper's `data` starts null; expose an empty Set so consumers can
+  // treat the value as a Set unconditionally.
+  const runningTileIds: Set<string> = runningData ?? new Set();
 
   // Detect browser profiles once on mount
   useEffect(() => {
@@ -128,25 +141,6 @@ export function useTiles(): UseTilesReturn {
     });
     return () => {
       cancelled = true;
-    };
-  }, []);
-
-  // Poll for running processes every 10 seconds
-  useEffect(() => {
-    let cancelled = false;
-
-    const poll = async () => {
-      const running = await detectRunningProcesses();
-      if (!cancelled) {
-        setRunningTileIds(running);
-      }
-    };
-
-    poll();
-    const interval = setInterval(poll, 10_000);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
     };
   }, []);
 

--- a/apps/studio/src/hooks/use-tunnel.ts
+++ b/apps/studio/src/hooks/use-tunnel.ts
@@ -1,79 +1,60 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { getTailscaleStatus, tailscaleDown, tailscaleUp } from '../lib/invoke';
 import type { TailscaleStatus } from '../types';
-
-interface TunnelState {
-  status: TailscaleStatus | null;
-  loading: boolean;
-  error: string | null;
-  toggling: boolean;
-}
+import { usePollingFetch } from './use-polling-fetch';
 
 const POLL_INTERVAL_MS = 10_000;
 
 export function useTunnel() {
-  const [state, setState] = useState<TunnelState>({
-    status: null,
-    loading: true,
-    error: null,
-    toggling: false,
-  });
+  const [toggling, setToggling] = useState(false);
+  // up/down operations produce errors not tied to the polling fetcher.
+  // Tracked locally so they stay visible until cleared by a fresh action.
+  const [actionError, setActionError] = useState<string | null>(null);
 
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const fetchFn = useCallback(
+    async (_signal: AbortSignal): Promise<TailscaleStatus> => getTailscaleStatus(),
+    [],
+  );
 
-  const fetchStatus = useCallback(async () => {
-    try {
-      const status = await getTailscaleStatus();
-      setState((prev) => ({ ...prev, status, loading: false, error: null }));
-    } catch (err) {
-      setState((prev) => ({
-        ...prev,
-        loading: false,
-        status: null,
-        error: err instanceof Error ? err.message : String(err),
-      }));
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchStatus();
-    intervalRef.current = setInterval(fetchStatus, POLL_INTERVAL_MS);
-    return () => {
-      if (intervalRef.current !== null) {
-        clearInterval(intervalRef.current);
-      }
-    };
-  }, [fetchStatus]);
+  const { data, error, loading, refresh } = usePollingFetch(fetchFn, POLL_INTERVAL_MS);
 
   const up = useCallback(async () => {
-    setState((prev) => ({ ...prev, toggling: true, error: null }));
+    setToggling(true);
+    setActionError(null);
     try {
       await tailscaleUp();
-      await fetchStatus();
+      await refresh();
     } catch (err) {
-      setState((prev) => ({
-        ...prev,
-        error: err instanceof Error ? err.message : String(err),
-      }));
+      setActionError(err instanceof Error ? err.message : String(err));
     } finally {
-      setState((prev) => ({ ...prev, toggling: false }));
+      setToggling(false);
     }
-  }, [fetchStatus]);
+  }, [refresh]);
 
   const down = useCallback(async () => {
-    setState((prev) => ({ ...prev, toggling: true, error: null }));
+    setToggling(true);
+    setActionError(null);
     try {
       await tailscaleDown();
-      await fetchStatus();
+      await refresh();
     } catch (err) {
-      setState((prev) => ({
-        ...prev,
-        error: err instanceof Error ? err.message : String(err),
-      }));
+      setActionError(err instanceof Error ? err.message : String(err));
     } finally {
-      setState((prev) => ({ ...prev, toggling: false }));
+      setToggling(false);
     }
-  }, [fetchStatus]);
+  }, [refresh]);
 
-  return { ...state, up, down, refresh: fetchStatus };
+  return useMemo(
+    () => ({
+      // Legacy shape: status is null on error (poll failed).
+      status: error ? null : (data ?? null),
+      loading,
+      error: actionError ?? error?.message ?? null,
+      toggling,
+      up,
+      down,
+      refresh,
+    }),
+    [data, error, loading, actionError, toggling, up, down, refresh],
+  );
 }

--- a/apps/studio/src/lib/billing-api.ts
+++ b/apps/studio/src/lib/billing-api.ts
@@ -27,13 +27,19 @@ export interface UsageResponse {
 
 // ── Client ──────────────────────────────────────────────────────────────────
 
-async function authedGet<T>(apiUrl: string, path: string, token: string): Promise<T> {
+async function authedGet<T>(
+  apiUrl: string,
+  path: string,
+  token: string,
+  signal?: AbortSignal,
+): Promise<T> {
   const res = await fetch(`${apiUrl}/api/billing${path}`, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
+    signal,
   });
 
   if (!res.ok) {
@@ -44,18 +50,26 @@ async function authedGet<T>(apiUrl: string, path: string, token: string): Promis
 }
 
 /**
- * Fetch the current user's subscription/license status.
+ * Fetch the current user's subscription/license status. Accepts an
+ * optional AbortSignal so callers (usePollingFetch) can cancel the
+ * fetch on unmount or when a new poll begins.
  */
 export async function fetchSubscription(
   apiUrl: string,
   token: string,
+  signal?: AbortSignal,
 ): Promise<SubscriptionResponse> {
-  return authedGet<SubscriptionResponse>(apiUrl, '/subscription', token);
+  return authedGet<SubscriptionResponse>(apiUrl, '/subscription', token, signal);
 }
 
 /**
- * Fetch the current billing cycle's agent task usage.
+ * Fetch the current billing cycle's agent task usage. Accepts an
+ * optional AbortSignal — see fetchSubscription.
  */
-export async function fetchUsage(apiUrl: string, token: string): Promise<UsageResponse> {
-  return authedGet<UsageResponse>(apiUrl, '/usage', token);
+export async function fetchUsage(
+  apiUrl: string,
+  token: string,
+  signal?: AbortSignal,
+): Promise<UsageResponse> {
+  return authedGet<UsageResponse>(apiUrl, '/usage', token, signal);
 }

--- a/apps/studio/src/lib/health-api.ts
+++ b/apps/studio/src/lib/health-api.ts
@@ -26,13 +26,27 @@ export interface HealthResponse {
 
 /**
  * Fetch the readiness probe from the API. Public endpoint — no auth needed.
- * Returns null if the API is unreachable (network error).
+ * Returns null if the API is unreachable (network error or timeout).
+ *
+ * Accepts an optional caller-supplied AbortSignal that's combined with
+ * an internal 5 s timeout via `AbortSignal.any` — either source aborting
+ * cancels the fetch. Callers using `usePollingFetch` should pass their
+ * call's signal so the fetch is canceled on unmount or when a new poll
+ * begins, instead of leaking a pending promise past component teardown
+ * (the bug closed by revdev#43 on Dashboard.test.tsx).
  */
-export async function fetchHealth(apiUrl: string): Promise<HealthResponse | null> {
+export async function fetchHealth(
+  apiUrl: string,
+  signal?: AbortSignal,
+): Promise<HealthResponse | null> {
+  const sources: AbortSignal[] = [AbortSignal.timeout(5_000)];
+  if (signal) sources.push(signal);
+  const combined = sources.length > 1 ? AbortSignal.any(sources) : sources[0];
+
   try {
     const res = await fetch(`${apiUrl}/health/ready`, {
       method: 'GET',
-      signal: AbortSignal.timeout(5_000),
+      signal: combined,
     });
     return (await res.json()) as HealthResponse;
   } catch {

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -20,3 +20,38 @@
 .cm-mergeView-gutter {
   flex-shrink: 0;
 }
+
+/* ── Visible scrollbars on Linux WebKit (WSLg + webkit2gtk) ──────────────── */
+/* webkit2gtk's default overlay scrollbars are nearly invisible on Linux,    */
+/* especially under WSLg. Force a visible custom scrollbar across all        */
+/* WebKit/Blink. Tailwind `overflow-y-auto` provides the scroll behavior;    */
+/* this just makes the indicator visible.                                     */
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgb(23 23 23 / 0.5); /* neutral-900/50 */
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgb(64 64 64); /* neutral-700 */
+  border-radius: 5px;
+  border: 2px solid rgb(23 23 23); /* neutral-900 — creates inset look */
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgb(82 82 82); /* neutral-600 */
+}
+
+::-webkit-scrollbar-corner {
+  background: rgb(23 23 23); /* neutral-900 */
+}
+
+/* Firefox fallback (if Studio ever ships in non-WebKit context) */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(64 64 64) rgb(23 23 23 / 0.5);
+}

--- a/docs/KEY_GENERATION.md
+++ b/docs/KEY_GENERATION.md
@@ -11,7 +11,7 @@ Signs Studio desktop binaries for auto-update verification.
 
 ```bash
 # Generate keypair (prompts for a password)
-cd ~/suite/revdev/apps/studio/src-tauri
+cd ~/revfleet/revdev/apps/studio/src-tauri
 npx @tauri-apps/cli signer generate -w ~/.tauri/revdev-studio.key
 
 # Store in revvault
@@ -35,7 +35,7 @@ Signs customer license keys (RVUI.v2 format) so the daemon can verify them.
 # Mint Ed25519 keypair; auto-stores both halves in revvault at
 # revdev/license-signing-{private,public}-key and prints the public PEM.
 # No plaintext key files ever land on disk.
-cd ~/suite/revdev
+cd ~/revfleet/revdev
 npx tsx scripts/issue-license.ts --generate-keypair
 
 # Wire the public key into the local daemon's environment.
@@ -50,7 +50,7 @@ export REVDEV_LICENSE_PUBLIC_KEY="$(revvault get --full revdev/license-signing-p
 Verify the key works by issuing yourself an enterprise license:
 
 ```bash
-cd ~/suite/revdev
+cd ~/revfleet/revdev
 npx tsx scripts/issue-license.ts --tier enterprise --perpetual
 ```
 

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -1,0 +1,159 @@
+# RevDev — Master Plan
+
+**Last Updated:** 2026-05-10
+**Status:** Pre-1.0 — Studio + Console + harness daemon all buildable; no public releases yet
+**Owner:** RevealUI Studio (`founder@revealui.com`)
+**Repo:** [RevealUIStudio/revdev](https://github.com/RevealUIStudio/revdev)
+**Fleet master index:** [`revealui-jv:docs/MASTER_INDEX.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_INDEX.md)
+
+> Fleet-level cross-cutting plans live in [`revealui-jv:docs/MASTER_PLAN.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_PLAN.md). This file is RevDev-scoped only.
+>
+> Detailed launch checklist (agent-executable + human-required tasks): [`docs/PRODUCTION_LAUNCH_PLAN.md`](./PRODUCTION_LAUNCH_PLAN.md). This MASTER_PLAN is the higher-level pointer; PRODUCTION_LAUNCH_PLAN is the per-task breakdown.
+
+---
+
+## Headline state
+
+RevDev is **one product, two interfaces, one daemon**:
+
+- **Studio** — Tauri 2 + React 19 desktop AI editor + agent coordination dashboard
+- **Console** — Go + Bubble Tea SSH TUI ops cockpit (agent health, deploys, billing, alerts)
+- **Harness daemon** (Node.js) — coordinates agents, manages PTY sessions, routes tools to RevealUI API. Studio + Console are different UIs for the same daemon.
+
+All three components build cleanly today. None has cut a public release. Distribution maturity differs:
+
+| Component | Status | How to get it today |
+|---|---|---|
+| Studio | Buildable, unsigned | `pnpm --filter studio tauri build` — produces a local binary. Signed/notarized auto-update pipeline defined in `.github/workflows/studio-release.yml` but not yet cutting public releases. |
+| Console | Buildable | `cd apps/console && go build -o ../../rvui .` — no root `go.mod`; the console module lives under `apps/console/` (CI pattern at `.github/workflows/ci.yml:78-79`). No release automation yet. |
+| Harness Daemon | Buildable, not published | Not on npm. Build from source: `pnpm --filter @revdev/daemon build`; run CLI at `packages/daemon/dist/cli.js`. |
+
+---
+
+## Current Reality (2026-05-10)
+
+### What works (verified by recent merges + smoke tests)
+
+- **Daemon JSON-RPC** — 45+ methods (`session.register`, `mail.*`, `files.*`, `tasks.*`, `events.log`, `harness.*`, etc.); PGlite-backed persistence at `~/.local/share/revealui/`
+- **Daemon self-detach** ([revdev#27](https://github.com/RevealUIStudio/revdev/pull/27), 2026-04-28) — `--detach` CLI flag + systemd-user unit at `packages/daemon/systemd/`; child runs in own session/PGID
+- **Agent-session pruning** ([revdev#23](https://github.com/RevealUIStudio/revdev/pull/23), 2026-04-28) — `harness.prune` RPC + setinterval hourly sweep; configurable via `REVDEV_STALE_THRESHOLD_DAYS` / `REVDEV_HARD_DELETE_DAYS`
+- **Ed25519 license acceptance** ([revdev#42](https://github.com/RevealUIStudio/revdev/pull/42), 2026-05-04) — Phase B of license-ed25519 migration; daemon accepts JWT signed with EdDSA, rejects RS256/dotted-v2/wrong-algorithm with explicit reasons
+- **Daemon memory limits** ([revdev#32](https://github.com/RevealUIStudio/revdev/pull/32)) — `MemoryHigh=800M` + `MemoryMax=1G` in systemd unit (sized to observed peak ~780 MiB)
+- **CI hardening** — SHA-pinned all 41 actions across 6 workflow files (#28); pnpm fix (#22); dependency review; CodeQL js-ts + go; gitleaks; secret scanning
+- **Studio dashboard test health** ([revdev#43](https://github.com/RevealUIStudio/revdev/pull/43), 2026-05-05) — `useHealth` initial-poll race fix; `vi.mock('../../lib/health-api')` mirroring billing-api pattern; 522/522 studio tests pass
+- **Daemon at runtime today** — running under systemd-user, license=ENTERPRISE, ping pong:true; managed via systemd or legacy `setsid + nohup` recipe
+
+### What does not exist yet
+
+- **Public Studio release** — needs Apple notarization cert + Windows code-signing cert + auto-update server hosting decision
+- **Public Console release** — `go build` + GitHub Releases pipeline pending
+- **Daemon → Neon sync (GAP-154)** — daemon writes to local PGlite only; Neon `coordination_*` tables not yet receiving writes; cross-machine coordination not yet wired
+- **Studio email send** — currently a stub that silently sets `setTestSent(true)` (`apps/studio/src/components/deploy/StepEmail.tsx:46`)
+- **Test→main promotion** — `revdev:test` ahead of `main` since 2026-05-03 (PR #34 closed-deferred on real libcrux CVE chain via russh; resume when upstream russh ships SemVer-compatible upgrade including libcrux-ml-kem fix)
+
+---
+
+## Composition with the rest of RevFleet
+
+| Other product | Relationship |
+|---|---|
+| **RevealUI** | Daemon talks to RevealUI API (Hono/Vercel) for tool routing; Studio is a UI over the same. RevDev is the dev-tools surface; RevealUI is the runtime. |
+| **RevVault** | Daemon license-signing keys live in RevVault (`revdev/license-signing-key`) per [`secrets.md`](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/secrets.md) |
+| **RevCon** | Studio integrates with RevCon for editor configs (Zed/VS Code/Cursor synced via symlinks) |
+| **RevKit** | Independent — RevKit provisions the workstation; RevDev runs on whatever workstation exists |
+| **RevForge / RevealCoin / RevSkills** | Independent |
+
+The daemon's coordination role for RevFleet agent sessions is documented in [`hooks-architecture.md`](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/hooks-architecture.md). Hook coordination is daemon-up-best-effort; soft no-op when daemon down.
+
+---
+
+## Active Work
+
+### Current branch: `fix/daemon-jwt-iss-aud-customerid` (clean)
+
+Active on the daemon JWT validation surface — adding `iss` + `aud` + `customerId` validation per Phase B follow-up. No conflict with master-of-masters scaffold.
+
+### Recently shipped (last ~2 weeks)
+
+- **revdev#43** (2026-05-05) — Studio dashboard test health mock fix
+- **revdev#42** (2026-05-04 merged) — Phase B license-ed25519 daemon acceptance + 11 negative tests
+- **revdev#33** (2026-05-03 merged) — sync main→test absorbing CI hardening (SHA-pins + pnpm fix)
+- **revdev#34** (2026-05-03 closed-deferred) — test→main promotion blocked on libcrux-sha3 CVE; resume on upstream russh upgrade
+- **revdev#32** (2026-05-03 merged) — daemon systemd memory limits
+- **revdev#31** (2026-05-03 merged) — fnm-PATH workaround in systemd unit
+- **revdev#30 / #29 / #21** (2026-05-03) — license CLI consolidation across 3 PRs
+
+---
+
+## Roadmap
+
+Detailed task-level breakdown in [`PRODUCTION_LAUNCH_PLAN.md`](./PRODUCTION_LAUNCH_PLAN.md). Higher-level phases below.
+
+Pre-1.0 per [`versioning.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/.claude/rules/versioning.md).
+
+### Phase 0 — Daemon production-grade (DONE)
+
+JSON-RPC stable; PGlite persistence; auto-detach; systemd-user unit; agent-session pruning; Ed25519 license acceptance; memory limits sized; license=ENTERPRISE running locally.
+
+### Phase 1 — Test→main promotion (BLOCKED on upstream)
+
+Resume condition: upstream `russh` ships SemVer-compatible upgrade including `libcrux-ml-kem` ≥ a version with `libcrux-sha3` ≥ 0.0.8 (RUSTSEC-2026-0074 fix). Watch `cargo update -p russh` for SemVer-compatible upgrade. Until then, `test` is ahead of `main` honestly.
+
+### Phase 2 — Public Studio release (NOT STARTED)
+
+| Sub-phase | Status | Owner |
+|---|---|---|
+| Apple notarization cert | NOT STARTED | Human |
+| Windows code-signing cert | NOT STARTED | Human |
+| Auto-update server hosting | NOT STARTED | Human (decision) |
+| Studio email-send: replace stub with real Gmail API call | NOT STARTED | Agent |
+
+### Phase 3 — Public Console release (NOT STARTED)
+
+| Sub-phase | Status |
+|---|---|
+| Cross-platform Go build matrix | NOT STARTED |
+| GitHub Releases pipeline | NOT STARTED |
+| Brew tap + Scoop bucket (optional) | NOT STARTED |
+
+### Phase 4 — Cross-machine coordination (DEFERRED — GAP-154)
+
+Daemon → Neon `coordination_*` tables sync; allows multiple workstations / cloud VMs to coordinate via the same daemon backend. Currently single-machine PGlite only.
+
+---
+
+## Owner Action Queue
+
+| # | Item | Unblocks | Priority |
+|---|---|---|---|
+| 1 | Decide Studio distribution channel (revealui.com download vs GitHub Releases vs other) | Phase 2 | Medium |
+| 2 | Procure Apple notarization + Windows code-signing certs | Phase 2 | Medium |
+| 3 | Auto-update server hosting decision | Phase 2 | Medium |
+| 4 | Watch `cargo update -p russh` for SemVer-compatible upgrade | Phase 1 unblock | Low |
+| 5 | License-issuance flow integration with RevForge `stamp.sh` | Cross-product | Low (Phase 3 scope) |
+
+---
+
+## Known follow-up gaps
+
+| Gap | Tracker | Status |
+|---|---|---|
+| Daemon → Neon coordination sync | GAP-154 | Open — large remaining gap |
+| GAP-152 daemon self-detach + auto-start | [revdev#27](https://github.com/RevealUIStudio/revdev/pull/27) | **CLOSED** 2026-04-28 |
+| GAP-153 stale `agent_sessions` row pruning | [revdev#23](https://github.com/RevealUIStudio/revdev/pull/23) | **CLOSED** 2026-04-28 (Phase 2 periodic prune) |
+| Studio email-send stub | `apps/studio/src/components/deploy/StepEmail.tsx:46` | Open — Phase 2 sub-task |
+
+---
+
+## See also
+
+- [`docs/MASTER_SPEC.md`](./MASTER_SPEC.md) — surface area, architecture, JSON-RPC method list
+- [`docs/PRODUCTION_LAUNCH_PLAN.md`](./PRODUCTION_LAUNCH_PLAN.md) — task-level launch checklist (agent + human)
+- [`docs/API_REFERENCE.md`](./API_REFERENCE.md) — API surface
+- [`docs/GETTING_STARTED.md`](./GETTING_STARTED.md) — quick start
+- [`docs/KEY_GENERATION.md`](./KEY_GENERATION.md) — license keypair gen
+- [`docs/TROUBLESHOOTING.md`](./TROUBLESHOOTING.md) — common issues
+- [`README.md`](../README.md) — overview + architecture diagram
+- [`CLAUDE.md`](../CLAUDE.md) — agent context
+- [`revealui:.claude/rules/hooks-architecture.md`](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/hooks-architecture.md) — RevDev daemon contract for fleet hooks
+- [`revealui-jv:docs/MASTER_INDEX.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_INDEX.md) — fleet-level navigation

--- a/docs/MASTER_SPEC.md
+++ b/docs/MASTER_SPEC.md
@@ -1,0 +1,232 @@
+# RevDev — Master Spec
+
+**Last Updated:** 2026-05-10
+**Status:** Pre-1.0 — daemon production-grade for studio internal use; Studio + Console builds clean; no public releases
+**Repo:** [RevealUIStudio/revdev](https://github.com/RevealUIStudio/revdev)
+
+> Surface area, architecture, JSON-RPC contract. Companion to [`MASTER_PLAN.md`](./MASTER_PLAN.md) (status + roadmap).
+
+---
+
+## Mission
+
+Native developer tools for RevealUI. **One product, two interfaces, one daemon.** Studio (Tauri 2) and Console (Go SSH TUI) are different UIs over the same JSON-RPC harness daemon. The daemon coordinates AI agents, manages PTY sessions, and routes tools to the RevealUI API.
+
+---
+
+## Repository structure
+
+```
+revdev/
+├── README.md
+├── CLAUDE.md                       # agent context
+├── NOTICE.md                       # third-party attributions
+├── package.json                    # pnpm workspace root
+├── pnpm-workspace.yaml
+├── apps/
+│   ├── studio/                     # Tauri 2 + React 19 desktop app
+│   └── console/                    # Go + Bubble Tea SSH TUI
+├── packages/
+│   ├── daemon/                     # @revdev/daemon — Node.js JSON-RPC server (PGlite + Unix socket)
+│   ├── protocol/                   # @revdev/protocol — TypeScript types for JSON-RPC contract
+│   ├── bridge/                     # @revdev/bridge — Tauri↔daemon IPC adapter
+│   └── theme/                      # @revdev/theme — shared visual tokens
+├── scripts/
+│   └── issue-license.ts            # CLI for issuing per-customer Ed25519 JWT licenses
+├── docs/                           # this directory
+├── config/                         # shared config (Biome, TS, etc.)
+└── biome.json
+```
+
+### Package boundaries
+
+| Package | Public name | Responsibility |
+|---|---|---|
+| `daemon` | `@revdev/daemon` | JSON-RPC server, PGlite persistence, agent session lifecycle, license validation, harness pruning |
+| `protocol` | `@revdev/protocol` | TypeScript types for every RPC method (single source of truth for the contract) |
+| `bridge` | `@revdev/bridge` | Tauri-side adapter: serializes RPC calls from Studio's React UI through Tauri IPC to the daemon socket |
+| `theme` | `@revdev/theme` | Shared color + spacing tokens between Studio + Console |
+
+### App boundaries
+
+| App | Tech | UI surface |
+|---|---|---|
+| `studio` | Tauri 2 + React 19 | Desktop dashboard — agent health, session viewer, deploy wizard, billing surface, alerts |
+| `console` | Go + Bubble Tea | SSH-friendly TUI — same surfaces over a terminal protocol; for production triage |
+
+Studio and Console NEVER talk to each other. Both talk to the daemon over JSON-RPC.
+
+---
+
+## Architecture
+
+```
+┌─────────┐     ┌──────────┐
+│ Studio  │     │ Console  │
+│ (Tauri) │     │   (Go)   │
+└────┬────┘     └────┬─────┘
+     │   JSON-RPC    │
+     └──────┬────────┘
+            │
+    ┌───────┴─────────┐
+    │ Harness Daemon  │
+    │   (Node.js)     │
+    └───────┬─────────┘
+            │
+    ┌───────┴─────────┐
+    │  RevealUI API   │
+    │ (Hono/Vercel)   │
+    └─────────────────┘
+```
+
+### Transport
+
+- **Studio ↔ Daemon**: Tauri IPC on the studio side; daemon-side it's a Unix socket at `~/.local/share/revealui/harness.sock`
+- **Console ↔ Daemon**: Direct Unix socket connection
+- **Daemon ↔ RevealUI API**: HTTPS over the public RevealUI deployment (Vercel) or self-hosted Fleet kit
+
+### Persistence
+
+- **Daemon-local**: PGlite at `~/.local/share/revealui/` — agent sessions, mail, files reservation, tasks, events log, license cache
+- **Cross-machine**: NOT YET WIRED (GAP-154) — daemon's PGlite-only model is the active gap; future Neon `coordination_*` table sync will allow multi-workstation coordination
+
+### Process model
+
+Daemon runs:
+- **Best-practice (post-[revdev#27](https://github.com/RevealUIStudio/revdev/pull/27))** — systemd-user unit at `packages/daemon/systemd/revdev-daemon.service`; install via `pnpm --filter @revdev/daemon setup:systemd`; survives logout via `loginctl enable-linger`
+- **Manual self-detach** — `node packages/daemon/dist/cli.js --detach`; child runs in own session/PGID; logs at `~/.local/share/revealui/daemon.log` (mode 0700)
+- **Legacy fallback** — `setsid nohup node packages/daemon/dist/cli.js > /tmp/revdev-daemon.log 2>&1 < /dev/null & disown`
+
+Memory limits ([revdev#32](https://github.com/RevealUIStudio/revdev/pull/32)): `MemoryHigh=800M` + `MemoryMax=1G` in systemd unit (sized to observed peak ~780 MiB; ~20 MiB cushion to MemoryHigh; ~31% headroom to MemoryMax).
+
+---
+
+## JSON-RPC surface
+
+The daemon exposes 45+ methods. Categories:
+
+| Category | Methods | Purpose |
+|---|---|---|
+| `session.*` | `register`, `attach`, `list`, `end` | Logical agent identity lifecycle |
+| `mail.*` | `send`, `inbox`, `archive`, `subscribe` | Inter-agent messaging |
+| `files.*` | `reserve`, `release`, `list-reservations` | Advisory file-locking for conflict prevention |
+| `tasks.*` | `claim`, `complete`, `list`, `release` | Task queue across agent sessions |
+| `events.*` | `log`, `tail`, `subscribe` | Audit + observability |
+| `harness.*` | `prune`, `stats`, `health`, `version` | Daemon ops; `prune` is the periodic stale-session sweep ([revdev#23](https://github.com/RevealUIStudio/revdev/pull/23)) |
+| `ping` | — | Liveness check; returns `{pong: true, ...}` |
+
+### Health check
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"ping"}' | nc -U ~/.local/share/revealui/harness.sock
+# → {"jsonrpc":"2.0","id":1,"result":{"pong":true,...}}
+```
+
+### Stale-session pruning
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `REVDEV_STALE_THRESHOLD_DAYS` | 7 | Sessions older than N days marked stale |
+| `REVDEV_HARD_DELETE_DAYS` | (configurable) | Hard-delete after N days |
+
+Hourly setinterval sweeps stale rows from `agent_sessions` table.
+
+---
+
+## License model
+
+Per `packages/daemon/src/license.ts` + `license-crypto.ts`:
+
+- **Format**: JWT, 3-part split (header.payload.sig)
+- **Algorithm**: EdDSA (Ed25519) per Phase A migration ([revealui#735](https://github.com/RevealUIStudio/revealui/pull/735), 2026-05-04) + Phase B daemon acceptance ([revdev#42](https://github.com/RevealUIStudio/revdev/pull/42), 2026-05-04)
+- **Hand-decode replacement**: `verifyLicenseJWT()` uses `node:crypto.verify(null, ...)`; zero new deps; ~30 LOC
+- **Rejection reasons**: dotted-v2 (legacy), v1 (RVUI-*), invalid formats, RS256-JWT (algorithm mismatch — explicit pre-Phase-A regression test), JWT signed with wrong key, JWT with non-JSON payload, unrecognized tier, expired JWT, 2-part malformed JWT
+- **Acceptance**: perpetual JWT (no exp), non-perpetual JWT with valid exp
+- **Tiers** (whitelist): `free` / `pro` / `max` / `enterprise`
+- **Detection branch** in `checkLicense()`: `if (key.startsWith('eyJ'))` — JWT path; legacy formats rejected with stderr message pointing customer at API/CLI for fresh JWT
+
+License signing key lives in RevVault at `revdev/license-signing-key`.
+
+---
+
+## CLI surface
+
+| CLI | Path | Purpose |
+|---|---|---|
+| `revdev-daemon` | `packages/daemon/dist/cli.js` | Daemon process; `--detach` flag |
+| `revdev issue-license` | `scripts/issue-license.ts` | Issue per-customer Ed25519 JWT (matches Phase A payload schema for API-CLI parity) |
+| `revdev` (TUI) | `apps/console` (Go binary) | SSH TUI ops cockpit |
+
+---
+
+## CI surface
+
+`.github/workflows/`:
+
+| Workflow | Triggers | Purpose |
+|---|---|---|
+| `ci.yml` | push + PR | Quality, Typecheck, Build, Test, Console (Go), Dependency Review, Secret Scanning, Submodule Audit |
+| `codeql.yml` | push + PR | CodeQL js-ts + go |
+| `studio-release.yml` | tag | Studio Tauri build (defined; not yet cutting public releases) |
+
+All actions SHA-pinned (per [revdev#28](https://github.com/RevealUIStudio/revdev/pull/28)).
+
+---
+
+## Studio surface
+
+Tauri 2 desktop app at `apps/studio/`. UI panels:
+
+| Panel | Backed by |
+|---|---|
+| Dashboard (agent health, session list) | `useHealth` hook polling daemon `harness.health` (test-mocked via `vi.mock('../../lib/health-api')` per [revdev#43](https://github.com/RevealUIStudio/revdev/pull/43)) |
+| Session viewer | Streaming subscribe to `events.tail` for the selected session |
+| Deploy wizard | Multi-step flow; current StepEmail is a stub silently setting `setTestSent(true)` (TODO Phase 2) |
+| Billing | RevealUI API consumer for billing surface |
+| Alerts | Subscribes to `events.subscribe` for alert-tagged events |
+
+Test count: 522/522 passing per [revdev#43](https://github.com/RevealUIStudio/revdev/pull/43).
+
+---
+
+## Security posture
+
+- **Unix socket** with mode `srw-------` (owner-only) — daemon binds at `~/.local/share/revealui/harness.sock` with `umask 077`
+- **Stale socket recovery** — `startDaemon()` unlinks any stale socket before binding (server.ts:606)
+- **License keypair** in RevVault (never in env vars or `.env` files)
+- **JWT verify** uses `node:crypto.verify(null, ...)` — Node built-in crypto, no third-party JWT lib (avoids algorithm-confusion CVE class)
+- **CodeQL js-ts + go** scanning in CI
+- **Gitleaks** + secret scanning + dependency review in CI
+
+---
+
+## Versioning
+
+Pre-1.0 per [`versioning.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/.claude/rules/versioning.md). Per-package SemVer (`@revdev/daemon`, `@revdev/protocol`, `@revdev/bridge`, `@revdev/theme` independent). Studio + Console app versions tracked separately per Tauri / Go release conventions.
+
+---
+
+## Compose / coexistence
+
+| Other product | Relationship |
+|---|---|
+| **RevealUI** | Daemon talks to RevealUI API for tool routing; license JWT issued by RevealUI's `packages/core/src/license.ts:521-543` `generateLicenseKey()` |
+| **RevVault** | License signing key at `revdev/license-signing-key`; per-customer license keys may be stored under `credentials/license/<customer>` |
+| **RevCon** | Studio integrates with RevCon for editor configs |
+| **RevForge** | Stamped Fleet kits include a per-customer license JWT (Phase 3 integration); RevForge `stamp.sh` will eventually call `revdev issue-license` |
+| **RevKit / RevealCoin / RevSkills** | Independent |
+
+---
+
+## See also
+
+- [`docs/MASTER_PLAN.md`](./MASTER_PLAN.md) — current status, phases, owner action queue
+- [`docs/PRODUCTION_LAUNCH_PLAN.md`](./PRODUCTION_LAUNCH_PLAN.md) — task-level launch checklist
+- [`docs/API_REFERENCE.md`](./API_REFERENCE.md) — JSON-RPC API reference
+- [`docs/GETTING_STARTED.md`](./GETTING_STARTED.md) — quick start
+- [`docs/KEY_GENERATION.md`](./KEY_GENERATION.md) — license keypair generation
+- [`docs/TROUBLESHOOTING.md`](./TROUBLESHOOTING.md) — common issues
+- [`CLAUDE.md`](../CLAUDE.md) — agent context
+- [`README.md`](../README.md) — overview + architecture
+- [`revealui:.claude/rules/hooks-architecture.md`](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/hooks-architecture.md) — fleet hook contract; the daemon's role in fleet coordination
+- [`revealui-jv:docs/MASTER_INDEX.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_INDEX.md) — fleet-level navigation

--- a/docs/PRODUCTION_LAUNCH_PLAN.md
+++ b/docs/PRODUCTION_LAUNCH_PLAN.md
@@ -3,7 +3,7 @@
 Complete spec for remaining work to ship RevDev as a commercial product.
 Covers both agent-executable (code) and human-required (secrets, accounts, infrastructure) tasks.
 
-Last updated: 2026-04-20
+Last updated: 2026-05-08
 
 ---
 
@@ -212,7 +212,7 @@ Tasks that require the founder's credentials, physical access, or business decis
 **Who**: Founder
 
 ```bash
-cd ~/suite/revdev/apps/studio/src-tauri
+cd ~/revfleet/revdev/apps/studio/src-tauri
 pnpm tauri signer generate -w ~/.tauri/revdev-studio.key
 ```
 
@@ -313,7 +313,7 @@ Add these secrets to `RevealUIStudio/revdev` → Settings → Secrets:
 **Who**: Founder
 
 ```bash
-cd ~/suite/revdev
+cd ~/revfleet/revdev
 
 # Build daemon
 pnpm --filter @revdev/daemon build
@@ -328,6 +328,8 @@ bash packages/daemon/service/install.sh
 # Verify
 systemctl --user status revdev-daemon
 ```
+
+✅ **DONE** — closed via [revdev#27](https://github.com/RevealUIStudio/revdev/pull/27) 2026-04-28 (GAP-152) + [revdev#23](https://github.com/RevealUIStudio/revdev/pull/23) 2026-04-28 (GAP-153)
 
 ---
 

--- a/packages/daemon/src/__tests__/flows.test.ts
+++ b/packages/daemon/src/__tests__/flows.test.ts
@@ -1,6 +1,8 @@
+import { generateKeyPairSync, sign } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { DAEMON_DEFAULTS } from '../config.js';
 import { checkLicense, isExemptMethod, LICENSE_TIERS } from '../license.js';
+import { verifyLicenseJWT } from '../license-crypto.js';
 import { SCHEMA_SQL } from '../storage/schema.js';
 import {
   clearTestLicenseEnv,
@@ -20,11 +22,43 @@ describe('license', () => {
     if (original) process.env.REVEALUI_LICENSE_KEY = original;
   });
 
-  it('validates a pro v2 license key', () => {
+  it('validates a pro JWT license key', () => {
     setTestLicenseEnv(generateTestLicense('pro'));
     const result = checkLicense();
     expect(result.tier).toBe('pro');
     expect(result.valid).toBe(true);
+    clearTestLicenseEnv();
+  });
+
+  it('validates a max JWT license key', () => {
+    setTestLicenseEnv(generateTestLicense('max'));
+    const result = checkLicense();
+    expect(result.tier).toBe('max');
+    expect(result.valid).toBe(true);
+    clearTestLicenseEnv();
+  });
+
+  it('validates an enterprise JWT license key', () => {
+    setTestLicenseEnv(generateTestLicense('enterprise'));
+    const result = checkLicense();
+    expect(result.tier).toBe('enterprise');
+    expect(result.valid).toBe(true);
+    clearTestLicenseEnv();
+  });
+
+  it('validates a non-perpetual JWT license key (with exp)', () => {
+    setTestLicenseEnv(generateTestLicense('pro', false, { daysUntilExpiry: 30 }));
+    const result = checkLicense();
+    expect(result.tier).toBe('pro');
+    expect(result.valid).toBe(true);
+    clearTestLicenseEnv();
+  });
+
+  it('rejects a dotted-v2 format license (legacy)', () => {
+    process.env.REVEALUI_LICENSE_KEY = 'RVUI.v2.pro.0.somesig';
+    const result = checkLicense();
+    expect(result.tier).toBe('free');
+    expect(result.valid).toBe(false);
     clearTestLicenseEnv();
   });
 
@@ -53,6 +87,131 @@ describe('license', () => {
     expect(isExemptMethod('session.register')).toBe(true);
     expect(isExemptMethod('agent.spawn')).toBe(false);
     expect(isExemptMethod('merge.request')).toBe(false);
+  });
+});
+
+describe('verifyLicenseJWT — negative cases', () => {
+  it('rejects an RS256-signed JWT (algorithm mismatch)', () => {
+    const { privateKey: rsaPriv, publicKey: edPub } = (() => {
+      const { privateKey } = generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      });
+      const { publicKey } = generateKeyPairSync('ed25519', {
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      });
+      return { privateKey, publicKey };
+    })();
+
+    const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+    const payload = Buffer.from(JSON.stringify({ tier: 'pro' })).toString('base64url');
+    const sig = sign('sha256', Buffer.from(`${header}.${payload}`), rsaPriv).toString('base64url');
+    const rs256Jwt = `${header}.${payload}.${sig}`;
+
+    const result = verifyLicenseJWT(rs256Jwt, edPub as string);
+    expect(result.valid).toBe(false);
+    expect('reason' in result && result.reason).toBe('unsupported algorithm');
+  });
+
+  it('rejects a JWT signed with the wrong Ed25519 key', () => {
+    const kit = generateTestLicense('pro');
+    const { publicKey: wrongPub } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const result = verifyLicenseJWT(kit.licenseKey, wrongPub as string);
+    expect(result.valid).toBe(false);
+    expect('reason' in result && result.reason).toBe('invalid signature');
+  });
+
+  it('rejects a JWT with non-JSON payload', () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
+    const payloadB64 = Buffer.from('not-json-at-all!!!').toString('base64url');
+    const message = `${header}.${payloadB64}`;
+    const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');
+
+    const result = verifyLicenseJWT(`${message}.${sig}`, publicKey as string);
+    expect(result.valid).toBe(false);
+    expect('reason' in result && result.reason).toBe('invalid format');
+  });
+
+  it('rejects a JWT with an unrecognized tier', () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
+    const payloadB64 = Buffer.from(
+      JSON.stringify({ tier: 'gold', iat: Math.floor(Date.now() / 1000) }),
+    ).toString('base64url');
+    const message = `${header}.${payloadB64}`;
+    const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');
+
+    const result = verifyLicenseJWT(`${message}.${sig}`, publicKey as string);
+    expect(result.valid).toBe(false);
+    expect('reason' in result && result.reason).toContain('invalid tier');
+  });
+
+  it('rejects an expired JWT', () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const now = Math.floor(Date.now() / 1000);
+    const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
+    const payloadB64 = Buffer.from(
+      JSON.stringify({ tier: 'pro', iat: now - 7200, exp: now - 3600 }),
+    ).toString('base64url');
+    const message = `${header}.${payloadB64}`;
+    const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');
+
+    const result = verifyLicenseJWT(`${message}.${sig}`, publicKey as string);
+    expect(result.valid).toBe(false);
+    expect('reason' in result && result.reason).toBe('license expired');
+  });
+
+  it('accepts a perpetual JWT (no exp claim)', () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const now = Math.floor(Date.now() / 1000);
+    const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
+    // No exp claim
+    const payloadB64 = Buffer.from(JSON.stringify({ tier: 'enterprise', iat: now })).toString(
+      'base64url',
+    );
+    const message = `${header}.${payloadB64}`;
+    const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');
+
+    const result = verifyLicenseJWT(`${message}.${sig}`, publicKey as string);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.tier).toBe('enterprise');
+      expect(result.expiresAt).toBe(0);
+    }
+  });
+
+  it('rejects a JWT with only two parts (malformed)', () => {
+    const { publicKey } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const result = verifyLicenseJWT('header.payload', publicKey as string);
+    expect(result.valid).toBe(false);
+    expect('reason' in result && result.reason).toBe('invalid format');
   });
 });
 

--- a/packages/daemon/src/__tests__/inference.test.ts
+++ b/packages/daemon/src/__tests__/inference.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('inference module — timeout configuration', () => {
+  const TIMEOUT_ENV_VARS = [
+    'REVDEV_OLLAMA_STATUS_TIMEOUT_MS',
+    'REVDEV_OLLAMA_STOP_TIMEOUT_MS',
+    'REVDEV_OLLAMA_START_TIMEOUT_MS',
+    'REVDEV_OLLAMA_CHAT_TIMEOUT_MS',
+    'REVDEV_OLLAMA_GENERATE_TIMEOUT_MS',
+    'REVDEV_OLLAMA_PULL_TIMEOUT_MS',
+  ] as const;
+
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const k of TIMEOUT_ENV_VARS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of TIMEOUT_ENV_VARS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('uses defaults when no env vars are set', async () => {
+    const { OLLAMA_TIMEOUTS } = await import('../inference.js');
+    expect(OLLAMA_TIMEOUTS.status).toBe(5_000);
+    expect(OLLAMA_TIMEOUTS.stop).toBe(5_000);
+    expect(OLLAMA_TIMEOUTS.start).toBe(60_000);
+    expect(OLLAMA_TIMEOUTS.chat).toBe(300_000);
+    expect(OLLAMA_TIMEOUTS.generate).toBe(300_000);
+    expect(OLLAMA_TIMEOUTS.pull).toBe(1_800_000);
+  });
+
+  it('honors env-var overrides per operation', async () => {
+    process.env.REVDEV_OLLAMA_STATUS_TIMEOUT_MS = '1000';
+    process.env.REVDEV_OLLAMA_CHAT_TIMEOUT_MS = '120000';
+    process.env.REVDEV_OLLAMA_PULL_TIMEOUT_MS = '900000';
+
+    const { OLLAMA_TIMEOUTS } = await import('../inference.js');
+    expect(OLLAMA_TIMEOUTS.status).toBe(1_000);
+    expect(OLLAMA_TIMEOUTS.chat).toBe(120_000);
+    expect(OLLAMA_TIMEOUTS.pull).toBe(900_000);
+    // Unset ones still default
+    expect(OLLAMA_TIMEOUTS.stop).toBe(5_000);
+    expect(OLLAMA_TIMEOUTS.generate).toBe(300_000);
+  });
+
+  it('falls back to default when env var is non-numeric', async () => {
+    process.env.REVDEV_OLLAMA_STATUS_TIMEOUT_MS = 'not-a-number';
+    const { OLLAMA_TIMEOUTS } = await import('../inference.js');
+    expect(OLLAMA_TIMEOUTS.status).toBe(5_000);
+  });
+
+  it('falls back to default when env var is zero or negative', async () => {
+    process.env.REVDEV_OLLAMA_STATUS_TIMEOUT_MS = '0';
+    process.env.REVDEV_OLLAMA_STOP_TIMEOUT_MS = '-1';
+    const { OLLAMA_TIMEOUTS } = await import('../inference.js');
+    expect(OLLAMA_TIMEOUTS.status).toBe(5_000);
+    expect(OLLAMA_TIMEOUTS.stop).toBe(5_000);
+  });
+});
+
+describe('inference module — isTimeoutError', () => {
+  it('identifies TimeoutError (Node 20+ AbortSignal.timeout shape)', async () => {
+    const { isTimeoutError } = await import('../inference.js');
+    const err = new Error('timed out');
+    err.name = 'TimeoutError';
+    expect(isTimeoutError(err)).toBe(true);
+  });
+
+  it('identifies AbortError (older runtime shape)', async () => {
+    const { isTimeoutError } = await import('../inference.js');
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    expect(isTimeoutError(err)).toBe(true);
+  });
+
+  it('identifies DOMException-shaped TimeoutError when AbortSignal.timeout fires for real', async () => {
+    const { isTimeoutError } = await import('../inference.js');
+    const signal = AbortSignal.timeout(1);
+    await new Promise<void>((resolve) => {
+      signal.addEventListener('abort', () => resolve(), { once: true });
+    });
+    expect(signal.aborted).toBe(true);
+    expect(isTimeoutError(signal.reason)).toBe(true);
+  });
+
+  it('rejects non-abort errors', async () => {
+    const { isTimeoutError } = await import('../inference.js');
+    expect(isTimeoutError(new Error('connection refused'))).toBe(false);
+    expect(isTimeoutError(new TypeError('fetch failed'))).toBe(false);
+  });
+
+  it('rejects non-Error values', async () => {
+    const { isTimeoutError } = await import('../inference.js');
+    expect(isTimeoutError(undefined)).toBe(false);
+    expect(isTimeoutError(null)).toBe(false);
+    expect(isTimeoutError('AbortError')).toBe(false);
+    expect(isTimeoutError({ name: 'TimeoutError' })).toBe(false);
+  });
+});

--- a/packages/daemon/src/__tests__/shutdown-drain.test.ts
+++ b/packages/daemon/src/__tests__/shutdown-drain.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for graceful-shutdown drain — server.close() waits for in-flight
+ * RPC handlers before tearing down PGlite + the Unix socket.
+ *
+ * Two layers:
+ *  - Direct exercise of the drain helper (`_drainActiveHandlersForTest`)
+ *    using the test-only counter setter (`_setActiveHandlerCountForTest`).
+ *    Deterministic; no daemon, no socket.
+ *  - One end-to-end sanity test that exercises a real startDaemon →
+ *    close() cycle with no in-flight handlers (drain returns immediately).
+ *    Confirms the close()-side wiring doesn't regress.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  _drainActiveHandlersForTest,
+  _setActiveHandlerCountForTest,
+  _setClosingForTest,
+  startDaemon,
+} from '../server.js';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+describe('drainActiveHandlers (helper)', () => {
+  beforeEach(() => {
+    _setActiveHandlerCountForTest(0);
+  });
+
+  afterEach(() => {
+    _setActiveHandlerCountForTest(0);
+  });
+
+  it('returns drained:true immediately when no handlers are in flight', async () => {
+    const start = Date.now();
+    const result = await _drainActiveHandlersForTest(1000);
+    const elapsed = Date.now() - start;
+    expect(result.drained).toBe(true);
+    expect(result.remaining).toBe(0);
+    // Should resolve well under the deadline — first poll observes count=0.
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  it('waits while count > 0 and resolves when it drops to zero', async () => {
+    _setActiveHandlerCountForTest(2);
+    // Decrement asynchronously so the drain has to poll.
+    setTimeout(() => _setActiveHandlerCountForTest(1), 30);
+    setTimeout(() => _setActiveHandlerCountForTest(0), 60);
+
+    const start = Date.now();
+    const result = await _drainActiveHandlersForTest(1000);
+    const elapsed = Date.now() - start;
+
+    expect(result.drained).toBe(true);
+    expect(result.remaining).toBe(0);
+    // Should finish near the second decrement (~60 ms) not near the deadline.
+    expect(elapsed).toBeGreaterThanOrEqual(50);
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('returns drained:false with remaining count when deadline expires', async () => {
+    _setActiveHandlerCountForTest(3);
+    const start = Date.now();
+    const result = await _drainActiveHandlersForTest(80);
+    const elapsed = Date.now() - start;
+
+    expect(result.drained).toBe(false);
+    expect(result.remaining).toBe(3);
+    // Deadline-bounded — should not significantly overshoot.
+    expect(elapsed).toBeGreaterThanOrEqual(70);
+    expect(elapsed).toBeLessThan(300);
+  });
+
+  it('handles fractional decrement progress that still misses the deadline', async () => {
+    _setActiveHandlerCountForTest(5);
+    // Drop to 2 inside the window; deadline still fires before reaching 0.
+    setTimeout(() => _setActiveHandlerCountForTest(2), 30);
+
+    const result = await _drainActiveHandlersForTest(80);
+    expect(result.drained).toBe(false);
+    expect(result.remaining).toBe(2);
+  });
+
+  it('respects a custom tick interval (slower polls still resolve)', async () => {
+    _setActiveHandlerCountForTest(1);
+    setTimeout(() => _setActiveHandlerCountForTest(0), 50);
+
+    const result = await _drainActiveHandlersForTest(1000, 25);
+    expect(result.drained).toBe(true);
+  });
+});
+
+describe('startDaemon().close() — drain integration', () => {
+  let dataDir: string;
+  let socketPath: string;
+  let originalLicenseKey: string | undefined;
+  let originalPublicKey: string | undefined;
+
+  beforeEach(async () => {
+    const { generateTestLicense, setTestLicenseEnv } = await import('./test-license-helper.js');
+    originalLicenseKey = process.env.REVEALUI_LICENSE_KEY;
+    originalPublicKey = process.env.REVDEV_LICENSE_PUBLIC_KEY;
+    setTestLicenseEnv(generateTestLicense('enterprise'));
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-drain-'));
+    socketPath = join(dataDir, 'harness.sock');
+    _setActiveHandlerCountForTest(0);
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+    _setActiveHandlerCountForTest(0);
+    const { clearTestLicenseEnv } = await import('./test-license-helper.js');
+    clearTestLicenseEnv();
+    if (originalLicenseKey) process.env.REVEALUI_LICENSE_KEY = originalLicenseKey;
+    if (originalPublicKey) process.env.REVDEV_LICENSE_PUBLIC_KEY = originalPublicKey;
+  });
+
+  it('completes promptly when no handlers are in flight', async () => {
+    const d = await startDaemon({ socketPath, dataDir, shutdownGracePeriodMs: 1000 });
+    const start = Date.now();
+    await d.close();
+    const elapsed = Date.now() - start;
+    // No handlers in flight — drain should resolve on the first poll.
+    // Most of the elapsed time is db.close() + unlink, not the drain.
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  it('does not exceed the configured grace period when a stuck handler is simulated', async () => {
+    const d = await startDaemon({ socketPath, dataDir, shutdownGracePeriodMs: 100 });
+    // Simulate a stuck handler by bumping the counter directly. close()'s
+    // drain should hit the deadline, log a warning, and proceed.
+    _setActiveHandlerCountForTest(1);
+    const start = Date.now();
+    await d.close();
+    const elapsed = Date.now() - start;
+    // Should pass the 100 ms drain deadline plus db.close() + unlink time,
+    // but shouldn't hang indefinitely.
+    expect(elapsed).toBeGreaterThanOrEqual(100);
+    expect(elapsed).toBeLessThan(3000);
+    // Counter is still 1 (we never decremented it from the test side).
+    // Reset for afterEach.
+    _setActiveHandlerCountForTest(0);
+  });
+});
+
+describe('shutdown gate (regression — Codex P2 catch on revdev#47)', () => {
+  let dataDir: string;
+  let socketPath: string;
+  let originalLicenseKey: string | undefined;
+  let originalPublicKey: string | undefined;
+
+  beforeEach(async () => {
+    const { generateTestLicense, setTestLicenseEnv } = await import('./test-license-helper.js');
+    originalLicenseKey = process.env.REVEALUI_LICENSE_KEY;
+    originalPublicKey = process.env.REVDEV_LICENSE_PUBLIC_KEY;
+    setTestLicenseEnv(generateTestLicense('enterprise'));
+    const { mkdtemp } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-closing-'));
+    socketPath = join(dataDir, 'harness.sock');
+    _setActiveHandlerCountForTest(0);
+    _setClosingForTest(false);
+  });
+
+  afterEach(async () => {
+    const { rm } = await import('node:fs/promises');
+    await rm(dataDir, { recursive: true, force: true });
+    _setActiveHandlerCountForTest(0);
+    _setClosingForTest(false);
+    const { clearTestLicenseEnv } = await import('./test-license-helper.js');
+    clearTestLicenseEnv();
+    if (originalLicenseKey) process.env.REVEALUI_LICENSE_KEY = originalLicenseKey;
+    if (originalPublicKey) process.env.REVDEV_LICENSE_PUBLIC_KEY = originalPublicKey;
+  });
+
+  function rpcOnce(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const sock: Socket = connect(socketPath);
+      let buf = '';
+      const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
+      sock.on('connect', () => sock.write(req));
+      sock.on('data', (d) => {
+        buf += d.toString();
+        const nl = buf.indexOf('\n');
+        if (nl === -1) return;
+        const line = buf.slice(0, nl);
+        sock.end();
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(e instanceof Error ? e : new Error(String(e)));
+        }
+      });
+      sock.on('error', reject);
+      sock.setTimeout(5000, () => {
+        sock.destroy();
+        reject(new Error(`RPC timeout: ${method}`));
+      });
+    });
+  }
+
+  it('rejects RPCs with -32099 once _closing is set, before incrementing the handler counter', async () => {
+    const d = await startDaemon({ socketPath, dataDir });
+    // Simulate the close() entrypoint having flipped the gate, but the
+    // listener is still up so the request reaches dispatch.
+    _setClosingForTest(true);
+
+    const resp = (await rpcOnce('ping')) as {
+      jsonrpc: string;
+      id: number;
+      error?: { code: number; message: string };
+      result?: unknown;
+    };
+    expect(resp.jsonrpc).toBe('2.0');
+    expect(resp.id).toBe(1);
+    expect(resp.result).toBeUndefined();
+    expect(resp.error).toBeDefined();
+    expect(resp.error?.code).toBe(-32099);
+    expect(resp.error?.message).toBe('Server is shutting down');
+
+    // Critical: the gated request must NOT have incremented the counter
+    // — otherwise close()'s drain would observe a phantom in-flight
+    // handler and either wait or warn unnecessarily.
+    expect((await _drainActiveHandlersForTest(0)).remaining).toBe(0);
+
+    _setClosingForTest(false);
+    await d.close();
+  });
+
+  it('clears _closing on a fresh startDaemon so the gate is independent across lifecycles', async () => {
+    const d1 = await startDaemon({ socketPath, dataDir });
+    await d1.close();
+    // After close() returns, _closing is reset to false. A new startDaemon
+    // observed in the same process must NOT carry over the gate.
+    const d2 = await startDaemon({ socketPath, dataDir });
+    const resp = (await rpcOnce('ping')) as { result?: { pong?: boolean } };
+    expect(resp.result?.pong).toBe(true);
+    await d2.close();
+  });
+
+  it('destroys persistent sockets on close — pre-existing connections cannot dispatch RPCs against a closed daemon (Codex round-2 catch)', async () => {
+    const d = await startDaemon({ socketPath, dataDir });
+
+    // Open a long-lived socket BEFORE close() — like a Studio app would.
+    const sock: Socket = connect(socketPath);
+    await new Promise<void>((resolve, reject) => {
+      sock.once('connect', () => resolve());
+      sock.once('error', reject);
+    });
+    expect(sock.destroyed).toBe(false);
+
+    // Trigger close(). Per the new sequence, all open sockets get
+    // destroyed before the drain.
+    await d.close();
+
+    // The pre-existing socket should now be destroyed. If it weren't,
+    // a `data` event could still fire and dispatch against the closed
+    // PGlite — the very race Codex flagged.
+    expect(sock.destroyed).toBe(true);
+  });
+});

--- a/packages/daemon/src/__tests__/socket-buffer-bound.test.ts
+++ b/packages/daemon/src/__tests__/socket-buffer-bound.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Per-socket reassembly buffer bound — DoS surface guard.
+ *
+ * Validates that a client who streams bytes without a newline cannot
+ * grow the daemon's per-socket buffer indefinitely. On overflow, the
+ * daemon must emit a JSON-RPC -32700 parse error (id null) and destroy
+ * the socket.
+ *
+ * Tests use a tiny `maxLineBytes` cap (4 KiB) so they run fast — the
+ * production default is 1 MiB.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { startDaemon } from '../server.js';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+const TEST_MAX_LINE_BYTES = 4096;
+
+let dataDir: string;
+let socketPath: string;
+let close: () => Promise<void>;
+let originalLicenseKey: string | undefined;
+let originalPublicKey: string | undefined;
+
+beforeAll(async () => {
+  const { generateTestLicense, setTestLicenseEnv } = await import('./test-license-helper.js');
+  originalLicenseKey = process.env.REVEALUI_LICENSE_KEY;
+  originalPublicKey = process.env.REVDEV_LICENSE_PUBLIC_KEY;
+  setTestLicenseEnv(generateTestLicense('enterprise'));
+  dataDir = await mkdtemp(join(tmpdir(), 'revdev-buffer-bound-'));
+  socketPath = join(dataDir, 'harness.sock');
+  const d = await startDaemon({ socketPath, dataDir, maxLineBytes: TEST_MAX_LINE_BYTES });
+  close = d.close;
+});
+
+afterAll(async () => {
+  await close?.();
+  await rm(dataDir, { recursive: true, force: true });
+  const { clearTestLicenseEnv } = await import('./test-license-helper.js');
+  clearTestLicenseEnv();
+  if (originalLicenseKey) process.env.REVEALUI_LICENSE_KEY = originalLicenseKey;
+  if (originalPublicKey) process.env.REVDEV_LICENSE_PUBLIC_KEY = originalPublicKey;
+});
+
+interface ServerEvent {
+  type: 'data' | 'close' | 'error';
+  data?: string;
+  err?: Error;
+}
+
+/**
+ * Open a raw socket, send chunks (no newline auto-added), and capture
+ * everything the server sends back plus the close event. Returns once
+ * the socket closes (either side) or after `idleMs` of silence with
+ * the connection still open.
+ */
+function rawExchange(payloads: string[], idleMs = 500): Promise<ServerEvent[]> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    const events: ServerEvent[] = [];
+    let idleTimer: NodeJS.Timeout | null = null;
+
+    const finish = () => {
+      if (idleTimer) clearTimeout(idleTimer);
+      try {
+        sock.destroy();
+      } catch {
+        /* socket may already be destroyed */
+      }
+      resolve(events);
+    };
+
+    const resetIdle = () => {
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(finish, idleMs);
+    };
+
+    sock.on('connect', () => {
+      for (const p of payloads) sock.write(p);
+      resetIdle();
+    });
+    sock.on('data', (d) => {
+      events.push({ type: 'data', data: d.toString() });
+      resetIdle();
+    });
+    sock.on('close', () => {
+      events.push({ type: 'close' });
+      finish();
+    });
+    sock.on('error', (err) => {
+      events.push({ type: 'error', err });
+      // Don't reject — overflow path destroys socket from server side, which
+      // can surface as ECONNRESET on the client. That's expected.
+      resetIdle();
+    });
+    sock.setTimeout(10_000, () => {
+      sock.destroy();
+      reject(new Error('rawExchange timeout (no events)'));
+    });
+  });
+}
+
+function joinedData(events: ServerEvent[]): string {
+  return events
+    .filter((e) => e.type === 'data')
+    .map((e) => e.data ?? '')
+    .join('');
+}
+
+function parseLines(joined: string): Array<Record<string, unknown>> {
+  return joined
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+describe('socket buffer bound', () => {
+  it('accepts a normal under-cap request followed by newline', async () => {
+    const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' })}\n`;
+    const events = await rawExchange([req]);
+
+    const responses = parseLines(joinedData(events));
+    expect(responses).toHaveLength(1);
+    expect(responses[0]?.id).toBe(1);
+    expect((responses[0]?.result as { pong?: boolean } | undefined)?.pong).toBe(true);
+  });
+
+  it('emits -32700 parse-error and destroys socket when a single frame exceeds maxLineBytes', async () => {
+    // Stream more than maxLineBytes without ever sending a newline. The
+    // server should drop the connection after emitting an error response.
+    const oversize = 'a'.repeat(TEST_MAX_LINE_BYTES + 1);
+    const events = await rawExchange([oversize]);
+
+    const responses = parseLines(joinedData(events));
+    expect(responses.length).toBeGreaterThanOrEqual(1);
+
+    const resp = responses[0] as {
+      jsonrpc: string;
+      id: number | null;
+      error: { code: number; message: string };
+    };
+    expect(resp.jsonrpc).toBe('2.0');
+    expect(resp.id).toBeNull();
+    expect(resp.error.code).toBe(-32700);
+    expect(resp.error.message).toMatch(/frame exceeded/);
+    expect(resp.error.message).toContain(String(TEST_MAX_LINE_BYTES));
+
+    // Server should have closed the socket.
+    expect(events.some((e) => e.type === 'close')).toBe(true);
+  });
+
+  it('still accepts pipelined small requests on a fresh socket after a prior connection was killed', async () => {
+    // Confirms the overflow path doesn't break the listener for new clients.
+    const reqs =
+      `${JSON.stringify({ jsonrpc: '2.0', id: 10, method: 'ping' })}\n` +
+      `${JSON.stringify({ jsonrpc: '2.0', id: 11, method: 'ping' })}\n`;
+    const events = await rawExchange([reqs]);
+
+    const responses = parseLines(joinedData(events));
+    expect(responses.length).toBe(2);
+    expect(responses.map((r) => r.id).sort()).toEqual([10, 11]);
+    for (const r of responses) {
+      expect((r.result as { pong?: boolean } | undefined)?.pong).toBe(true);
+    }
+  });
+
+  it('accumulates across chunks under the cap (split JSON across two writes is fine)', async () => {
+    const full = `${JSON.stringify({ jsonrpc: '2.0', id: 20, method: 'ping' })}\n`;
+    const halfway = Math.floor(full.length / 2);
+    const events = await rawExchange([full.slice(0, halfway), full.slice(halfway)]);
+
+    const responses = parseLines(joinedData(events));
+    expect(responses).toHaveLength(1);
+    expect(responses[0]?.id).toBe(20);
+    expect((responses[0]?.result as { pong?: boolean } | undefined)?.pong).toBe(true);
+  });
+
+  it('regression — does NOT reject pipelined valid frames whose combined byte count exceeds the cap', async () => {
+    // Two valid pings in a single chunk where each is below the cap
+    // but their concatenation exceeds the cap. Pre-fix this tripped
+    // the bound because the check ran on the accumulated chunk before
+    // the split; post-fix only the partial remainder + each individual
+    // line are checked.
+    const buildFrame = (id: number, padBytes: number): string =>
+      JSON.stringify({ jsonrpc: '2.0', id, method: 'ping', _pad: 'x'.repeat(padBytes) });
+
+    // Each frame ~ TEST_MAX_LINE_BYTES * 0.7 → individually under cap,
+    // together (with two newlines) > cap.
+    const padPerFrame = Math.floor(TEST_MAX_LINE_BYTES * 0.7);
+    const frame1 = buildFrame(30, padPerFrame);
+    const frame2 = buildFrame(31, padPerFrame);
+    expect(Buffer.byteLength(frame1, 'utf8')).toBeLessThan(TEST_MAX_LINE_BYTES);
+    expect(Buffer.byteLength(frame2, 'utf8')).toBeLessThan(TEST_MAX_LINE_BYTES);
+    const chunk = `${frame1}\n${frame2}\n`;
+    expect(Buffer.byteLength(chunk, 'utf8')).toBeGreaterThan(TEST_MAX_LINE_BYTES);
+
+    const events = await rawExchange([chunk]);
+    const responses = parseLines(joinedData(events));
+    expect(responses).toHaveLength(2);
+    expect(responses.map((r) => r.id).sort()).toEqual([30, 31]);
+    for (const r of responses) {
+      expect((r.result as { pong?: boolean } | undefined)?.pong).toBe(true);
+    }
+    // No -32700 should appear (both frames are individually under the cap).
+    const errs = responses.filter((r) => {
+      const e = r.error as { code?: number } | undefined;
+      return e?.code === -32700;
+    });
+    expect(errs).toHaveLength(0);
+  });
+
+  it('regression — accepts a frame exactly at the cap followed by its newline', async () => {
+    // Pre-fix, `buffer.length > cap` ran on the accumulated chunk
+    // BEFORE the split, so a frame of exactly cap bytes plus a newline
+    // (cap+1 total) tripped the check even though the frame itself
+    // honored the boundary. Post-fix, the partial-remainder check sees
+    // an empty buffer (the newline split everything off) and the
+    // per-line check sees a frame at exactly the cap, both passing.
+    //
+    // We can't actually build a valid JSON-RPC frame of exactly
+    // TEST_MAX_LINE_BYTES bytes without padding — instead we use a
+    // valid ping padded with a string field to land exactly at the cap.
+    const baseFrame = JSON.stringify({ jsonrpc: '2.0', id: 40, method: 'ping', _pad: '' });
+    const padNeeded = TEST_MAX_LINE_BYTES - Buffer.byteLength(baseFrame, 'utf8');
+    expect(padNeeded).toBeGreaterThan(0);
+    const exactFrame = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 40,
+      method: 'ping',
+      _pad: 'x'.repeat(padNeeded),
+    });
+    expect(Buffer.byteLength(exactFrame, 'utf8')).toBe(TEST_MAX_LINE_BYTES);
+
+    const events = await rawExchange([`${exactFrame}\n`]);
+    const responses = parseLines(joinedData(events));
+    expect(responses).toHaveLength(1);
+    expect(responses[0]?.id).toBe(40);
+    expect((responses[0]?.result as { pong?: boolean } | undefined)?.pong).toBe(true);
+  });
+
+  it('regression — rejects a complete oversized frame with -32700 but keeps the socket open', async () => {
+    // A single chunk arrives containing a newline-terminated frame
+    // larger than the cap. The frame should be rejected with -32700
+    // but the connection must NOT be destroyed — the client framed the
+    // boundary correctly, they just sent too much data. A second valid
+    // frame in the same connection should still get a response.
+    const oversize = `${'a'.repeat(TEST_MAX_LINE_BYTES + 1)}\n`;
+    const followUp = `${JSON.stringify({ jsonrpc: '2.0', id: 50, method: 'ping' })}\n`;
+    const events = await rawExchange([oversize, followUp]);
+
+    const responses = parseLines(joinedData(events));
+    // Expect: one -32700 for the oversize frame, then one ok ping response.
+    const errs = responses.filter((r) => {
+      const e = r.error as { code?: number; message?: string } | undefined;
+      return e?.code === -32700;
+    });
+    expect(errs.length).toBeGreaterThanOrEqual(1);
+    const ping = responses.find((r) => r.id === 50);
+    expect(ping).toBeDefined();
+    expect((ping?.result as { pong?: boolean } | undefined)?.pong).toBe(true);
+    // Socket should NOT have been destroyed by the oversize frame
+    // alone — close should only fire from our test-side rawExchange
+    // teardown after idle.
+  });
+
+  it('regression — counts UTF-8 bytes, not UTF-16 code units, against the cap', async () => {
+    // A multibyte payload (4-byte UTF-8 emoji) of 1500 chars is 6000
+    // bytes. With cap=4096, this should be rejected. With the old
+    // string.length check (counting UTF-16 code units), the same
+    // payload was 3000 code units and bypassed the cap.
+    const emoji = '\u{1F600}'; // grinning face — 4 UTF-8 bytes, 2 UTF-16 code units
+    const payload = emoji.repeat(1500);
+    expect(Buffer.byteLength(payload, 'utf8')).toBeGreaterThan(TEST_MAX_LINE_BYTES);
+    expect(payload.length).toBeLessThan(TEST_MAX_LINE_BYTES);
+
+    const events = await rawExchange([payload]);
+    // Payload had no newline → partial-remainder path → -32700 + destroy.
+    const responses = parseLines(joinedData(events));
+    expect(responses.length).toBeGreaterThanOrEqual(1);
+    const err = responses[0]?.error as { code?: number } | undefined;
+    expect(err?.code).toBe(-32700);
+    expect(events.some((e) => e.type === 'close')).toBe(true);
+  });
+});

--- a/packages/daemon/src/__tests__/test-license-helper.ts
+++ b/packages/daemon/src/__tests__/test-license-helper.ts
@@ -1,5 +1,5 @@
 /**
- * Test helper: generates Ed25519-signed v2 license keys for tests.
+ * Test helper: generates Ed25519-signed JWT license keys for tests.
  * Creates a fresh keypair per call — no secrets needed.
  */
 
@@ -10,28 +10,53 @@ export interface TestLicenseKit {
   licenseKey: string;
   /** Set as REVDEV_LICENSE_PUBLIC_KEY */
   publicKey: string;
+  /** The private key PEM — available for constructing adversarial fixtures */
+  privateKey: string;
 }
 
 /**
- * Generate a real Ed25519-signed v2 license key for testing.
+ * Generate a real Ed25519-signed JWT license key for testing.
  * Returns both the key and the public key to set in env.
+ *
+ * opts.daysUntilExpiry: if set, JWT includes an exp claim that far in the future.
+ * perpetual (default true): JWT omits exp claim.
  */
 export function generateTestLicense(
   tier: 'pro' | 'max' | 'enterprise' = 'enterprise',
   perpetual = true,
+  opts: { daysUntilExpiry?: number; customerId?: string } = {},
 ): TestLicenseKit {
   const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
     publicKeyEncoding: { type: 'spki', format: 'pem' },
     privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
   });
 
-  const expiresAt = perpetual ? '0' : String(Math.floor(Date.now() / 1000) + 86400);
-  const message = `${tier}.${expiresAt}`;
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'EdDSA', typ: 'JWT' };
+  const payload: Record<string, unknown> = {
+    tier,
+    iat: now,
+    iss: 'https://revealui.com',
+    aud: 'revealui-license',
+  };
+
+  if (opts.customerId) {
+    payload.customerId = opts.customerId;
+  }
+
+  if (!perpetual) {
+    payload.exp = now + (opts.daysUntilExpiry ?? 1) * 86400;
+  }
+
+  const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const message = `${headerB64}.${payloadB64}`;
   const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');
 
   return {
-    licenseKey: `RVUI.v2.${tier}.${expiresAt}.${sig}`,
+    licenseKey: `${message}.${sig}`,
     publicKey: publicKey as string,
+    privateKey: privateKey as string,
   };
 }
 

--- a/packages/daemon/src/__tests__/validation.test.ts
+++ b/packages/daemon/src/__tests__/validation.test.ts
@@ -329,6 +329,58 @@ describe('merge.list validation', () => {
   });
 });
 
+describe('harness.health validation', () => {
+  it('accepts empty payload', () => {
+    expect(validateParams('harness.health', {}).valid).toBe(true);
+  });
+
+  it('accepts actorAgentId', () => {
+    expect(validateParams('harness.health', { actorAgentId: 'agent-1' }).valid).toBe(true);
+  });
+
+  it('passes through extra fields (passthrough)', () => {
+    expect(validateParams('harness.health', { extra: 'ignored' }).valid).toBe(true);
+  });
+});
+
+describe('harness.prune validation', () => {
+  it('accepts empty payload (handler defaults apply)', () => {
+    expect(validateParams('harness.prune', {}).valid).toBe(true);
+  });
+
+  it('accepts integer staleDays + hardDeleteDays', () => {
+    expect(validateParams('harness.prune', { staleDays: 7, hardDeleteDays: 30 }).valid).toBe(true);
+  });
+
+  it('accepts fractional days (test helpers use these to avoid long sleeps)', () => {
+    expect(validateParams('harness.prune', { staleDays: 0.00001 }).valid).toBe(true);
+  });
+
+  it('accepts negative days (handler defensive clamp is the safety net)', () => {
+    expect(validateParams('harness.prune', { staleDays: -1, hardDeleteDays: -7 }).valid).toBe(true);
+  });
+
+  it('rejects non-numeric staleDays', () => {
+    const result = validateParams('harness.prune', { staleDays: 'forever' });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects non-numeric hardDeleteDays', () => {
+    const result = validateParams('harness.prune', { hardDeleteDays: { days: 30 } });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('inference.status validation', () => {
+  it('accepts empty payload', () => {
+    expect(validateParams('inference.status', {}).valid).toBe(true);
+  });
+
+  it('accepts actorAgentId', () => {
+    expect(validateParams('inference.status', { actorAgentId: 'agent-1' }).valid).toBe(true);
+  });
+});
+
 describe('No-schema methods (pass-through)', () => {
   it('ping passes through with empty payload', () => {
     expect(validateParams('ping', {}).valid).toBe(true);

--- a/packages/daemon/src/__tests__/vcs.test.ts
+++ b/packages/daemon/src/__tests__/vcs.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for vcs.ts runChild — timeout + abort + shutdown propagation.
+ *
+ * runChild is the testable core under runGit; we exercise it via `node -e`
+ * commands so the tests are self-contained (no git binary needed beyond
+ * what already runs in CI) and deterministic.
+ */
+
+import { tmpdir } from 'node:os';
+import { describe, expect, it, vi } from 'vitest';
+import { runChild } from '../vcs.js';
+
+vi.setConfig({ testTimeout: 10_000, hookTimeout: 10_000 });
+
+const NODE = process.execPath;
+const CWD = tmpdir();
+
+describe('runChild', () => {
+  it('returns ok:true with stdout for a successful child', async () => {
+    const result = await runChild(NODE, ['-e', 'process.stdout.write("hello")'], {
+      cwd: CWD,
+      timeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.stdout).toBe('hello');
+    expect(result.code).toBe(0);
+    expect(result.aborted).toBeUndefined();
+  });
+
+  it('returns ok:false with non-zero exit code for a failing child', async () => {
+    const result = await runChild(NODE, ['-e', 'process.exit(7)'], {
+      cwd: CWD,
+      timeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe(7);
+    expect(result.aborted).toBeUndefined();
+  });
+
+  it('SIGTERMs and reports abortReason="timeout" when the child exceeds timeoutMs', async () => {
+    // setInterval keeps the process alive; only an external signal can
+    // bring it down.
+    const result = await runChild(NODE, ['-e', 'setInterval(() => {}, 1000)'], {
+      cwd: CWD,
+      timeoutMs: 100,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.aborted).toBe(true);
+    expect(result.abortReason).toBe('timeout');
+    expect(result.stderr).toContain('timed out after 100ms');
+  });
+
+  it('SIGTERMs and reports abortReason="shutdown" when the externalSignal aborts', async () => {
+    const ctrl = new AbortController();
+    // Abort 50ms after spawn — give the child time to start up.
+    setTimeout(() => ctrl.abort(), 50);
+    const result = await runChild(NODE, ['-e', 'setInterval(() => {}, 1000)'], {
+      cwd: CWD,
+      timeoutMs: 5_000,
+      externalSignal: ctrl.signal,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.aborted).toBe(true);
+    expect(result.abortReason).toBe('shutdown');
+    expect(result.stderr).toContain('aborted by daemon shutdown');
+  });
+
+  it('treats a pre-aborted externalSignal as immediate shutdown abort', async () => {
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const result = await runChild(NODE, ['-e', 'setInterval(() => {}, 1000)'], {
+      cwd: CWD,
+      timeoutMs: 5_000,
+      externalSignal: ctrl.signal,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.aborted).toBe(true);
+    expect(result.abortReason).toBe('shutdown');
+  });
+
+  it('returns ok:false with stderr.message for a non-existent command', async () => {
+    const result = await runChild('/nonexistent-binary-revdev-test', [], {
+      cwd: CWD,
+      timeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.aborted).toBeUndefined();
+    expect(result.code).toBe(-1);
+    // The exact error message varies (ENOENT on Linux, etc.) — just
+    // confirm we got an error string back rather than crashing.
+    expect(result.stderr.length).toBeGreaterThan(0);
+  });
+
+  it('captures stderr from a child that prints to stderr and exits non-zero', async () => {
+    const result = await runChild(NODE, ['-e', 'process.stderr.write("oops"); process.exit(1)'], {
+      cwd: CWD,
+      timeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toBe('oops');
+    expect(result.aborted).toBeUndefined();
+  });
+
+  it('honors timeout precedence over external signal when timeout fires first', async () => {
+    const ctrl = new AbortController();
+    setTimeout(() => ctrl.abort(), 5_000); // would-be later abort
+    const result = await runChild(NODE, ['-e', 'setInterval(() => {}, 1000)'], {
+      cwd: CWD,
+      timeoutMs: 100,
+      externalSignal: ctrl.signal,
+    });
+    expect(result.aborted).toBe(true);
+    expect(result.abortReason).toBe('timeout');
+  });
+});

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -14,6 +14,7 @@
  *   REVDEV_DAEMON_DATA       # Override data directory
  *   REVDEV_DAEMON_PID        # Override PID file path
  *   REVDEV_DAEMON_LOG        # Where stdout/stderr go in --detach mode (default: /tmp/revdev-daemon.log)
+ *   REVDEV_DAEMON_MAX_LINE_BYTES  # Max bytes per JSON-RPC frame (default: 1_048_576 = 1 MiB)
  */
 
 import { spawn } from 'node:child_process';
@@ -58,6 +59,7 @@ Environment:
   REVDEV_DAEMON_DATA          Data directory (default: ${DAEMON_DEFAULTS.dataDir})
   REVDEV_DAEMON_PID           PID file path (default: ${DAEMON_DEFAULTS.pidFile})
   REVDEV_DAEMON_LOG           Log file for --detach mode (default: ~/.local/share/revealui/daemon.log)
+  REVDEV_DAEMON_MAX_LINE_BYTES  Max bytes per JSON-RPC frame (default: ${DAEMON_DEFAULTS.maxLineBytes}, ~1 MiB)
 
 License tiers:
   free         Session management only
@@ -90,9 +92,17 @@ if (args.includes('--detach')) {
   process.exit(0);
 }
 
+function parsePositiveInt(envName: string, defaultValue: number): number {
+  const raw = process.env[envName];
+  if (!raw) return defaultValue;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+}
+
 const config = {
   socketPath: process.env.REVDEV_DAEMON_SOCKET ?? DAEMON_DEFAULTS.socketPath,
   dataDir: process.env.REVDEV_DAEMON_DATA ?? DAEMON_DEFAULTS.dataDir,
+  maxLineBytes: parsePositiveInt('REVDEV_DAEMON_MAX_LINE_BYTES', DAEMON_DEFAULTS.maxLineBytes),
 };
 
 const pidFile = process.env.REVDEV_DAEMON_PID ?? DAEMON_DEFAULTS.pidFile;

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -15,6 +15,7 @@
  *   REVDEV_DAEMON_PID        # Override PID file path
  *   REVDEV_DAEMON_LOG        # Where stdout/stderr go in --detach mode (default: /tmp/revdev-daemon.log)
  *   REVDEV_DAEMON_MAX_LINE_BYTES  # Max bytes per JSON-RPC frame (default: 1_048_576 = 1 MiB)
+ *   REVDEV_DAEMON_GIT_TIMEOUT_MS  # Max wall-clock per git spawn (default: 60_000 = 60 s)
  */
 
 import { spawn } from 'node:child_process';
@@ -60,6 +61,7 @@ Environment:
   REVDEV_DAEMON_PID           PID file path (default: ${DAEMON_DEFAULTS.pidFile})
   REVDEV_DAEMON_LOG           Log file for --detach mode (default: ~/.local/share/revealui/daemon.log)
   REVDEV_DAEMON_MAX_LINE_BYTES  Max bytes per JSON-RPC frame (default: ${DAEMON_DEFAULTS.maxLineBytes}, ~1 MiB)
+  REVDEV_DAEMON_GIT_TIMEOUT_MS  Max wall-clock per git spawn (default: ${DAEMON_DEFAULTS.gitTimeoutMs} ms = ${DAEMON_DEFAULTS.gitTimeoutMs / 1000} s)
 
 License tiers:
   free         Session management only
@@ -103,6 +105,7 @@ const config = {
   socketPath: process.env.REVDEV_DAEMON_SOCKET ?? DAEMON_DEFAULTS.socketPath,
   dataDir: process.env.REVDEV_DAEMON_DATA ?? DAEMON_DEFAULTS.dataDir,
   maxLineBytes: parsePositiveInt('REVDEV_DAEMON_MAX_LINE_BYTES', DAEMON_DEFAULTS.maxLineBytes),
+  gitTimeoutMs: parsePositiveInt('REVDEV_DAEMON_GIT_TIMEOUT_MS', DAEMON_DEFAULTS.gitTimeoutMs),
 };
 
 const pidFile = process.env.REVDEV_DAEMON_PID ?? DAEMON_DEFAULTS.pidFile;

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -16,6 +16,7 @@
  *   REVDEV_DAEMON_LOG        # Where stdout/stderr go in --detach mode (default: /tmp/revdev-daemon.log)
  *   REVDEV_DAEMON_MAX_LINE_BYTES  # Max bytes per JSON-RPC frame (default: 1_048_576 = 1 MiB)
  *   REVDEV_DAEMON_GIT_TIMEOUT_MS  # Max wall-clock per git spawn (default: 60_000 = 60 s)
+ *   REVDEV_DAEMON_SHUTDOWN_GRACE_MS  # Max wait for in-flight handlers in close() (default: 5_000 = 5 s)
  */
 
 import { spawn } from 'node:child_process';
@@ -62,6 +63,7 @@ Environment:
   REVDEV_DAEMON_LOG           Log file for --detach mode (default: ~/.local/share/revealui/daemon.log)
   REVDEV_DAEMON_MAX_LINE_BYTES  Max bytes per JSON-RPC frame (default: ${DAEMON_DEFAULTS.maxLineBytes}, ~1 MiB)
   REVDEV_DAEMON_GIT_TIMEOUT_MS  Max wall-clock per git spawn (default: ${DAEMON_DEFAULTS.gitTimeoutMs} ms = ${DAEMON_DEFAULTS.gitTimeoutMs / 1000} s)
+  REVDEV_DAEMON_SHUTDOWN_GRACE_MS  Max wait for in-flight handlers during close() (default: ${DAEMON_DEFAULTS.shutdownGracePeriodMs} ms = ${DAEMON_DEFAULTS.shutdownGracePeriodMs / 1000} s)
 
 License tiers:
   free         Session management only
@@ -106,6 +108,10 @@ const config = {
   dataDir: process.env.REVDEV_DAEMON_DATA ?? DAEMON_DEFAULTS.dataDir,
   maxLineBytes: parsePositiveInt('REVDEV_DAEMON_MAX_LINE_BYTES', DAEMON_DEFAULTS.maxLineBytes),
   gitTimeoutMs: parsePositiveInt('REVDEV_DAEMON_GIT_TIMEOUT_MS', DAEMON_DEFAULTS.gitTimeoutMs),
+  shutdownGracePeriodMs: parsePositiveInt(
+    'REVDEV_DAEMON_SHUTDOWN_GRACE_MS',
+    DAEMON_DEFAULTS.shutdownGracePeriodMs,
+  ),
 };
 
 const pidFile = process.env.REVDEV_DAEMON_PID ?? DAEMON_DEFAULTS.pidFile;

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -48,6 +48,25 @@ export interface DaemonConfig {
    * 250k-token prompt fits) and tight enough to defeat unbounded growth.
    */
   maxLineBytes: number;
+  /**
+   * Maximum wall-clock time (in ms) for a single git child-process spawn
+   * inside the daemon (worktree.create / worktree.remove). Without this,
+   * a runaway git command (credential prompt on a private base branch,
+   * a corrupt object DB requiring fsck, a giant repo, a hung remote)
+   * holds the daemon socket forever — SIGTERM to the daemon does not
+   * propagate to the orphaned git child.
+   *
+   * On timeout, the daemon SIGTERMs the child via the per-call
+   * AbortSignal passed to spawn(), waits briefly for clean exit, and
+   * returns a structured error response. On daemon shutdown, all
+   * in-flight git children get SIGTERM via a shared AbortController
+   * aborted from server.close().
+   *
+   * 60 s default covers any healthy worktree create/remove against a
+   * reasonable repo. Override via REVDEV_DAEMON_GIT_TIMEOUT_MS for
+   * deployers with very large repos or slow filesystems.
+   */
+  gitTimeoutMs: number;
 }
 
 const homeDir = process.env.HOME ?? '/tmp';
@@ -64,4 +83,5 @@ export const DAEMON_DEFAULTS: DaemonConfig = {
   hardDeleteDays: 30,
   pruneIntervalMs: 60 * 60 * 1000, // 1 hour
   maxLineBytes: 1_048_576, // 1 MiB
+  gitTimeoutMs: 60_000, // 60 s
 };

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -67,6 +67,29 @@ export interface DaemonConfig {
    * deployers with very large repos or slow filesystems.
    */
   gitTimeoutMs: number;
+  /**
+   * Maximum wall-clock time (in ms) the daemon's `close()` waits for
+   * in-flight RPC handlers to complete before tearing down PGlite and
+   * the Unix socket. Pre-this-flag, `db.close()` raced with active
+   * `await db.query(...)` calls — a long handler (e.g. worktree.create
+   * shelling out to git on a private base branch) could throw mid-query
+   * if the database closed under it.
+   *
+   * Sequence inside close():
+   *   1. Abort the daemon shutdown signal — this SIGTERMs every
+   *      in-flight git child, etc., letting them error out fast.
+   *   2. Stop accepting new connections.
+   *   3. Drain — poll the active-handler counter for up to
+   *      `shutdownGracePeriodMs`; resolve as soon as it hits zero.
+   *   4. db.close() + unlink socket.
+   *
+   * If the deadline passes with handlers still running (rare — almost
+   * everything either completes within milliseconds or honors the abort
+   * signal), the daemon logs a warning naming the leftover count and
+   * proceeds to db.close(). Default 5 s covers any realistic handler;
+   * tune via REVDEV_DAEMON_SHUTDOWN_GRACE_MS for slower environments.
+   */
+  shutdownGracePeriodMs: number;
 }
 
 const homeDir = process.env.HOME ?? '/tmp';
@@ -84,4 +107,5 @@ export const DAEMON_DEFAULTS: DaemonConfig = {
   pruneIntervalMs: 60 * 60 * 1000, // 1 hour
   maxLineBytes: 1_048_576, // 1 MiB
   gitTimeoutMs: 60_000, // 60 s
+  shutdownGracePeriodMs: 5_000, // 5 s
 };

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -23,6 +23,31 @@ export interface DaemonConfig {
   hardDeleteDays: number;
   /** How often to run the periodic prune (ms). Set to 0 to disable. */
   pruneIntervalMs: number;
+  /**
+   * Maximum size in UTF-8 bytes of a single newline-delimited JSON-RPC
+   * frame on a client socket. Two failure modes are guarded:
+   *
+   *   1. Unbounded-growth attack — a client streams bytes without a
+   *      newline; the per-socket reassembly buffer would grow linearly.
+   *      On overflow, the daemon emits a JSON-RPC -32700 parse-error
+   *      with id null AND destroys the socket. The client must
+   *      reconnect.
+   *
+   *   2. Oversized complete frame — a single chunk arrives containing
+   *      a newline-terminated frame larger than the cap. The frame is
+   *      rejected with -32700 but the socket stays open; the client
+   *      framed the boundary correctly, they just sent too much data.
+   *
+   * Comparisons use `Buffer.byteLength(s, 'utf8')` so the cap is
+   * enforced in real UTF-8 bytes (matching the documented "bytes"
+   * semantics) rather than UTF-16 code units — otherwise multibyte
+   * payloads (emoji, non-Latin text) bypass the intended protection.
+   *
+   * 1 MiB default is generous for any plausible RPC (largest legitimate
+   * payloads are inference.chat / inference.generate prompts; even a
+   * 250k-token prompt fits) and tight enough to defeat unbounded growth.
+   */
+  maxLineBytes: number;
 }
 
 const homeDir = process.env.HOME ?? '/tmp';
@@ -38,4 +63,5 @@ export const DAEMON_DEFAULTS: DaemonConfig = {
   staleSessionDays: 7,
   hardDeleteDays: 30,
   pruneIntervalMs: 60 * 60 * 1000, // 1 hour
+  maxLineBytes: 1_048_576, // 1 MiB
 };

--- a/packages/daemon/src/inference.ts
+++ b/packages/daemon/src/inference.ts
@@ -4,18 +4,62 @@
  * These handlers provide model management and chat completion through
  * the daemon's license-gated RPC surface. Free tier gets local inference
  * if Ollama is running; Pro+ gets full management (pull, start, stop).
+ *
+ * Every handler enforces a per-operation timeout via AbortSignal. Without
+ * this, a stuck Ollama (accepts the connection but never responds) would
+ * hold the daemon socket indefinitely — any caller could DoS the daemon
+ * with a single inference.status call. Timeouts are env-overridable so
+ * deployers can tune for slow hardware, large models, and slow networks.
+ *
+ * Error envelope: every handler returns a structured response on timeout
+ * or connection failure rather than throwing to the daemon's central
+ * error path. This matches the existing inference.status precedent and
+ * gives callers a consistent error shape they can render.
  */
 
 import { registerHandler } from './server.js';
 
 const OLLAMA_URL = process.env.OLLAMA_BASE_URL ?? 'http://localhost:11434';
 
-async function ollamaFetch(path: string, options?: RequestInit): Promise<Response> {
+function readTimeoutMs(envName: string, defaultMs: number): number {
+  const raw = process.env[envName];
+  if (!raw) return defaultMs;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultMs;
+}
+
+export const OLLAMA_TIMEOUTS = {
+  status: readTimeoutMs('REVDEV_OLLAMA_STATUS_TIMEOUT_MS', 5_000),
+  stop: readTimeoutMs('REVDEV_OLLAMA_STOP_TIMEOUT_MS', 5_000),
+  start: readTimeoutMs('REVDEV_OLLAMA_START_TIMEOUT_MS', 60_000),
+  chat: readTimeoutMs('REVDEV_OLLAMA_CHAT_TIMEOUT_MS', 300_000),
+  generate: readTimeoutMs('REVDEV_OLLAMA_GENERATE_TIMEOUT_MS', 300_000),
+  pull: readTimeoutMs('REVDEV_OLLAMA_PULL_TIMEOUT_MS', 1_800_000),
+} as const;
+
+interface OllamaFetchOptions extends Omit<RequestInit, 'signal'> {
+  timeoutMs: number;
+}
+
+async function ollamaFetch(path: string, opts: OllamaFetchOptions): Promise<Response> {
+  const { timeoutMs, headers, ...rest } = opts;
   return fetch(`${OLLAMA_URL}${path}`, {
-    ...options,
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    ...rest,
+    signal: AbortSignal.timeout(timeoutMs),
+    headers: { 'Content-Type': 'application/json', ...headers },
   });
 }
+
+export function isTimeoutError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === 'TimeoutError' || err.name === 'AbortError';
+}
+
+function timeoutMessage(op: keyof typeof OLLAMA_TIMEOUTS): string {
+  return `Ollama did not respond within ${OLLAMA_TIMEOUTS[op]}ms`;
+}
+
+const CONNECT_ERROR = 'Cannot connect to Ollama. Run: ollama serve';
 
 // ---------------------------------------------------------------------------
 // inference.status — check Ollama health + loaded models
@@ -24,12 +68,12 @@ async function ollamaFetch(path: string, options?: RequestInit): Promise<Respons
 registerHandler('inference.status', async () => {
   try {
     const [versionRes, modelsRes] = await Promise.all([
-      ollamaFetch('/api/version'),
-      ollamaFetch('/api/tags'),
+      ollamaFetch('/api/version', { timeoutMs: OLLAMA_TIMEOUTS.status }),
+      ollamaFetch('/api/tags', { timeoutMs: OLLAMA_TIMEOUTS.status }),
     ]);
 
     if (!versionRes.ok) {
-      return { running: false, error: 'Ollama not responding' };
+      return { running: false, error: 'Ollama not responding', url: OLLAMA_URL };
     }
 
     const version = (await versionRes.json()) as { version: string };
@@ -47,12 +91,11 @@ registerHandler('inference.status', async () => {
         modified: m.modified_at,
       })),
     };
-  } catch {
-    return {
-      running: false,
-      error: 'Cannot connect to Ollama. Run: ollama serve',
-      url: OLLAMA_URL,
-    };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return { running: false, error: timeoutMessage('status'), url: OLLAMA_URL };
+    }
+    return { running: false, error: CONNECT_ERROR, url: OLLAMA_URL };
   }
 });
 
@@ -63,18 +106,26 @@ registerHandler('inference.status', async () => {
 registerHandler('inference.pull', async (params) => {
   const { model } = params as { model: string };
 
-  const res = await ollamaFetch('/api/pull', {
-    method: 'POST',
-    body: JSON.stringify({ name: model, stream: false }),
-  });
+  try {
+    const res = await ollamaFetch('/api/pull', {
+      method: 'POST',
+      body: JSON.stringify({ name: model, stream: false }),
+      timeoutMs: OLLAMA_TIMEOUTS.pull,
+    });
 
-  if (!res.ok) {
-    const text = await res.text();
-    return { success: false, error: `Pull failed (${res.status}): ${text}` };
+    if (!res.ok) {
+      const text = await res.text();
+      return { success: false, error: `Pull failed (${res.status}): ${text}` };
+    }
+
+    const result = (await res.json()) as { status: string };
+    return { success: true, model, status: result.status };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return { success: false, error: timeoutMessage('pull') };
+    }
+    return { success: false, error: CONNECT_ERROR };
   }
-
-  const result = (await res.json()) as { status: string };
-  return { success: true, model, status: result.status };
 });
 
 // ---------------------------------------------------------------------------
@@ -84,18 +135,26 @@ registerHandler('inference.pull', async (params) => {
 registerHandler('inference.start', async (params) => {
   const { model } = params as { model: string };
 
-  // Ollama loads models on first request — send empty generate to warm up
-  const res = await ollamaFetch('/api/generate', {
-    method: 'POST',
-    body: JSON.stringify({ model, prompt: '', stream: false }),
-  });
+  try {
+    // Ollama loads models on first request — send empty generate to warm up
+    const res = await ollamaFetch('/api/generate', {
+      method: 'POST',
+      body: JSON.stringify({ model, prompt: '', stream: false }),
+      timeoutMs: OLLAMA_TIMEOUTS.start,
+    });
 
-  if (!res.ok) {
-    const text = await res.text();
-    return { loaded: false, error: `Load failed (${res.status}): ${text}` };
+    if (!res.ok) {
+      const text = await res.text();
+      return { loaded: false, error: `Load failed (${res.status}): ${text}` };
+    }
+
+    return { loaded: true, model };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return { loaded: false, error: timeoutMessage('start') };
+    }
+    return { loaded: false, error: CONNECT_ERROR };
   }
-
-  return { loaded: true, model };
 });
 
 // ---------------------------------------------------------------------------
@@ -105,17 +164,25 @@ registerHandler('inference.start', async (params) => {
 registerHandler('inference.stop', async (params) => {
   const { model } = params as { model: string };
 
-  // Ollama uses keep_alive: 0 to immediately unload
-  const res = await ollamaFetch('/api/generate', {
-    method: 'POST',
-    body: JSON.stringify({ model, prompt: '', keep_alive: 0, stream: false }),
-  });
+  try {
+    // Ollama uses keep_alive: 0 to immediately unload
+    const res = await ollamaFetch('/api/generate', {
+      method: 'POST',
+      body: JSON.stringify({ model, prompt: '', keep_alive: 0, stream: false }),
+      timeoutMs: OLLAMA_TIMEOUTS.stop,
+    });
 
-  if (!res.ok) {
-    return { unloaded: false, error: `Unload failed (${res.status})` };
+    if (!res.ok) {
+      return { unloaded: false, error: `Unload failed (${res.status})` };
+    }
+
+    return { unloaded: true, model };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return { unloaded: false, error: timeoutMessage('stop') };
+    }
+    return { unloaded: false, error: CONNECT_ERROR };
   }
-
-  return { unloaded: true, model };
 });
 
 // ---------------------------------------------------------------------------
@@ -130,41 +197,49 @@ registerHandler('inference.chat', async (params) => {
     maxTokens?: number;
   };
 
-  const res = await ollamaFetch('/api/chat', {
-    method: 'POST',
-    body: JSON.stringify({
-      model,
-      messages,
-      stream: false,
-      options: {
-        ...(temperature !== undefined && { temperature }),
-        ...(maxTokens !== undefined && { num_predict: maxTokens }),
+  try {
+    const res = await ollamaFetch('/api/chat', {
+      method: 'POST',
+      body: JSON.stringify({
+        model,
+        messages,
+        stream: false,
+        options: {
+          ...(temperature !== undefined && { temperature }),
+          ...(maxTokens !== undefined && { num_predict: maxTokens }),
+        },
+      }),
+      timeoutMs: OLLAMA_TIMEOUTS.chat,
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      return { error: `Chat failed (${res.status}): ${text}` };
+    }
+
+    const result = (await res.json()) as {
+      message: { role: string; content: string };
+      total_duration: number;
+      eval_count: number;
+      eval_duration: number;
+    };
+
+    return {
+      message: result.message,
+      stats: {
+        totalMs: Math.round(result.total_duration / 1_000_000),
+        tokens: result.eval_count,
+        tokensPerSecond: result.eval_duration
+          ? Math.round((result.eval_count / result.eval_duration) * 1_000_000_000)
+          : 0,
       },
-    }),
-  });
-
-  if (!res.ok) {
-    const text = await res.text();
-    return { error: `Chat failed (${res.status}): ${text}` };
+    };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return { error: timeoutMessage('chat') };
+    }
+    return { error: CONNECT_ERROR };
   }
-
-  const result = (await res.json()) as {
-    message: { role: string; content: string };
-    total_duration: number;
-    eval_count: number;
-    eval_duration: number;
-  };
-
-  return {
-    message: result.message,
-    stats: {
-      totalMs: Math.round(result.total_duration / 1_000_000),
-      tokens: result.eval_count,
-      tokensPerSecond: result.eval_duration
-        ? Math.round((result.eval_count / result.eval_duration) * 1_000_000_000)
-        : 0,
-    },
-  };
 });
 
 // ---------------------------------------------------------------------------
@@ -180,40 +255,48 @@ registerHandler('inference.generate', async (params) => {
     maxTokens?: number;
   };
 
-  const res = await ollamaFetch('/api/generate', {
-    method: 'POST',
-    body: JSON.stringify({
-      model,
-      prompt,
-      system,
-      stream: false,
-      options: {
-        ...(temperature !== undefined && { temperature }),
-        ...(maxTokens !== undefined && { num_predict: maxTokens }),
+  try {
+    const res = await ollamaFetch('/api/generate', {
+      method: 'POST',
+      body: JSON.stringify({
+        model,
+        prompt,
+        system,
+        stream: false,
+        options: {
+          ...(temperature !== undefined && { temperature }),
+          ...(maxTokens !== undefined && { num_predict: maxTokens }),
+        },
+      }),
+      timeoutMs: OLLAMA_TIMEOUTS.generate,
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      return { error: `Generate failed (${res.status}): ${text}` };
+    }
+
+    const result = (await res.json()) as {
+      response: string;
+      total_duration: number;
+      eval_count: number;
+      eval_duration: number;
+    };
+
+    return {
+      response: result.response,
+      stats: {
+        totalMs: Math.round(result.total_duration / 1_000_000),
+        tokens: result.eval_count,
+        tokensPerSecond: result.eval_duration
+          ? Math.round((result.eval_count / result.eval_duration) * 1_000_000_000)
+          : 0,
       },
-    }),
-  });
-
-  if (!res.ok) {
-    const text = await res.text();
-    return { error: `Generate failed (${res.status}): ${text}` };
+    };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return { error: timeoutMessage('generate') };
+    }
+    return { error: CONNECT_ERROR };
   }
-
-  const result = (await res.json()) as {
-    response: string;
-    total_duration: number;
-    eval_count: number;
-    eval_duration: number;
-  };
-
-  return {
-    response: result.response,
-    stats: {
-      totalMs: Math.round(result.total_duration / 1_000_000),
-      tokens: result.eval_count,
-      tokensPerSecond: result.eval_duration
-        ? Math.round((result.eval_count / result.eval_duration) * 1_000_000_000)
-        : 0,
-    },
-  };
 });

--- a/packages/daemon/src/license-crypto.ts
+++ b/packages/daemon/src/license-crypto.ts
@@ -1,11 +1,14 @@
 /**
- * Ed25519 license key cryptography for RevDev.
+ * Ed25519 JWT license key cryptography for RevDev.
  *
- * License format: RVUI.v2.<tier>.<expiresAt>.<signature-base64url>
+ * License format: Ed25519-signed JWT (RFC 7519)
+ *   Header: { "alg": "EdDSA", "typ": "JWT" }
+ *   Payload: { tier, iat, iss, aud, customerId?, exp? }
  *
- * - <tier>: pro | max | enterprise
- * - <expiresAt>: unix timestamp (seconds), or "0" for perpetual
- * - <signature>: Ed25519 signature over "<tier>.<expiresAt>" in base64url
+ * - tier: "pro" | "max" | "enterprise"
+ * - exp: unix timestamp (seconds); absent = perpetual
+ * - iss: "https://revealui.com"
+ * - aud: "revealui-license"
  *
  * The vendor public key is read from the REVDEV_LICENSE_PUBLIC_KEY env var
  * (also stored in revvault at `revdev/license-signing-public-key`). The
@@ -13,8 +16,14 @@
  * and is only used by the key issuing CLI (`scripts/issue-license.ts`,
  * which also has a `--generate-keypair` mode for first-time setup).
  *
+ * Verification is hand-decoded (no jose dep): split on ".", base64url-decode
+ * header+payload, assert alg=EdDSA, verify Ed25519 signature over the raw
+ * "<headerB64url>.<payloadB64url>" bytes via node:crypto.verify(null, ...).
+ *
  * Threat model: blocks casual forgery. Determined attackers can patch
  * the binary, but that's a separate concern from tier-gate enforcement.
+ *
+ * Per CR8-P0-01 spec (Phase B), ships after Phase A revealui#735.
  */
 
 import { verify } from 'node:crypto';
@@ -28,86 +37,117 @@ import { verify } from 'node:crypto';
  * That writes both halves to revvault and prints the PEM-formatted public
  * key to copy into the daemon's environment / Studio bundle.
  */
-function getVendorPublicKey(): string {
+export function getVendorPublicKey(): string {
   return process.env.REVDEV_LICENSE_PUBLIC_KEY ?? '';
 }
 
 const VALID_TIERS = new Set(['pro', 'max', 'enterprise']);
 
-export interface LicenseV2Result {
+export interface LicenseJWTResult {
   tier: 'pro' | 'max' | 'enterprise';
   expiresAt: number; // unix seconds, 0 = perpetual
   valid: true;
 }
 
-export interface LicenseV2Failure {
+export interface LicenseJWTFailure {
   tier: 'free';
   valid: false;
   reason: string;
 }
 
+function decodeBase64url(input: string): Buffer {
+  return Buffer.from(input, 'base64url');
+}
+
 /**
- * Verify an Ed25519-signed license key.
+ * Verify an Ed25519-signed JWT license key.
  *
  * Returns the tier + expiration if valid, or { valid: false, reason } if not.
+ * Never throws — all parse/verify errors are returned as failures.
  */
-export function verifyLicenseV2(key: string): LicenseV2Result | LicenseV2Failure {
-  // Parse format: RVUI.v2.<tier>.<expiresAt>.<signature>
-  const parts = key.split('.');
-  if (parts.length !== 5 || parts[0] !== 'RVUI' || parts[1] !== 'v2') {
-    return { tier: 'free', valid: false, reason: 'invalid format' };
-  }
-
-  const [, , tierStr, expiresAtStr, signatureB64] = parts;
-
-  if (!tierStr || !VALID_TIERS.has(tierStr)) {
-    return { tier: 'free', valid: false, reason: `invalid tier: ${tierStr}` };
-  }
-
-  if (!expiresAtStr || !signatureB64) {
-    return { tier: 'free', valid: false, reason: 'missing fields' };
-  }
-
-  const expiresAt = parseInt(expiresAtStr, 10);
-  if (Number.isNaN(expiresAt)) {
-    return { tier: 'free', valid: false, reason: 'invalid expiresAt' };
-  }
-
-  // Check expiration (0 = perpetual, never expires)
-  if (expiresAt > 0) {
-    const nowSeconds = Math.floor(Date.now() / 1000);
-    if (nowSeconds > expiresAt) {
-      return { tier: 'free', valid: false, reason: 'license expired' };
-    }
-  }
-
-  // Verify Ed25519 signature
-  const vendorKey = getVendorPublicKey();
-  if (!vendorKey) {
-    return {
-      tier: 'free',
-      valid: false,
-      reason: 'REVDEV_LICENSE_PUBLIC_KEY not set — cannot verify signature',
-    };
-  }
-
-  const message = `${tierStr}.${expiresAtStr}`;
-  const signature = Buffer.from(signatureB64, 'base64url');
-
+export function verifyLicenseJWT(
+  token: string,
+  publicKey: string,
+): LicenseJWTResult | LicenseJWTFailure {
   try {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return { tier: 'free', valid: false, reason: 'invalid format' };
+    }
+
+    const [headerB64, payloadB64, signatureB64] = parts as [string, string, string];
+
+    // Decode + parse header
+    let header: Record<string, unknown>;
+    try {
+      header = JSON.parse(decodeBase64url(headerB64).toString('utf-8')) as Record<string, unknown>;
+    } catch {
+      return { tier: 'free', valid: false, reason: 'invalid format' };
+    }
+
+    if (header.alg !== 'EdDSA') {
+      return { tier: 'free', valid: false, reason: 'unsupported algorithm' };
+    }
+
+    // Decode + parse payload
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(decodeBase64url(payloadB64).toString('utf-8')) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      return { tier: 'free', valid: false, reason: 'invalid format' };
+    }
+
+    // Validate tier
+    const tier = payload.tier;
+    if (typeof tier !== 'string' || !VALID_TIERS.has(tier)) {
+      return { tier: 'free', valid: false, reason: `invalid tier: ${String(tier)}` };
+    }
+
+    // Validate exp (absent = perpetual; present = must be a number)
+    const exp = payload.exp;
+    if (exp !== undefined && typeof exp !== 'number') {
+      return { tier: 'free', valid: false, reason: 'invalid exp claim' };
+    }
+
+    // Check expiration if exp is present
+    if (typeof exp === 'number') {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      if (nowSeconds > exp) {
+        return { tier: 'free', valid: false, reason: 'license expired' };
+      }
+    }
+
+    if (!publicKey) {
+      return {
+        tier: 'free',
+        valid: false,
+        reason: 'REVDEV_LICENSE_PUBLIC_KEY not set — cannot verify signature',
+      };
+    }
+
+    // The signed message is the literal "<headerB64url>.<payloadB64url>" string
+    const message = `${headerB64}.${payloadB64}`;
+    const signatureBuffer = decodeBase64url(signatureB64);
+
     // Ed25519 doesn't use a separate digest — pass null as algorithm
-    const isValid = verify(null, Buffer.from(message), vendorKey, signature);
+    const isValid = verify(null, Buffer.from(message, 'utf-8'), publicKey, signatureBuffer);
 
     if (!isValid) {
       return { tier: 'free', valid: false, reason: 'invalid signature' };
     }
-  } catch {
-    return { tier: 'free', valid: false, reason: 'signature verification failed' };
-  }
 
-  return {
-    tier: tierStr as 'pro' | 'max' | 'enterprise',
-    expiresAt,
-    valid: true,
-  };
+    // expiresAt: 0 = perpetual (mirrors dotted-v2 semantics)
+    const expiresAt = typeof exp === 'number' ? exp : 0;
+
+    return {
+      tier: tier as 'pro' | 'max' | 'enterprise',
+      expiresAt,
+      valid: true,
+    };
+  } catch {
+    return { tier: 'free', valid: false, reason: 'invalid format' };
+  }
 }

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -7,7 +7,16 @@
  *
  * When running as a standalone daemon (outside the RevealUI monorepo),
  * license validation is done via the REVEALUI_LICENSE_KEY env var.
+ *
+ * License format: Ed25519-signed JWT (RFC 7519) — keys start with "eyJ".
+ * Issued by the RevealUI license API or `revdev/scripts/issue-license.ts`.
+ *
+ * Legacy formats (RVUI.v2.*, RVUI-*) are rejected per CR8-P0-01 Q2
+ * (immediate dotted-v2 removal, no deprecation window, 2026-05-04).
  */
+
+// Import statically — same ESM module, no circular risk.
+import { getVendorPublicKey, verifyLicenseJWT } from './license-crypto.js';
 
 export const LICENSE_TIERS = ['free', 'pro', 'max', 'enterprise'] as const;
 export type LicenseTier = (typeof LICENSE_TIERS)[number];
@@ -26,17 +35,7 @@ const EXEMPT_METHODS = new Set([
  * Returns the detected tier, or 'free' if no valid license is found.
  * The daemon runs in degraded mode on free tier: session management
  * works, but spawning, inference, and merge pipeline are gated.
- *
- * License format:
- *   v2 (Ed25519): RVUI.v2.<tier>.<expiresAt>.<ed25519-sig-base64url>
- *   v1 (legacy):  RVUI-<tier>-<32 hex chars> — DEPRECATED, rejected
- *
- * v1 keys are no longer accepted. If you have a v1 key, contact
- * support@revealui.com for a v2 replacement.
  */
-// Import verifyLicenseV2 statically — same ESM module, no circular risk.
-import { verifyLicenseV2 } from './license-crypto.js';
-
 export function checkLicense(): { tier: LicenseTier; valid: boolean } {
   const key = process.env.REVEALUI_LICENSE_KEY;
 
@@ -44,9 +43,9 @@ export function checkLicense(): { tier: LicenseTier; valid: boolean } {
     return { tier: 'free', valid: false };
   }
 
-  // v2 format: RVUI.v2.<tier>.<expiresAt>.<signature>
-  if (key.startsWith('RVUI.v2.')) {
-    const result = verifyLicenseV2(key);
+  // JWT format (Ed25519-signed): header starts with base64url-encoded "{"
+  if (key.startsWith('eyJ')) {
+    const result = verifyLicenseJWT(key, getVendorPublicKey());
     if (result.valid) {
       return { tier: result.tier, valid: true };
     }
@@ -56,11 +55,12 @@ export function checkLicense(): { tier: LicenseTier; valid: boolean } {
     return { tier: 'free', valid: false };
   }
 
-  // v1 format: RVUI-<tier>-<hash> — REJECTED (not cryptographically bound)
-  if (key.match(/^RVUI-/i)) {
+  // Legacy formats — REJECTED outright per CR8-P0-01 Q2
+  if (key.startsWith('RVUI.v2.') || key.match(/^RVUI-/i)) {
     process.stderr.write(
-      '[revdev] v1 license keys (RVUI-<tier>-<hash>) are no longer accepted. ' +
-        'Contact support@revealui.com for a v2 Ed25519-signed key.\n',
+      '[revdev] Legacy license formats (RVUI.v2.*, RVUI-*) are no longer accepted. ' +
+        'Mint an Ed25519-signed JWT via the RevealUI license API or ' +
+        '`revdev/scripts/issue-license.ts`.\n',
     );
     return { tier: 'free', valid: false };
   }

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -185,6 +185,27 @@ export function registerHandler(method: string, handler: RpcHandler): void {
 }
 
 // ---------------------------------------------------------------------------
+// Shutdown signal — module-level AbortController whose `.signal` aborts when
+// the daemon is closing. Long-running helpers (e.g. git child-process spawn
+// in vcs.ts) listen to this so they get SIGTERM'd before the daemon exits,
+// rather than orphaning. Reset to a fresh controller on every startDaemon()
+// so multiple sequential lifecycles in the same process (e.g. test setup +
+// teardown loops) get independent shutdown windows.
+// ---------------------------------------------------------------------------
+
+let _shutdownController: AbortController | null = null;
+
+/**
+ * Returns the daemon's current shutdown AbortSignal, or `undefined` if the
+ * daemon has not started (or has fully shut down). Helpers that spawn
+ * child processes or hold long-running async work should pass this signal
+ * to their abort-aware APIs.
+ */
+export function getShutdownSignal(): AbortSignal | undefined {
+  return _shutdownController?.signal;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -824,6 +845,9 @@ export async function startDaemon(
 ): Promise<{ close: () => Promise<void> }> {
   const cfg = { ...DAEMON_DEFAULTS, ...config };
 
+  // Reset shutdown signal for this daemon lifecycle. Aborted in close().
+  _shutdownController = new AbortController();
+
   // Initialize license guard (logs banner)
   initLicenseGuard();
 
@@ -1073,6 +1097,13 @@ export async function startDaemon(
 
       resolve({
         close: async () => {
+          // Abort first so in-flight child processes (git spawn in vcs.ts)
+          // get SIGTERM before db.close() — otherwise they orphan and the
+          // socket can race with active queries. Then clear the prune
+          // timer, stop accepting new connections, close PGlite, and
+          // unlink the Unix socket.
+          _shutdownController?.abort();
+          _shutdownController = null;
           if (pruneTimer) clearInterval(pruneTimer);
           server.close();
           await db.close();

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -206,6 +206,63 @@ export function getShutdownSignal(): AbortSignal | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// In-flight handler counter + shutdown gate.
+//
+// `_activeHandlerCount` is incremented before each `await handler()` and
+// decremented in finally; close() drains it before tearing down PGlite so
+// a long-running handler (e.g. worktree.create shelling out to git) does
+// not race with `db.close()`.
+//
+// `_closing` is set at the START of close() to gate any future dispatches
+// on already-connected sockets — `server.close()` only stops new accepts,
+// not new requests on existing sockets, so without this gate a persistent
+// client could send a request that increments the counter AFTER the drain
+// has observed zero and runs against a closing/closed PGlite. When set,
+// dispatch responds with JSON-RPC -32099 ("Server is shutting down") and
+// bails before the counter increment.
+// ---------------------------------------------------------------------------
+
+let _activeHandlerCount = 0;
+let _closing = false;
+
+/** Wait until `_activeHandlerCount === 0` or `deadlineMs` elapses. Polls
+ *  every `tickMs` (default 10 ms). Returns `{drained, remaining}` so the
+ *  caller can log a warning when the deadline passes with handlers still
+ *  running. */
+async function drainActiveHandlers(
+  deadlineMs: number,
+  tickMs = 10,
+): Promise<{ drained: boolean; remaining: number }> {
+  const start = Date.now();
+  while (_activeHandlerCount > 0 && Date.now() - start < deadlineMs) {
+    await new Promise((r) => setTimeout(r, tickMs));
+  }
+  return { drained: _activeHandlerCount === 0, remaining: _activeHandlerCount };
+}
+
+/** @internal — test-only seam. Lets the unit test set the counter directly
+ *  to exercise the drain logic without spinning up a real daemon. */
+export function _setActiveHandlerCountForTest(n: number): void {
+  _activeHandlerCount = n;
+}
+
+/** @internal — test-only seam. Direct access to the drain helper so the
+ *  unit test can verify deadline / immediate-resolve / progressive-drain
+ *  behavior without going through close(). */
+export function _drainActiveHandlersForTest(
+  deadlineMs: number,
+  tickMs?: number,
+): Promise<{ drained: boolean; remaining: number }> {
+  return drainActiveHandlers(deadlineMs, tickMs);
+}
+
+/** @internal — test-only seam. Set/clear the shutdown gate directly to
+ *  verify dispatch rejection without spinning a full close() cycle. */
+export function _setClosingForTest(closing: boolean): void {
+  _closing = closing;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -845,8 +902,11 @@ export async function startDaemon(
 ): Promise<{ close: () => Promise<void> }> {
   const cfg = { ...DAEMON_DEFAULTS, ...config };
 
-  // Reset shutdown signal for this daemon lifecycle. Aborted in close().
+  // Reset shutdown signal + closing gate for this daemon lifecycle.
+  // _shutdownController is aborted in close(); _closing is set to true
+  // at the start of close() and reset to false at the end.
   _shutdownController = new AbortController();
+  _closing = false;
 
   // Initialize license guard (logs banner)
   initLicenseGuard();
@@ -891,8 +951,17 @@ export async function startDaemon(
   const { unlink, chmod } = await import('node:fs/promises');
   await unlink(cfg.socketPath).catch(() => {});
 
+  // Track open sockets so close() can force-destroy them before
+  // resetting state. server.close() only stops new accepts; existing
+  // sockets stay alive until the client disconnects, which means their
+  // `data` handlers can fire AFTER close() returns and dispatch against
+  // a closed PGlite or against a fresh startDaemon()'s state in the
+  // same process. Destroying sockets in close() prevents that.
+  const openSockets = new Set<Socket>();
+
   // Start Unix socket server
   const server = createServer((socket: Socket) => {
+    openSockets.add(socket);
     onConnect();
     const ctx: SocketContext = { agentId: null, agentName: null, boundVia: null };
     let buffer = '';
@@ -1019,7 +1088,25 @@ export async function startDaemon(
           continue;
         }
 
+        // Shutdown gate. close() sets _closing BEFORE the drain so a
+        // request arriving on an already-connected socket after shutdown
+        // started cannot increment the counter past the drain observation
+        // window and run against a closing/closed PGlite. We respond with
+        // JSON-RPC -32099 ("Server is shutting down") and bail before the
+        // counter increment.
+        if (_closing) {
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: '2.0',
+              id: req.id,
+              error: { code: -32099, message: 'Server is shutting down' },
+            })}\n`,
+          );
+          continue;
+        }
+
         const startMs = Date.now();
+        _activeHandlerCount++;
         try {
           const result = await handler(req.params ?? {}, db, ctx);
           trackRpcCall(req.method, 'ok', Date.now() - startMs);
@@ -1036,11 +1123,14 @@ export async function startDaemon(
               },
             })}\n`,
           );
+        } finally {
+          _activeHandlerCount--;
         }
       }
     });
 
     socket.on('close', async () => {
+      openSockets.delete(socket);
       onDisconnect();
       // Auto-release transient reservations when a long-lived agent
       // disconnects. Fresh-per-call clients (boundVia = 'param') don't
@@ -1055,7 +1145,12 @@ export async function startDaemon(
       // refinement (keepalive flag in session.register, or socket-
       // lifetime threshold) could re-introduce socket-close auto-end
       // for genuinely-long-lived agents — see GAP-153 notes.
-      if (ctx.agentId && (ctx.boundVia === 'register' || ctx.boundVia === 'attach')) {
+      // Skip cleanup when shutdown has begun — db may already be closed.
+      // close() destroys all sockets, which fires this handler; we don't
+      // want it to race with db.close(). The .catch(() => {}) below
+      // would swallow the resulting error anyway, but bailing here is
+      // explicit + avoids the dangling Promise.
+      if (!_closing && ctx.agentId && (ctx.boundVia === 'register' || ctx.boundVia === 'attach')) {
         await db
           .query(`DELETE FROM file_reservations WHERE agent_id = $1`, [ctx.agentId])
           .catch(() => {});
@@ -1097,17 +1192,46 @@ export async function startDaemon(
 
       resolve({
         close: async () => {
-          // Abort first so in-flight child processes (git spawn in vcs.ts)
-          // get SIGTERM before db.close() — otherwise they orphan and the
-          // socket can race with active queries. Then clear the prune
-          // timer, stop accepting new connections, close PGlite, and
-          // unlink the Unix socket.
+          // Sequence:
+          //   1. Set _closing FIRST so any RPC arriving on an existing
+          //      socket from this point onward bails out with -32099
+          //      before the counter increment.
+          //   2. Abort the shutdown signal — SIGTERMs git children
+          //      (vcs.ts) and aborts inference.* fetches; honoring
+          //      handlers complete fast.
+          //   3. server.close() — stop accepting NEW connections.
+          //   4. Force-destroy ALL existing sockets — server.close()
+          //      doesn't close them; without this, a persistent client
+          //      could fire another `data` event with an old socket
+          //      after close() returns and dispatch against a closed
+          //      PGlite (Codex P2 catch on revdev#47 round 2).
+          //   5. Drain still-running handlers (started BEFORE step 1)
+          //      within the grace period.
+          //   6. db.close() + unlink Unix socket.
+          //   7. Reset _closing — safe now because no live socket
+          //      references this state.
+          _closing = true;
           _shutdownController?.abort();
           _shutdownController = null;
           if (pruneTimer) clearInterval(pruneTimer);
           server.close();
+          for (const s of openSockets) {
+            s.destroy();
+          }
+          openSockets.clear();
+          const drainResult = await drainActiveHandlers(cfg.shutdownGracePeriodMs);
+          if (!drainResult.drained) {
+            log.warn('shutdown grace period exceeded with handlers still running', {
+              remaining: drainResult.remaining,
+              gracePeriodMs: cfg.shutdownGracePeriodMs,
+            });
+          }
           await db.close();
           await unlink(cfg.socketPath).catch(() => {});
+          // Now safe to reset — no live socket has a reference to module
+          // state, and a fresh startDaemon() in the same process (test
+          // setup/teardown loops) starts with a clean gate.
+          _closing = false;
           log.info('shut down');
         },
       });

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -875,11 +875,64 @@ export async function startDaemon(
 
     socket.on('data', async (data) => {
       buffer += data.toString();
+
       const lines = buffer.split('\n');
       buffer = lines.pop() ?? '';
 
+      // Bound the per-socket reassembly buffer's _partial_ remainder. A
+      // client that streams bytes without a newline grows `buffer`
+      // linearly; without this check, a malicious or stuck client could
+      // exhaust daemon memory via a single open socket. On overflow,
+      // emit a JSON-RPC -32700 parse-error (id null — we never reached
+      // a JSON boundary) and destroy the socket. The client must
+      // reconnect. Use Buffer.byteLength so the cap is enforced in
+      // UTF-8 bytes (matching the documented "bytes" semantics) rather
+      // than UTF-16 code units, otherwise multibyte payloads bypass the
+      // intended protection.
+      if (Buffer.byteLength(buffer, 'utf8') > cfg.maxLineBytes) {
+        log.warn('socket partial frame exceeded max line bytes; dropping connection', {
+          bytes: Buffer.byteLength(buffer, 'utf8'),
+          max: cfg.maxLineBytes,
+        });
+        socket.write(
+          `${JSON.stringify({
+            jsonrpc: '2.0',
+            id: null,
+            error: {
+              code: -32700,
+              message: `Parse error: frame exceeded ${cfg.maxLineBytes} bytes without a newline`,
+            },
+          })}\n`,
+        );
+        buffer = '';
+        socket.destroy();
+        return;
+      }
+
       for (const line of lines) {
         if (!line.trim()) continue;
+
+        // A complete (newline-terminated) frame can still exceed the cap
+        // when an oversize chunk lands all in one event. Reject such a
+        // frame with -32700 but keep the socket open — the client framed
+        // the boundary correctly, they just sent too much data.
+        if (Buffer.byteLength(line, 'utf8') > cfg.maxLineBytes) {
+          log.warn('socket received oversized frame; rejecting', {
+            bytes: Buffer.byteLength(line, 'utf8'),
+            max: cfg.maxLineBytes,
+          });
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: '2.0',
+              id: null,
+              error: {
+                code: -32700,
+                message: `Parse error: frame exceeded ${cfg.maxLineBytes} bytes`,
+              },
+            })}\n`,
+          );
+          continue;
+        }
 
         let req: RpcRequest;
         try {

--- a/packages/daemon/src/validation/index.ts
+++ b/packages/daemon/src/validation/index.ts
@@ -1,9 +1,11 @@
 /**
  * RPC input validation — validates params before handler dispatch.
  *
- * Methods without a schema pass through unchecked (ping, harness.health,
- * inference.status). Methods with a schema are validated and rejected with
- * JSON-RPC -32602 (Invalid params) on failure.
+ * The only registered method without a schema is `ping` (intentional —
+ * no params). Methods with a schema are validated and rejected with
+ * JSON-RPC -32602 (Invalid params) on failure. Unknown methods also
+ * pass through here (the registry only validates known methods; the
+ * dispatcher surfaces -32601 Method not found later).
  */
 
 import { schemas } from './schemas.js';

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -291,7 +291,45 @@ export const schemas: Record<string, z.ZodType> = {
     })
     .passthrough(),
 
+  // -- Health -----------------------------------------------------------------
+  // Both handlers (`server.ts:registerHandler('harness.health', ...)` and
+  // `harness.prune`) previously bypassed `validateParams` because no
+  // schema existed in the registry. Adding them here completes the
+  // Option A direction (schemas as canonical) shipped by GAP-173 —
+  // every live handler should have a schema entry. Schemas are
+  // intentionally TYPE-ONLY (no integer / non-negative / upper-bound
+  // constraints on `staleDays` / `hardDeleteDays`): the prune handler
+  // already runs a defensive clamp via `Number.isFinite` + `Math.max(0,
+  // ...)`, AND the integration tests legitimately pass fractional days
+  // (e.g. `staleDays: 0.00001` ≈ 0.86s) to exercise the prune logic
+  // without 24h sleeps + negative days to verify the defensive clamp.
+  // Adding `int()` / `min(0)` here would break those tests and move
+  // safety enforcement away from the handler where it belongs.
+  'harness.health': z
+    .object({
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'harness.prune': z
+    .object({
+      staleDays: z.number().optional(),
+      hardDeleteDays: z.number().optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
   // -- Inference --------------------------------------------------------------
+  // `inference.status` takes no required params (handler signature is
+  // `async ()` — no params destructured). Schema added for symmetry with
+  // the rest of the inference.* methods + so the only remaining bare
+  // method in the registry is `ping` (intentional, no params).
+  'inference.status': z
+    .object({
+      actorAgentId,
+    })
+    .passthrough(),
+
   'inference.pull': z
     .object({
       model: z.string().max(256),

--- a/packages/daemon/src/vcs.ts
+++ b/packages/daemon/src/vcs.ts
@@ -5,30 +5,123 @@
  * agent's working directory. Merge requests are tracked in the
  * `merge_requests` table; actual PR creation is left to the client
  * (agents call `gh pr create` themselves and then update status here).
+ *
+ * Reliability: every git spawn is bounded by `DAEMON_DEFAULTS.gitTimeoutMs`
+ * (default 60 s, env-overridable via REVDEV_DAEMON_GIT_TIMEOUT_MS) AND
+ * aborted on daemon shutdown via the shared shutdown signal from
+ * server.ts. Without this, a runaway git command (credential prompt on
+ * a private base branch, corrupt object DB, hung remote) would hold
+ * the daemon socket forever — SIGTERM to the daemon does not propagate
+ * to orphaned children. On timeout or shutdown abort, the child receives
+ * SIGTERM via spawn's native AbortSignal handling and the handler
+ * returns a structured error response.
  */
 
 import { spawn } from 'node:child_process';
-import { registerHandler } from './server.js';
+import { DAEMON_DEFAULTS } from './config.js';
+import { getShutdownSignal, registerHandler } from './server.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-interface ShellResult {
+export interface ShellResult {
   ok: boolean;
   stdout: string;
   stderr: string;
   code: number;
+  /** True if the child was aborted before clean exit (timeout or shutdown). */
+  aborted?: boolean;
+  /** Disambiguates timeout vs caller/shutdown abort. Only set when aborted. */
+  abortReason?: 'timeout' | 'shutdown';
 }
 
-function runGit(args: string[], cwd: string): Promise<ShellResult> {
+export interface RunChildOptions {
+  cwd: string;
+  /** Per-call timeout. Defaults to DAEMON_DEFAULTS.gitTimeoutMs (60 s). */
+  timeoutMs?: number;
+  /**
+   * Optional external signal — combined with the daemon shutdown signal
+   * and the timeout via `AbortSignal.any` so the spawned child gets
+   * SIGTERM if any source aborts.
+   */
+  externalSignal?: AbortSignal;
+}
+
+/**
+ * Spawn a child process with timeout + shutdown awareness. Returns a
+ * structured ShellResult; never throws. On abort, the spawned child is
+ * SIGTERM'd via Node's native AbortSignal handling on the spawn options.
+ *
+ * Exported for testing — production code uses `runGit` below.
+ */
+export function runChild(
+  command: string,
+  args: string[],
+  opts: RunChildOptions,
+): Promise<ShellResult> {
   return new Promise((resolve) => {
-    const child = spawn('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    const timeoutMs = opts.timeoutMs ?? DAEMON_DEFAULTS.gitTimeoutMs;
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    const shutdownSignal = getShutdownSignal();
+
+    const sources: AbortSignal[] = [timeoutSignal];
+    if (shutdownSignal) sources.push(shutdownSignal);
+    if (opts.externalSignal) sources.push(opts.externalSignal);
+    // sources always contains at least timeoutSignal, so AbortSignal.any
+    // is well-defined; the single-source branch avoids one allocation.
+    const signal = sources.length > 1 ? AbortSignal.any(sources) : timeoutSignal;
+
+    let aborted = false;
+    let abortReason: 'timeout' | 'shutdown' | undefined;
+    const onAbort = () => {
+      if (aborted) return;
+      aborted = true;
+      // Timeout takes precedence in disambiguation. External signals are
+      // reported as "shutdown" — caller-driven cancellation semantically
+      // matches shutdown for our purposes (the child gets SIGTERM either
+      // way; the disambiguation is only for the human-readable message).
+      abortReason = timeoutSignal.aborted ? 'timeout' : 'shutdown';
+    };
+    if (signal.aborted) onAbort();
+    else signal.addEventListener('abort', onAbort, { once: true });
+
+    const child = spawn(command, args, {
+      cwd: opts.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      signal,
+    });
+
     let stdout = '';
     let stderr = '';
-    child.stdout.on('data', (d) => (stdout += d.toString()));
-    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.stdout.on('data', (d) => {
+      stdout += d.toString();
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d.toString();
+    });
+
+    const buildAbortedResult = (code: number): ShellResult => {
+      const reason = abortReason ?? 'shutdown';
+      const message =
+        reason === 'timeout'
+          ? `${command} timed out after ${timeoutMs}ms`
+          : `${command} aborted by daemon shutdown`;
+      return {
+        ok: false,
+        stdout: stdout.trim(),
+        stderr: stderr.trim() || message,
+        code,
+        aborted: true,
+        abortReason: reason,
+      };
+    };
+
     child.on('close', (code) => {
+      if (aborted) {
+        resolve(buildAbortedResult(code ?? -1));
+        return;
+      }
       resolve({
         ok: code === 0,
         stdout: stdout.trim(),
@@ -36,10 +129,27 @@ function runGit(args: string[], cwd: string): Promise<ShellResult> {
         code: code ?? -1,
       });
     });
+
     child.on('error', (err) => {
+      // spawn() emits AbortError on signal abort; the close handler may or
+      // may not also fire depending on whether the child started. Resolve
+      // here for the abort-before-spawn case; close handler is no-op'd
+      // because Promises only resolve once.
+      if (aborted || (err as NodeJS.ErrnoException).name === 'AbortError') {
+        resolve(buildAbortedResult(-1));
+        return;
+      }
       resolve({ ok: false, stdout: '', stderr: err.message, code: -1 });
     });
   });
+}
+
+function runGit(
+  args: string[],
+  cwd: string,
+  opts?: Partial<RunChildOptions>,
+): Promise<ShellResult> {
+  return runChild('git', args, { cwd, ...opts });
 }
 
 function str(v: unknown, fallback = ''): string {

--- a/scripts/issue-license.ts
+++ b/scripts/issue-license.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --import=tsx
 
 /**
- * Issue a RevDev license key (Ed25519-signed v2 format), or generate the
+ * Issue a RevDev license key (Ed25519-signed JWT), or generate the
  * Ed25519 keypair the daemon uses to verify those keys.
  *
  * Usage:
@@ -15,6 +15,10 @@
  *
  * Signing private key is read from revvault at revdev/license-signing-private-key
  * (or REVDEV_LICENSE_PRIVATE_KEY env, or ~/.revealui/license-private.pem).
+ *
+ * Output: Ed25519-signed JWT (RFC 7519). Header: { alg: "EdDSA", typ: "JWT" }.
+ * Payload: { tier, iat, iss, aud, customerId?, exp? }.
+ * Format matches the RevealUI license API issuer (revealui#735, Phase A).
  */
 
 import { execSync } from 'node:child_process';
@@ -49,7 +53,7 @@ function parseArgs(): Options {
       case '--help':
       case '-h':
         console.log(`
-Issue RevDev License Key (Ed25519 v2)
+Issue RevDev License Key (Ed25519-signed JWT)
 
 Usage:
   npx tsx scripts/issue-license.ts --generate-keypair
@@ -60,10 +64,12 @@ Options:
                                 (revdev/license-signing-{private,public}-key).
                                 Exits before signing.
   --tier <pro|max|enterprise>   License tier (required for signing)
-  --customer <name>             Customer identifier (informational; not signed)
+  --customer <name>             Customer identifier (embedded in JWT payload)
   --days <n>                    Expiry in days (default: 365)
-  --perpetual                   Never expires
+  --perpetual                   Never expires (omits exp claim)
   --help                        Show this help
+
+Output format: Ed25519-signed JWT (RFC 7519). Set as REVEALUI_LICENSE_KEY on the daemon.
 `);
         process.exit(0);
     }
@@ -108,14 +114,29 @@ function issueLicense(opts: Options): string {
   const privateKeyPem = getPrivateKey();
   const privateKey = createPrivateKey(privateKeyPem);
 
-  const expiresAt = opts.perpetual
-    ? '0'
-    : String(Math.floor(Date.now() / 1000) + (opts.days ?? 365) * 86400);
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'EdDSA', typ: 'JWT' };
+  const payload: Record<string, unknown> = {
+    tier: opts.tier,
+    iat: now,
+    iss: 'https://revealui.com',
+    aud: 'revealui-license',
+  };
 
-  const message = `${opts.tier}.${expiresAt}`;
+  if (opts.customer) {
+    payload.customerId = opts.customer;
+  }
+
+  if (!opts.perpetual) {
+    payload.exp = now + (opts.days ?? 365) * 86400;
+  }
+
+  const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const message = `${headerB64}.${payloadB64}`;
   const signature = sign(null, Buffer.from(message), privateKey).toString('base64url');
 
-  return `RVUI.v2.${opts.tier}.${expiresAt}.${signature}`;
+  return `${message}.${signature}`;
 }
 
 function revvaultSet(path: string, value: string): void {
@@ -174,6 +195,7 @@ console.log('  ──────────────────');
 console.log(`  Tier:     ${opts.tier.toUpperCase()}`);
 console.log(`  Customer: ${opts.customer ?? '(not specified)'}`);
 console.log(`  Expires:  ${opts.perpetual ? 'Never (perpetual)' : `${opts.days ?? 365} days`}`);
+console.log(`  Format:   Ed25519-signed JWT (RFC 7519)`);
 console.log('');
 console.log('  Key:');
 console.log(`  ${key}`);


### PR DESCRIPTION
Promotes `test` into `main` ahead of the Studio Windows-build dogfood push. Clean fast-forward (verified via `git merge-base origin/main origin/test` == `origin/main`). All CI runs on `test` green at HEAD.

## What lands

**Daemon hardening (security + reliability)**:
- #44 per-operation fetch timeouts + structured error envelope
- #45 bound per-socket reassembly buffer to defeat unbounded-growth DoS
- #46 bound git child-process spawns + propagate daemon shutdown to children
- #47 graceful-shutdown drain — wait for in-flight RPC before db.close()

**Studio improvements**:
- #48 introduce `usePollingFetch` helper + migrate useStatus / useHealth / useSubscription
- #49 complete §B-2 — migrate useApps + useInference to polling helper
- #50 visible scrollbars on Linux webkit2gtk (WSLg) — useful even for Windows-native builds (style fix is general)

**Planning + docs**:
- #51 Phase D-2 rename + state refresh
- #53 add MASTER_PLAN.md + MASTER_SPEC.md
- #54 fix Console build/run commands in CLAUDE.md (Codex finding)
- Plus #41-#43 (daemon validation schemas, jsdom mock, Ed25519 JWT acceptor Phase B)

## Test plan

- [x] Verified clean fast-forward over origin/main (no merge commit needed)
- [x] CI on test green (last 3 runs all success)
- [ ] CI on PR runs against main HEAD (auto)
- [ ] After merge: cut Studio Windows build from fresh main and dogfood
