### PR TITLE
promote: test → main (Studio Phase 1 dogfood — @revealui/presentation@0.6.0)

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -16,6 +16,7 @@
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.41.0",
     "@revealui/contracts": "^1.3.6",
+    "@revealui/presentation": "^0.6.0",
     "@solana/kit": "^6.7.0",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.7.0",

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "@revealui/presentation/tokens.css";
 
 /* ── CodeMirror MergeView layout ──────────────────────────────────────────── */
 /* Make MergeView fill the parent container height. Each side scrolls          */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@revealui/contracts':
         specifier: ^1.3.6
         version: 1.3.6(typescript@6.0.2)
+      '@revealui/presentation':
+        specifier: ^0.6.0
+        version: 0.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@solana/kit':
         specifier: ^6.7.0
         version: 6.8.0(typescript@6.0.2)
@@ -1062,6 +1065,13 @@ packages:
 
   '@revealui/core@0.6.0':
     resolution: {integrity: sha512-rE1HToRpFCzme7TOaLX8zNFJGjYVecip9YtW4u4YQpC6GOddlf3ezcv+WWIMFmvHpm7AyzpokaTXf0gAYixK9Q==}
+    engines: {node: '>=24.13.0'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@revealui/presentation@0.6.0':
+    resolution: {integrity: sha512-ju9jw4KQpaWYlX+fmxbyetoksg7uvXSHPnpRuvlSVvbeGaKXqglFD4bvl4YGY3MM2v19NcyDezaS7Exn4n8JJA==}
     engines: {node: '>=24.13.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -2901,6 +2911,9 @@ packages:
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
@@ -3992,6 +4005,12 @@ snapshots:
       - next
       - pg-native
       - typescript
+
+  '@revealui/presentation@0.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tailwind-merge: 3.6.0
 
   '@revealui/resilience@0.2.4': {}
 
@@ -5750,6 +5769,8 @@ snapshots:
   symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
+
+  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.2.2: {}
 


### PR DESCRIPTION
## Summary

Promote `test → main` to ship Studio Phase 1 (emerald brand dogfood) to production. One PR in this batch: [#67](https://github.com/RevealUIStudio/revdev/pull/67) (`feat(studio): Phase 1 dogfood — consume @revealui/presentation tokens`).

This closes the chain that started with revealui#891 → @revealui/presentation@0.6.0 publish → Studio's first dogfood of the canonical fleet brand tokens.

## What's in this promotion

| Commit | PR | Scope |
|---|---|---|
| `8c59504` | [#67](https://github.com/RevealUIStudio/revdev/pull/67) | `apps/studio/package.json` gains `@revealui/presentation: ^0.6.0` dependency. `apps/studio/src/styles.css` line 2 gets `@import "@revealui/presentation/tokens.css";` (immediately after `@import "tailwindcss";` so token CSS vars are in scope but utility classes still cascade as expected). No override block — emerald defaults match the fleet brand-convergence ADR. |

## Per the brand-convergence ADR

ADR `2026-05-16-fleet-brand-emerald-convergence` (in an internal repo) Phase 0 was prereq (PR revealui#890 + presentation@0.6.0 publish, both done). This is Phase 1 ship. Phases 2–4 remain ahead (component swap + sweep of 64 raw `orange-*` callsites + promote Studio patterns back into presentation).

**Phase 1 has zero visible brand change** — raw Tailwind utility classes still win over CSS-var defaults. Phase 1's value is establishing the dep + token surface so Phase 2/3 can consume them.

## Merge strategy

**Merge commit** (NOT squash) per the `test → main` convention (see PRs #63, #66 today, #56 prior). Preserves the constituent PR history on main's first-parent walk.

## Verification

- Test branch CI was green when #67 merged
- `git log origin/main..origin/test` shows exactly 2 commits: the #67 merge + its feat commit
- npm latest of `@revealui/presentation` confirmed at `0.6.0`
- No open revdev PRs (clean slate after this promo)

## Out of scope

- Phase 2 (component primitive swap — 8-10h)
- Phase 3 (orange-utility sweep — 8-12h, multiple sub-PRs)
- Phase 4 (promote Studio patterns to presentation — 3-4h)
- Marketing/docs/agency cross-brand audit
