### PR TITLE
promote: test → main (revvault async-error fix from #65)

### DIFF
--- a/packages/daemon/src/__tests__/revvault-client.test.ts
+++ b/packages/daemon/src/__tests__/revvault-client.test.ts
@@ -168,7 +168,7 @@ describe('revvaultSet', () => {
       capturedArgs = [bin, ...args];
       const EventEmitter = require('node:events').EventEmitter;
       const child = new EventEmitter();
-      child.stdin = { end: vi.fn() };
+      child.stdin = { end: vi.fn(), on: vi.fn() };
       child.exitCode = 0;
       Promise.resolve().then(() => child.emit('exit', 0));
       return child;
@@ -177,7 +177,30 @@ describe('revvaultSet', () => {
     expect(result).toEqual({ ok: true });
   });
 
-  it('returns ok:false reason:cli-not-installed on ENOENT', async () => {
+  it('returns ok:false reason:cli-not-installed on async ENOENT error event (does not crash daemon)', async () => {
+    // Real-world execFileCb does NOT throw synchronously on ENOENT — it
+    // returns a child that emits an async 'error' event. Mocking that
+    // real behavior. Previous mock (synchronous throw only) hid Codex P1
+    // finding: an unhandled 'error' from a missing CLI would crash the
+    // daemon in production.
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation(() => {
+      const EventEmitter = require('node:events').EventEmitter;
+      const child = new EventEmitter();
+      child.stdin = { end: vi.fn(), on: vi.fn() };
+      Promise.resolve().then(() => {
+        const err = Object.assign(new Error('spawn revvault ENOENT'), { code: 'ENOENT' });
+        child.emit('error', err);
+      });
+      return child;
+    });
+    const result = await revvaultSet('some/path', 'value');
+    expect(result).toEqual({ ok: false, reason: 'cli-not-installed' });
+  });
+
+  it('returns ok:false reason:cli-not-installed on synchronous ENOENT throw (rare edge case)', async () => {
+    // Some platforms / Node versions may throw synchronously on bad spawn
+    // arguments. Coverage preserved for the synchronous path.
     const execFileMock = childProcess.execFile as unknown as Mock;
     execFileMock.mockImplementation(() => {
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
@@ -187,12 +210,48 @@ describe('revvaultSet', () => {
     expect(result).toEqual({ ok: false, reason: 'cli-not-installed' });
   });
 
+  it('does not leak unhandled error events from child or stdin', async () => {
+    // Regression for Codex P1: missing revvault used to surface an
+    // unhandled 'error' event that crashed the daemon. With explicit
+    // child.on('error') + child.stdin.on('error') listeners, the daemon
+    // gets a clean RevvaultSetFailResult and process.on('uncaughtException')
+    // is never reached.
+    const uncaught: Error[] = [];
+    const handler = (err: Error) => uncaught.push(err);
+    process.on('uncaughtException', handler);
+
+    const execFileMock = childProcess.execFile as unknown as Mock;
+    execFileMock.mockImplementation(() => {
+      const EventEmitter = require('node:events').EventEmitter;
+      const child = new EventEmitter();
+      const stdin = new EventEmitter();
+      (stdin as unknown as { end: () => void }).end = () => {
+        // Broken pipe: stdin emits its own error after end()
+        Promise.resolve().then(() => stdin.emit('error', new Error('EPIPE')));
+      };
+      child.stdin = stdin;
+      Promise.resolve().then(() => {
+        const err = Object.assign(new Error('spawn revvault ENOENT'), { code: 'ENOENT' });
+        child.emit('error', err);
+      });
+      return child;
+    });
+
+    const result = await revvaultSet('some/path', 'value');
+    // Drain deferred microtasks before asserting no leaks.
+    await new Promise((r) => setImmediate(r));
+    process.off('uncaughtException', handler);
+
+    expect(result).toEqual({ ok: false, reason: 'cli-not-installed' });
+    expect(uncaught).toEqual([]);
+  });
+
   it('returns ok:false reason:cli-failure on non-zero exit', async () => {
     const execFileMock = childProcess.execFile as unknown as Mock;
     execFileMock.mockImplementation(() => {
       const EventEmitter = require('node:events').EventEmitter;
       const child = new EventEmitter();
-      child.stdin = { end: vi.fn() };
+      child.stdin = { end: vi.fn(), on: vi.fn() };
       child.exitCode = 1;
       Promise.resolve().then(() => child.emit('exit', 1));
       return child;
@@ -207,7 +266,7 @@ describe('revvaultSet', () => {
       capturedArgs = [bin, ...args];
       const EventEmitter = require('node:events').EventEmitter;
       const child = new EventEmitter();
-      child.stdin = { end: vi.fn() };
+      child.stdin = { end: vi.fn(), on: vi.fn() };
       child.exitCode = 0;
       Promise.resolve().then(() => child.emit('exit', 0));
       return child;
@@ -225,7 +284,7 @@ describe('revvaultSet', () => {
       capturedArgs = [bin, ...args];
       const EventEmitter = require('node:events').EventEmitter;
       const child = new EventEmitter();
-      child.stdin = { end: vi.fn() };
+      child.stdin = { end: vi.fn(), on: vi.fn() };
       child.exitCode = 0;
       Promise.resolve().then(() => child.emit('exit', 0));
       return child;

--- a/packages/daemon/src/revvault-client.ts
+++ b/packages/daemon/src/revvault-client.ts
@@ -1,5 +1,4 @@
 import { execFile as execFileCb } from 'node:child_process';
-import { once } from 'node:events';
 import { promisify } from 'node:util';
 
 const execFile = promisify(execFileCb);
@@ -72,32 +71,67 @@ export async function revvaultGet(
   }
 }
 
-export async function revvaultSet(
+export function revvaultSet(
   path: string,
   value: string,
   options?: RevvaultClientOptions,
 ): Promise<RevvaultSetUnion> {
   const binary = options?.binary ?? 'revvault';
   const timeout = options?.timeout ?? 5000;
-  try {
-    // --force: revvault set without --force fails on existing paths. Identity
-    // rotation re-writes the same paths, so without --force the vault retains
-    // the OLD private key while the DB has the NEW DID — signing would fail
-    // verification. Same pattern as scripts/issue-license.ts.
-    const child = execFileCb(binary, ['--json', 'set', '--force', path], { timeout });
-    child.stdin?.end(value);
-    await once(child, 'exit');
-    const code = child.exitCode;
-    if (code !== 0) {
-      return { ok: false, reason: 'cli-failure' } as const;
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: RevvaultSetUnion): void => {
+      if (!settled) {
+        settled = true;
+        resolve(result);
+      }
+    };
+
+    // execFileCb may throw synchronously on bad arguments (rare); guard
+    // explicitly so the daemon never receives an uncaught throw from this
+    // helper. The common ENOENT path (missing binary on PATH) is async —
+    // see the child.on('error', ...) listener below.
+    // --force: revvault set without --force fails on existing paths.
+    // Identity rotation re-writes the same paths; without --force the vault
+    // retains the OLD private key while the DB has the NEW DID — signing
+    // would fail verification. Same pattern as scripts/issue-license.ts.
+    let child: ReturnType<typeof execFileCb>;
+    try {
+      child = execFileCb(binary, ['--json', 'set', '--force', path], { timeout });
+    } catch (err: unknown) {
+      finish({ ok: false, reason: isEnoent(err) ? 'cli-not-installed' : 'cli-failure' });
+      return;
     }
-    return { ok: true } as const;
-  } catch (err: unknown) {
-    if (isEnoent(err)) {
-      return { ok: false, reason: 'cli-not-installed' } as const;
+
+    // Async 'error' event covers the real-world ENOENT path: execFileCb
+    // returns a child synchronously, then libuv reports the spawn failure
+    // (e.g. binary not on PATH) on the next tick via 'error'. Without this
+    // listener Node's default unhandled-error behavior crashes the daemon.
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      finish({ ok: false, reason: err.code === 'ENOENT' ? 'cli-not-installed' : 'cli-failure' });
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        finish({ ok: true });
+      } else {
+        finish({ ok: false, reason: 'cli-failure' });
+      }
+    });
+
+    // stdin can emit its own 'error' when the child died before accepting
+    // input (broken pipe). Swallow it here so the daemon doesn't crash;
+    // the child's 'error' or 'exit' listener above produces the actual
+    // result.
+    child.stdin?.on('error', () => {});
+
+    try {
+      child.stdin?.end(value);
+    } catch {
+      // Synchronous throw on .end() can happen if the pipe is already
+      // closed; the result is reported via child's 'error' / 'exit'.
     }
-    return { ok: false, reason: 'cli-failure' } as const;
-  }
+  });
 }
 
 export async function isRevvaultAvailable(options?: RevvaultClientOptions): Promise<boolean> {


### PR DESCRIPTION
## Summary

Follow-up `test → main` promotion. Ships [#65](https://github.com/RevealUIStudio/revdev/pull/65) (`fix(daemon): handle async child-process error from revvault CLI` — Codex P1) to production.

Why a separate promotion: #65 merged to test at `2026-05-16T18:34:42Z` — five minutes AFTER PR [#63](https://github.com/RevealUIStudio/revdev/pull/63) promoted at `2026-05-16T18:29:36Z`. So #65 didn't make the earlier promotion window. Closing the daemon-crash window in production for missing-revvault now.

## What's in this promotion

| Commit | PR | Scope |
|---|---|---|
| `a607f69` | [#65](https://github.com/RevealUIStudio/revdev/pull/65) | Rewrites `revvaultSet` with explicit `child.on('error')` + `child.on('exit')` listeners. Previous code only listened for `'exit'`; real-world `execFileCb` emits async `'error'` on ENOENT, which the daemon's default unhandled-error behavior would convert into a crash. Adds `child.stdin?.on('error')` guard + regression test asserting `process.on('uncaughtException')` stays empty. Updates existing ENOENT test to mock the real async behavior (was incorrectly mocking sync throw). |

## Verification

- 15/15 `revvault-client.test.ts` tests pass after #65 merge to test
- All 12 required CI checks were green on #65 before merge
- Zero behavior change on the success path; only failure handling improved

## Merge strategy

**Merge commit** (NOT squash) per the existing `test → main` pattern (see PRs #56, #40, #13 — all merged via `Merge pull request #N from RevealUIStudio/test`). Squash would strip the constituent PR's history from main's first-parent walk.

## Out of scope

- The test branch has nothing else ahead of main (`git log origin/main..origin/test` returns only the #65 commit). This is a single-commit promotion.
