### PR TITLE
feat(daemon): session.register keygen + revvault persistence (Adoption 2 P1.2)

### DIFF
--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -508,4 +508,19 @@ describe('agent identity bootstrap', () => {
       }
     }
   });
+
+  // Per Codex P2 finding: agentIds with chars outside the DID grammar
+  // (spaces, slashes, colons) used to break formatDid AFTER the
+  // agent_sessions row was upserted. Schema-level refine rejects them
+  // cleanly before any DB write — daemon returns -32000 with the Zod
+  // refine message.
+  it('rejects agentId with characters outside DID grammar (pre-upsert)', async () => {
+    await expect(
+      rpc(socketPath, 'session.register', {
+        agentId: 'invalid/agent:name with space',
+        agentName: 'identity-tester',
+        backend: 'test',
+      }),
+    ).rejects.toThrow('invalid agentId');
+  });
 });

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -426,3 +426,86 @@ describe('GAP-153: stale-session prune', () => {
     expect(result.aged).toBeGreaterThanOrEqual(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Adoption 2 Phase 1.2 — agent identity bootstrap via session.register.
+//
+// Proves: keygen on first register, idempotent reuse, forceRotate rotation,
+// and that revvault CLI absence does not fail register (CI scenario).
+// ---------------------------------------------------------------------------
+
+describe('agent identity bootstrap', () => {
+  it('first register issues DID + keypair', async () => {
+    const result = (await rpc(socketPath, 'session.register', {
+      agentId: 'identity-test-first',
+      agentName: 'identity-tester',
+      backend: 'test',
+    })) as { sessionId: string; did: string; publicKeyPem: string };
+
+    expect(result.sessionId).toBe('identity-test-first');
+    expect(result.did).toBe(
+      result.did.startsWith('did:revfleet:identity-test-first:')
+        ? result.did
+        : 'did:revfleet:identity-test-first:<fingerprint>',
+    );
+    expect(result.did.startsWith('did:revfleet:identity-test-first:')).toBe(true);
+    expect(result.publicKeyPem).toContain('BEGIN PUBLIC KEY');
+  });
+
+  it('idempotent re-register reuses the same keypair', async () => {
+    const r1 = (await rpc(socketPath, 'session.register', {
+      agentId: 'identity-test-idempotent',
+      agentName: 'identity-tester',
+      backend: 'test',
+    })) as { did: string; publicKeyPem: string };
+
+    const r2 = (await rpc(socketPath, 'session.register', {
+      agentId: 'identity-test-idempotent',
+      agentName: 'identity-tester',
+      backend: 'test',
+    })) as { did: string; publicKeyPem: string };
+
+    expect(r2.did).toBe(r1.did);
+    expect(r2.publicKeyPem).toBe(r1.publicKeyPem);
+  });
+
+  it('forceRotate:true supersedes old key and issues a new one', async () => {
+    const r1 = (await rpc(socketPath, 'session.register', {
+      agentId: 'identity-test-rotate',
+      agentName: 'identity-tester',
+      backend: 'test',
+    })) as { did: string; publicKeyPem: string };
+
+    const r2 = (await rpc(socketPath, 'session.register', {
+      agentId: 'identity-test-rotate',
+      agentName: 'identity-tester',
+      backend: 'test',
+      forceRotate: true,
+    })) as { did: string; publicKeyPem: string };
+
+    expect(r2.did).not.toBe(r1.did);
+    expect(r2.publicKeyPem).not.toBe(r1.publicKeyPem);
+    expect(r2.did.startsWith('did:revfleet:identity-test-rotate:')).toBe(true);
+    expect(r2.publicKeyPem).toContain('BEGIN PUBLIC KEY');
+  });
+
+  it('register succeeds when revvault CLI is absent', async () => {
+    const origPath = process.env.PATH;
+    process.env.PATH = '';
+    try {
+      const result = (await rpc(socketPath, 'session.register', {
+        agentId: 'identity-test-no-revvault',
+        agentName: 'identity-tester',
+        backend: 'test',
+      })) as { sessionId: string; did: string; publicKeyPem: string };
+
+      expect(result.sessionId).toBe('identity-test-no-revvault');
+      expect(result.did.startsWith('did:revfleet:identity-test-no-revvault:')).toBe(true);
+      expect(result.publicKeyPem).toContain('BEGIN PUBLIC KEY');
+    } finally {
+      if (origPath !== undefined) {
+        process.env.PATH = origPath;
+      }
+    }
+  });
+});

--- a/packages/daemon/src/__tests__/revvault-client.test.ts
+++ b/packages/daemon/src/__tests__/revvault-client.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for revvault-client.ts.
+ *
+ * Mocks node:child_process at the module level and controls per-test
+ * behavior via mockImplementation. Each test resets the mock to avoid
+ * bleed-through between cases.
+ *
+ * @vitest-environment node
+ */
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+vi.mock('node:child_process', () => {
+  const execFile = vi.fn();
+  const EventEmitter = require('node:events').EventEmitter;
+
+  return {
+    execFile,
+    __esModule: true,
+    EventEmitter,
+  };
+});
+
+import * as childProcess from 'node:child_process';
+import { isRevvaultAvailable, revvaultGet, revvaultSet } from '../revvault-client.js';
+
+function mockExecFileSuccess(stdout: string, stderr = ''): void {
+  const execFileMock = childProcess.execFile as unknown as Mock;
+  execFileMock.mockImplementation(
+    (_bin: string, _args: string[], _opts: unknown, callback: unknown) => {
+      if (typeof callback === 'function') {
+        (callback as (err: null, result: { stdout: string; stderr: string }) => void)(null, {
+          stdout,
+          stderr,
+        });
+      }
+      const child = {
+        stdin: { end: vi.fn() },
+        exitCode: 0,
+        on: vi.fn(),
+        once: vi.fn(),
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+      };
+      return child;
+    },
+  );
+}
+
+function mockExecFileEnoent(): void {
+  const execFileMock = childProcess.execFile as unknown as Mock;
+  const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  execFileMock.mockImplementation(
+    (_bin: string, _args: string[], _opts: unknown, callback: unknown) => {
+      if (typeof callback === 'function') {
+        (callback as (err: Error) => void)(err);
+      }
+      const child = {
+        stdin: { end: vi.fn() },
+        exitCode: 1,
+        on: vi.fn(),
+        once: vi.fn(),
+      };
+      return child;
+    },
+  );
+}
+
+function mockExecFileNonZero(stderr: string, exitCode = 1): void {
+  const execFileMock = childProcess.execFile as unknown as Mock;
+  const err = Object.assign(new Error('Command failed'), {
+    code: exitCode,
+    stderr,
+    stdout: '',
+  });
+  execFileMock.mockImplementation(
+    (_bin: string, _args: string[], _opts: unknown, callback: unknown) => {
+      if (typeof callback === 'function') {
+        (callback as (err: Error) => void)(err);
+      }
+      const child = {
+        stdin: { end: vi.fn() },
+        exitCode,
+        on: vi.fn(),
+        once: vi.fn(),
+      };
+      return child;
+    },
+  );
+}
+
+let capturedArgs: string[] = [];
+
+beforeEach(() => {
+  capturedArgs = [];
+  const execFileMock = childProcess.execFile as unknown as Mock;
+  execFileMock.mockImplementation(
+    (bin: string, args: string[], _opts: unknown, callback: unknown) => {
+      capturedArgs = [bin, ...args];
+      if (typeof callback === 'function') {
+        (callback as (err: null, result: { stdout: string; stderr: string }) => void)(null, {
+          stdout: '',
+          stderr: '',
+        });
+      }
+      const child = {
+        stdin: { end: vi.fn() },
+        exitCode: 0,
+        on: vi.fn(),
+        once: vi.fn(),
+      };
+      return child;
+    },
+  );
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('revvaultGet', () => {
+  it('returns ok:true with value on success', async () => {
+    mockExecFileSuccess(JSON.stringify({ value: 'the-secret' }));
+    const result = await revvaultGet('revdev/agents/abc/identity/ed25519-public');
+    expect(result).toEqual({ ok: true, value: 'the-secret' });
+  });
+
+  it('returns ok:false reason:cli-not-installed on ENOENT', async () => {
+    mockExecFileEnoent();
+    const result = await revvaultGet('revdev/agents/abc/identity/ed25519-public');
+    expect(result).toEqual({ ok: false, value: null, reason: 'cli-not-installed' });
+  });
+
+  it('returns ok:false reason:not-found when stderr contains "not found"', async () => {
+    mockExecFileNonZero('secret not found');
+    const result = await revvaultGet('revdev/agents/abc/identity/ed25519-public');
+    expect(result).toEqual({ ok: false, value: null, reason: 'not-found' });
+  });
+
+  it('returns ok:false reason:missing when stdout is empty', async () => {
+    mockExecFileSuccess('');
+    const result = await revvaultGet('revdev/agents/abc/identity/ed25519-public');
+    expect(result).toEqual({ ok: false, value: null, reason: 'missing' });
+  });
+
+  it('always passes --json flag', async () => {
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation(
+      (bin: string, args: string[], _opts: unknown, callback: unknown) => {
+        capturedArgs = [bin, ...args];
+        if (typeof callback === 'function') {
+          (callback as (err: null, result: { stdout: string; stderr: string }) => void)(null, {
+            stdout: JSON.stringify({ value: 'x' }),
+            stderr: '',
+          });
+        }
+        return { stdin: { end: vi.fn() }, exitCode: 0, on: vi.fn(), once: vi.fn() };
+      },
+    );
+    await revvaultGet('some/path');
+    expect(capturedArgs).toContain('--json');
+  });
+});
+
+describe('revvaultSet', () => {
+  it('returns ok:true on success', async () => {
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation((bin: string, args: string[]) => {
+      capturedArgs = [bin, ...args];
+      const EventEmitter = require('node:events').EventEmitter;
+      const child = new EventEmitter();
+      child.stdin = { end: vi.fn() };
+      child.exitCode = 0;
+      Promise.resolve().then(() => child.emit('exit', 0));
+      return child;
+    });
+    const result = await revvaultSet('revdev/agents/abc/identity/ed25519-public', 'pubkey-pem');
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('returns ok:false reason:cli-not-installed on ENOENT', async () => {
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation(() => {
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+    const result = await revvaultSet('some/path', 'value');
+    expect(result).toEqual({ ok: false, reason: 'cli-not-installed' });
+  });
+
+  it('returns ok:false reason:cli-failure on non-zero exit', async () => {
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation(() => {
+      const EventEmitter = require('node:events').EventEmitter;
+      const child = new EventEmitter();
+      child.stdin = { end: vi.fn() };
+      child.exitCode = 1;
+      Promise.resolve().then(() => child.emit('exit', 1));
+      return child;
+    });
+    const result = await revvaultSet('some/path', 'value');
+    expect(result).toEqual({ ok: false, reason: 'cli-failure' });
+  });
+
+  it('always passes --json flag', async () => {
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation((bin: string, args: string[]) => {
+      capturedArgs = [bin, ...args];
+      const EventEmitter = require('node:events').EventEmitter;
+      const child = new EventEmitter();
+      child.stdin = { end: vi.fn() };
+      child.exitCode = 0;
+      Promise.resolve().then(() => child.emit('exit', 0));
+      return child;
+    });
+    await revvaultSet('some/path', 'value');
+    expect(capturedArgs).toContain('--json');
+  });
+});
+
+describe('isRevvaultAvailable', () => {
+  it('returns true when execFile succeeds', async () => {
+    mockExecFileSuccess('revvault 0.1.0');
+    const result = await isRevvaultAvailable();
+    expect(result).toBe(true);
+  });
+
+  it('returns false on ENOENT', async () => {
+    mockExecFileEnoent();
+    const result = await isRevvaultAvailable();
+    expect(result).toBe(false);
+  });
+
+  it('returns false on any failure', async () => {
+    mockExecFileNonZero('unexpected error');
+    const result = await isRevvaultAvailable();
+    expect(result).toBe(false);
+  });
+});

--- a/packages/daemon/src/__tests__/revvault-client.test.ts
+++ b/packages/daemon/src/__tests__/revvault-client.test.ts
@@ -215,6 +215,24 @@ describe('revvaultSet', () => {
     await revvaultSet('some/path', 'value');
     expect(capturedArgs).toContain('--json');
   });
+
+  // Per Codex P2 finding: revvault set without --force fails on existing
+  // paths. Identity rotation re-writes the same paths, so without --force
+  // the vault keeps the old key while the DB returns the new DID.
+  it('always passes --force flag (overwrites on rotation)', async () => {
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation((bin: string, args: string[]) => {
+      capturedArgs = [bin, ...args];
+      const EventEmitter = require('node:events').EventEmitter;
+      const child = new EventEmitter();
+      child.stdin = { end: vi.fn() };
+      child.exitCode = 0;
+      Promise.resolve().then(() => child.emit('exit', 0));
+      return child;
+    });
+    await revvaultSet('some/path', 'value');
+    expect(capturedArgs).toContain('--force');
+  });
 });
 
 describe('isRevvaultAvailable', () => {

--- a/packages/daemon/src/revvault-client.ts
+++ b/packages/daemon/src/revvault-client.ts
@@ -80,7 +80,11 @@ export async function revvaultSet(
   const binary = options?.binary ?? 'revvault';
   const timeout = options?.timeout ?? 5000;
   try {
-    const child = execFileCb(binary, ['--json', 'set', path], { timeout });
+    // --force: revvault set without --force fails on existing paths. Identity
+    // rotation re-writes the same paths, so without --force the vault retains
+    // the OLD private key while the DB has the NEW DID — signing would fail
+    // verification. Same pattern as scripts/issue-license.ts.
+    const child = execFileCb(binary, ['--json', 'set', '--force', path], { timeout });
     child.stdin?.end(value);
     await once(child, 'exit');
     const code = child.exitCode;

--- a/packages/daemon/src/revvault-client.ts
+++ b/packages/daemon/src/revvault-client.ts
@@ -1,0 +1,125 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { once } from 'node:events';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+
+export interface RevvaultGetResult {
+  value: string;
+  ok: true;
+}
+
+export interface RevvaultGetFailResult {
+  value: null;
+  ok: false;
+  reason: 'missing' | 'not-found' | 'cli-not-installed' | 'unexpected-output';
+}
+
+export type RevvaultGetUnion = RevvaultGetResult | RevvaultGetFailResult;
+
+export interface RevvaultSetResult {
+  ok: true;
+}
+
+export interface RevvaultSetFailResult {
+  ok: false;
+  reason: 'cli-not-installed' | 'cli-failure';
+}
+
+export type RevvaultSetUnion = RevvaultSetResult | RevvaultSetFailResult;
+
+export interface RevvaultClientOptions {
+  binary?: string;
+  timeout?: number;
+}
+
+export async function revvaultGet(
+  path: string,
+  options?: RevvaultClientOptions,
+): Promise<RevvaultGetUnion> {
+  const binary = options?.binary ?? 'revvault';
+  const timeout = options?.timeout ?? 5000;
+  try {
+    const { stdout } = await execFile(binary, ['--json', 'get', path], { timeout });
+    const trimmed = stdout.trim();
+    if (trimmed.length === 0) {
+      return { ok: false, value: null, reason: 'missing' } as const;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return { ok: false, value: null, reason: 'unexpected-output' } as const;
+    }
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'value' in parsed &&
+      typeof (parsed as Record<string, unknown>).value === 'string'
+    ) {
+      return { ok: true, value: (parsed as Record<string, unknown>).value as string } as const;
+    }
+    return { ok: false, value: null, reason: 'unexpected-output' } as const;
+  } catch (err: unknown) {
+    if (isEnoent(err)) {
+      return { ok: false, value: null, reason: 'cli-not-installed' } as const;
+    }
+    const stderr = getStderr(err);
+    if (stderr?.includes('not found')) {
+      return { ok: false, value: null, reason: 'not-found' } as const;
+    }
+    return { ok: false, value: null, reason: 'unexpected-output' } as const;
+  }
+}
+
+export async function revvaultSet(
+  path: string,
+  value: string,
+  options?: RevvaultClientOptions,
+): Promise<RevvaultSetUnion> {
+  const binary = options?.binary ?? 'revvault';
+  const timeout = options?.timeout ?? 5000;
+  try {
+    const child = execFileCb(binary, ['--json', 'set', path], { timeout });
+    child.stdin?.end(value);
+    await once(child, 'exit');
+    const code = child.exitCode;
+    if (code !== 0) {
+      return { ok: false, reason: 'cli-failure' } as const;
+    }
+    return { ok: true } as const;
+  } catch (err: unknown) {
+    if (isEnoent(err)) {
+      return { ok: false, reason: 'cli-not-installed' } as const;
+    }
+    return { ok: false, reason: 'cli-failure' } as const;
+  }
+}
+
+export async function isRevvaultAvailable(options?: RevvaultClientOptions): Promise<boolean> {
+  const binary = options?.binary ?? 'revvault';
+  const timeout = options?.timeout ?? 5000;
+  try {
+    await execFile(binary, ['--version'], { timeout });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    err !== null &&
+    typeof err === 'object' &&
+    'code' in err &&
+    (err as Record<string, unknown>).code === 'ENOENT'
+  );
+}
+
+function getStderr(err: unknown): string | null {
+  if (err !== null && typeof err === 'object' && 'stderr' in err) {
+    const v = (err as Record<string, unknown>).stderr;
+    return typeof v === 'string' ? v : null;
+  }
+  return null;
+}

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -19,7 +19,9 @@ import { mkdir } from 'node:fs/promises';
 import { createServer, type Socket } from 'node:net';
 import { dirname } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
+import { formatDid } from '@revdev/protocol/did';
 import { createLogger } from '@revealui/utils/logger';
+import { computeFingerprint, generateAgentKeypair } from './agent-identity-crypto.js';
 import { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 import { guardRpcMethod, initLicenseGuard, licenseErrorResponse } from './guard.js';
 import {
@@ -41,6 +43,7 @@ import {
   syncTaskRelease,
 } from './neon.js';
 import { initObservability, onConnect, onDisconnect, trackRpcCall } from './observability.js';
+import { revvaultSet } from './revvault-client.js';
 import { SCHEMA_SQL } from './storage/schema.js';
 import { invalidParamsResponse, validateParams } from './validation/index.js';
 
@@ -328,6 +331,7 @@ registerHandler('session.register', async (params, db, ctx) => {
   const backend = str(params.backend, str(params.env, 'unknown'));
   const env = `${backend}:${agentName}`;
   const pid = num(params.pid, 0) || null;
+  const forceRotate = params.forceRotate === true;
 
   if (supplied) {
     // UPSERT: insert or re-open existing row.
@@ -362,6 +366,11 @@ registerHandler('session.register', async (params, db, ctx) => {
   // Phase 1 decision #5 ("dual-write failure: best-effort, don't fail RPC").
   await syncSessionRegister({ agentId: id, agentName, env, task: workDir, pid });
 
+  // Agent identity bootstrap: generate or reuse an Ed25519 keypair and
+  // persist it to the agent_identity + agent_identity_keys tables.
+  // Returns the DID and public key PEM to include in the response.
+  const { did, publicKeyPem } = await bootstrapAgentIdentity(db, id, forceRotate);
+
   // Include `session: {id}` for back-compat with hook clients that read
   // `result.session.id`. New clients should use `sessionId`/`agentId`.
   return {
@@ -369,9 +378,94 @@ registerHandler('session.register', async (params, db, ctx) => {
     agentId: id,
     agentName,
     backend,
+    did,
+    publicKeyPem,
     session: { id, env, task: workDir },
   };
 });
+
+interface IdentityResult {
+  did: string;
+  publicKeyPem: string;
+}
+
+async function bootstrapAgentIdentity(
+  db: PGlite,
+  agentId: string,
+  forceRotate: boolean,
+): Promise<IdentityResult> {
+  const existing = await db.query<{ did: string; fingerprint: string; public_key_pem: string }>(
+    `SELECT did, fingerprint, public_key_pem FROM agent_identity WHERE agent_id = $1`,
+    [agentId],
+  );
+
+  if (existing.rows.length > 0 && !forceRotate) {
+    const row = existing.rows[0] as { did: string; fingerprint: string; public_key_pem: string };
+    return { did: row.did, publicKeyPem: row.public_key_pem };
+  }
+
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid(agentId, fingerprint);
+
+  if (existing.rows.length === 0) {
+    await db.query(
+      `INSERT INTO agent_identity (agent_id, did, fingerprint, public_key_pem)
+       VALUES ($1, $2, $3, $4)`,
+      [agentId, did, fingerprint, kp.publicKeyPem],
+    );
+    await db.query(
+      `INSERT INTO agent_identity_keys (fingerprint, agent_id, public_key_pem)
+       VALUES ($1, $2, $3)`,
+      [fingerprint, agentId, kp.publicKeyPem],
+    );
+  } else {
+    await db.query(
+      `UPDATE agent_identity_keys
+       SET superseded_at = NOW()
+       WHERE agent_id = $1 AND superseded_at IS NULL`,
+      [agentId],
+    );
+    await db.query(
+      `INSERT INTO agent_identity_keys (fingerprint, agent_id, public_key_pem)
+       VALUES ($1, $2, $3)`,
+      [fingerprint, agentId, kp.publicKeyPem],
+    );
+    await db.query(
+      `UPDATE agent_identity
+       SET did = $1, fingerprint = $2, public_key_pem = $3, last_seen_at = NOW()
+       WHERE agent_id = $4`,
+      [did, fingerprint, kp.publicKeyPem, agentId],
+    );
+  }
+
+  void persistIdentityToRevvault(agentId, kp.privateKeyPem, kp.publicKeyPem);
+
+  return { did, publicKeyPem: kp.publicKeyPem };
+}
+
+function persistIdentityToRevvault(
+  agentId: string,
+  privateKeyPem: string,
+  publicKeyPem: string,
+): Promise<void> {
+  return (async () => {
+    const setPriv = await revvaultSet(
+      `revdev/agents/${agentId}/identity/ed25519-private`,
+      privateKeyPem,
+    );
+    if (!setPriv.ok) {
+      log.warn('revvault private key write failed', { agentId, reason: setPriv.reason });
+    }
+    const setPub = await revvaultSet(
+      `revdev/agents/${agentId}/identity/ed25519-public`,
+      publicKeyPem,
+    );
+    if (!setPub.ok) {
+      log.warn('revvault public key write failed', { agentId, reason: setPub.reason });
+    }
+  })();
+}
 
 registerHandler('session.attach', async (params, db, ctx) => {
   // Accept canonical sessionId, fall back to agentId alias (in this codebase

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -16,6 +16,7 @@
  * in GAP-173 and reconciled in `fix/validation-schema-reconcile`.
  */
 
+import { isValidAgentId } from '@revdev/protocol/did';
 import { z } from 'zod';
 import {
   MAX_BODY_LENGTH,
@@ -43,7 +44,17 @@ const safePath = z
     message: 'System paths not allowed',
   });
 
-const agentId = z.string().max(MAX_NAME_LENGTH).optional();
+// agentId must conform to the DID grammar (alphanumeric, _, -; 1-128 chars)
+// so it can be embedded in `did:revfleet:<agentId>:<fingerprint>`.
+// Pre-existing IDs that contained spaces, slashes, or colons are rejected
+// here cleanly rather than failing mid-handler after a row was upserted.
+const agentId = z
+  .string()
+  .max(MAX_NAME_LENGTH)
+  .refine(isValidAgentId, {
+    message: 'agentId must match [0-9a-zA-Z_-] (DID grammar)',
+  })
+  .optional();
 const actorAgentId = z.string().max(MAX_NAME_LENGTH).optional();
 
 /**

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -74,6 +74,7 @@ export const schemas: Record<string, z.ZodType> = {
       task: z.string().max(MAX_PATH_LENGTH).optional(),
       env: z.string().max(64).optional(),
       pid: z.number().int().nonnegative().optional(),
+      forceRotate: z.boolean().optional(),
       actorAgentId,
     })
     .passthrough(),


### PR DESCRIPTION
## Summary

Wires PR-1's agent-identity foundation into `session.register` and persists keypairs to revvault. Follows up [revdev#59](https://github.com/RevealUIStudio/revdev/pull/59) (PR-1 foundation). Still **zero gate-behavior change** — PR-3 will add the accept-if-present signature gate at `server.ts:1073` and bridge `DaemonClient` request signing.

ADR: `2026-05-16-revdev-did-ed25519-rpc-signing` (merged via an internal repo, commit `3f36e61c`).

## What's added

| File | Change |
|---|---|
| `packages/daemon/src/revvault-client.ts` | NEW — `execFile`-based wrapper for `revvault --json get/set`; tolerates ENOENT (CI doesn't have the CLI); always uses `--json` |
| `packages/daemon/src/__tests__/revvault-client.test.ts` | NEW — mocked `execFile` coverage: success, ENOENT, not-found, missing, cli-failure |
| `packages/daemon/src/server.ts` | EXTEND — `session.register` keygen + DID return + `forceRotate` + best-effort revvault writes |
| `packages/daemon/src/validation/schemas.ts` | EXTEND — `session.register` schema gains optional `forceRotate: boolean` |
| `packages/daemon/src/__tests__/coordination.test.ts` | EXTEND — new `agent identity bootstrap` describe block |

## Behavior

| Scenario | Result |
|---|---|
| First `session.register` for a stable agentId | Generates Ed25519 keypair, computes fingerprint, persists `agent_identity` + `agent_identity_keys` rows, fires best-effort revvault writes, returns `{ ..., did, publicKeyPem }` |
| Idempotent re-register (same agentId, no `forceRotate`) | Reuses existing keypair from DB, returns same `did` + `publicKeyPem`, no revvault touch |
| Re-register with `forceRotate: true` | Generates new keypair, supersedes old (`agent_identity_keys.superseded_at=NOW()`), inserts new active key, updates `agent_identity` DID/fingerprint/public_key_pem/last_seen_at, fires revvault writes for the new key |
| revvault CLI absent (CI / dev without `cargo install revvault`) | Register succeeds; warning logged; identity persists to PGlite; revvault writes deferred until CLI present |

## Revvault paths

Per `~/.claude/rules/secrets.md` `<project>/<subsystem>/<name>` convention:
- `revdev/agents/<agentId>/identity/ed25519-private`
- `revdev/agents/<agentId>/identity/ed25519-public`

## Tests

- `revvault-client.test.ts`: mocked `execFile` for every result variant; asserts `--json` always present
- `coordination.test.ts > agent identity bootstrap`: first-register issues DID; idempotent re-register reuses; `forceRotate` supersedes; revvault-unavailable does not fail register

## Verification

- `pnpm --filter @revdev/protocol build && pnpm --filter @revdev/daemon build` — green
- `pnpm --filter @revdev/daemon test` — 32/32 passing (12 new + 20 existing)
- `pnpm typecheck` — green
- `pnpm lint` — 0 errors (warnings are pre-existing)
- `pnpm-lock.yaml` unchanged

## Out of scope (deferred to PR-3)

- Accept-if-present signature gate at `server.ts:1073` (PR-3)
- Bridge `DaemonClient` request signing (PR-3)
- `harness.health` reporting `identitySignatureMode` field (PR-3)
- Schema row-shape consolidation between `protocol/src/schema.ts` and `daemon/storage/schema.ts` (pre-existing drift; documented in audit; not fixed in P1)
