### PR TITLE
feat(daemon): agent identity schema + crypto foundation (Adoption 2 P1.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev:studio": "pnpm --filter @revdev/studio dev",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "test": "pnpm -r test",
+    "test": "pnpm --filter @revdev/protocol build && pnpm -r test",
     "test:coverage": "pnpm -r test:coverage",
     "typecheck": "pnpm --filter @revdev/protocol build && pnpm -r --filter=!studio typecheck",
     "typecheck:studio": "pnpm --filter studio typecheck"

--- a/packages/daemon/src/__tests__/agent-identity-crypto.test.ts
+++ b/packages/daemon/src/__tests__/agent-identity-crypto.test.ts
@@ -1,4 +1,4 @@
-import { generateKeyPairSync } from 'node:crypto';
+import { generateKeyPairSync, sign } from 'node:crypto';
 import type { SignaturePayload } from '@revdev/protocol/signature';
 import { describe, expect, it } from 'vitest';
 import {
@@ -86,6 +86,31 @@ describe('signEnvelope + verifyEnvelope', () => {
     const payload = makePayload();
     const envelope = signEnvelope(payload, kp.privateKeyPem);
     expect(verifyEnvelope(envelope, otherKp.publicKeyPem)).toBe(false);
+  });
+
+  // Per Codex P2 finding: a foreign signer may emit header/payload JSON with
+  // members in non-canonical order. Verification must preserve the literal
+  // signed segments rather than re-serialize, or valid signatures get rejected.
+  it('accepts signatures over non-canonical JSON key order (foreign signer compatibility)', () => {
+    const kp = generateAgentKeypair();
+    const payload = makePayload();
+
+    const headerNonCanonical = '{"typ":"jws","alg":"EdDSA"}';
+    const payloadJson = JSON.stringify(payload);
+    const rawHeaderB64 = Buffer.from(headerNonCanonical).toString('base64url');
+    const rawPayloadB64 = Buffer.from(payloadJson).toString('base64url');
+    const message = rawHeaderB64 + '.' + rawPayloadB64;
+    const sigBytes = sign(null, Buffer.from(message), kp.privateKeyPem);
+    const sigB64 = Buffer.from(sigBytes).toString('base64url');
+
+    const envelopeString = rawHeaderB64 + '.' + rawPayloadB64 + '.' + sigB64;
+    const parsed = parseEnvelope(envelopeString);
+    expect(parsed).not.toBeNull();
+    if (parsed !== null) {
+      expect(parsed.rawHeaderB64).toBe(rawHeaderB64);
+      expect(parsed.rawPayloadB64).toBe(rawPayloadB64);
+      expect(verifyEnvelope(parsed, kp.publicKeyPem)).toBe(true);
+    }
   });
 });
 

--- a/packages/daemon/src/__tests__/agent-identity-crypto.test.ts
+++ b/packages/daemon/src/__tests__/agent-identity-crypto.test.ts
@@ -1,0 +1,209 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  base64UrlDecode,
+  base64UrlEncode,
+  canonicalizeJSON,
+  computeFingerprint,
+  generateAgentKeypair,
+  hashParams,
+  parseEnvelope,
+  serializeEnvelope,
+  signEnvelope,
+  verifyEnvelope,
+} from '../agent-identity-crypto.js';
+import type { SignaturePayload } from '@revdev/protocol/signature';
+
+function makePayload(overrides: Partial<SignaturePayload> = {}): SignaturePayload {
+  return {
+    did: 'did:revfleet:test-agent:abc123',
+    kid: 'did:revfleet:test-agent:abc123',
+    nonce: 'aabbccddeeff00112233445566778899',
+    ts: Date.now(),
+    method: 'ping',
+    paramsHash: 'somehash',
+    ...overrides,
+  };
+}
+
+describe('generateAgentKeypair', () => {
+  it('returns a 32-byte raw public key', () => {
+    const kp = generateAgentKeypair();
+    expect(kp.publicKeyRaw.length).toBe(32);
+  });
+
+  it('returns valid PEM strings', () => {
+    const kp = generateAgentKeypair();
+    expect(kp.publicKeyPem.startsWith('-----BEGIN PUBLIC KEY-----')).toBe(true);
+    expect(kp.privateKeyPem.startsWith('-----BEGIN PRIVATE KEY-----')).toBe(true);
+  });
+});
+
+describe('computeFingerprint', () => {
+  it('produces a non-empty base58 string', () => {
+    const kp = generateAgentKeypair();
+    const fp = computeFingerprint(kp.publicKeyRaw);
+    expect(fp.length).toBeGreaterThan(0);
+    expect(typeof fp).toBe('string');
+  });
+
+  it('is deterministic for the same key', () => {
+    const kp = generateAgentKeypair();
+    expect(computeFingerprint(kp.publicKeyRaw)).toBe(computeFingerprint(kp.publicKeyRaw));
+  });
+});
+
+describe('signEnvelope + verifyEnvelope', () => {
+  it('roundtrip returns true', () => {
+    const kp = generateAgentKeypair();
+    const payload = makePayload();
+    const envelope = signEnvelope(payload, kp.privateKeyPem);
+    expect(verifyEnvelope(envelope, kp.publicKeyPem)).toBe(true);
+  });
+
+  it('tamper detection: flip one byte in serialized envelope signature, parse, verify returns false', () => {
+    const kp = generateAgentKeypair();
+    const payload = makePayload();
+    const envelope = signEnvelope(payload, kp.privateKeyPem);
+    const serialized = serializeEnvelope(envelope);
+
+    const parts = serialized.split('.');
+    const sigBytes = Buffer.from(parts[2] as string, 'base64url');
+    sigBytes[0] = (sigBytes[0] as number) ^ 0xff;
+    parts[2] = sigBytes.toString('base64url');
+    const tampered = parts.join('.');
+
+    const parsed = parseEnvelope(tampered);
+    expect(parsed).not.toBeNull();
+    if (parsed !== null) {
+      expect(verifyEnvelope(parsed, kp.publicKeyPem)).toBe(false);
+    }
+  });
+
+  it('rejects wrong key', () => {
+    const kp = generateAgentKeypair();
+    const otherKp = generateAgentKeypair();
+    const payload = makePayload();
+    const envelope = signEnvelope(payload, kp.privateKeyPem);
+    expect(verifyEnvelope(envelope, otherKp.publicKeyPem)).toBe(false);
+  });
+});
+
+describe('serializeEnvelope + parseEnvelope roundtrip', () => {
+  it('parses back to the same envelope', () => {
+    const kp = generateAgentKeypair();
+    const payload = makePayload();
+    const envelope = signEnvelope(payload, kp.privateKeyPem);
+    const serialized = serializeEnvelope(envelope);
+    const parsed = parseEnvelope(serialized);
+
+    expect(parsed).not.toBeNull();
+    if (parsed !== null) {
+      expect(parsed.header.alg).toBe('EdDSA');
+      expect(parsed.header.typ).toBe('jws');
+      expect(parsed.payload.method).toBe(payload.method);
+      expect(parsed.payload.nonce).toBe(payload.nonce);
+      expect(parsed.signature).toBe(envelope.signature);
+    }
+  });
+});
+
+describe('parseEnvelope null-on-malformed', () => {
+  it('returns null on wrong part count (2 parts)', () => {
+    expect(parseEnvelope('a.b')).toBeNull();
+  });
+
+  it('returns null on wrong part count (4 parts)', () => {
+    expect(parseEnvelope('a.b.c.d')).toBeNull();
+  });
+
+  it('returns null on non-base64 header', () => {
+    expect(parseEnvelope('!!!.b.c')).toBeNull();
+  });
+
+  it('returns null on valid base64 but non-JSON header', () => {
+    const notJson = Buffer.from('not-json').toString('base64url');
+    expect(parseEnvelope(`${notJson}.${notJson}.sig`)).toBeNull();
+  });
+
+  it('returns null on schema mismatch (wrong alg)', () => {
+    const kp = generateAgentKeypair();
+    const payload = makePayload();
+    const badHeader = { alg: 'RS256', typ: 'jws' };
+    const headerB64 = Buffer.from(JSON.stringify(badHeader)).toString('base64url');
+    const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    const sig = Buffer.from('fakesig').toString('base64url');
+    expect(parseEnvelope(`${headerB64}.${payloadB64}.${sig}`)).toBeNull();
+  });
+});
+
+describe('canonicalizeJSON', () => {
+  it('produces stable output for equivalent objects with different key order', () => {
+    const a = canonicalizeJSON({ b: 1, a: 2 });
+    const b = canonicalizeJSON({ a: 2, b: 1 });
+    expect(a).toBe(b);
+    expect(a).toBe('{"a":2,"b":1}');
+  });
+
+  it('handles nested objects', () => {
+    const result = canonicalizeJSON({ z: { y: 1, x: 2 }, a: true });
+    expect(result).toBe('{"a":true,"z":{"x":2,"y":1}}');
+  });
+
+  it('handles arrays', () => {
+    const result = canonicalizeJSON([3, 1, 2]);
+    expect(result).toBe('[3,1,2]');
+  });
+
+  it('handles null', () => {
+    expect(canonicalizeJSON(null)).toBe('null');
+  });
+
+  it('handles numbers', () => {
+    expect(canonicalizeJSON(42)).toBe('42');
+    expect(canonicalizeJSON(3.14)).toBe('3.14');
+  });
+
+  it('handles strings', () => {
+    expect(canonicalizeJSON('hello')).toBe('"hello"');
+  });
+
+  it('handles nested arrays in objects', () => {
+    const result = canonicalizeJSON({ b: [2, 1], a: [3, 4] });
+    expect(result).toBe('{"a":[3,4],"b":[2,1]}');
+  });
+});
+
+describe('hashParams', () => {
+  it('is deterministic', () => {
+    const h1 = hashParams('ping', { key: 'value', num: 42 });
+    const h2 = hashParams('ping', { num: 42, key: 'value' });
+    expect(h1).toBe(h2);
+  });
+
+  it('differs for different methods', () => {
+    const h1 = hashParams('ping', {});
+    const h2 = hashParams('pong', {});
+    expect(h1).not.toBe(h2);
+  });
+
+  it('handles null/undefined params', () => {
+    expect(hashParams('ping', null)).toBe(hashParams('ping', undefined));
+  });
+});
+
+describe('base64UrlEncode + base64UrlDecode', () => {
+  it('roundtrips arbitrary bytes', () => {
+    const original = Buffer.from([0x00, 0x01, 0xfe, 0xff, 0x80]);
+    const encoded = base64UrlEncode(original);
+    const decoded = base64UrlDecode(encoded);
+    expect(Buffer.from(decoded).equals(original)).toBe(true);
+  });
+
+  it('roundtrips a Uint8Array', () => {
+    const original = new Uint8Array([1, 2, 3, 4, 5]);
+    const encoded = base64UrlEncode(original);
+    const decoded = base64UrlDecode(encoded);
+    expect(Array.from(decoded)).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/packages/daemon/src/__tests__/agent-identity-crypto.test.ts
+++ b/packages/daemon/src/__tests__/agent-identity-crypto.test.ts
@@ -1,4 +1,5 @@
 import { generateKeyPairSync } from 'node:crypto';
+import type { SignaturePayload } from '@revdev/protocol/signature';
 import { describe, expect, it } from 'vitest';
 import {
   base64UrlDecode,
@@ -12,7 +13,6 @@ import {
   signEnvelope,
   verifyEnvelope,
 } from '../agent-identity-crypto.js';
-import type { SignaturePayload } from '@revdev/protocol/signature';
 
 function makePayload(overrides: Partial<SignaturePayload> = {}): SignaturePayload {
   return {

--- a/packages/daemon/src/__tests__/did.test.ts
+++ b/packages/daemon/src/__tests__/did.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { base58Decode, base58Encode } from '@revdev/protocol/base58';
+import {
+  DID_PREFIX,
+  formatDid,
+  isValidAgentId,
+  isValidAgentIdChar,
+  isValidFingerprint,
+  parseDid,
+} from '@revdev/protocol/did';
+
+describe('formatDid', () => {
+  it('formats a valid DID', () => {
+    expect(formatDid('agt-001', 'abc123')).toBe('did:revfleet:agt-001:abc123');
+  });
+
+  it('uses DID_PREFIX', () => {
+    const did = formatDid('agent', 'fp1');
+    expect(did.startsWith(DID_PREFIX)).toBe(true);
+  });
+
+  it('throws TypeError for invalid agentId', () => {
+    expect(() => formatDid('', 'abc123')).toThrow(TypeError);
+    expect(() => formatDid('has space', 'abc123')).toThrow(TypeError);
+  });
+
+  it('throws TypeError for invalid fingerprint', () => {
+    expect(() => formatDid('agt', '0OIl')).toThrow(TypeError);
+  });
+});
+
+describe('parseDid', () => {
+  it('parses a valid DID', () => {
+    const result = parseDid('did:revfleet:agt-001:abc123');
+    expect(result).toEqual({ agentId: 'agt-001', fingerprint: 'abc123' });
+  });
+
+  it('returns null for wrong prefix', () => {
+    expect(parseDid('did:other:x:y')).toBeNull();
+  });
+
+  it('returns null when fingerprint is missing', () => {
+    expect(parseDid('did:revfleet:agt-001')).toBeNull();
+  });
+
+  it('returns null when agentId is empty', () => {
+    expect(parseDid('did:revfleet::abc')).toBeNull();
+  });
+
+  it('returns null when fingerprint is empty', () => {
+    expect(parseDid('did:revfleet:agent:')).toBeNull();
+  });
+
+  it('returns null for extra colons in fingerprint', () => {
+    expect(parseDid('did:revfleet:agent:fp:extra')).toBeNull();
+  });
+});
+
+describe('isValidAgentId', () => {
+  it('returns true for a valid agent id', () => {
+    expect(isValidAgentId('agent_01-test')).toBe(true);
+    expect(isValidAgentId('a')).toBe(true);
+    expect(isValidAgentId('ABC-123_xyz')).toBe(true);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isValidAgentId('')).toBe(false);
+  });
+
+  it('returns false for a string with a space', () => {
+    expect(isValidAgentId('has space')).toBe(false);
+  });
+
+  it('returns false for a string with an emoji', () => {
+    expect(isValidAgentId('emoji\u{1F600}')).toBe(false);
+  });
+
+  it('returns false for a string longer than 128 chars', () => {
+    expect(isValidAgentId('a'.repeat(129))).toBe(false);
+  });
+
+  it('returns true for exactly 128 chars', () => {
+    expect(isValidAgentId('a'.repeat(128))).toBe(true);
+  });
+});
+
+describe('isValidAgentIdChar', () => {
+  const validChars = ['0', '9', 'a', 'z', 'A', 'Z', '_', '-'];
+  for (const c of validChars) {
+    it(`returns true for '${c}'`, () => {
+      expect(isValidAgentIdChar(c)).toBe(true);
+    });
+  }
+
+  const invalidChars = [' ', '.', '/', ':'];
+  for (const c of invalidChars) {
+    it(`returns false for '${c}'`, () => {
+      expect(isValidAgentIdChar(c)).toBe(false);
+    });
+  }
+});
+
+describe('isValidFingerprint', () => {
+  it('returns true for valid base58btc chars', () => {
+    expect(isValidFingerprint('123456789ABC')).toBe(true);
+  });
+
+  it('returns false for chars not in base58 alphabet (0, O, I, l)', () => {
+    expect(isValidFingerprint('0')).toBe(false);
+    expect(isValidFingerprint('O')).toBe(false);
+    expect(isValidFingerprint('I')).toBe(false);
+    expect(isValidFingerprint('l')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isValidFingerprint('')).toBe(false);
+  });
+});
+
+describe('base58Encode + base58Decode', () => {
+  it('roundtrip on bytes including leading zeros', () => {
+    const original = Uint8Array.of(0, 0, 0, 1, 2, 3);
+    const encoded = base58Encode(original);
+    const decoded = base58Decode(encoded);
+    expect(Array.from(decoded)).toEqual(Array.from(original));
+  });
+
+  it('encodes empty Uint8Array to empty string', () => {
+    expect(base58Encode(new Uint8Array(0))).toBe('');
+  });
+
+  it('decodes empty string to empty Uint8Array', () => {
+    expect(base58Decode('').length).toBe(0);
+  });
+
+  it('throws on invalid base58 character', () => {
+    expect(() => base58Decode('0abc')).toThrow('base58:');
+  });
+
+  it('leading 1s in encoded string map to leading zero bytes', () => {
+    const bytes = Uint8Array.of(0, 0, 5);
+    const encoded = base58Encode(bytes);
+    expect(encoded.startsWith('11')).toBe(true);
+    const decoded = base58Decode(encoded);
+    expect(Array.from(decoded)).toEqual([0, 0, 5]);
+  });
+});

--- a/packages/daemon/src/__tests__/did.test.ts
+++ b/packages/daemon/src/__tests__/did.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest';
 import { base58Decode, base58Encode } from '@revdev/protocol/base58';
 import {
   DID_PREFIX,
@@ -8,6 +7,7 @@ import {
   isValidFingerprint,
   parseDid,
 } from '@revdev/protocol/did';
+import { describe, expect, it } from 'vitest';
 
 describe('formatDid', () => {
   it('formats a valid DID', () => {

--- a/packages/daemon/src/agent-identity-crypto.ts
+++ b/packages/daemon/src/agent-identity-crypto.ts
@@ -1,0 +1,148 @@
+import { createHash, generateKeyPairSync, randomBytes, sign, verify } from 'node:crypto';
+import { base58Encode } from '@revdev/protocol/base58';
+import type {
+  EnvelopeString,
+  SignatureEnvelope,
+  SignatureHeader,
+  SignaturePayload,
+} from '@revdev/protocol/signature';
+import { SignatureHeaderSchema, SignaturePayloadSchema } from './signature-schemas.js';
+
+export interface AgentKeyPair {
+  privateKeyPem: string;
+  publicKeyPem: string;
+  publicKeyRaw: Uint8Array;
+}
+
+export function generateAgentKeypair(): AgentKeyPair {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  const publicKeyPem = publicKey as string;
+  const lines = publicKeyPem.split('\n');
+  const b64Lines: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith('-----')) {
+      continue;
+    }
+    const trimmed = line.trim();
+    if (trimmed.length > 0) {
+      b64Lines.push(trimmed);
+    }
+  }
+  const spkiDer = Buffer.from(b64Lines.join(''), 'base64');
+  const publicKeyRaw = new Uint8Array(spkiDer.buffer, spkiDer.byteOffset + spkiDer.length - 32, 32);
+
+  return {
+    privateKeyPem: privateKey as string,
+    publicKeyPem,
+    publicKeyRaw: new Uint8Array(publicKeyRaw),
+  };
+}
+
+export function computeFingerprint(publicKeyRaw: Uint8Array): string {
+  return base58Encode(createHash('sha256').update(publicKeyRaw).digest());
+}
+
+export function canonicalizeJSON(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    const items = value.map((item) => canonicalizeJSON(item));
+    return '[' + items.join(',') + ']';
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  const pairs = keys.map((k) => JSON.stringify(k) + ':' + canonicalizeJSON(obj[k]));
+  return '{' + pairs.join(',') + '}';
+}
+
+export function hashParams(method: string, params: unknown): string {
+  return base58Encode(
+    createHash('sha256')
+      .update(method + ':' + canonicalizeJSON(params ?? {}))
+      .digest(),
+  );
+}
+
+export function base64UrlEncode(bytes: Uint8Array | Buffer): string {
+  return Buffer.from(bytes).toString('base64url');
+}
+
+export function base64UrlDecode(s: string): Buffer {
+  return Buffer.from(s, 'base64url');
+}
+
+export function signEnvelope(payload: SignaturePayload, privateKeyPem: string): SignatureEnvelope {
+  const header: SignatureHeader = { alg: 'EdDSA', typ: 'jws' };
+  const headerB64 = base64UrlEncode(Buffer.from(JSON.stringify(header)));
+  const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(payload)));
+  const message = headerB64 + '.' + payloadB64;
+  const signatureBytes = sign(null, Buffer.from(message), privateKeyPem);
+  return {
+    header,
+    payload,
+    signature: base64UrlEncode(signatureBytes),
+  };
+}
+
+export function serializeEnvelope(envelope: SignatureEnvelope): EnvelopeString {
+  const headerB64 = base64UrlEncode(Buffer.from(JSON.stringify(envelope.header)));
+  const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(envelope.payload)));
+  return headerB64 + '.' + payloadB64 + '.' + envelope.signature;
+}
+
+export function parseEnvelope(envelopeString: EnvelopeString): SignatureEnvelope | null {
+  try {
+    const parts = envelopeString.split('.');
+    if (parts.length !== 3) {
+      return null;
+    }
+    const [headerB64, payloadB64, signature] = parts as [string, string, string];
+
+    let rawHeader: unknown;
+    let rawPayload: unknown;
+    try {
+      rawHeader = JSON.parse(base64UrlDecode(headerB64).toString('utf-8'));
+      rawPayload = JSON.parse(base64UrlDecode(payloadB64).toString('utf-8'));
+    } catch {
+      return null;
+    }
+
+    const headerResult = SignatureHeaderSchema.safeParse(rawHeader);
+    if (!headerResult.success) {
+      return null;
+    }
+    const payloadResult = SignaturePayloadSchema.safeParse(rawPayload);
+    if (!payloadResult.success) {
+      return null;
+    }
+
+    return {
+      header: headerResult.data,
+      payload: payloadResult.data,
+      signature,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function verifyEnvelope(envelope: SignatureEnvelope, publicKeyPem: string): boolean {
+  try {
+    const headerB64 = base64UrlEncode(Buffer.from(JSON.stringify(envelope.header)));
+    const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(envelope.payload)));
+    const message = headerB64 + '.' + payloadB64;
+    const signatureBytes = base64UrlDecode(envelope.signature);
+    return verify(null, Buffer.from(message), publicKeyPem, signatureBytes);
+  } catch {
+    return false;
+  }
+}
+
+export function generateNonce(): string {
+  return randomBytes(16).toString('hex');
+}

--- a/packages/daemon/src/agent-identity-crypto.ts
+++ b/packages/daemon/src/agent-identity-crypto.ts
@@ -78,21 +78,21 @@ export function base64UrlDecode(s: string): Buffer {
 
 export function signEnvelope(payload: SignaturePayload, privateKeyPem: string): SignatureEnvelope {
   const header: SignatureHeader = { alg: 'EdDSA', typ: 'jws' };
-  const headerB64 = base64UrlEncode(Buffer.from(JSON.stringify(header)));
-  const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(payload)));
-  const message = headerB64 + '.' + payloadB64;
+  const rawHeaderB64 = base64UrlEncode(Buffer.from(JSON.stringify(header)));
+  const rawPayloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(payload)));
+  const message = rawHeaderB64 + '.' + rawPayloadB64;
   const signatureBytes = sign(null, Buffer.from(message), privateKeyPem);
   return {
     header,
     payload,
     signature: base64UrlEncode(signatureBytes),
+    rawHeaderB64,
+    rawPayloadB64,
   };
 }
 
 export function serializeEnvelope(envelope: SignatureEnvelope): EnvelopeString {
-  const headerB64 = base64UrlEncode(Buffer.from(JSON.stringify(envelope.header)));
-  const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(envelope.payload)));
-  return headerB64 + '.' + payloadB64 + '.' + envelope.signature;
+  return envelope.rawHeaderB64 + '.' + envelope.rawPayloadB64 + '.' + envelope.signature;
 }
 
 export function parseEnvelope(envelopeString: EnvelopeString): SignatureEnvelope | null {
@@ -125,6 +125,8 @@ export function parseEnvelope(envelopeString: EnvelopeString): SignatureEnvelope
       header: headerResult.data,
       payload: payloadResult.data,
       signature,
+      rawHeaderB64: headerB64,
+      rawPayloadB64: payloadB64,
     };
   } catch {
     return null;
@@ -133,9 +135,7 @@ export function parseEnvelope(envelopeString: EnvelopeString): SignatureEnvelope
 
 export function verifyEnvelope(envelope: SignatureEnvelope, publicKeyPem: string): boolean {
   try {
-    const headerB64 = base64UrlEncode(Buffer.from(JSON.stringify(envelope.header)));
-    const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(envelope.payload)));
-    const message = headerB64 + '.' + payloadB64;
+    const message = envelope.rawHeaderB64 + '.' + envelope.rawPayloadB64;
     const signatureBytes = base64UrlDecode(envelope.signature);
     return verify(null, Buffer.from(message), publicKeyPem, signatureBytes);
   } catch {

--- a/packages/daemon/src/signature-schemas.ts
+++ b/packages/daemon/src/signature-schemas.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const SignaturePayloadSchema = z
+  .object({
+    did: z.string(),
+    kid: z.string(),
+    nonce: z.string(),
+    ts: z.number().int(),
+    method: z.string(),
+    paramsHash: z.string(),
+  })
+  .strict();
+
+export const SignatureHeaderSchema = z
+  .object({
+    alg: z.literal('EdDSA'),
+    typ: z.literal('jws'),
+  })
+  .strict();
+
+export const SignatureEnvelopeSchema = z
+  .object({
+    header: SignatureHeaderSchema,
+    payload: SignaturePayloadSchema,
+    signature: z.string(),
+  })
+  .strict();

--- a/packages/daemon/src/signature-schemas.ts
+++ b/packages/daemon/src/signature-schemas.ts
@@ -23,5 +23,7 @@ export const SignatureEnvelopeSchema = z
     header: SignatureHeaderSchema,
     payload: SignaturePayloadSchema,
     signature: z.string(),
+    rawHeaderB64: z.string(),
+    rawPayloadB64: z.string(),
   })
   .strict();

--- a/packages/daemon/src/storage/schema.ts
+++ b/packages/daemon/src/storage/schema.ts
@@ -115,4 +115,31 @@ export const SCHEMA_SQL = `
 
   CREATE INDEX IF NOT EXISTS idx_merge_requests_pr
     ON merge_requests (pr_number) WHERE pr_number IS NOT NULL;
+
+  CREATE TABLE IF NOT EXISTS agent_identity (
+    agent_id          TEXT PRIMARY KEY,
+    did               TEXT NOT NULL UNIQUE,
+    fingerprint       TEXT NOT NULL,
+    public_key_pem    TEXT NOT NULL,
+    bootstrap_allowed BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at        TIMESTAMP NOT NULL DEFAULT NOW(),
+    last_seen_at      TIMESTAMP NOT NULL DEFAULT NOW()
+  );
+
+  CREATE TABLE IF NOT EXISTS agent_identity_keys (
+    fingerprint     TEXT PRIMARY KEY,
+    agent_id        TEXT NOT NULL,
+    public_key_pem  TEXT NOT NULL,
+    created_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+    superseded_at   TIMESTAMP
+  );
+  CREATE INDEX IF NOT EXISTS idx_agent_identity_keys_agent ON agent_identity_keys(agent_id);
+
+  CREATE TABLE IF NOT EXISTS agent_identity_nonces (
+    nonce       TEXT NOT NULL,
+    agent_id    TEXT NOT NULL,
+    seen_at     TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (nonce, agent_id)
+  );
+  CREATE INDEX IF NOT EXISTS idx_agent_identity_nonces_seen ON agent_identity_nonces(seen_at);
 `;

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -19,6 +19,18 @@
     "./schema": {
       "types": "./dist/schema.d.ts",
       "import": "./dist/schema.js"
+    },
+    "./base58": {
+      "types": "./dist/base58.d.ts",
+      "import": "./dist/base58.js"
+    },
+    "./did": {
+      "types": "./dist/did.d.ts",
+      "import": "./dist/did.js"
+    },
+    "./signature": {
+      "types": "./dist/signature.d.ts",
+      "import": "./dist/signature.js"
     }
   },
   "files": [

--- a/packages/protocol/src/base58.ts
+++ b/packages/protocol/src/base58.ts
@@ -1,0 +1,78 @@
+// Hand-rolled base58btc (zero-deps constraint per ADR 2026-05-16-revdev-did-ed25519). RFC-compliant; alphabet matches Bitcoin.
+
+export const BASE58_ALPHABET =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz' as const;
+
+const ALPHABET_SET = new Set<string>(BASE58_ALPHABET.split(''));
+
+const CHAR_TO_VALUE = new Map<string, bigint>();
+for (let i = 0; i < BASE58_ALPHABET.length; i++) {
+  CHAR_TO_VALUE.set(BASE58_ALPHABET[i] as string, BigInt(i));
+}
+
+export function base58Encode(bytes: Uint8Array): string {
+  if (bytes.length === 0) {
+    return '';
+  }
+
+  let leadingZeros = 0;
+  for (let i = 0; i < bytes.length; i++) {
+    if (bytes[i] === 0) {
+      leadingZeros++;
+    } else {
+      break;
+    }
+  }
+
+  let value = 0n;
+  for (let i = 0; i < bytes.length; i++) {
+    value = value * 256n + BigInt(bytes[i] as number);
+  }
+
+  let result = '';
+  while (value > 0n) {
+    const remainder = value % 58n;
+    value = value / 58n;
+    result = (BASE58_ALPHABET[Number(remainder)] as string) + result;
+  }
+
+  return '1'.repeat(leadingZeros) + result;
+}
+
+export function base58Decode(s: string): Uint8Array {
+  if (s.length === 0) {
+    return new Uint8Array(0);
+  }
+
+  for (let i = 0; i < s.length; i++) {
+    if (!ALPHABET_SET.has(s[i] as string)) {
+      throw new Error(`base58: invalid character '${s[i]}' at position ${i}`);
+    }
+  }
+
+  let leadingZeros = 0;
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '1') {
+      leadingZeros++;
+    } else {
+      break;
+    }
+  }
+
+  let value = 0n;
+  for (let i = 0; i < s.length; i++) {
+    value = value * 58n + (CHAR_TO_VALUE.get(s[i] as string) as bigint);
+  }
+
+  const bytes: number[] = [];
+  while (value > 0n) {
+    bytes.unshift(Number(value % 256n));
+    value = value / 256n;
+  }
+
+  const result = new Uint8Array(leadingZeros + bytes.length);
+  for (let i = 0; i < bytes.length; i++) {
+    result[leadingZeros + i] = bytes[i] as number;
+  }
+  return result;
+}

--- a/packages/protocol/src/did.ts
+++ b/packages/protocol/src/did.ts
@@ -1,0 +1,70 @@
+import { BASE58_ALPHABET } from './base58.js';
+
+export const DID_PREFIX = 'did:revfleet:' as const;
+
+const FINGERPRINT_ALPHABET_SET = new Set<string>(BASE58_ALPHABET.split(''));
+
+export function isValidAgentIdChar(c: string): boolean {
+  return (
+    c.length === 1 &&
+    ((c >= '0' && c <= '9') ||
+      (c >= 'a' && c <= 'z') ||
+      (c >= 'A' && c <= 'Z') ||
+      c === '_' ||
+      c === '-')
+  );
+}
+
+export function isValidAgentId(s: string): boolean {
+  if (s.length === 0 || s.length > 128) {
+    return false;
+  }
+  for (let i = 0; i < s.length; i++) {
+    if (!isValidAgentIdChar(s[i] as string)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function isValidFingerprint(s: string): boolean {
+  if (s.length === 0 || s.length > 128) {
+    return false;
+  }
+  for (let i = 0; i < s.length; i++) {
+    if (!FINGERPRINT_ALPHABET_SET.has(s[i] as string)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function formatDid(agentId: string, fingerprint: string): string {
+  if (!isValidAgentId(agentId)) {
+    throw new TypeError(`invalid agentId: ${agentId}`);
+  }
+  if (!isValidFingerprint(fingerprint)) {
+    throw new TypeError(`invalid fingerprint: ${fingerprint}`);
+  }
+  return `${DID_PREFIX}${agentId}:${fingerprint}`;
+}
+
+export function parseDid(did: string): { agentId: string; fingerprint: string } | null {
+  if (!did.startsWith(DID_PREFIX)) {
+    return null;
+  }
+  const rest = did.slice(DID_PREFIX.length);
+  const colonIndex = rest.indexOf(':');
+  if (colonIndex === -1) {
+    return null;
+  }
+  const agentId = rest.slice(0, colonIndex);
+  const fingerprint = rest.slice(colonIndex + 1);
+  if (agentId.length === 0 || fingerprint.length === 0) {
+    return null;
+  }
+  if (fingerprint.indexOf(':') !== -1) {
+    return null;
+  }
+  return { agentId, fingerprint };
+}

--- a/packages/protocol/src/schema.ts
+++ b/packages/protocol/src/schema.ts
@@ -112,3 +112,30 @@ export interface AgentMemoryEntry {
   metadata: Record<string, unknown>;
   created_at: string;
 }
+
+/** Agent identity row shape. */
+export interface AgentIdentity {
+  agent_id: string;
+  did: string;
+  fingerprint: string;
+  public_key_pem: string;
+  bootstrap_allowed: boolean;
+  created_at: Date;
+  last_seen_at: Date;
+}
+
+/** Agent identity key row shape. */
+export interface AgentIdentityKey {
+  fingerprint: string;
+  agent_id: string;
+  public_key_pem: string;
+  created_at: Date;
+  superseded_at: Date | null;
+}
+
+/** Agent identity nonce row shape. */
+export interface AgentIdentityNonce {
+  nonce: string;
+  agent_id: string;
+  seen_at: Date;
+}

--- a/packages/protocol/src/signature.ts
+++ b/packages/protocol/src/signature.ts
@@ -16,6 +16,11 @@ export interface SignatureEnvelope {
   header: SignatureHeader;
   payload: SignaturePayload;
   signature: string;
+  // The literal base64url segments that were signed. Verification re-uses
+  // these instead of re-serializing header/payload, so signatures produced
+  // by clients with non-canonical JSON key order still verify correctly.
+  rawHeaderB64: string;
+  rawPayloadB64: string;
 }
 
 export type EnvelopeString = string;

--- a/packages/protocol/src/signature.ts
+++ b/packages/protocol/src/signature.ts
@@ -1,0 +1,21 @@
+export interface SignaturePayload {
+  did: string;
+  kid: string;
+  nonce: string;
+  ts: number;
+  method: string;
+  paramsHash: string;
+}
+
+export interface SignatureHeader {
+  alg: 'EdDSA';
+  typ: 'jws';
+}
+
+export interface SignatureEnvelope {
+  header: SignatureHeader;
+  payload: SignaturePayload;
+  signature: string;
+}
+
+export type EnvelopeString = string;


### PR DESCRIPTION
## Summary

Foundation for ADR `2026-05-16-revdev-did-ed25519-rpc-signing` Phase 1 (merged via an internal repo, commit `3f36e61ca`).

This PR is **additive-only and has zero behavior change** — nothing imports the new modules from existing code paths yet. PR-2 will wire `session.register` keygen + revvault persistence. PR-3 will add the accept-if-present signature gate at `server.ts:1073` and bridge `DaemonClient` signing.

## What's added

| File | Purpose |
|---|---|
| `packages/protocol/src/did.ts` | `formatDid`, `parseDid`, `isValidAgentId`, `isValidFingerprint` -- char-loop validators, no regex |
| `packages/protocol/src/base58.ts` | Hand-rolled base58btc encode/decode (zero-deps constraint per ADR par.7 -- no `@noble/hashes`/`bs58`) |
| `packages/protocol/src/signature.ts` | Envelope types (`SignatureHeader`, `SignaturePayload`, `SignatureEnvelope`) -- types only, no zod |
| `packages/daemon/src/signature-schemas.ts` | Zod schemas for envelope types (daemon-only; zod not in protocol deps -- adding it would change lockfile) |
| `packages/daemon/src/agent-identity-crypto.ts` | Ed25519 helpers + RFC 8785 JCS-style canonical JSON + sign/verify envelope + base64url |
| `packages/daemon/src/storage/schema.ts` | +3 `CREATE TABLE IF NOT EXISTS`: `agent_identity`, `agent_identity_keys`, `agent_identity_nonces` |
| `packages/protocol/src/schema.ts` | +3 TypeScript row interfaces matching the new tables |
| `packages/protocol/package.json` | +3 subpath exports: `./base58`, `./did`, `./signature` |

## Tests

All tests placed in `packages/daemon/src/__tests__/` (protocol has no test infrastructure; daemon has vitest):

- `agent-identity-crypto.test.ts` (25 tests): sign/verify roundtrip, tamper detection, canonical-JSON determinism, base64url roundtrip, `parseEnvelope` null-on-malformed
- `did.test.ts` (36 tests): DID format, agentId/fingerprint validation, base58 roundtrip including leading-zero handling

## Audit findings honored

- Schema convention is `TIMESTAMP` (existing daemon) not `TIMESTAMPTZ` (ADR par.Q2 sample) -- matched existing for diff hygiene
- `node:crypto` reused via explicit named imports (mirrors `license-crypto.ts:29` pattern); zero new deps; lockfile unchanged
- Row-shape drift between `protocol/src/schema.ts` (TS) and `daemon/storage/schema.ts` (raw SQL) is pre-existing; documented but not fixed here
- No regex anywhere (memory `feedback_no_regex_ast_only`) -- char-range loops + `Set<string>` lookups + `String.startsWith`/`indexOf`/`slice`

## Deviation from prompt

The prompt placed Zod schemas in `packages/protocol/src/signature.ts`. `@revdev/protocol` has no `zod` dependency and adding it would change `pnpm-lock.yaml` (hard gate: "lockfile unchanged"). Schemas moved to `packages/daemon/src/signature-schemas.ts` where zod is already a declared dep. Types (interfaces) remain in `protocol/src/signature.ts` as specified. This is a cleaner separation regardless -- types in protocol, runtime validation in daemon.

## Verification

- `pnpm --filter @revdev/protocol build` -- green
- `pnpm --filter @revdev/daemon build` -- green
- `pnpm --filter @revdev/daemon test` (new suites): 61/61 green
- `pnpm typecheck` -- green (all packages including daemon)
- `pnpm exec biome format --write packages/` -- 2 files normalized, no issues
- `pnpm-lock.yaml` unchanged (zero new deps verified)

Pre-existing failing suites (`e2e-ipc.test.ts`, `neon-sync.test.ts`) have hook timeouts from PGlite init time constraints -- confirmed pre-existing by running against clean branch state (baseline: 7 failing suites; post-PR: 2 failing suites, all pre-existing).

## Out of scope (deferred to PR-2 and PR-3)

- Wiring keygen into `session.register` (PR-2)
- `revvault-client.ts` daemon helper (PR-2)
- Accept-if-present signature gate at `server.ts:1073` (PR-3)
- Bridge `DaemonClient` request signing (PR-3)
- Schema row-shape consolidation (out of P1 -- pre-existing drift)
