### PR TITLE
chore(daemon): suppress js/user-controlled-bypass on empty-frame skip

### DIFF
--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1241,6 +1241,15 @@ export async function startDaemon(
       }
 
       for (const line of lines) {
+        // The empty-line skip is a parsing aid (TCP can deliver partial
+        // frames; an empty token between two newlines is not a request).
+        // It is not a security check: an attacker sending an empty frame
+        // gets nothing dispatched, which is the same protection an empty
+        // frame produces in any other JSON-RPC line-delimited server.
+        // The real authorization gates run downstream (license, validation,
+        // signature, identity) and are tested in
+        // packages/daemon/src/__tests__/coordination.test.ts.
+        // codeql[js/user-controlled-bypass]
         if (!line.trim()) continue;
 
         // A complete (newline-terminated) frame can still exceed the cap


### PR DESCRIPTION
## Summary

Suppress CodeQL false-positive `js/user-controlled-bypass` alert ([#4](https://github.com/RevealUIStudio/revdev/security/code-scanning/4)) introduced by PR [#61](https://github.com/RevealUIStudio/revdev/pull/61) at `packages/daemon/src/server.ts:1244` (the empty-frame skip in the dispatch loop).

## Why this is a false positive

CodeQL traces user-controlled data from the socket buffer → `JSON.parse(line)` → `req['x-revdev-signature']` → `ctx.agentId`, and flags the `if (!line.trim()) continue;` check as a "user-controlled bypass of security check" because an attacker can supposedly "skip" the request by sending an empty frame.

**This isn't an exploit vector.** Skipping an empty frame benefits no attacker — they get zero handler dispatch and the next non-empty frame is still subject to the full gate chain. The empty-skip is a parsing aid for TCP fragmentation (an empty token between two `\n`s is not a request).

The real authorization gates run **downstream** of this skip:

| Gate | What it checks |
|---|---|
| `guardRpcMethod(req.method)` | License-tier gating for Pro+ RPCs |
| `validateParams(req.method, req.params)` | Zod schema, includes `isValidAgentId` refine introduced by PR [#60](https://github.com/RevealUIStudio/revdev/pull/60) |
| `verifyOrWarn(req, db, ctx)` | Signature verification against DB-stored public key, looked up by `(fingerprint, agent_id)` — attacker cannot bind to an agent without that agent's private key |
| Identity gate at `server.ts:1073` | Refuses unregistered requests (returns `-32002`) |

Test coverage at `packages/daemon/src/__tests__/coordination.test.ts > signature acceptance` (8 tests covers: valid binds, invalid falls through, missing falls through, nonce replay rejected, ts-outside-window rejected, tamper detected, `harness.health` exposes the mode, signed-then-unsigned on reused socket does NOT inherit signature identity (Codex P1 fix in PR #61).

## Changes

| File | Change |
|---|---|
| `packages/daemon/src/server.ts:1243-1252` | Added `// codeql[js/user-controlled-bypass]` suppression + an 8-line comment block explaining why the empty-skip is benign and where the real gates live |

No behavior change. No new dependencies. No test changes.

## Verification

- `pnpm exec biome check packages/daemon/src/server.ts` — 0 errors (1 pre-existing warning on unrelated line)
- `pnpm typecheck` — 4 packages all Done (protocol, theme, daemon, bridge)
- CodeQL should re-run on the new commit; if it still flags despite the suppression comment, alert #4 is the rationale for dismissing via the Security tab as "false positive (sanitization performed)"

## Out of scope

- A real refactor of `verifyOrWarn` to make the signature → DB-lookup → assignment chain more explicit to static analyzers would be a P2 cleanup; not warranted here since the security model is correct.
- Audit of any OTHER CodeQL alerts not introduced by PR #61 (the 2 other alerts in the run are pre-existing notes marked as "fixed").
