### PR TITLE
feat(studio): Phase 1 dogfood — consume @revealui/presentation tokens

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -16,6 +16,7 @@
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.41.0",
     "@revealui/contracts": "^1.3.6",
+    "@revealui/presentation": "^0.6.0",
     "@solana/kit": "^6.7.0",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.7.0",

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "@revealui/presentation/tokens.css";
 
 /* ── CodeMirror MergeView layout ──────────────────────────────────────────── */
 /* Make MergeView fill the parent container height. Each side scrolls          */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@revealui/contracts':
         specifier: ^1.3.6
         version: 1.3.6(typescript@6.0.2)
+      '@revealui/presentation':
+        specifier: ^0.6.0
+        version: 0.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@solana/kit':
         specifier: ^6.7.0
         version: 6.8.0(typescript@6.0.2)
@@ -1062,6 +1065,13 @@ packages:
 
   '@revealui/core@0.6.0':
     resolution: {integrity: sha512-rE1HToRpFCzme7TOaLX8zNFJGjYVecip9YtW4u4YQpC6GOddlf3ezcv+WWIMFmvHpm7AyzpokaTXf0gAYixK9Q==}
+    engines: {node: '>=24.13.0'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@revealui/presentation@0.6.0':
+    resolution: {integrity: sha512-ju9jw4KQpaWYlX+fmxbyetoksg7uvXSHPnpRuvlSVvbeGaKXqglFD4bvl4YGY3MM2v19NcyDezaS7Exn4n8JJA==}
     engines: {node: '>=24.13.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -2901,6 +2911,9 @@ packages:
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
@@ -3992,6 +4005,12 @@ snapshots:
       - next
       - pg-native
       - typescript
+
+  '@revealui/presentation@0.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tailwind-merge: 3.6.0
 
   '@revealui/resilience@0.2.4': {}
 
@@ -5750,6 +5769,8 @@ snapshots:
   symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
+
+  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.2.2: {}
 


### PR DESCRIPTION
## Summary

Studio dogfood Phase 1 — wire `@revealui/presentation@^0.6.0` into Studio's webview and import its tokens. Per the fleet brand emerald convergence ADR (2026-05-16), Studio adopts emerald by consuming the presentation tokens directly with no override block.

## Changes (3 files)

- **`apps/studio/package.json`** — add `"@revealui/presentation": "^0.6.0"` to dependencies
- **`apps/studio/src/styles.css`** — add `@import "@revealui/presentation/tokens.css";` after the Tailwind import
- **`pnpm-lock.yaml`** — synced via `pnpm install`

That's it. Phase 1 intentionally swaps **no components yet** — just makes the tokens available. Studio's existing `bg-orange-*` Tailwind utilities still render orange (Tailwind utility wins over CSS-var defaults). Phases 2-3 do the actual orange → emerald swap by replacing primitives + sweeping utility callsites.

## Why this PR is small

Per the Studio dogfood audit (senior-architect dispatch 2026-05-16):
- **No override block needed** — owner chose Option B (fleet emerald alignment) over Option A (keep orange + override), so we consume presentation's defaults directly
- **No Webview2/WebKit compat blockers** — presentation's CSS surface (oklch, no container queries, no `:has()`, no `color-mix()`) is well-supported in all Tauri webview targets
- **No Tauri build pipeline changes** — `build-windows.ps1` already does `pnpm install --frozen-lockfile` post-reset, picks up the new dep automatically
- **Bundle impact** — presentation adds ~30-60 KB gzipped to Studio's webview bundle; the Tauri installer increase is <2 MB out of ~10 MB baseline (acceptable for desktop distribution)

## Test plan

- [ ] CI quality gate passes (studio is excluded from workspace typecheck per `ci.yml` — runs in `studio-release.yml`)
- [ ] After merge, CI Tauri build artifact builds successfully (smoke-test the Windows installer launches)
- [ ] Visual smoke test: Studio UI looks byte-identical to pre-PR state (Phase 1 doesn't touch any components yet)

## Why this matters

Closes a fleet-hardline violation (`feedback_dogfood_revealui_for_migrations`) and the fourth pillar (`feedback_focus_pivot_4_pillars` — "RevDev dogfoodable"). Selling RevDev Studio at the Stripe-live flip moment with Studio not consuming the design system was a brand-coherence break customers would see at purchase. Phase 1 wires the tokens; Phases 2-4 swap components and complete the brand convergence to emerald.

## Out of scope (next phases)

- **Phase 2** (8-10 hours): swap Studio's 10 local UI primitives in `apps/studio/src/components/ui/` with presentation equivalents via shim layer preserving Studio's component APIs
- **Phase 3** (8-12 hours, multiple sub-PRs per panel): sweep the 93 raw `<button>` and 17 raw `<input>` callsites + 64 `orange-*` Tailwind utilities across `components/`
- **Phase 4** (3-4 hours): promote useful Studio patterns (StatusDot, PanelHeader) into `@revealui/presentation`; delete or wire orphan `@revdev/theme` package

## Related

- ADR: fleet brand emerald convergence (in internal coordination repo)
- [revealui#890](https://github.com/RevealUIStudio/revealui/pull/890) — presentation 0.6.0 with tailwind-merge (the prereq that made Studio's brand override path deterministic; merged via train this session)
- [revealui#897](https://github.com/RevealUIStudio/revealui/pull/897) — version-packages PR that published 0.6.0 to npm
