### PR TITLE
chore(leakignore): exempt docs/INDEX.md (intentional .jv refs)

### DIFF
--- a/.leakignore
+++ b/.leakignore
@@ -15,3 +15,11 @@ apps/studio/src/__tests__/hooks/use-ssh.test.ts           abs-home-path
 # Test fixture: the license-key shape matches the regex but the body is a
 # repeating hex pattern (abcdef-0123456789 doubled). Not a real key.
 packages/daemon/src/__tests__/flows.test.ts               license-key
+
+# Fleet-anchor cold-context ramp doc. The .jv/ path references in the
+# "Fleet coordination" section are an intentional cross-fleet navigation
+# aid for agents working in `~/revfleet/revdev/` with .jv access; they
+# point to the private coordination hub (master index, plan, lanes, gaps,
+# workboard, ADRs). Public readers without .jv see broken links — by
+# design; the file is for agent ramp, not customer docs.
+docs/INDEX.md                                              private-jv-repo


### PR DESCRIPTION
## Summary

Exempt `docs/INDEX.md` from the `private-jv-repo` leak-scan tag — the file's internal docs/` references are an **intentional cross-fleet navigation aid for agents with internal docs access**, not accidental leaks.

## Why

`docs/INDEX.md` was added by [#58](https://github.com/RevealUIStudio/revdev/pull/58) ("fleet-anchor INDEX.md (cold-context agent ramp)") to give incoming fleet agents a single entry point to discover the rest of the fleet's coordination surfaces. Its "Fleet coordination" section legitimately points to internal docs paths — that's the doc's stated purpose.

The leak scan added by [#55](https://github.com/RevealUIStudio/revdev/pull/55) now flags those 6 lines during the [#63](https://github.com/RevealUIStudio/revdev/pull/63) test→main promotion. The scan is correct (its job is to catch unintentional internal docs/` leaks); the right fix is an explicit exemption with rationale, not weakening the scan or making the doc useless for its audience.

## Unblocks

- [#63](https://github.com/RevealUIStudio/revdev/pull/63) — `promote: test → main` (currently failing `Private Leak Scan` with 6 violations all in `docs/INDEX.md`)
- Once this PR merges to `test`, #63's merge result will include the exemption and the leak scan will pass cleanly.

## Test plan

- [ ] CI passes (`Private Leak Scan` should now skip `docs/INDEX.md private-jv-repo` matches)
- [ ] After merge, re-run #63's CI → `Private Leak Scan` flips to pass
- [ ] #63's other blocker (CodeQL HIGH at `packages/daemon/src/server.ts:1253`) remains owner-gated (separate UI-dismissal action — see PR #63 thread)

## Out of scope

No code, no doc, no script changes. Single 8-line `.leakignore` addition.
