### PR TITLE
promote: test → main (Adoption 2 P1 phases + CI leak-scan)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,12 @@ jobs:
           cache-dependency-path: apps/console/go.sum
       - run: cd apps/console && go test ./...
       - run: cd apps/console && go build -o /dev/null .
+
+  private-leak-scan:
+    name: Private Leak Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Scan for private paths and credentials
+        run: bash scripts/check-no-private-leaks.sh

--- a/.leakignore
+++ b/.leakignore
@@ -15,3 +15,11 @@ apps/studio/src/__tests__/hooks/use-ssh.test.ts           abs-home-path
 # Test fixture: the license-key shape matches the regex but the body is a
 # repeating hex pattern (abcdef-0123456789 doubled). Not a real key.
 packages/daemon/src/__tests__/flows.test.ts               license-key
+
+# Fleet-anchor cold-context ramp doc. The .jv/ path references in the
+# "Fleet coordination" section are an intentional cross-fleet navigation
+# aid for agents working in `~/revfleet/revdev/` with .jv access; they
+# point to the private coordination hub (master index, plan, lanes, gaps,
+# workboard, ADRs). Public readers without .jv see broken links — by
+# design; the file is for agent ramp, not customer docs.
+docs/INDEX.md                                              private-jv-repo

--- a/.leakignore
+++ b/.leakignore
@@ -1,0 +1,17 @@
+# .leakignore — allowed private-path references in this public repo.
+#
+# Format: <path-glob> <tag[,tag...]>   # reason
+#
+# The leak scanner (scripts/check-no-private-leaks.sh) ignores matches where
+# BOTH the file path matches the glob AND the leak tag is listed. Unknown
+# leaks still fail CI.
+
+# Test fixtures use a generic placeholder username (not a real developer).
+# The scanner's abs-home-path regex matches any /home/<word>, including
+# placeholder fixtures in unit tests.
+apps/studio/src/__tests__/hooks/use-local-shell.test.ts   abs-home-path
+apps/studio/src/__tests__/hooks/use-ssh.test.ts           abs-home-path
+
+# Test fixture: the license-key shape matches the regex but the body is a
+# repeating hex pattern (abcdef-0123456789 doubled). Not a real key.
+packages/daemon/src/__tests__/flows.test.ts               license-key

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -4,9 +4,9 @@
 **Status:** Pre-1.0 — Studio + Console + harness daemon all buildable; no public releases yet
 **Owner:** RevealUI Studio (`founder@revealui.com`)
 **Repo:** [RevealUIStudio/revdev](https://github.com/RevealUIStudio/revdev)
-**Fleet master index:** [`revealui-jv:docs/MASTER_INDEX.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_INDEX.md)
+**Fleet master index:** RevealUI Studio internal coordination hub (`MASTER_INDEX.md`, private).
 
-> Fleet-level cross-cutting plans live in [`revealui-jv:docs/MASTER_PLAN.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_PLAN.md). This file is RevDev-scoped only.
+> Fleet-level cross-cutting plans live in the internal coordination hub's `MASTER_PLAN.md`. This file is RevDev-scoped only.
 >
 > Detailed launch checklist (agent-executable + human-required tasks): [`docs/PRODUCTION_LAUNCH_PLAN.md`](./PRODUCTION_LAUNCH_PLAN.md). This MASTER_PLAN is the higher-level pointer; PRODUCTION_LAUNCH_PLAN is the per-task breakdown.
 
@@ -89,7 +89,7 @@ Active on the daemon JWT validation surface — adding `iss` + `aud` + `customer
 
 Detailed task-level breakdown in [`PRODUCTION_LAUNCH_PLAN.md`](./PRODUCTION_LAUNCH_PLAN.md). Higher-level phases below.
 
-Pre-1.0 per [`versioning.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/.claude/rules/versioning.md).
+Pre-1.0 per the fleet versioning convention (RevealUI Studio internal).
 
 ### Phase 0 — Daemon production-grade (DONE)
 
@@ -156,4 +156,4 @@ Daemon → Neon `coordination_*` tables sync; allows multiple workstations / clo
 - [`README.md`](../README.md) — overview + architecture diagram
 - [`CLAUDE.md`](../CLAUDE.md) — agent context
 - [`revealui:.claude/rules/hooks-architecture.md`](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/hooks-architecture.md) — RevDev daemon contract for fleet hooks
-- [`revealui-jv:docs/MASTER_INDEX.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_INDEX.md) — fleet-level navigation
+- Fleet master index (`MASTER_INDEX.md` in the RevealUI Studio internal coordination hub) — fleet-level navigation

--- a/docs/MASTER_SPEC.md
+++ b/docs/MASTER_SPEC.md
@@ -202,7 +202,7 @@ Test count: 522/522 passing per [revdev#43](https://github.com/RevealUIStudio/re
 
 ## Versioning
 
-Pre-1.0 per [`versioning.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/.claude/rules/versioning.md). Per-package SemVer (`@revdev/daemon`, `@revdev/protocol`, `@revdev/bridge`, `@revdev/theme` independent). Studio + Console app versions tracked separately per Tauri / Go release conventions.
+Pre-1.0 per the fleet versioning convention (RevealUI Studio internal). Per-package SemVer (`@revdev/daemon`, `@revdev/protocol`, `@revdev/bridge`, `@revdev/theme` independent). Studio + Console app versions tracked separately per Tauri / Go release conventions.
 
 ---
 
@@ -229,4 +229,4 @@ Pre-1.0 per [`versioning.md`](https://github.com/RevealUIStudio/revealui-jv/blob
 - [`CLAUDE.md`](../CLAUDE.md) — agent context
 - [`README.md`](../README.md) — overview + architecture
 - [`revealui:.claude/rules/hooks-architecture.md`](https://github.com/RevealUIStudio/revealui/blob/main/.claude/rules/hooks-architecture.md) — fleet hook contract; the daemon's role in fleet coordination
-- [`revealui-jv:docs/MASTER_INDEX.md`](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/MASTER_INDEX.md) — fleet-level navigation
+- Fleet master index (`MASTER_INDEX.md` in the RevealUI Studio internal coordination hub) — fleet-level navigation

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev:studio": "pnpm --filter @revdev/studio dev",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "test": "pnpm -r test",
+    "test": "pnpm --filter @revdev/protocol build && pnpm -r test",
     "test:coverage": "pnpm -r test:coverage",
     "typecheck": "pnpm --filter @revdev/protocol build && pnpm -r --filter=!studio typecheck",
     "typecheck:studio": "pnpm --filter studio typecheck"

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "dev:studio": "pnpm --filter @revdev/studio dev",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "test": "pnpm --filter @revdev/protocol build && pnpm -r test",
+    "test": "pnpm --filter @revdev/protocol build && pnpm --filter @revdev/daemon build && pnpm -r test",
     "test:coverage": "pnpm -r test:coverage",
-    "typecheck": "pnpm --filter @revdev/protocol build && pnpm -r --filter=!studio typecheck",
+    "typecheck": "pnpm --filter @revdev/protocol build && pnpm --filter @revdev/daemon build && pnpm -r --filter=!studio typecheck",
     "typecheck:studio": "pnpm --filter studio typecheck"
   },
   "devDependencies": {

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "@revdev/daemon": "workspace:*",
     "@revdev/protocol": "workspace:*",
     "zod": "^4.3.6"
   },

--- a/packages/bridge/src/__tests__/client-signing.test.ts
+++ b/packages/bridge/src/__tests__/client-signing.test.ts
@@ -1,0 +1,164 @@
+/**
+ * DaemonClient request signing tests.
+ *
+ * DaemonClient accepts an optional signingConfig in its constructor
+ * (second parameter) so tests can inject a known keypair without touching
+ * env vars. The module-level env-based path is exercised via resolveSigningConfig().
+ *
+ * Socket I/O is intercepted by mocking node:net's connect() to return a
+ * fake EventEmitter that captures written frames.
+ *
+ * @vitest-environment node
+ */
+
+import { EventEmitter } from 'node:events';
+import { computeFingerprint, generateAgentKeypair } from '@revdev/daemon/crypto';
+import { formatDid } from '@revdev/protocol/did';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DaemonClient, resolveSigningConfig } from '../client.js';
+
+vi.mock('node:net', () => ({
+  connect: vi.fn(),
+}));
+
+interface FakeSocket extends EventEmitter {
+  write: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+  setTimeout: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeSocket(replyResult: unknown = { pong: true }): FakeSocket {
+  const sock = new EventEmitter() as FakeSocket;
+  sock.end = vi.fn();
+  sock.destroy = vi.fn();
+  sock.setTimeout = vi.fn();
+  sock.write = vi.fn((data: string) => {
+    const parsed = JSON.parse(data.trim()) as { id: number };
+    const reply = `${JSON.stringify({ jsonrpc: '2.0', id: parsed.id, result: replyResult })}\n`;
+    setImmediate(() => sock.emit('data', Buffer.from(reply)));
+    return true;
+  });
+  return sock;
+}
+
+function buildValidConfig(): {
+  did: string;
+  fingerprint: string;
+  privateKeyPem: string;
+  publicKeyPem: string;
+} {
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid('bridge-test-agent', fingerprint);
+  return { did, fingerprint, privateKeyPem: kp.privateKeyPem, publicKeyPem: kp.publicKeyPem };
+}
+
+let fakeSocket: FakeSocket;
+let connectMock: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+  fakeSocket = makeFakeSocket();
+  const net = await import('node:net');
+  connectMock = net.connect as ReturnType<typeof vi.fn>;
+  connectMock.mockReturnValue(fakeSocket);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+async function _captureFrame(
+  client: DaemonClient,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  let frame: Record<string, unknown> = {};
+  fakeSocket.write = vi.fn((data: string) => {
+    const parsed = JSON.parse(data.trim()) as { id: number } & Record<string, unknown>;
+    frame = parsed;
+    const reply = `${JSON.stringify({ jsonrpc: '2.0', id: parsed.id, result: { ok: true } })}\n`;
+    setImmediate(() => {
+      fakeSocket.emit('connect');
+      fakeSocket.emit('data', Buffer.from(reply));
+    });
+    return true;
+  });
+
+  const callPromise = client.call(method, params);
+  fakeSocket.emit('connect');
+  await callPromise;
+  return frame;
+}
+
+describe('DaemonClient signing', () => {
+  it('sends x-revdev-signature when signingConfig is provided', async () => {
+    const cfg = buildValidConfig();
+    const client = new DaemonClient('/tmp/test.sock', {
+      did: cfg.did,
+      fingerprint: cfg.fingerprint,
+      privateKeyPem: cfg.privateKeyPem,
+    });
+
+    let writtenFrame: Record<string, unknown> = {};
+    fakeSocket.write = vi.fn((data: string) => {
+      writtenFrame = JSON.parse(data.trim()) as Record<string, unknown>;
+      const id = (writtenFrame as { id: number }).id;
+      const reply = `${JSON.stringify({ jsonrpc: '2.0', id, result: { ok: true } })}\n`;
+      setImmediate(() => fakeSocket.emit('data', Buffer.from(reply)));
+      return true;
+    });
+
+    const callPromise = client.call('ping', {});
+    fakeSocket.emit('connect');
+    await callPromise;
+
+    expect(typeof writtenFrame['x-revdev-signature']).toBe('string');
+    const sig = writtenFrame['x-revdev-signature'] as string;
+    expect(sig.split('.').length).toBe(3);
+  });
+
+  it('does not send x-revdev-signature when signingConfig is null', async () => {
+    const client = new DaemonClient('/tmp/test.sock', null);
+
+    let writtenFrame: Record<string, unknown> = {};
+    fakeSocket.write = vi.fn((data: string) => {
+      writtenFrame = JSON.parse(data.trim()) as Record<string, unknown>;
+      const id = (writtenFrame as { id: number }).id;
+      const reply = `${JSON.stringify({ jsonrpc: '2.0', id, result: { ok: true } })}\n`;
+      setImmediate(() => fakeSocket.emit('data', Buffer.from(reply)));
+      return true;
+    });
+
+    const callPromise = client.call('ping', {});
+    fakeSocket.emit('connect');
+    await callPromise;
+
+    expect(writtenFrame['x-revdev-signature']).toBeUndefined();
+  });
+
+  it('does not send signature when only REVDEV_AGENT_DID is set (no private key)', () => {
+    const { did } = buildValidConfig();
+    vi.stubEnv('REVDEV_AGENT_DID', did);
+    const config = resolveSigningConfig();
+    expect(config).toBeNull();
+  });
+
+  it('does not send signature when REVDEV_AGENT_DID is invalid format', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubEnv('REVDEV_AGENT_DID', 'not-a-valid-did');
+    vi.stubEnv('REVDEV_AGENT_PRIVATE_KEY_PEM', 'some-key');
+
+    const config = resolveSigningConfig();
+
+    expect(config).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid REVDEV_AGENT_DID'));
+    warnSpy.mockRestore();
+  });
+
+  it('both env vars absent: resolveSigningConfig returns null', () => {
+    const config = resolveSigningConfig();
+    expect(config).toBeNull();
+  });
+});

--- a/packages/bridge/src/client.ts
+++ b/packages/bridge/src/client.ts
@@ -1,0 +1,114 @@
+import { connect } from 'node:net';
+import { generateNonce, hashParams, serializeEnvelope, signEnvelope } from '@revdev/daemon/crypto';
+import { parseDid } from '@revdev/protocol/did';
+
+interface RpcRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+  'x-revdev-signature'?: string;
+}
+
+interface RpcResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+interface SigningConfig {
+  did: string;
+  fingerprint: string;
+  privateKeyPem: string;
+}
+
+export function resolveSigningConfig(): SigningConfig | null {
+  const did = process.env.REVDEV_AGENT_DID;
+  const privateKeyPem = process.env.REVDEV_AGENT_PRIVATE_KEY_PEM;
+  if (!did || !privateKeyPem) return null;
+  const parsed = parseDid(did);
+  if (!parsed) {
+    console.warn('[revdev-bridge] invalid REVDEV_AGENT_DID, bridge will run unsigned');
+    return null;
+  }
+  return { did, fingerprint: parsed.fingerprint, privateKeyPem };
+}
+
+export class DaemonClient {
+  private socketPath: string;
+  private nextId = 1;
+  private signingConfig: SigningConfig | null;
+
+  constructor(socketPath?: string, signingConfig?: SigningConfig | null) {
+    const home = process.env.HOME ?? '/tmp';
+    this.socketPath = socketPath ?? `${home}/.local/share/revealui/harness.sock`;
+    this.signingConfig = signingConfig !== undefined ? signingConfig : resolveSigningConfig();
+  }
+
+  async call(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = this.nextId++;
+      const req: RpcRequest = { jsonrpc: '2.0', id, method, params };
+
+      if (this.signingConfig) {
+        const payload = {
+          did: this.signingConfig.did,
+          kid: this.signingConfig.fingerprint,
+          nonce: generateNonce(),
+          ts: Math.floor(Date.now() / 1000),
+          method,
+          paramsHash: hashParams(method, params),
+        };
+        const envelope = signEnvelope(payload, this.signingConfig.privateKeyPem);
+        req['x-revdev-signature'] = serializeEnvelope(envelope);
+      }
+
+      const socket = connect(this.socketPath);
+      let buffer = '';
+
+      socket.on('connect', () => {
+        socket.write(`${JSON.stringify(req)}\n`);
+      });
+
+      socket.on('data', (data) => {
+        buffer += data.toString();
+        const lines = buffer.split('\n');
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const resp: RpcResponse = JSON.parse(line);
+            if (resp.id === id) {
+              socket.end();
+              if (resp.error) {
+                reject(new Error(`Daemon error ${resp.error.code}: ${resp.error.message}`));
+              } else {
+                resolve(resp.result);
+              }
+            }
+          } catch {
+            // incomplete JSON, wait for more data
+          }
+        }
+      });
+
+      socket.on('error', (err) => {
+        reject(new Error(`Daemon connection failed: ${err.message}. Is revdev-daemon running?`));
+      });
+
+      socket.setTimeout(10_000, () => {
+        socket.destroy();
+        reject(new Error('Daemon request timed out'));
+      });
+    });
+  }
+
+  async ping(): Promise<boolean> {
+    try {
+      await this.call('ping');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -11,92 +11,11 @@
  * @packageDocumentation
  */
 
-import { connect } from 'node:net';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { RPC_METHODS } from '@revdev/protocol';
 import { z } from 'zod';
-
-// ---------------------------------------------------------------------------
-// Daemon RPC client
-// ---------------------------------------------------------------------------
-
-interface RpcRequest {
-  jsonrpc: '2.0';
-  id: number;
-  method: string;
-  params?: Record<string, unknown>;
-}
-
-interface RpcResponse {
-  jsonrpc: '2.0';
-  id: number;
-  result?: unknown;
-  error?: { code: number; message: string };
-}
-
-class DaemonClient {
-  private socketPath: string;
-  private nextId = 1;
-
-  constructor(socketPath?: string) {
-    const home = process.env.HOME ?? '/tmp';
-    this.socketPath = socketPath ?? `${home}/.local/share/revealui/harness.sock`;
-  }
-
-  async call(method: string, params?: Record<string, unknown>): Promise<unknown> {
-    return new Promise((resolve, reject) => {
-      const id = this.nextId++;
-      const req: RpcRequest = { jsonrpc: '2.0', id, method, params };
-
-      const socket = connect(this.socketPath);
-      let buffer = '';
-
-      socket.on('connect', () => {
-        socket.write(`${JSON.stringify(req)}\n`);
-      });
-
-      socket.on('data', (data) => {
-        buffer += data.toString();
-        const lines = buffer.split('\n');
-        for (const line of lines) {
-          if (!line.trim()) continue;
-          try {
-            const resp: RpcResponse = JSON.parse(line);
-            if (resp.id === id) {
-              socket.end();
-              if (resp.error) {
-                reject(new Error(`Daemon error ${resp.error.code}: ${resp.error.message}`));
-              } else {
-                resolve(resp.result);
-              }
-            }
-          } catch {
-            // incomplete JSON, wait for more data
-          }
-        }
-      });
-
-      socket.on('error', (err) => {
-        reject(new Error(`Daemon connection failed: ${err.message}. Is revdev-daemon running?`));
-      });
-
-      socket.setTimeout(10_000, () => {
-        socket.destroy();
-        reject(new Error('Daemon request timed out'));
-      });
-    });
-  }
-
-  async ping(): Promise<boolean> {
-    try {
-      await this.call(RPC_METHODS.ping);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-}
+import { DaemonClient } from './client.js';
 
 // ---------------------------------------------------------------------------
 // MCP Server

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./crypto": {
+      "types": "./dist/agent-identity-crypto.d.ts",
+      "import": "./dist/agent-identity-crypto.js"
+    },
     "./storage": {
       "types": "./dist/storage/index.d.ts",
       "import": "./dist/storage/index.js"
@@ -30,7 +34,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc --emitDeclarationOnly --declaration --declarationDir dist --noEmit false",
     "clean": "rm -rf dist",
     "dev": "tsup --watch",
     "start": "node dist/cli.js",

--- a/packages/daemon/src/__tests__/agent-identity-crypto.test.ts
+++ b/packages/daemon/src/__tests__/agent-identity-crypto.test.ts
@@ -1,0 +1,234 @@
+import { generateKeyPairSync, sign } from 'node:crypto';
+import type { SignaturePayload } from '@revdev/protocol/signature';
+import { describe, expect, it } from 'vitest';
+import {
+  base64UrlDecode,
+  base64UrlEncode,
+  canonicalizeJSON,
+  computeFingerprint,
+  generateAgentKeypair,
+  hashParams,
+  parseEnvelope,
+  serializeEnvelope,
+  signEnvelope,
+  verifyEnvelope,
+} from '../agent-identity-crypto.js';
+
+function makePayload(overrides: Partial<SignaturePayload> = {}): SignaturePayload {
+  return {
+    did: 'did:revfleet:test-agent:abc123',
+    kid: 'did:revfleet:test-agent:abc123',
+    nonce: 'aabbccddeeff00112233445566778899',
+    ts: Date.now(),
+    method: 'ping',
+    paramsHash: 'somehash',
+    ...overrides,
+  };
+}
+
+describe('generateAgentKeypair', () => {
+  it('returns a 32-byte raw public key', () => {
+    const kp = generateAgentKeypair();
+    expect(kp.publicKeyRaw.length).toBe(32);
+  });
+
+  it('returns valid PEM strings', () => {
+    const kp = generateAgentKeypair();
+    expect(kp.publicKeyPem.startsWith('-----BEGIN PUBLIC KEY-----')).toBe(true);
+    expect(kp.privateKeyPem.startsWith('-----BEGIN PRIVATE KEY-----')).toBe(true);
+  });
+});
+
+describe('computeFingerprint', () => {
+  it('produces a non-empty base58 string', () => {
+    const kp = generateAgentKeypair();
+    const fp = computeFingerprint(kp.publicKeyRaw);
+    expect(fp.length).toBeGreaterThan(0);
+    expect(typeof fp).toBe('string');
+  });
+
+  it('is deterministic for the same key', () => {
+    const kp = generateAgentKeypair();
+    expect(computeFingerprint(kp.publicKeyRaw)).toBe(computeFingerprint(kp.publicKeyRaw));
+  });
+});
+
+describe('signEnvelope + verifyEnvelope', () => {
+  it('roundtrip returns true', () => {
+    const kp = generateAgentKeypair();
+    const payload = makePayload();
+    const envelope = signEnvelope(payload, kp.privateKeyPem);
+    expect(verifyEnvelope(envelope, kp.publicKeyPem)).toBe(true);
+  });
+
+  it('tamper detection: flip one byte in serialized envelope signature, parse, verify returns false', () => {
+    const kp = generateAgentKeypair();
+    const payload = makePayload();
+    const envelope = signEnvelope(payload, kp.privateKeyPem);
+    const serialized = serializeEnvelope(envelope);
+
+    const parts = serialized.split('.');
+    const sigBytes = Buffer.from(parts[2] as string, 'base64url');
+    sigBytes[0] = (sigBytes[0] as number) ^ 0xff;
+    parts[2] = sigBytes.toString('base64url');
+    const tampered = parts.join('.');
+
+    const parsed = parseEnvelope(tampered);
+    expect(parsed).not.toBeNull();
+    if (parsed !== null) {
+      expect(verifyEnvelope(parsed, kp.publicKeyPem)).toBe(false);
+    }
+  });
+
+  it('rejects wrong key', () => {
+    const kp = generateAgentKeypair();
+    const otherKp = generateAgentKeypair();
+    const payload = makePayload();
+    const envelope = signEnvelope(payload, kp.privateKeyPem);
+    expect(verifyEnvelope(envelope, otherKp.publicKeyPem)).toBe(false);
+  });
+
+  // Per Codex P2 finding: a foreign signer may emit header/payload JSON with
+  // members in non-canonical order. Verification must preserve the literal
+  // signed segments rather than re-serialize, or valid signatures get rejected.
+  it('accepts signatures over non-canonical JSON key order (foreign signer compatibility)', () => {
+    const kp = generateAgentKeypair();
+    const payload = makePayload();
+
+    const headerNonCanonical = '{"typ":"jws","alg":"EdDSA"}';
+    const payloadJson = JSON.stringify(payload);
+    const rawHeaderB64 = Buffer.from(headerNonCanonical).toString('base64url');
+    const rawPayloadB64 = Buffer.from(payloadJson).toString('base64url');
+    const message = rawHeaderB64 + '.' + rawPayloadB64;
+    const sigBytes = sign(null, Buffer.from(message), kp.privateKeyPem);
+    const sigB64 = Buffer.from(sigBytes).toString('base64url');
+
+    const envelopeString = rawHeaderB64 + '.' + rawPayloadB64 + '.' + sigB64;
+    const parsed = parseEnvelope(envelopeString);
+    expect(parsed).not.toBeNull();
+    if (parsed !== null) {
+      expect(parsed.rawHeaderB64).toBe(rawHeaderB64);
+      expect(parsed.rawPayloadB64).toBe(rawPayloadB64);
+      expect(verifyEnvelope(parsed, kp.publicKeyPem)).toBe(true);
+    }
+  });
+});
+
+describe('serializeEnvelope + parseEnvelope roundtrip', () => {
+  it('parses back to the same envelope', () => {
+    const kp = generateAgentKeypair();
+    const payload = makePayload();
+    const envelope = signEnvelope(payload, kp.privateKeyPem);
+    const serialized = serializeEnvelope(envelope);
+    const parsed = parseEnvelope(serialized);
+
+    expect(parsed).not.toBeNull();
+    if (parsed !== null) {
+      expect(parsed.header.alg).toBe('EdDSA');
+      expect(parsed.header.typ).toBe('jws');
+      expect(parsed.payload.method).toBe(payload.method);
+      expect(parsed.payload.nonce).toBe(payload.nonce);
+      expect(parsed.signature).toBe(envelope.signature);
+    }
+  });
+});
+
+describe('parseEnvelope null-on-malformed', () => {
+  it('returns null on wrong part count (2 parts)', () => {
+    expect(parseEnvelope('a.b')).toBeNull();
+  });
+
+  it('returns null on wrong part count (4 parts)', () => {
+    expect(parseEnvelope('a.b.c.d')).toBeNull();
+  });
+
+  it('returns null on non-base64 header', () => {
+    expect(parseEnvelope('!!!.b.c')).toBeNull();
+  });
+
+  it('returns null on valid base64 but non-JSON header', () => {
+    const notJson = Buffer.from('not-json').toString('base64url');
+    expect(parseEnvelope(`${notJson}.${notJson}.sig`)).toBeNull();
+  });
+
+  it('returns null on schema mismatch (wrong alg)', () => {
+    const kp = generateAgentKeypair();
+    const payload = makePayload();
+    const badHeader = { alg: 'RS256', typ: 'jws' };
+    const headerB64 = Buffer.from(JSON.stringify(badHeader)).toString('base64url');
+    const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    const sig = Buffer.from('fakesig').toString('base64url');
+    expect(parseEnvelope(`${headerB64}.${payloadB64}.${sig}`)).toBeNull();
+  });
+});
+
+describe('canonicalizeJSON', () => {
+  it('produces stable output for equivalent objects with different key order', () => {
+    const a = canonicalizeJSON({ b: 1, a: 2 });
+    const b = canonicalizeJSON({ a: 2, b: 1 });
+    expect(a).toBe(b);
+    expect(a).toBe('{"a":2,"b":1}');
+  });
+
+  it('handles nested objects', () => {
+    const result = canonicalizeJSON({ z: { y: 1, x: 2 }, a: true });
+    expect(result).toBe('{"a":true,"z":{"x":2,"y":1}}');
+  });
+
+  it('handles arrays', () => {
+    const result = canonicalizeJSON([3, 1, 2]);
+    expect(result).toBe('[3,1,2]');
+  });
+
+  it('handles null', () => {
+    expect(canonicalizeJSON(null)).toBe('null');
+  });
+
+  it('handles numbers', () => {
+    expect(canonicalizeJSON(42)).toBe('42');
+    expect(canonicalizeJSON(3.14)).toBe('3.14');
+  });
+
+  it('handles strings', () => {
+    expect(canonicalizeJSON('hello')).toBe('"hello"');
+  });
+
+  it('handles nested arrays in objects', () => {
+    const result = canonicalizeJSON({ b: [2, 1], a: [3, 4] });
+    expect(result).toBe('{"a":[3,4],"b":[2,1]}');
+  });
+});
+
+describe('hashParams', () => {
+  it('is deterministic', () => {
+    const h1 = hashParams('ping', { key: 'value', num: 42 });
+    const h2 = hashParams('ping', { num: 42, key: 'value' });
+    expect(h1).toBe(h2);
+  });
+
+  it('differs for different methods', () => {
+    const h1 = hashParams('ping', {});
+    const h2 = hashParams('pong', {});
+    expect(h1).not.toBe(h2);
+  });
+
+  it('handles null/undefined params', () => {
+    expect(hashParams('ping', null)).toBe(hashParams('ping', undefined));
+  });
+});
+
+describe('base64UrlEncode + base64UrlDecode', () => {
+  it('roundtrips arbitrary bytes', () => {
+    const original = Buffer.from([0x00, 0x01, 0xfe, 0xff, 0x80]);
+    const encoded = base64UrlEncode(original);
+    const decoded = base64UrlDecode(encoded);
+    expect(Buffer.from(decoded).equals(original)).toBe(true);
+  });
+
+  it('roundtrips a Uint8Array', () => {
+    const original = new Uint8Array([1, 2, 3, 4, 5]);
+    const encoded = base64UrlEncode(original);
+    const decoded = base64UrlDecode(encoded);
+    expect(Array.from(decoded)).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -426,3 +426,101 @@ describe('GAP-153: stale-session prune', () => {
     expect(result.aged).toBeGreaterThanOrEqual(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Adoption 2 Phase 1.2 — agent identity bootstrap via session.register.
+//
+// Proves: keygen on first register, idempotent reuse, forceRotate rotation,
+// and that revvault CLI absence does not fail register (CI scenario).
+// ---------------------------------------------------------------------------
+
+describe('agent identity bootstrap', () => {
+  it('first register issues DID + keypair', async () => {
+    const result = (await rpc(socketPath, 'session.register', {
+      agentId: 'identity-test-first',
+      agentName: 'identity-tester',
+      backend: 'test',
+    })) as { sessionId: string; did: string; publicKeyPem: string };
+
+    expect(result.sessionId).toBe('identity-test-first');
+    expect(result.did).toBe(
+      result.did.startsWith('did:revfleet:identity-test-first:')
+        ? result.did
+        : 'did:revfleet:identity-test-first:<fingerprint>',
+    );
+    expect(result.did.startsWith('did:revfleet:identity-test-first:')).toBe(true);
+    expect(result.publicKeyPem).toContain('BEGIN PUBLIC KEY');
+  });
+
+  it('idempotent re-register reuses the same keypair', async () => {
+    const r1 = (await rpc(socketPath, 'session.register', {
+      agentId: 'identity-test-idempotent',
+      agentName: 'identity-tester',
+      backend: 'test',
+    })) as { did: string; publicKeyPem: string };
+
+    const r2 = (await rpc(socketPath, 'session.register', {
+      agentId: 'identity-test-idempotent',
+      agentName: 'identity-tester',
+      backend: 'test',
+    })) as { did: string; publicKeyPem: string };
+
+    expect(r2.did).toBe(r1.did);
+    expect(r2.publicKeyPem).toBe(r1.publicKeyPem);
+  });
+
+  it('forceRotate:true supersedes old key and issues a new one', async () => {
+    const r1 = (await rpc(socketPath, 'session.register', {
+      agentId: 'identity-test-rotate',
+      agentName: 'identity-tester',
+      backend: 'test',
+    })) as { did: string; publicKeyPem: string };
+
+    const r2 = (await rpc(socketPath, 'session.register', {
+      agentId: 'identity-test-rotate',
+      agentName: 'identity-tester',
+      backend: 'test',
+      forceRotate: true,
+    })) as { did: string; publicKeyPem: string };
+
+    expect(r2.did).not.toBe(r1.did);
+    expect(r2.publicKeyPem).not.toBe(r1.publicKeyPem);
+    expect(r2.did.startsWith('did:revfleet:identity-test-rotate:')).toBe(true);
+    expect(r2.publicKeyPem).toContain('BEGIN PUBLIC KEY');
+  });
+
+  it('register succeeds when revvault CLI is absent', async () => {
+    const origPath = process.env.PATH;
+    process.env.PATH = '';
+    try {
+      const result = (await rpc(socketPath, 'session.register', {
+        agentId: 'identity-test-no-revvault',
+        agentName: 'identity-tester',
+        backend: 'test',
+      })) as { sessionId: string; did: string; publicKeyPem: string };
+
+      expect(result.sessionId).toBe('identity-test-no-revvault');
+      expect(result.did.startsWith('did:revfleet:identity-test-no-revvault:')).toBe(true);
+      expect(result.publicKeyPem).toContain('BEGIN PUBLIC KEY');
+    } finally {
+      if (origPath !== undefined) {
+        process.env.PATH = origPath;
+      }
+    }
+  });
+
+  // Per Codex P2 finding: agentIds with chars outside the DID grammar
+  // (spaces, slashes, colons) used to break formatDid AFTER the
+  // agent_sessions row was upserted. Schema-level refine rejects them
+  // cleanly before any DB write — daemon returns -32000 with the Zod
+  // refine message.
+  it('rejects agentId with characters outside DID grammar (pre-upsert)', async () => {
+    await expect(
+      rpc(socketPath, 'session.register', {
+        agentId: 'invalid/agent:name with space',
+        agentName: 'identity-tester',
+        backend: 'test',
+      }),
+    ).rejects.toThrow('invalid agentId');
+  });
+});

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -19,7 +19,16 @@ import { mkdtemp, rm, stat } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { PGlite } from '@electric-sql/pglite';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  generateNonce,
+  hashParams,
+  serializeEnvelope,
+  signEnvelope,
+} from '../agent-identity-crypto.js';
 import { startDaemon } from '../server.js';
 
 // ---------------------------------------------------------------------------
@@ -65,6 +74,7 @@ function rpc(
 let dataDir: string;
 let socketPath: string;
 let close: () => Promise<void>;
+let db: PGlite;
 let originalLicenseKey: string | undefined;
 
 beforeAll(async () => {
@@ -77,6 +87,7 @@ beforeAll(async () => {
   socketPath = join(dataDir, 'harness.sock');
   const d = await startDaemon({ socketPath, dataDir });
   close = d.close;
+  db = d._db;
 });
 
 afterAll(async () => {
@@ -522,5 +533,386 @@ describe('agent identity bootstrap', () => {
         backend: 'test',
       }),
     ).rejects.toThrow('invalid agentId');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adoption 2 Phase 1.3 — accept-if-present signature gate.
+//
+// Tests use pre-seeded DB rows (known keypairs inserted directly into
+// agent_identity + agent_identity_keys via the _db handle) so the test
+// holds both the public and private key — bypassing revvault, which is not
+// available in CI.
+// ---------------------------------------------------------------------------
+
+function signedRpc(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown>,
+  opts: { did: string; fingerprint: string; privateKeyPem: string },
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const payload = {
+      did: opts.did,
+      kid: opts.fingerprint,
+      nonce: generateNonce(),
+      ts: Math.floor(Date.now() / 1000),
+      method,
+      paramsHash: hashParams(method, params),
+    };
+    const envelope = signEnvelope(payload, opts.privateKeyPem);
+    const sig = serializeEnvelope(envelope);
+    const frame = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params, 'x-revdev-signature': sig })}\n`;
+    sock.on('connect', () => sock.write(frame));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      const line = buf.slice(0, nl);
+      sock.end();
+      try {
+        const resp = JSON.parse(line);
+        if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
+        else resolve(resp.result);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error(`signedRpc timeout: ${method}`));
+    });
+  });
+}
+
+async function seedIdentity(agentId: string): Promise<{
+  did: string;
+  fingerprint: string;
+  privateKeyPem: string;
+  publicKeyPem: string;
+}> {
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const { formatDid } = await import('@revdev/protocol/did');
+  const did = formatDid(agentId, fingerprint);
+  await db.query(
+    `INSERT INTO agent_identity (agent_id, did, fingerprint, public_key_pem)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (agent_id) DO UPDATE
+       SET did = EXCLUDED.did,
+           fingerprint = EXCLUDED.fingerprint,
+           public_key_pem = EXCLUDED.public_key_pem`,
+    [agentId, did, fingerprint, kp.publicKeyPem],
+  );
+  await db.query(
+    `UPDATE agent_identity_keys SET superseded_at = NOW() WHERE agent_id = $1 AND superseded_at IS NULL`,
+    [agentId],
+  );
+  await db.query(
+    `INSERT INTO agent_identity_keys (fingerprint, agent_id, public_key_pem)
+     VALUES ($1, $2, $3)`,
+    [fingerprint, agentId, kp.publicKeyPem],
+  );
+  await db.query(
+    `INSERT INTO agent_sessions (id, env, task) VALUES ($1, $2, $3)
+     ON CONFLICT (id) DO UPDATE SET ended_at = NULL, exit_summary = NULL`,
+    [agentId, `test:${agentId}`, ''],
+  );
+  return { did, fingerprint, privateKeyPem: kp.privateKeyPem, publicKeyPem: kp.publicKeyPem };
+}
+
+describe('signature acceptance', () => {
+  it('harness.health returns identitySignatureMode: accept-if-present', async () => {
+    const health = (await rpc(socketPath, 'harness.health')) as {
+      identitySignatureMode: string;
+    };
+    expect(health.identitySignatureMode).toBe('accept-if-present');
+  });
+
+  it('valid signature binds identity (signed mail.inbox without actorAgentId)', async () => {
+    const agentId = 'sig-test-valid';
+    const { did, fingerprint, privateKeyPem } = await seedIdentity(agentId);
+
+    const result = (await signedRpc(
+      socketPath,
+      'mail.inbox',
+      { unreadOnly: false },
+      { did, fingerprint, privateKeyPem },
+    )) as { messages: unknown[] };
+
+    expect(Array.isArray(result.messages)).toBe(true);
+  });
+
+  it('missing signature falls through to actorAgentId (existing behavior unchanged)', async () => {
+    const agentId = 'sig-test-missing';
+    await seedIdentity(agentId);
+
+    const result = (await rpc(socketPath, 'mail.inbox', {
+      actorAgentId: agentId,
+      unreadOnly: false,
+    })) as { messages: unknown[] };
+    expect(Array.isArray(result.messages)).toBe(true);
+  });
+
+  it('invalid signature falls through: returns -32002 without actorAgentId', async () => {
+    const agentId = 'sig-test-invalid';
+    const { did, fingerprint } = await seedIdentity(agentId);
+    const other = generateAgentKeypair();
+
+    await expect(
+      signedRpc(
+        socketPath,
+        'mail.inbox',
+        { unreadOnly: false },
+        { did, fingerprint, privateKeyPem: other.privateKeyPem },
+      ),
+    ).rejects.toThrow('-32002');
+  });
+
+  it('nonce replay falls through on second send: -32002 without actorAgentId', async () => {
+    const agentId = 'sig-test-nonce-replay';
+    const { did, fingerprint, privateKeyPem } = await seedIdentity(agentId);
+
+    const nonce = generateNonce();
+    const ts = Math.floor(Date.now() / 1000);
+
+    function sendWithFixedNonce(): Promise<unknown> {
+      return new Promise((resolve, reject) => {
+        const sock: Socket = connect(socketPath);
+        let buf = '';
+        const payload = {
+          did,
+          kid: fingerprint,
+          nonce,
+          ts,
+          method: 'mail.inbox',
+          paramsHash: hashParams('mail.inbox', { unreadOnly: false }),
+        };
+        const envelope = signEnvelope(payload, privateKeyPem);
+        const sig = serializeEnvelope(envelope);
+        const frame = `${JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'mail.inbox',
+          params: { unreadOnly: false },
+          'x-revdev-signature': sig,
+        })}\n`;
+        sock.on('connect', () => sock.write(frame));
+        sock.on('data', (d) => {
+          buf += d.toString();
+          const nl = buf.indexOf('\n');
+          if (nl === -1) return;
+          const line = buf.slice(0, nl);
+          sock.end();
+          try {
+            const resp = JSON.parse(line);
+            if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
+            else resolve(resp.result);
+          } catch (e) {
+            reject(e instanceof Error ? e : new Error(String(e)));
+          }
+        });
+        sock.on('error', reject);
+        sock.setTimeout(5000, () => {
+          sock.destroy();
+          reject(new Error('timeout'));
+        });
+      });
+    }
+
+    await sendWithFixedNonce();
+
+    await expect(sendWithFixedNonce()).rejects.toThrow('-32002');
+  });
+
+  it('ts-outside-window falls through: -32002 without actorAgentId', async () => {
+    const agentId = 'sig-test-ts-window';
+    const { did, fingerprint, privateKeyPem } = await seedIdentity(agentId);
+
+    const staleTs = Math.floor(Date.now() / 1000) - 120;
+    const payload = {
+      did,
+      kid: fingerprint,
+      nonce: generateNonce(),
+      ts: staleTs,
+      method: 'mail.inbox',
+      paramsHash: hashParams('mail.inbox', { unreadOnly: false }),
+    };
+    const envelope = signEnvelope(payload, privateKeyPem);
+    const sig = serializeEnvelope(envelope);
+
+    await expect(
+      new Promise((resolve, reject) => {
+        const sock: Socket = connect(socketPath);
+        let buf = '';
+        const frame = `${JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'mail.inbox',
+          params: { unreadOnly: false },
+          'x-revdev-signature': sig,
+        })}\n`;
+        sock.on('connect', () => sock.write(frame));
+        sock.on('data', (d) => {
+          buf += d.toString();
+          const nl = buf.indexOf('\n');
+          if (nl === -1) return;
+          const line = buf.slice(0, nl);
+          sock.end();
+          try {
+            const resp = JSON.parse(line);
+            if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
+            else resolve(resp.result);
+          } catch (e) {
+            reject(e instanceof Error ? e : new Error(String(e)));
+          }
+        });
+        sock.on('error', reject);
+        sock.setTimeout(5000, () => {
+          sock.destroy();
+          reject(new Error('timeout'));
+        });
+      }),
+    ).rejects.toThrow('-32002');
+  });
+
+  it('envelope tamper detected: signature verify fails, falls through to -32002', async () => {
+    const agentId = 'sig-test-tamper';
+    const { did, fingerprint, privateKeyPem } = await seedIdentity(agentId);
+
+    const payload = {
+      did,
+      kid: fingerprint,
+      nonce: generateNonce(),
+      ts: Math.floor(Date.now() / 1000),
+      method: 'mail.inbox',
+      paramsHash: hashParams('mail.inbox', { unreadOnly: false }),
+    };
+    const envelope = signEnvelope(payload, privateKeyPem);
+    const serialized = serializeEnvelope(envelope);
+    const parts = serialized.split('.');
+    const sigBytes = Buffer.from(parts[2] ?? '', 'base64url');
+    if (sigBytes.length > 0) sigBytes[0] = (sigBytes[0] ?? 0) ^ 0xff;
+    const tampered = `${parts[0]}.${parts[1]}.${sigBytes.toString('base64url')}`;
+
+    await expect(
+      new Promise((resolve, reject) => {
+        const sock: Socket = connect(socketPath);
+        let buf = '';
+        const frame = `${JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'mail.inbox',
+          params: { unreadOnly: false },
+          'x-revdev-signature': tampered,
+        })}\n`;
+        sock.on('connect', () => sock.write(frame));
+        sock.on('data', (d) => {
+          buf += d.toString();
+          const nl = buf.indexOf('\n');
+          if (nl === -1) return;
+          const line = buf.slice(0, nl);
+          sock.end();
+          try {
+            const resp = JSON.parse(line);
+            if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
+            else resolve(resp.result);
+          } catch (e) {
+            reject(e instanceof Error ? e : new Error(String(e)));
+          }
+        });
+        sock.on('error', reject);
+        sock.setTimeout(5000, () => {
+          sock.destroy();
+          reject(new Error('timeout'));
+        });
+      }),
+    ).rejects.toThrow('-32002');
+  });
+
+  // Per Codex P1 finding: a signed request on a reused socket must NOT leave
+  // ctx.agentId set for subsequent unsigned requests. verifyOrWarn resets the
+  // signature binding on every call; the next unsigned call sees the connection
+  // back at its pre-signature state (here: unbound) and is rejected with -32002.
+  it('signed-then-unsigned on same socket: unsigned does NOT inherit signature identity', async () => {
+    const agentId = 'sig-test-leak-cleanup';
+    const { did, fingerprint, privateKeyPem } = await seedIdentity(agentId);
+
+    const payload = {
+      did,
+      kid: fingerprint,
+      nonce: generateNonce(),
+      ts: Math.floor(Date.now() / 1000),
+      method: 'mail.inbox',
+      paramsHash: hashParams('mail.inbox', { unreadOnly: false }),
+    };
+    const envelope = signEnvelope(payload, privateKeyPem);
+    const sig = serializeEnvelope(envelope);
+
+    const responses = await new Promise<Array<Record<string, unknown>>>((resolve, reject) => {
+      const sock: Socket = connect(socketPath);
+      const out: Array<Record<string, unknown>> = [];
+      let buf = '';
+
+      const signedFrame = `${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'mail.inbox',
+        params: { unreadOnly: false },
+        'x-revdev-signature': sig,
+      })}\n`;
+      const unsignedFrame = `${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'mail.inbox',
+        params: { unreadOnly: false },
+      })}\n`;
+
+      sock.on('connect', () => {
+        sock.write(signedFrame);
+        sock.write(unsignedFrame);
+      });
+      sock.on('data', (d) => {
+        buf += d.toString();
+        let nl = buf.indexOf('\n');
+        while (nl !== -1) {
+          const line = buf.slice(0, nl);
+          buf = buf.slice(nl + 1);
+          if (line.length > 0) {
+            try {
+              out.push(JSON.parse(line) as Record<string, unknown>);
+            } catch (e) {
+              reject(e instanceof Error ? e : new Error(String(e)));
+              return;
+            }
+          }
+          if (out.length === 2) {
+            sock.end();
+            resolve(out);
+            return;
+          }
+          nl = buf.indexOf('\n');
+        }
+      });
+      sock.on('error', reject);
+      sock.setTimeout(5000, () => {
+        sock.destroy();
+        reject(new Error('socket reuse test timeout'));
+      });
+    });
+
+    // First (signed) call succeeded as the signed agent.
+    expect(responses[0]?.id).toBe(1);
+    expect(responses[0]?.error).toBeUndefined();
+
+    // Second (unsigned) call on the SAME socket was rejected with -32002.
+    // If the signature identity had leaked, the unsigned call would have
+    // succeeded as the signed agent — proving the cleanup logic correct.
+    expect(responses[1]?.id).toBe(2);
+    const err = responses[1]?.error as { code: number; message: string } | undefined;
+    expect(err?.code).toBe(-32002);
   });
 });

--- a/packages/daemon/src/__tests__/did.test.ts
+++ b/packages/daemon/src/__tests__/did.test.ts
@@ -1,0 +1,147 @@
+import { base58Decode, base58Encode } from '@revdev/protocol/base58';
+import {
+  DID_PREFIX,
+  formatDid,
+  isValidAgentId,
+  isValidAgentIdChar,
+  isValidFingerprint,
+  parseDid,
+} from '@revdev/protocol/did';
+import { describe, expect, it } from 'vitest';
+
+describe('formatDid', () => {
+  it('formats a valid DID', () => {
+    expect(formatDid('agt-001', 'abc123')).toBe('did:revfleet:agt-001:abc123');
+  });
+
+  it('uses DID_PREFIX', () => {
+    const did = formatDid('agent', 'fp1');
+    expect(did.startsWith(DID_PREFIX)).toBe(true);
+  });
+
+  it('throws TypeError for invalid agentId', () => {
+    expect(() => formatDid('', 'abc123')).toThrow(TypeError);
+    expect(() => formatDid('has space', 'abc123')).toThrow(TypeError);
+  });
+
+  it('throws TypeError for invalid fingerprint', () => {
+    expect(() => formatDid('agt', '0OIl')).toThrow(TypeError);
+  });
+});
+
+describe('parseDid', () => {
+  it('parses a valid DID', () => {
+    const result = parseDid('did:revfleet:agt-001:abc123');
+    expect(result).toEqual({ agentId: 'agt-001', fingerprint: 'abc123' });
+  });
+
+  it('returns null for wrong prefix', () => {
+    expect(parseDid('did:other:x:y')).toBeNull();
+  });
+
+  it('returns null when fingerprint is missing', () => {
+    expect(parseDid('did:revfleet:agt-001')).toBeNull();
+  });
+
+  it('returns null when agentId is empty', () => {
+    expect(parseDid('did:revfleet::abc')).toBeNull();
+  });
+
+  it('returns null when fingerprint is empty', () => {
+    expect(parseDid('did:revfleet:agent:')).toBeNull();
+  });
+
+  it('returns null for extra colons in fingerprint', () => {
+    expect(parseDid('did:revfleet:agent:fp:extra')).toBeNull();
+  });
+});
+
+describe('isValidAgentId', () => {
+  it('returns true for a valid agent id', () => {
+    expect(isValidAgentId('agent_01-test')).toBe(true);
+    expect(isValidAgentId('a')).toBe(true);
+    expect(isValidAgentId('ABC-123_xyz')).toBe(true);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isValidAgentId('')).toBe(false);
+  });
+
+  it('returns false for a string with a space', () => {
+    expect(isValidAgentId('has space')).toBe(false);
+  });
+
+  it('returns false for a string with an emoji', () => {
+    expect(isValidAgentId('emoji\u{1F600}')).toBe(false);
+  });
+
+  it('returns false for a string longer than 128 chars', () => {
+    expect(isValidAgentId('a'.repeat(129))).toBe(false);
+  });
+
+  it('returns true for exactly 128 chars', () => {
+    expect(isValidAgentId('a'.repeat(128))).toBe(true);
+  });
+});
+
+describe('isValidAgentIdChar', () => {
+  const validChars = ['0', '9', 'a', 'z', 'A', 'Z', '_', '-'];
+  for (const c of validChars) {
+    it(`returns true for '${c}'`, () => {
+      expect(isValidAgentIdChar(c)).toBe(true);
+    });
+  }
+
+  const invalidChars = [' ', '.', '/', ':'];
+  for (const c of invalidChars) {
+    it(`returns false for '${c}'`, () => {
+      expect(isValidAgentIdChar(c)).toBe(false);
+    });
+  }
+});
+
+describe('isValidFingerprint', () => {
+  it('returns true for valid base58btc chars', () => {
+    expect(isValidFingerprint('123456789ABC')).toBe(true);
+  });
+
+  it('returns false for chars not in base58 alphabet (0, O, I, l)', () => {
+    expect(isValidFingerprint('0')).toBe(false);
+    expect(isValidFingerprint('O')).toBe(false);
+    expect(isValidFingerprint('I')).toBe(false);
+    expect(isValidFingerprint('l')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isValidFingerprint('')).toBe(false);
+  });
+});
+
+describe('base58Encode + base58Decode', () => {
+  it('roundtrip on bytes including leading zeros', () => {
+    const original = Uint8Array.of(0, 0, 0, 1, 2, 3);
+    const encoded = base58Encode(original);
+    const decoded = base58Decode(encoded);
+    expect(Array.from(decoded)).toEqual(Array.from(original));
+  });
+
+  it('encodes empty Uint8Array to empty string', () => {
+    expect(base58Encode(new Uint8Array(0))).toBe('');
+  });
+
+  it('decodes empty string to empty Uint8Array', () => {
+    expect(base58Decode('').length).toBe(0);
+  });
+
+  it('throws on invalid base58 character', () => {
+    expect(() => base58Decode('0abc')).toThrow('base58:');
+  });
+
+  it('leading 1s in encoded string map to leading zero bytes', () => {
+    const bytes = Uint8Array.of(0, 0, 5);
+    const encoded = base58Encode(bytes);
+    expect(encoded.startsWith('11')).toBe(true);
+    const decoded = base58Decode(encoded);
+    expect(Array.from(decoded)).toEqual([0, 0, 5]);
+  });
+});

--- a/packages/daemon/src/__tests__/revvault-client.test.ts
+++ b/packages/daemon/src/__tests__/revvault-client.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for revvault-client.ts.
+ *
+ * Mocks node:child_process at the module level and controls per-test
+ * behavior via mockImplementation. Each test resets the mock to avoid
+ * bleed-through between cases.
+ *
+ * @vitest-environment node
+ */
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+vi.mock('node:child_process', () => {
+  const execFile = vi.fn();
+  const EventEmitter = require('node:events').EventEmitter;
+
+  return {
+    execFile,
+    __esModule: true,
+    EventEmitter,
+  };
+});
+
+import * as childProcess from 'node:child_process';
+import { isRevvaultAvailable, revvaultGet, revvaultSet } from '../revvault-client.js';
+
+function mockExecFileSuccess(stdout: string, stderr = ''): void {
+  const execFileMock = childProcess.execFile as unknown as Mock;
+  execFileMock.mockImplementation(
+    (_bin: string, _args: string[], _opts: unknown, callback: unknown) => {
+      if (typeof callback === 'function') {
+        (callback as (err: null, result: { stdout: string; stderr: string }) => void)(null, {
+          stdout,
+          stderr,
+        });
+      }
+      const child = {
+        stdin: { end: vi.fn() },
+        exitCode: 0,
+        on: vi.fn(),
+        once: vi.fn(),
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+      };
+      return child;
+    },
+  );
+}
+
+function mockExecFileEnoent(): void {
+  const execFileMock = childProcess.execFile as unknown as Mock;
+  const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  execFileMock.mockImplementation(
+    (_bin: string, _args: string[], _opts: unknown, callback: unknown) => {
+      if (typeof callback === 'function') {
+        (callback as (err: Error) => void)(err);
+      }
+      const child = {
+        stdin: { end: vi.fn() },
+        exitCode: 1,
+        on: vi.fn(),
+        once: vi.fn(),
+      };
+      return child;
+    },
+  );
+}
+
+function mockExecFileNonZero(stderr: string, exitCode = 1): void {
+  const execFileMock = childProcess.execFile as unknown as Mock;
+  const err = Object.assign(new Error('Command failed'), {
+    code: exitCode,
+    stderr,
+    stdout: '',
+  });
+  execFileMock.mockImplementation(
+    (_bin: string, _args: string[], _opts: unknown, callback: unknown) => {
+      if (typeof callback === 'function') {
+        (callback as (err: Error) => void)(err);
+      }
+      const child = {
+        stdin: { end: vi.fn() },
+        exitCode,
+        on: vi.fn(),
+        once: vi.fn(),
+      };
+      return child;
+    },
+  );
+}
+
+let capturedArgs: string[] = [];
+
+beforeEach(() => {
+  capturedArgs = [];
+  const execFileMock = childProcess.execFile as unknown as Mock;
+  execFileMock.mockImplementation(
+    (bin: string, args: string[], _opts: unknown, callback: unknown) => {
+      capturedArgs = [bin, ...args];
+      if (typeof callback === 'function') {
+        (callback as (err: null, result: { stdout: string; stderr: string }) => void)(null, {
+          stdout: '',
+          stderr: '',
+        });
+      }
+      const child = {
+        stdin: { end: vi.fn() },
+        exitCode: 0,
+        on: vi.fn(),
+        once: vi.fn(),
+      };
+      return child;
+    },
+  );
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('revvaultGet', () => {
+  it('returns ok:true with value on success', async () => {
+    mockExecFileSuccess(JSON.stringify({ value: 'the-secret' }));
+    const result = await revvaultGet('revdev/agents/abc/identity/ed25519-public');
+    expect(result).toEqual({ ok: true, value: 'the-secret' });
+  });
+
+  it('returns ok:false reason:cli-not-installed on ENOENT', async () => {
+    mockExecFileEnoent();
+    const result = await revvaultGet('revdev/agents/abc/identity/ed25519-public');
+    expect(result).toEqual({ ok: false, value: null, reason: 'cli-not-installed' });
+  });
+
+  it('returns ok:false reason:not-found when stderr contains "not found"', async () => {
+    mockExecFileNonZero('secret not found');
+    const result = await revvaultGet('revdev/agents/abc/identity/ed25519-public');
+    expect(result).toEqual({ ok: false, value: null, reason: 'not-found' });
+  });
+
+  it('returns ok:false reason:missing when stdout is empty', async () => {
+    mockExecFileSuccess('');
+    const result = await revvaultGet('revdev/agents/abc/identity/ed25519-public');
+    expect(result).toEqual({ ok: false, value: null, reason: 'missing' });
+  });
+
+  it('always passes --json flag', async () => {
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation(
+      (bin: string, args: string[], _opts: unknown, callback: unknown) => {
+        capturedArgs = [bin, ...args];
+        if (typeof callback === 'function') {
+          (callback as (err: null, result: { stdout: string; stderr: string }) => void)(null, {
+            stdout: JSON.stringify({ value: 'x' }),
+            stderr: '',
+          });
+        }
+        return { stdin: { end: vi.fn() }, exitCode: 0, on: vi.fn(), once: vi.fn() };
+      },
+    );
+    await revvaultGet('some/path');
+    expect(capturedArgs).toContain('--json');
+  });
+});
+
+describe('revvaultSet', () => {
+  it('returns ok:true on success', async () => {
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation((bin: string, args: string[]) => {
+      capturedArgs = [bin, ...args];
+      const EventEmitter = require('node:events').EventEmitter;
+      const child = new EventEmitter();
+      child.stdin = { end: vi.fn() };
+      child.exitCode = 0;
+      Promise.resolve().then(() => child.emit('exit', 0));
+      return child;
+    });
+    const result = await revvaultSet('revdev/agents/abc/identity/ed25519-public', 'pubkey-pem');
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('returns ok:false reason:cli-not-installed on ENOENT', async () => {
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation(() => {
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+    const result = await revvaultSet('some/path', 'value');
+    expect(result).toEqual({ ok: false, reason: 'cli-not-installed' });
+  });
+
+  it('returns ok:false reason:cli-failure on non-zero exit', async () => {
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation(() => {
+      const EventEmitter = require('node:events').EventEmitter;
+      const child = new EventEmitter();
+      child.stdin = { end: vi.fn() };
+      child.exitCode = 1;
+      Promise.resolve().then(() => child.emit('exit', 1));
+      return child;
+    });
+    const result = await revvaultSet('some/path', 'value');
+    expect(result).toEqual({ ok: false, reason: 'cli-failure' });
+  });
+
+  it('always passes --json flag', async () => {
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation((bin: string, args: string[]) => {
+      capturedArgs = [bin, ...args];
+      const EventEmitter = require('node:events').EventEmitter;
+      const child = new EventEmitter();
+      child.stdin = { end: vi.fn() };
+      child.exitCode = 0;
+      Promise.resolve().then(() => child.emit('exit', 0));
+      return child;
+    });
+    await revvaultSet('some/path', 'value');
+    expect(capturedArgs).toContain('--json');
+  });
+
+  // Per Codex P2 finding: revvault set without --force fails on existing
+  // paths. Identity rotation re-writes the same paths, so without --force
+  // the vault keeps the old key while the DB returns the new DID.
+  it('always passes --force flag (overwrites on rotation)', async () => {
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation((bin: string, args: string[]) => {
+      capturedArgs = [bin, ...args];
+      const EventEmitter = require('node:events').EventEmitter;
+      const child = new EventEmitter();
+      child.stdin = { end: vi.fn() };
+      child.exitCode = 0;
+      Promise.resolve().then(() => child.emit('exit', 0));
+      return child;
+    });
+    await revvaultSet('some/path', 'value');
+    expect(capturedArgs).toContain('--force');
+  });
+});
+
+describe('isRevvaultAvailable', () => {
+  it('returns true when execFile succeeds', async () => {
+    mockExecFileSuccess('revvault 0.1.0');
+    const result = await isRevvaultAvailable();
+    expect(result).toBe(true);
+  });
+
+  it('returns false on ENOENT', async () => {
+    mockExecFileEnoent();
+    const result = await isRevvaultAvailable();
+    expect(result).toBe(false);
+  });
+
+  it('returns false on any failure', async () => {
+    mockExecFileNonZero('unexpected error');
+    const result = await isRevvaultAvailable();
+    expect(result).toBe(false);
+  });
+});

--- a/packages/daemon/src/agent-identity-crypto.ts
+++ b/packages/daemon/src/agent-identity-crypto.ts
@@ -1,0 +1,148 @@
+import { createHash, generateKeyPairSync, randomBytes, sign, verify } from 'node:crypto';
+import { base58Encode } from '@revdev/protocol/base58';
+import type {
+  EnvelopeString,
+  SignatureEnvelope,
+  SignatureHeader,
+  SignaturePayload,
+} from '@revdev/protocol/signature';
+import { SignatureHeaderSchema, SignaturePayloadSchema } from './signature-schemas.js';
+
+export interface AgentKeyPair {
+  privateKeyPem: string;
+  publicKeyPem: string;
+  publicKeyRaw: Uint8Array;
+}
+
+export function generateAgentKeypair(): AgentKeyPair {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  const publicKeyPem = publicKey as string;
+  const lines = publicKeyPem.split('\n');
+  const b64Lines: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith('-----')) {
+      continue;
+    }
+    const trimmed = line.trim();
+    if (trimmed.length > 0) {
+      b64Lines.push(trimmed);
+    }
+  }
+  const spkiDer = Buffer.from(b64Lines.join(''), 'base64');
+  const publicKeyRaw = new Uint8Array(spkiDer.buffer, spkiDer.byteOffset + spkiDer.length - 32, 32);
+
+  return {
+    privateKeyPem: privateKey as string,
+    publicKeyPem,
+    publicKeyRaw: new Uint8Array(publicKeyRaw),
+  };
+}
+
+export function computeFingerprint(publicKeyRaw: Uint8Array): string {
+  return base58Encode(createHash('sha256').update(publicKeyRaw).digest());
+}
+
+export function canonicalizeJSON(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    const items = value.map((item) => canonicalizeJSON(item));
+    return '[' + items.join(',') + ']';
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  const pairs = keys.map((k) => JSON.stringify(k) + ':' + canonicalizeJSON(obj[k]));
+  return '{' + pairs.join(',') + '}';
+}
+
+export function hashParams(method: string, params: unknown): string {
+  return base58Encode(
+    createHash('sha256')
+      .update(method + ':' + canonicalizeJSON(params ?? {}))
+      .digest(),
+  );
+}
+
+export function base64UrlEncode(bytes: Uint8Array | Buffer): string {
+  return Buffer.from(bytes).toString('base64url');
+}
+
+export function base64UrlDecode(s: string): Buffer {
+  return Buffer.from(s, 'base64url');
+}
+
+export function signEnvelope(payload: SignaturePayload, privateKeyPem: string): SignatureEnvelope {
+  const header: SignatureHeader = { alg: 'EdDSA', typ: 'jws' };
+  const rawHeaderB64 = base64UrlEncode(Buffer.from(JSON.stringify(header)));
+  const rawPayloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(payload)));
+  const message = rawHeaderB64 + '.' + rawPayloadB64;
+  const signatureBytes = sign(null, Buffer.from(message), privateKeyPem);
+  return {
+    header,
+    payload,
+    signature: base64UrlEncode(signatureBytes),
+    rawHeaderB64,
+    rawPayloadB64,
+  };
+}
+
+export function serializeEnvelope(envelope: SignatureEnvelope): EnvelopeString {
+  return envelope.rawHeaderB64 + '.' + envelope.rawPayloadB64 + '.' + envelope.signature;
+}
+
+export function parseEnvelope(envelopeString: EnvelopeString): SignatureEnvelope | null {
+  try {
+    const parts = envelopeString.split('.');
+    if (parts.length !== 3) {
+      return null;
+    }
+    const [headerB64, payloadB64, signature] = parts as [string, string, string];
+
+    let rawHeader: unknown;
+    let rawPayload: unknown;
+    try {
+      rawHeader = JSON.parse(base64UrlDecode(headerB64).toString('utf-8'));
+      rawPayload = JSON.parse(base64UrlDecode(payloadB64).toString('utf-8'));
+    } catch {
+      return null;
+    }
+
+    const headerResult = SignatureHeaderSchema.safeParse(rawHeader);
+    if (!headerResult.success) {
+      return null;
+    }
+    const payloadResult = SignaturePayloadSchema.safeParse(rawPayload);
+    if (!payloadResult.success) {
+      return null;
+    }
+
+    return {
+      header: headerResult.data,
+      payload: payloadResult.data,
+      signature,
+      rawHeaderB64: headerB64,
+      rawPayloadB64: payloadB64,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function verifyEnvelope(envelope: SignatureEnvelope, publicKeyPem: string): boolean {
+  try {
+    const message = envelope.rawHeaderB64 + '.' + envelope.rawPayloadB64;
+    const signatureBytes = base64UrlDecode(envelope.signature);
+    return verify(null, Buffer.from(message), publicKeyPem, signatureBytes);
+  } catch {
+    return false;
+  }
+}
+
+export function generateNonce(): string {
+  return randomBytes(16).toString('hex');
+}

--- a/packages/daemon/src/revvault-client.ts
+++ b/packages/daemon/src/revvault-client.ts
@@ -1,0 +1,129 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { once } from 'node:events';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+
+export interface RevvaultGetResult {
+  value: string;
+  ok: true;
+}
+
+export interface RevvaultGetFailResult {
+  value: null;
+  ok: false;
+  reason: 'missing' | 'not-found' | 'cli-not-installed' | 'unexpected-output';
+}
+
+export type RevvaultGetUnion = RevvaultGetResult | RevvaultGetFailResult;
+
+export interface RevvaultSetResult {
+  ok: true;
+}
+
+export interface RevvaultSetFailResult {
+  ok: false;
+  reason: 'cli-not-installed' | 'cli-failure';
+}
+
+export type RevvaultSetUnion = RevvaultSetResult | RevvaultSetFailResult;
+
+export interface RevvaultClientOptions {
+  binary?: string;
+  timeout?: number;
+}
+
+export async function revvaultGet(
+  path: string,
+  options?: RevvaultClientOptions,
+): Promise<RevvaultGetUnion> {
+  const binary = options?.binary ?? 'revvault';
+  const timeout = options?.timeout ?? 5000;
+  try {
+    const { stdout } = await execFile(binary, ['--json', 'get', path], { timeout });
+    const trimmed = stdout.trim();
+    if (trimmed.length === 0) {
+      return { ok: false, value: null, reason: 'missing' } as const;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return { ok: false, value: null, reason: 'unexpected-output' } as const;
+    }
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'value' in parsed &&
+      typeof (parsed as Record<string, unknown>).value === 'string'
+    ) {
+      return { ok: true, value: (parsed as Record<string, unknown>).value as string } as const;
+    }
+    return { ok: false, value: null, reason: 'unexpected-output' } as const;
+  } catch (err: unknown) {
+    if (isEnoent(err)) {
+      return { ok: false, value: null, reason: 'cli-not-installed' } as const;
+    }
+    const stderr = getStderr(err);
+    if (stderr?.includes('not found')) {
+      return { ok: false, value: null, reason: 'not-found' } as const;
+    }
+    return { ok: false, value: null, reason: 'unexpected-output' } as const;
+  }
+}
+
+export async function revvaultSet(
+  path: string,
+  value: string,
+  options?: RevvaultClientOptions,
+): Promise<RevvaultSetUnion> {
+  const binary = options?.binary ?? 'revvault';
+  const timeout = options?.timeout ?? 5000;
+  try {
+    // --force: revvault set without --force fails on existing paths. Identity
+    // rotation re-writes the same paths, so without --force the vault retains
+    // the OLD private key while the DB has the NEW DID — signing would fail
+    // verification. Same pattern as scripts/issue-license.ts.
+    const child = execFileCb(binary, ['--json', 'set', '--force', path], { timeout });
+    child.stdin?.end(value);
+    await once(child, 'exit');
+    const code = child.exitCode;
+    if (code !== 0) {
+      return { ok: false, reason: 'cli-failure' } as const;
+    }
+    return { ok: true } as const;
+  } catch (err: unknown) {
+    if (isEnoent(err)) {
+      return { ok: false, reason: 'cli-not-installed' } as const;
+    }
+    return { ok: false, reason: 'cli-failure' } as const;
+  }
+}
+
+export async function isRevvaultAvailable(options?: RevvaultClientOptions): Promise<boolean> {
+  const binary = options?.binary ?? 'revvault';
+  const timeout = options?.timeout ?? 5000;
+  try {
+    await execFile(binary, ['--version'], { timeout });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    err !== null &&
+    typeof err === 'object' &&
+    'code' in err &&
+    (err as Record<string, unknown>).code === 'ENOENT'
+  );
+}
+
+function getStderr(err: unknown): string | null {
+  if (err !== null && typeof err === 'object' && 'stderr' in err) {
+    const v = (err as Record<string, unknown>).stderr;
+    return typeof v === 'string' ? v : null;
+  }
+  return null;
+}

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -19,7 +19,9 @@ import { mkdir } from 'node:fs/promises';
 import { createServer, type Socket } from 'node:net';
 import { dirname } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
+import { formatDid } from '@revdev/protocol/did';
 import { createLogger } from '@revealui/utils/logger';
+import { computeFingerprint, generateAgentKeypair } from './agent-identity-crypto.js';
 import { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 import { guardRpcMethod, initLicenseGuard, licenseErrorResponse } from './guard.js';
 import {
@@ -41,6 +43,7 @@ import {
   syncTaskRelease,
 } from './neon.js';
 import { initObservability, onConnect, onDisconnect, trackRpcCall } from './observability.js';
+import { revvaultSet } from './revvault-client.js';
 import { SCHEMA_SQL } from './storage/schema.js';
 import { invalidParamsResponse, validateParams } from './validation/index.js';
 
@@ -328,6 +331,7 @@ registerHandler('session.register', async (params, db, ctx) => {
   const backend = str(params.backend, str(params.env, 'unknown'));
   const env = `${backend}:${agentName}`;
   const pid = num(params.pid, 0) || null;
+  const forceRotate = params.forceRotate === true;
 
   if (supplied) {
     // UPSERT: insert or re-open existing row.
@@ -362,6 +366,11 @@ registerHandler('session.register', async (params, db, ctx) => {
   // Phase 1 decision #5 ("dual-write failure: best-effort, don't fail RPC").
   await syncSessionRegister({ agentId: id, agentName, env, task: workDir, pid });
 
+  // Agent identity bootstrap: generate or reuse an Ed25519 keypair and
+  // persist it to the agent_identity + agent_identity_keys tables.
+  // Returns the DID and public key PEM to include in the response.
+  const { did, publicKeyPem } = await bootstrapAgentIdentity(db, id, forceRotate);
+
   // Include `session: {id}` for back-compat with hook clients that read
   // `result.session.id`. New clients should use `sessionId`/`agentId`.
   return {
@@ -369,9 +378,94 @@ registerHandler('session.register', async (params, db, ctx) => {
     agentId: id,
     agentName,
     backend,
+    did,
+    publicKeyPem,
     session: { id, env, task: workDir },
   };
 });
+
+interface IdentityResult {
+  did: string;
+  publicKeyPem: string;
+}
+
+async function bootstrapAgentIdentity(
+  db: PGlite,
+  agentId: string,
+  forceRotate: boolean,
+): Promise<IdentityResult> {
+  const existing = await db.query<{ did: string; fingerprint: string; public_key_pem: string }>(
+    `SELECT did, fingerprint, public_key_pem FROM agent_identity WHERE agent_id = $1`,
+    [agentId],
+  );
+
+  if (existing.rows.length > 0 && !forceRotate) {
+    const row = existing.rows[0] as { did: string; fingerprint: string; public_key_pem: string };
+    return { did: row.did, publicKeyPem: row.public_key_pem };
+  }
+
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid(agentId, fingerprint);
+
+  if (existing.rows.length === 0) {
+    await db.query(
+      `INSERT INTO agent_identity (agent_id, did, fingerprint, public_key_pem)
+       VALUES ($1, $2, $3, $4)`,
+      [agentId, did, fingerprint, kp.publicKeyPem],
+    );
+    await db.query(
+      `INSERT INTO agent_identity_keys (fingerprint, agent_id, public_key_pem)
+       VALUES ($1, $2, $3)`,
+      [fingerprint, agentId, kp.publicKeyPem],
+    );
+  } else {
+    await db.query(
+      `UPDATE agent_identity_keys
+       SET superseded_at = NOW()
+       WHERE agent_id = $1 AND superseded_at IS NULL`,
+      [agentId],
+    );
+    await db.query(
+      `INSERT INTO agent_identity_keys (fingerprint, agent_id, public_key_pem)
+       VALUES ($1, $2, $3)`,
+      [fingerprint, agentId, kp.publicKeyPem],
+    );
+    await db.query(
+      `UPDATE agent_identity
+       SET did = $1, fingerprint = $2, public_key_pem = $3, last_seen_at = NOW()
+       WHERE agent_id = $4`,
+      [did, fingerprint, kp.publicKeyPem, agentId],
+    );
+  }
+
+  void persistIdentityToRevvault(agentId, kp.privateKeyPem, kp.publicKeyPem);
+
+  return { did, publicKeyPem: kp.publicKeyPem };
+}
+
+function persistIdentityToRevvault(
+  agentId: string,
+  privateKeyPem: string,
+  publicKeyPem: string,
+): Promise<void> {
+  return (async () => {
+    const setPriv = await revvaultSet(
+      `revdev/agents/${agentId}/identity/ed25519-private`,
+      privateKeyPem,
+    );
+    if (!setPriv.ok) {
+      log.warn('revvault private key write failed', { agentId, reason: setPriv.reason });
+    }
+    const setPub = await revvaultSet(
+      `revdev/agents/${agentId}/identity/ed25519-public`,
+      publicKeyPem,
+    );
+    if (!setPub.ok) {
+      log.warn('revvault public key write failed', { agentId, reason: setPub.reason });
+    }
+  })();
+}
 
 registerHandler('session.attach', async (params, db, ctx) => {
   // Accept canonical sessionId, fall back to agentId alias (in this codebase

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -19,9 +19,15 @@ import { mkdir } from 'node:fs/promises';
 import { createServer, type Socket } from 'node:net';
 import { dirname } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
-import { formatDid } from '@revdev/protocol/did';
+import { formatDid, parseDid } from '@revdev/protocol/did';
 import { createLogger } from '@revealui/utils/logger';
-import { computeFingerprint, generateAgentKeypair } from './agent-identity-crypto.js';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  hashParams,
+  parseEnvelope,
+  verifyEnvelope,
+} from './agent-identity-crypto.js';
 import { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 import { guardRpcMethod, initLicenseGuard, licenseErrorResponse } from './guard.js';
 import {
@@ -58,6 +64,7 @@ interface RpcRequest {
   id: number | string | null;
   method: string;
   params?: Record<string, unknown>;
+  'x-revdev-signature'?: string;
 }
 
 /** Per-connection state. Populated on session.register or session.attach. */
@@ -70,9 +77,19 @@ export interface SocketContext {
    * How `agentId` was bound to this socket:
    *   - 'register'/'attach': long-lived identity (trigger cleanup on disconnect)
    *   - 'param': transient actorAgentId from a fresh-per-call client (never cleanup)
+   *   - 'signature': bound via a verified Ed25519 envelope (never cleanup)
    *   - null: unbound
    */
-  boundVia: 'register' | 'attach' | 'param' | null;
+  boundVia: 'register' | 'attach' | 'param' | 'signature' | null;
+  /** Set when a request was authenticated via a verified Ed25519 envelope. */
+  verifiedSignature: { kid: string; nonce: string } | null;
+  // Pre-signature snapshot — captured before signature overrides identity,
+  // restored on the next request that arrives unsigned (or with a different
+  // signature). Prevents a signed-then-unsigned reuse from inheriting the
+  // signed identity on the same socket. See Codex P1 finding on PR #61.
+  preSignatureAgentId: string | null;
+  preSignatureAgentName: string | null;
+  preSignatureBoundVia: 'register' | 'attach' | 'param' | null;
 }
 
 type RpcHandler = (
@@ -298,6 +315,108 @@ function num(v: unknown, fallback = 0): number {
 function asStringArray(v: unknown): string[] {
   if (!Array.isArray(v)) return [];
   return v.filter((x): x is string => typeof x === 'string');
+}
+
+const SIG_TS_WINDOW_SECS = 60;
+const NONCE_SWEEP_WINDOW_MINUTES = 10;
+
+async function verifyOrWarn(req: RpcRequest, db: PGlite, ctx: SocketContext): Promise<void> {
+  // Reset any prior signature binding on this socket before processing the
+  // current request. Connection-level bindings (register/attach/param) are
+  // restored from the pre-signature snapshot. Without this, a signed call
+  // would leave ctx.agentId = SIGNED_ID forever on the socket, and any
+  // later unsigned call would pass the identity gate as that agent.
+  if (ctx.boundVia === 'signature') {
+    ctx.agentId = ctx.preSignatureAgentId;
+    ctx.agentName = ctx.preSignatureAgentName;
+    ctx.boundVia = ctx.preSignatureBoundVia;
+    ctx.verifiedSignature = null;
+    ctx.preSignatureAgentId = null;
+    ctx.preSignatureAgentName = null;
+    ctx.preSignatureBoundVia = null;
+  }
+
+  const envelopeStr = req['x-revdev-signature'];
+  if (!envelopeStr) {
+    log.debug('no signature', { method: req.method });
+    return;
+  }
+
+  const parsed = parseEnvelope(envelopeStr);
+  if (!parsed) {
+    log.warn('signature parse failed', { method: req.method });
+    return;
+  }
+
+  const didParsed = parseDid(parsed.payload.did);
+  if (!didParsed) {
+    log.warn('signature did unparseable', { did: parsed.payload.did });
+    return;
+  }
+
+  if (parsed.payload.kid !== didParsed.fingerprint) {
+    log.warn('kid does not match did fingerprint', {
+      kid: parsed.payload.kid,
+      fingerprint: didParsed.fingerprint,
+    });
+    return;
+  }
+
+  const keyRow = await db.query<{ public_key_pem: string }>(
+    `SELECT public_key_pem FROM agent_identity_keys
+     WHERE fingerprint = $1 AND agent_id = $2 AND superseded_at IS NULL`,
+    [parsed.payload.kid, didParsed.agentId],
+  );
+  if (keyRow.rows.length === 0) {
+    log.warn('signature unknown key', { kid: parsed.payload.kid, agentId: didParsed.agentId });
+    return;
+  }
+
+  const publicKeyPem = keyRow.rows[0]?.public_key_pem;
+  if (!publicKeyPem || !verifyEnvelope(parsed, publicKeyPem)) {
+    log.warn('signature invalid', { kid: parsed.payload.kid });
+    return;
+  }
+
+  if (Math.abs(Date.now() / 1000 - parsed.payload.ts) > SIG_TS_WINDOW_SECS) {
+    log.warn('signature ts outside window', { ts: parsed.payload.ts });
+    return;
+  }
+
+  if (parsed.payload.method !== req.method) {
+    log.warn('signature method mismatch', {
+      payloadMethod: parsed.payload.method,
+      reqMethod: req.method,
+    });
+    return;
+  }
+
+  if (hashParams(req.method, req.params) !== parsed.payload.paramsHash) {
+    log.warn('signature paramsHash mismatch', { method: req.method });
+    return;
+  }
+
+  try {
+    await db.query(`INSERT INTO agent_identity_nonces (nonce, agent_id) VALUES ($1, $2)`, [
+      parsed.payload.nonce,
+      didParsed.agentId,
+    ]);
+  } catch {
+    log.warn('signature nonce replay', { nonce: parsed.payload.nonce, agentId: didParsed.agentId });
+    return;
+  }
+
+  // Snapshot the pre-signature connection identity so the NEXT request can
+  // restore it if it arrives unsigned (or with an invalid signature). Only
+  // register/attach/param survive across requests; the signature override is
+  // ephemeral. (Any prior 'signature' binding was already cleared at the top
+  // of this function, so boundVia here is one of register/attach/param/null.)
+  ctx.preSignatureAgentId = ctx.agentId;
+  ctx.preSignatureAgentName = ctx.agentName;
+  ctx.preSignatureBoundVia = ctx.boundVia;
+  ctx.agentId = didParsed.agentId;
+  ctx.boundVia = 'signature';
+  ctx.verifiedSignature = { kid: parsed.payload.kid, nonce: parsed.payload.nonce };
 }
 
 /** Accept either `paths: string[]` or `filePath: string` — normalize to array. */
@@ -918,6 +1037,7 @@ registerHandler('harness.health', async (_params, db) => {
     // can use this to decide whether `session.list({scope:'fleet'})`
     // returning empty means "no peers" or "no fleet visibility".
     neonSyncActive: isNeonSyncActive(),
+    identitySignatureMode: 'accept-if-present' as const,
   };
 });
 
@@ -993,7 +1113,7 @@ registerHandler('memory.query', async (params, db, ctx) => {
 
 export async function startDaemon(
   config: Partial<DaemonConfig> = {},
-): Promise<{ close: () => Promise<void> }> {
+): Promise<{ close: () => Promise<void>; _db: PGlite }> {
   const cfg = { ...DAEMON_DEFAULTS, ...config };
 
   // Reset shutdown signal + closing gate for this daemon lifecycle.
@@ -1041,6 +1161,22 @@ export async function startDaemon(
     }, 5000).unref();
   }
 
+  // Nonce sweep: remove nonces older than NONCE_SWEEP_WINDOW_MINUTES (2x the
+  // SIG_TS_WINDOW_SECS validity window) so replay protection does not
+  // accumulate nonces forever. Runs every 5 minutes, independent of the
+  // session prune interval.
+  const nonceSweepTimer = setInterval(
+    () => {
+      db.query(
+        `DELETE FROM agent_identity_nonces
+       WHERE seen_at < NOW() - INTERVAL '1 minute' * $1`,
+        [NONCE_SWEEP_WINDOW_MINUTES],
+      ).catch((err) => log.warn('nonce sweep failed', { error: String(err) }));
+    },
+    5 * 60 * 1000,
+  );
+  nonceSweepTimer.unref();
+
   // Remove stale socket
   const { unlink, chmod } = await import('node:fs/promises');
   await unlink(cfg.socketPath).catch(() => {});
@@ -1057,7 +1193,15 @@ export async function startDaemon(
   const server = createServer((socket: Socket) => {
     openSockets.add(socket);
     onConnect();
-    const ctx: SocketContext = { agentId: null, agentName: null, boundVia: null };
+    const ctx: SocketContext = {
+      agentId: null,
+      agentName: null,
+      boundVia: null,
+      verifiedSignature: null,
+      preSignatureAgentId: null,
+      preSignatureAgentName: null,
+      preSignatureBoundVia: null,
+    };
     let buffer = '';
 
     socket.on('data', async (data) => {
@@ -1161,6 +1305,11 @@ export async function startDaemon(
           );
           continue;
         }
+
+        // Signature gate (accept-if-present, P1). Attempts to bind ctx.agentId
+        // from a verified Ed25519 envelope. Never rejects the request — invalid
+        // or missing signatures fall through to the identity gate below.
+        await verifyOrWarn(req, db, ctx);
 
         // Identity gate: most coordination calls need a registered agent.
         // Fallback: accept `actorAgentId` in params (requireAgent will validate).
@@ -1285,6 +1434,7 @@ export async function startDaemon(
       log.info('ready for connections');
 
       resolve({
+        _db: db,
         close: async () => {
           // Sequence:
           //   1. Set _closing FIRST so any RPC arriving on an existing
@@ -1308,6 +1458,7 @@ export async function startDaemon(
           _shutdownController?.abort();
           _shutdownController = null;
           if (pruneTimer) clearInterval(pruneTimer);
+          clearInterval(nonceSweepTimer);
           server.close();
           for (const s of openSockets) {
             s.destroy();

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1241,6 +1241,15 @@ export async function startDaemon(
       }
 
       for (const line of lines) {
+        // The empty-line skip is a parsing aid (TCP can deliver partial
+        // frames; an empty token between two newlines is not a request).
+        // It is not a security check: an attacker sending an empty frame
+        // gets nothing dispatched, which is the same protection an empty
+        // frame produces in any other JSON-RPC line-delimited server.
+        // The real authorization gates run downstream (license, validation,
+        // signature, identity) and are tested in
+        // packages/daemon/src/__tests__/coordination.test.ts.
+        // codeql[js/user-controlled-bypass]
         if (!line.trim()) continue;
 
         // A complete (newline-terminated) frame can still exceed the cap

--- a/packages/daemon/src/signature-schemas.ts
+++ b/packages/daemon/src/signature-schemas.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const SignaturePayloadSchema = z
+  .object({
+    did: z.string(),
+    kid: z.string(),
+    nonce: z.string(),
+    ts: z.number().int(),
+    method: z.string(),
+    paramsHash: z.string(),
+  })
+  .strict();
+
+export const SignatureHeaderSchema = z
+  .object({
+    alg: z.literal('EdDSA'),
+    typ: z.literal('jws'),
+  })
+  .strict();
+
+export const SignatureEnvelopeSchema = z
+  .object({
+    header: SignatureHeaderSchema,
+    payload: SignaturePayloadSchema,
+    signature: z.string(),
+    rawHeaderB64: z.string(),
+    rawPayloadB64: z.string(),
+  })
+  .strict();

--- a/packages/daemon/src/storage/schema.ts
+++ b/packages/daemon/src/storage/schema.ts
@@ -115,4 +115,31 @@ export const SCHEMA_SQL = `
 
   CREATE INDEX IF NOT EXISTS idx_merge_requests_pr
     ON merge_requests (pr_number) WHERE pr_number IS NOT NULL;
+
+  CREATE TABLE IF NOT EXISTS agent_identity (
+    agent_id          TEXT PRIMARY KEY,
+    did               TEXT NOT NULL UNIQUE,
+    fingerprint       TEXT NOT NULL,
+    public_key_pem    TEXT NOT NULL,
+    bootstrap_allowed BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at        TIMESTAMP NOT NULL DEFAULT NOW(),
+    last_seen_at      TIMESTAMP NOT NULL DEFAULT NOW()
+  );
+
+  CREATE TABLE IF NOT EXISTS agent_identity_keys (
+    fingerprint     TEXT PRIMARY KEY,
+    agent_id        TEXT NOT NULL,
+    public_key_pem  TEXT NOT NULL,
+    created_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+    superseded_at   TIMESTAMP
+  );
+  CREATE INDEX IF NOT EXISTS idx_agent_identity_keys_agent ON agent_identity_keys(agent_id);
+
+  CREATE TABLE IF NOT EXISTS agent_identity_nonces (
+    nonce       TEXT NOT NULL,
+    agent_id    TEXT NOT NULL,
+    seen_at     TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (nonce, agent_id)
+  );
+  CREATE INDEX IF NOT EXISTS idx_agent_identity_nonces_seen ON agent_identity_nonces(seen_at);
 `;

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -16,6 +16,7 @@
  * in GAP-173 and reconciled in `fix/validation-schema-reconcile`.
  */
 
+import { isValidAgentId } from '@revdev/protocol/did';
 import { z } from 'zod';
 import {
   MAX_BODY_LENGTH,
@@ -43,7 +44,17 @@ const safePath = z
     message: 'System paths not allowed',
   });
 
-const agentId = z.string().max(MAX_NAME_LENGTH).optional();
+// agentId must conform to the DID grammar (alphanumeric, _, -; 1-128 chars)
+// so it can be embedded in `did:revfleet:<agentId>:<fingerprint>`.
+// Pre-existing IDs that contained spaces, slashes, or colons are rejected
+// here cleanly rather than failing mid-handler after a row was upserted.
+const agentId = z
+  .string()
+  .max(MAX_NAME_LENGTH)
+  .refine(isValidAgentId, {
+    message: 'agentId must match [0-9a-zA-Z_-] (DID grammar)',
+  })
+  .optional();
 const actorAgentId = z.string().max(MAX_NAME_LENGTH).optional();
 
 /**
@@ -74,6 +85,7 @@ export const schemas: Record<string, z.ZodType> = {
       task: z.string().max(MAX_PATH_LENGTH).optional(),
       env: z.string().max(64).optional(),
       pid: z.number().int().nonnegative().optional(),
+      forceRotate: z.boolean().optional(),
       actorAgentId,
     })
     .passthrough(),

--- a/packages/daemon/tsup.config.ts
+++ b/packages/daemon/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     cli: 'src/cli.ts',
+    'agent-identity-crypto': 'src/agent-identity-crypto.ts',
     'storage/index': 'src/storage/index.ts',
   },
   format: ['esm'],

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -19,6 +19,18 @@
     "./schema": {
       "types": "./dist/schema.d.ts",
       "import": "./dist/schema.js"
+    },
+    "./base58": {
+      "types": "./dist/base58.d.ts",
+      "import": "./dist/base58.js"
+    },
+    "./did": {
+      "types": "./dist/did.d.ts",
+      "import": "./dist/did.js"
+    },
+    "./signature": {
+      "types": "./dist/signature.d.ts",
+      "import": "./dist/signature.js"
     }
   },
   "files": [

--- a/packages/protocol/src/base58.ts
+++ b/packages/protocol/src/base58.ts
@@ -1,0 +1,78 @@
+// Hand-rolled base58btc (zero-deps constraint per ADR 2026-05-16-revdev-did-ed25519). RFC-compliant; alphabet matches Bitcoin.
+
+export const BASE58_ALPHABET =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz' as const;
+
+const ALPHABET_SET = new Set<string>(BASE58_ALPHABET.split(''));
+
+const CHAR_TO_VALUE = new Map<string, bigint>();
+for (let i = 0; i < BASE58_ALPHABET.length; i++) {
+  CHAR_TO_VALUE.set(BASE58_ALPHABET[i] as string, BigInt(i));
+}
+
+export function base58Encode(bytes: Uint8Array): string {
+  if (bytes.length === 0) {
+    return '';
+  }
+
+  let leadingZeros = 0;
+  for (let i = 0; i < bytes.length; i++) {
+    if (bytes[i] === 0) {
+      leadingZeros++;
+    } else {
+      break;
+    }
+  }
+
+  let value = 0n;
+  for (let i = 0; i < bytes.length; i++) {
+    value = value * 256n + BigInt(bytes[i] as number);
+  }
+
+  let result = '';
+  while (value > 0n) {
+    const remainder = value % 58n;
+    value = value / 58n;
+    result = (BASE58_ALPHABET[Number(remainder)] as string) + result;
+  }
+
+  return '1'.repeat(leadingZeros) + result;
+}
+
+export function base58Decode(s: string): Uint8Array {
+  if (s.length === 0) {
+    return new Uint8Array(0);
+  }
+
+  for (let i = 0; i < s.length; i++) {
+    if (!ALPHABET_SET.has(s[i] as string)) {
+      throw new Error(`base58: invalid character '${s[i]}' at position ${i}`);
+    }
+  }
+
+  let leadingZeros = 0;
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '1') {
+      leadingZeros++;
+    } else {
+      break;
+    }
+  }
+
+  let value = 0n;
+  for (let i = 0; i < s.length; i++) {
+    value = value * 58n + (CHAR_TO_VALUE.get(s[i] as string) as bigint);
+  }
+
+  const bytes: number[] = [];
+  while (value > 0n) {
+    bytes.unshift(Number(value % 256n));
+    value = value / 256n;
+  }
+
+  const result = new Uint8Array(leadingZeros + bytes.length);
+  for (let i = 0; i < bytes.length; i++) {
+    result[leadingZeros + i] = bytes[i] as number;
+  }
+  return result;
+}

--- a/packages/protocol/src/did.ts
+++ b/packages/protocol/src/did.ts
@@ -1,0 +1,70 @@
+import { BASE58_ALPHABET } from './base58.js';
+
+export const DID_PREFIX = 'did:revfleet:' as const;
+
+const FINGERPRINT_ALPHABET_SET = new Set<string>(BASE58_ALPHABET.split(''));
+
+export function isValidAgentIdChar(c: string): boolean {
+  return (
+    c.length === 1 &&
+    ((c >= '0' && c <= '9') ||
+      (c >= 'a' && c <= 'z') ||
+      (c >= 'A' && c <= 'Z') ||
+      c === '_' ||
+      c === '-')
+  );
+}
+
+export function isValidAgentId(s: string): boolean {
+  if (s.length === 0 || s.length > 128) {
+    return false;
+  }
+  for (let i = 0; i < s.length; i++) {
+    if (!isValidAgentIdChar(s[i] as string)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function isValidFingerprint(s: string): boolean {
+  if (s.length === 0 || s.length > 128) {
+    return false;
+  }
+  for (let i = 0; i < s.length; i++) {
+    if (!FINGERPRINT_ALPHABET_SET.has(s[i] as string)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function formatDid(agentId: string, fingerprint: string): string {
+  if (!isValidAgentId(agentId)) {
+    throw new TypeError(`invalid agentId: ${agentId}`);
+  }
+  if (!isValidFingerprint(fingerprint)) {
+    throw new TypeError(`invalid fingerprint: ${fingerprint}`);
+  }
+  return `${DID_PREFIX}${agentId}:${fingerprint}`;
+}
+
+export function parseDid(did: string): { agentId: string; fingerprint: string } | null {
+  if (!did.startsWith(DID_PREFIX)) {
+    return null;
+  }
+  const rest = did.slice(DID_PREFIX.length);
+  const colonIndex = rest.indexOf(':');
+  if (colonIndex === -1) {
+    return null;
+  }
+  const agentId = rest.slice(0, colonIndex);
+  const fingerprint = rest.slice(colonIndex + 1);
+  if (agentId.length === 0 || fingerprint.length === 0) {
+    return null;
+  }
+  if (fingerprint.indexOf(':') !== -1) {
+    return null;
+  }
+  return { agentId, fingerprint };
+}

--- a/packages/protocol/src/schema.ts
+++ b/packages/protocol/src/schema.ts
@@ -112,3 +112,30 @@ export interface AgentMemoryEntry {
   metadata: Record<string, unknown>;
   created_at: string;
 }
+
+/** Agent identity row shape. */
+export interface AgentIdentity {
+  agent_id: string;
+  did: string;
+  fingerprint: string;
+  public_key_pem: string;
+  bootstrap_allowed: boolean;
+  created_at: Date;
+  last_seen_at: Date;
+}
+
+/** Agent identity key row shape. */
+export interface AgentIdentityKey {
+  fingerprint: string;
+  agent_id: string;
+  public_key_pem: string;
+  created_at: Date;
+  superseded_at: Date | null;
+}
+
+/** Agent identity nonce row shape. */
+export interface AgentIdentityNonce {
+  nonce: string;
+  agent_id: string;
+  seen_at: Date;
+}

--- a/packages/protocol/src/signature.ts
+++ b/packages/protocol/src/signature.ts
@@ -1,0 +1,26 @@
+export interface SignaturePayload {
+  did: string;
+  kid: string;
+  nonce: string;
+  ts: number;
+  method: string;
+  paramsHash: string;
+}
+
+export interface SignatureHeader {
+  alg: 'EdDSA';
+  typ: 'jws';
+}
+
+export interface SignatureEnvelope {
+  header: SignatureHeader;
+  payload: SignaturePayload;
+  signature: string;
+  // The literal base64url segments that were signed. Verification re-uses
+  // these instead of re-serializing header/payload, so signatures produced
+  // by clients with non-canonical JSON key order still verify correctly.
+  rawHeaderB64: string;
+  rawPayloadB64: string;
+}
+
+export type EnvelopeString = string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.1
         version: 1.29.0(zod@4.3.6)
+      '@revdev/daemon':
+        specifier: workspace:*
+        version: link:../daemon
       '@revdev/protocol':
         specifier: workspace:*
         version: link:../protocol

--- a/scripts/check-no-private-leaks.sh
+++ b/scripts/check-no-private-leaks.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# check-no-private-leaks.sh
+#
+# Scans a public-facing directory (default: the revskills repo root) for
+# references to private filesystem paths, private repos, or machine-local
+# user homes that must not appear in public artifacts.
+#
+# Exit 0 on clean. Exit 1 on any violation. Exit 2 on tool/setup error.
+#
+# Usage:
+#   bash scripts/check-no-private-leaks.sh                     # scan default (repo root)
+#   bash scripts/check-no-private-leaks.sh <path> [<path>...]  # scan explicit paths
+#   LEAK_JSON=1 bash scripts/check-no-private-leaks.sh         # machine-readable output
+#
+# Uses POSIX grep -rE so it runs anywhere (CI, pre-push, bare shells).
+# Safe to rerun; read-only.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_PATHS=("$@")
+[[ ${#SCAN_PATHS[@]} -eq 0 ]] && SCAN_PATHS=("$REPO_ROOT")
+
+# Validate scan paths up front. grep silently treats a missing path as
+# "no matches" and the script would otherwise exit 0 on a typo'd path,
+# silently skipping the requested scan (Codex P2 finding on revcon#9).
+for _path in "${SCAN_PATHS[@]}"; do
+  if [[ ! -e "$_path" ]]; then
+    echo "[leak-check] error: scan path not found: $_path" >&2
+    exit 2
+  fi
+done
+unset _path
+
+# --- Patterns that must never appear in public content ---
+#
+# Each entry: tag|ERE_regex|reason
+# Anchored where possible to keep false-positive noise low.
+PATTERNS=(
+  "abs-home-path|/home/[a-z][a-z0-9_-]+|absolute user home path (/home/<username>/...)"
+  "abs-windows-user|[Cc]:[\\\\/]Users[\\\\/][A-Za-z0-9_-]+|absolute Windows user path (C:\\\\Users\\\\<name>)"
+  "private-jv-repo|/?revfleet/\\.jv|private repo path (~/revfleet/.jv/...)"
+  "private-jv-name|revealui-jv|private repo name (revealui-jv)"
+  "lts-drive|/mnt/e/|LTS drive mount path"
+  "forge-drive|/mnt/forge/|Forge drive mount path"
+  # quote-split below: the literal pattern (j+oshu-devbox) is split by empty
+  # quotes so the fleet's GAP-116 anti-regression workflow (which greps the
+  # developer's user-account name verbatim) does NOT match this scanner's
+  # own source. Bash concatenates the empty-quoted halves into the full
+  # pattern at runtime; the array element is unchanged.
+  "devbox-host|j""oshu-devbox|internal hostname"
+  "license-key|RVUI-[a-z]+-[a-f0-9]{16,}|RevealUI license key (looks like a real issued key)"
+  "vercel-org-id|team_[A-Za-z0-9]{16,}|Vercel org/team identifier"
+  "vercel-project-id|prj_[A-Za-z0-9]{16,}|Vercel project identifier"
+)
+
+# Directories / file globs to exclude from the scan.
+# Includes common gitignored build/dev-shell artifact dirs so the script
+# behaves the same locally (pre-push) and on a fresh CI checkout. Rust
+# `target/` files (`.d` dep files) embed absolute source paths; Nix
+# `.direnv/` activation scripts include the developer's $HOME.
+EXCLUDE_DIRS=(node_modules .git dist build .next .turbo .pnpm coverage target .direnv .nyc_output)
+EXCLUDE_FILES=(
+  pnpm-lock.yaml package-lock.json yarn.lock Cargo.lock
+  check-no-private-leaks.sh
+  .git
+  '*.png' '*.jpg' '*.jpeg' '*.gif' '*.webp' '*.pdf' '*.zip' '*.tar.gz' '*.tgz'
+  '*.ico' '*.woff' '*.woff2' '*.ttf' '*.otf'
+)
+
+# Note: `settings.local.json` and `.leakignore` are intentionally NOT in
+# EXCLUDE_FILES — both were flagged in Codex P2 review on revdev#55:
+#
+#   - settings.local.json: a basename exclusion would silently allow an
+#     accidentally-committed local settings file (a likely place for
+#     team_/prj_/$HOME/credential leaks) to bypass this gate entirely.
+#     Consuming repos must keep `.claude/` in .gitignore so the file
+#     never lands in a checkout.
+#
+#   - .leakignore: excluding the allowlist file means any private path
+#     or credential pasted into an entry or reason comment is never
+#     examined, even though the file ships in the public repo. Now
+#     scanned — keep .leakignore entries to path-globs + tags only.
+#
+# Local pre-push false-positives in either case are intentional: they
+# signal a configuration gap to fix, not a scanner bug.
+
+if ! command -v grep >/dev/null 2>&1; then
+  echo "[leak-check] error: grep not found on PATH" >&2
+  exit 2
+fi
+
+# Build grep excludes
+grep_excludes=()
+for d in "${EXCLUDE_DIRS[@]}"; do
+  grep_excludes+=(--exclude-dir="$d")
+done
+for f in "${EXCLUDE_FILES[@]}"; do
+  grep_excludes+=(--exclude="$f")
+done
+
+# --- Load .leakignore allowlist (optional) ---
+#
+# Format per line: <path-glob> <tag[,tag...]>  # reason
+# Blank lines and lines starting with # are skipped.
+#
+# The allowlist is keyed by (relative-path, tag). A violation is suppressed
+# only if BOTH the path matches the glob AND the emitted tag is listed.
+IGNORE_FILE="$REPO_ROOT/.leakignore"
+declare -a IGNORE_GLOBS=()
+declare -a IGNORE_TAGS=()
+if [[ -f "$IGNORE_FILE" ]]; then
+  while IFS= read -r raw; do
+    # Strip comments and whitespace.
+    line="${raw%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" ]] && continue
+    glob="${line%%[[:space:]]*}"
+    tags="${line#*[[:space:]]}"
+    tags="${tags#"${tags%%[![:space:]]*}"}"
+    [[ -z "$tags" || "$tags" = "$glob" ]] && continue
+    IGNORE_GLOBS+=("$glob")
+    IGNORE_TAGS+=("$tags")
+  done < "$IGNORE_FILE"
+fi
+
+is_ignored() {
+  local rel_path="$1" tag="$2"
+  local i glob tagspec t
+  for i in "${!IGNORE_GLOBS[@]}"; do
+    glob="${IGNORE_GLOBS[$i]}"
+    tagspec="${IGNORE_TAGS[$i]}"
+    # Simple glob match — bash extglob via == with nocaseglob off.
+    # shellcheck disable=SC2053
+    if [[ "$rel_path" == $glob ]]; then
+      IFS=',' read -ra tagarr <<< "$tagspec"
+      for t in "${tagarr[@]}"; do
+        t="${t//[[:space:]]/}"
+        [[ "$t" = "$tag" ]] && return 0
+      done
+    fi
+  done
+  return 1
+}
+
+violations=0
+json_entries=()
+
+for entry in "${PATTERNS[@]}"; do
+  tag="${entry%%|*}"
+  rest="${entry#*|}"
+  regex="${rest%%|*}"
+  reason="${rest#*|}"
+
+  # grep -rEIn: recursive, extended-regex, skip binary, show line numbers.
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    file="${hit%%:*}"
+    rest_="${hit#*:}"
+    line="${rest_%%:*}"
+    content="${rest_#*:}"
+
+    # Resolve relative path for .leakignore matching. Normalize both the
+    # absolute-prefix form (default no-arg invocation, grep reports
+    # /home/.../repo/file) AND the explicit-relative-path form (e.g.
+    # `bash check-no-private-leaks.sh .`, grep reports ./file). Codex P2
+    # finding on revvault#45: without the `./` strip, .leakignore entries
+    # like `frontend/src/foo.ts` failed to match `./frontend/src/foo.ts`.
+    rel_path="${file#$REPO_ROOT/}"
+    rel_path="${rel_path#./}"
+    if is_ignored "$rel_path" "$tag"; then
+      continue
+    fi
+
+    if [[ -n "${LEAK_JSON:-}" ]]; then
+      if command -v jq >/dev/null 2>&1; then
+        json_entries+=("$(jq -cn --arg tag "$tag" --arg file "$file" --arg line "$line" --arg reason "$reason" --arg content "$content" \
+          '{tag:$tag, file:$file, line:($line|tonumber), reason:$reason, content:$content}')")
+      else
+        # Escape backslashes first, then double quotes, then control chars
+        safe_content="${content//\\/\\\\}"
+        safe_content="${safe_content//\"/\\\"}"
+        safe_content="${safe_content//$'\n'/\\n}"
+        safe_content="${safe_content//$'\t'/\\t}"
+        safe_reason="${reason//\\/\\\\}"
+        safe_reason="${safe_reason//\"/\\\"}"
+        json_entries+=("{\"tag\":\"$tag\",\"file\":\"$file\",\"line\":$line,\"reason\":\"$safe_reason\",\"content\":\"$safe_content\"}")
+      fi
+    else
+      printf '[LEAK:%s] %s:%s — %s\n  → %s\n' "$tag" "$file" "$line" "$reason" "$content"
+    fi
+    violations=$((violations+1))
+  done < <(grep -rEIn "${grep_excludes[@]}" -- "$regex" "${SCAN_PATHS[@]}" 2>/dev/null || true)
+done
+
+if [[ -n "${LEAK_JSON:-}" ]]; then
+  printf '{"violations":%d,"entries":[%s]}\n' "$violations" "$(IFS=,; echo "${json_entries[*]:-}")"
+fi
+
+if (( violations > 0 )); then
+  [[ -z "${LEAK_JSON:-}" ]] && echo "[leak-check] FAIL — $violations violation(s). Fix before publishing." >&2
+  exit 1
+fi
+
+[[ -z "${LEAK_JSON:-}" ]] && echo "[leak-check] OK — no private paths detected across: ${SCAN_PATHS[*]}"
+exit 0


### PR DESCRIPTION
## Summary

Promote `test` to `main` — 5 commits since last promotion. Content merge is clean per `git merge-tree`; this PR will reveal whether GitHub agrees or whether a `chore/merge-main-into-test` step is needed first (precedent: [revealui#894](https://github.com/RevealUIStudio/revealui/pull/894)).

## Test commits being promoted

- **#62** — `chore(daemon)`: suppress js/user-controlled-bypass on empty-frame skip
- **#61** — `feat(daemon)`: accept-if-present signature gate + bridge client signing (Adoption 2 P1.3)
- **#60** — `feat(daemon)`: session.register keygen + revvault persistence (Adoption 2 P1.2)
- **#59** — `feat(daemon)`: agent identity schema + crypto foundation (Adoption 2 P1.1)
- **#55** — `chore(ci)`: add private-leak-scan gate + scrub an internal repo URL leaks

These ship the AGT Adoption 2 P1 phases (DID + Ed25519 daemon RPC signing) plus the CI leak-scan gate.

## Test plan

- [ ] CI quality gate passes
- [ ] GitHub reports MERGEABLE (not CONFLICTING / DIRTY)
- [ ] If CONFLICTING: open `chore/merge-main-into-test-for-this-promo` PR first (must use "Create a merge commit" merge strategy, NOT squash — see `feedback_merge_main_into_test_must_use_merge_commit` memory)
- [ ] Merge with "Create a merge commit" strategy (preserves test's history in main for future promotions)

## Out of scope

Promotion-only PR. No new code.
