### PR TITLE
fix(daemon): handle async child-process error from revvault CLI (Codex P1)

### DIFF
--- a/packages/daemon/src/__tests__/revvault-client.test.ts
+++ b/packages/daemon/src/__tests__/revvault-client.test.ts
@@ -168,7 +168,7 @@ describe('revvaultSet', () => {
       capturedArgs = [bin, ...args];
       const EventEmitter = require('node:events').EventEmitter;
       const child = new EventEmitter();
-      child.stdin = { end: vi.fn() };
+      child.stdin = { end: vi.fn(), on: vi.fn() };
       child.exitCode = 0;
       Promise.resolve().then(() => child.emit('exit', 0));
       return child;
@@ -177,7 +177,30 @@ describe('revvaultSet', () => {
     expect(result).toEqual({ ok: true });
   });
 
-  it('returns ok:false reason:cli-not-installed on ENOENT', async () => {
+  it('returns ok:false reason:cli-not-installed on async ENOENT error event (does not crash daemon)', async () => {
+    // Real-world execFileCb does NOT throw synchronously on ENOENT — it
+    // returns a child that emits an async 'error' event. Mocking that
+    // real behavior. Previous mock (synchronous throw only) hid Codex P1
+    // finding: an unhandled 'error' from a missing CLI would crash the
+    // daemon in production.
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation(() => {
+      const EventEmitter = require('node:events').EventEmitter;
+      const child = new EventEmitter();
+      child.stdin = { end: vi.fn(), on: vi.fn() };
+      Promise.resolve().then(() => {
+        const err = Object.assign(new Error('spawn revvault ENOENT'), { code: 'ENOENT' });
+        child.emit('error', err);
+      });
+      return child;
+    });
+    const result = await revvaultSet('some/path', 'value');
+    expect(result).toEqual({ ok: false, reason: 'cli-not-installed' });
+  });
+
+  it('returns ok:false reason:cli-not-installed on synchronous ENOENT throw (rare edge case)', async () => {
+    // Some platforms / Node versions may throw synchronously on bad spawn
+    // arguments. Coverage preserved for the synchronous path.
     const execFileMock = childProcess.execFile as unknown as Mock;
     execFileMock.mockImplementation(() => {
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
@@ -187,12 +210,48 @@ describe('revvaultSet', () => {
     expect(result).toEqual({ ok: false, reason: 'cli-not-installed' });
   });
 
+  it('does not leak unhandled error events from child or stdin', async () => {
+    // Regression for Codex P1: missing revvault used to surface an
+    // unhandled 'error' event that crashed the daemon. With explicit
+    // child.on('error') + child.stdin.on('error') listeners, the daemon
+    // gets a clean RevvaultSetFailResult and process.on('uncaughtException')
+    // is never reached.
+    const uncaught: Error[] = [];
+    const handler = (err: Error) => uncaught.push(err);
+    process.on('uncaughtException', handler);
+
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation(() => {
+      const EventEmitter = require('node:events').EventEmitter;
+      const child = new EventEmitter();
+      const stdin = new EventEmitter();
+      (stdin as unknown as { end: () => void }).end = () => {
+        // Broken pipe: stdin emits its own error after end()
+        Promise.resolve().then(() => stdin.emit('error', new Error('EPIPE')));
+      };
+      child.stdin = stdin;
+      Promise.resolve().then(() => {
+        const err = Object.assign(new Error('spawn revvault ENOENT'), { code: 'ENOENT' });
+        child.emit('error', err);
+      });
+      return child;
+    });
+
+    const result = await revvaultSet('some/path', 'value');
+    // Drain deferred microtasks before asserting no leaks.
+    await new Promise((r) => setImmediate(r));
+    process.off('uncaughtException', handler);
+
+    expect(result).toEqual({ ok: false, reason: 'cli-not-installed' });
+    expect(uncaught).toEqual([]);
+  });
+
   it('returns ok:false reason:cli-failure on non-zero exit', async () => {
     const execFileMock = childProcess.execFile as unknown as Mock;
     execFileMock.mockImplementation(() => {
       const EventEmitter = require('node:events').EventEmitter;
       const child = new EventEmitter();
-      child.stdin = { end: vi.fn() };
+      child.stdin = { end: vi.fn(), on: vi.fn() };
       child.exitCode = 1;
       Promise.resolve().then(() => child.emit('exit', 1));
       return child;
@@ -207,7 +266,7 @@ describe('revvaultSet', () => {
       capturedArgs = [bin, ...args];
       const EventEmitter = require('node:events').EventEmitter;
       const child = new EventEmitter();
-      child.stdin = { end: vi.fn() };
+      child.stdin = { end: vi.fn(), on: vi.fn() };
       child.exitCode = 0;
       Promise.resolve().then(() => child.emit('exit', 0));
       return child;
@@ -225,7 +284,7 @@ describe('revvaultSet', () => {
       capturedArgs = [bin, ...args];
       const EventEmitter = require('node:events').EventEmitter;
       const child = new EventEmitter();
-      child.stdin = { end: vi.fn() };
+      child.stdin = { end: vi.fn(), on: vi.fn() };
       child.exitCode = 0;
       Promise.resolve().then(() => child.emit('exit', 0));
       return child;

--- a/packages/daemon/src/revvault-client.ts
+++ b/packages/daemon/src/revvault-client.ts
@@ -1,5 +1,4 @@
 import { execFile as execFileCb } from 'node:child_process';
-import { once } from 'node:events';
 import { promisify } from 'node:util';
 
 const execFile = promisify(execFileCb);
@@ -72,32 +71,67 @@ export async function revvaultGet(
   }
 }
 
-export async function revvaultSet(
+export function revvaultSet(
   path: string,
   value: string,
   options?: RevvaultClientOptions,
 ): Promise<RevvaultSetUnion> {
   const binary = options?.binary ?? 'revvault';
   const timeout = options?.timeout ?? 5000;
-  try {
-    // --force: revvault set without --force fails on existing paths. Identity
-    // rotation re-writes the same paths, so without --force the vault retains
-    // the OLD private key while the DB has the NEW DID — signing would fail
-    // verification. Same pattern as scripts/issue-license.ts.
-    const child = execFileCb(binary, ['--json', 'set', '--force', path], { timeout });
-    child.stdin?.end(value);
-    await once(child, 'exit');
-    const code = child.exitCode;
-    if (code !== 0) {
-      return { ok: false, reason: 'cli-failure' } as const;
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: RevvaultSetUnion): void => {
+      if (!settled) {
+        settled = true;
+        resolve(result);
+      }
+    };
+
+    // execFileCb may throw synchronously on bad arguments (rare); guard
+    // explicitly so the daemon never receives an uncaught throw from this
+    // helper. The common ENOENT path (missing binary on PATH) is async —
+    // see the child.on('error', ...) listener below.
+    // --force: revvault set without --force fails on existing paths.
+    // Identity rotation re-writes the same paths; without --force the vault
+    // retains the OLD private key while the DB has the NEW DID — signing
+    // would fail verification. Same pattern as scripts/issue-license.ts.
+    let child: ReturnType<typeof execFileCb>;
+    try {
+      child = execFileCb(binary, ['--json', 'set', '--force', path], { timeout });
+    } catch (err: unknown) {
+      finish({ ok: false, reason: isEnoent(err) ? 'cli-not-installed' : 'cli-failure' });
+      return;
     }
-    return { ok: true } as const;
-  } catch (err: unknown) {
-    if (isEnoent(err)) {
-      return { ok: false, reason: 'cli-not-installed' } as const;
+
+    // Async 'error' event covers the real-world ENOENT path: execFileCb
+    // returns a child synchronously, then libuv reports the spawn failure
+    // (e.g. binary not on PATH) on the next tick via 'error'. Without this
+    // listener Node's default unhandled-error behavior crashes the daemon.
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      finish({ ok: false, reason: err.code === 'ENOENT' ? 'cli-not-installed' : 'cli-failure' });
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        finish({ ok: true });
+      } else {
+        finish({ ok: false, reason: 'cli-failure' });
+      }
+    });
+
+    // stdin can emit its own 'error' when the child died before accepting
+    // input (broken pipe). Swallow it here so the daemon doesn't crash;
+    // the child's 'error' or 'exit' listener above produces the actual
+    // result.
+    child.stdin?.on('error', () => {});
+
+    try {
+      child.stdin?.end(value);
+    } catch {
+      // Synchronous throw on .end() can happen if the pipe is already
+      // closed; the result is reported via child's 'error' / 'exit'.
     }
-    return { ok: false, reason: 'cli-failure' } as const;
-  }
+  });
 }
 
 export async function isRevvaultAvailable(options?: RevvaultClientOptions): Promise<boolean> {


### PR DESCRIPTION
## Summary

Addresses Codex P1 finding on PR [#63](https://github.com/RevealUIStudio/revdev/pull/63) at `packages/daemon/src/revvault-client.ts:87` — missing `revvault` CLI surfaced an async `error` event that crashed the daemon instead of returning the documented `{ ok: false, reason: 'cli-not-installed' }`.

## Root cause

`execFileCb()` does NOT throw synchronously when the binary is missing from `PATH` — libuv reports the spawn failure asynchronously via an `'error'` event on the next tick. The previous code only registered a listener for `'exit'`:

```typescript
const child = execFileCb(...);
child.stdin?.end(value);
await once(child, 'exit');   // never fires; daemon crashes on unhandled 'error'
```

Without a `'error'` listener, Node's default unhandled-error behavior terminates the process. This affected fresh installs and CI environments where revvault is optional.

## Why the existing test missed it

The mock for `cli-not-installed` was a **synchronous throw** from `execFile`:

```typescript
execFileMock.mockImplementation(() => {
  const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
  throw err;
});
```

That doesn't model real Node behavior — `execFileCb` returns the child synchronously and emits the error asynchronously. The test passed because the code's `try/catch` caught the synthetic throw; production would never have hit that path.

## Fix

Rewrote `revvaultSet` with explicit `child.on('error')` + `child.on('exit')` listeners wrapped in a Promise (single `finish()` guarded by `settled` flag). Added `child.stdin?.on('error')` for broken-pipe defensiveness. Preserved the synchronous-throw catch for rare-edge-case platforms.

## Tests

| Test | What it proves |
|---|---|
| `returns ok:false reason:cli-not-installed on async ENOENT error event` (NEW behavior) | Mock now emits `child.emit('error', {code: 'ENOENT'})` async; verifies the real production path |
| `returns ok:false reason:cli-not-installed on synchronous ENOENT throw (rare edge case)` (preserved) | Coverage for platforms that may throw sync |
| `does not leak unhandled error events from child or stdin` (NEW) | Registers a `process.on('uncaughtException')` handler before invocation; asserts the array stays empty after both child + stdin emit errors |

**15/15 revvault-client tests pass.** All 4 packages typecheck Done. Zero behavior change for the success path. Zero new deps.

## Out of scope

- `isRevvaultAvailable` uses promisified `execFile` (callback-style) which auto-converts both `'exit'` and `'error'` into the promise lifecycle — already safe. Audited; no change needed.
- `revvaultGet` uses promisified `execFile` and `await execFile(...)` — also safe.

## Verification

- `pnpm exec biome check packages/daemon/src/revvault-client.ts packages/daemon/src/__tests__/revvault-client.test.ts` — 0 errors
- `pnpm --filter @revdev/daemon exec vitest run src/__tests__/revvault-client.test.ts` — 15/15 pass
- `pnpm typecheck` — protocol + theme + daemon + bridge all Done

## Unblocks

PR [#63](https://github.com/RevealUIStudio/revdev/pull/63) — Codex review thread `PRRT_kwDOR_9Rqs6Ck-5-` resolved on merge. Once #63's CodeQL umbrella also clears (alert #4 dismissed via Security tab earlier today), the test→main promotion can proceed.
