### PR TITLE
docs(index): add fleet-anchor INDEX.md (cold-context agent ramp)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,26 @@
+---
+type: repo-doc-index
+repo: revdev
+updated: 2026-05-15
+---
+
+# RevDev — Documentation Index
+
+Agent-first SDLC toolkit: Studio (Tauri 2 desktop) + Console (Go SSH TUI) + harness daemon (JSON-RPC over Unix socket).
+
+## This repo's masters
+
+- [`MASTER_PLAN.md`](./MASTER_PLAN.md) — authoritative plan for RevDev
+- [`MASTER_SPEC.md`](./MASTER_SPEC.md) — design spec
+- [`PRODUCTION_LAUNCH_PLAN.md`](./PRODUCTION_LAUNCH_PLAN.md) — task-level breakdown for production launch
+
+## Fleet coordination
+
+Part of [RevFleet](https://github.com/RevealUIStudio). For agents working in `~/revfleet/revdev/`:
+
+- Fleet master index: `~/revfleet/.jv/docs/MASTER_INDEX.md`
+- Fleet master plan: `~/revfleet/.jv/docs/MASTER_PLAN.md`
+- Active lanes (multi-session work): `~/revfleet/.jv/docs/lanes/`
+- GAP tracker: `~/revfleet/.jv/docs/gaps/` + `~/revfleet/.jv/docs/gap-specs/`
+- Live workboard: `~/revfleet/.jv/.claude/workboard.md`
+- ADR for lanes convention: `~/revfleet/.jv/docs/decisions/2026-05-15-docs-organization-lanes.md`


### PR DESCRIPTION
## Summary

Adds `docs/INDEX.md` as a cold-context anchor for this repo. When an agent (or any cold reader) lands here from scratch, INDEX.md points them at:

- This repo's `MASTER_PLAN.md` + `MASTER_SPEC.md`
- Fleet master index, master plan, lanes/, gaps/, workboard (internal paths under `~/revfleet/internal docs/`, agent-readable when working locally)
- ADR `2026-05-15-docs-organization-lanes` (the lanes/ convention)

Improvement 3 of the 2026-05-15 docs reorg. Companion to:
- an internal repo ADR `docs/decisions/2026-05-15-docs-organization-lanes.md`
- an internal repo `lanes/` structure

## Test plan

- [ ] File renders correctly on GitHub
- [ ] Frontmatter is well-formed YAML
- [ ] No CI dependencies (single new file, no consumers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
