### PR TITLE
fix(daemon): verify iss/aud/nbf claims and add jti revocation hook

### DIFF
--- a/packages/daemon/src/__tests__/flows.test.ts
+++ b/packages/daemon/src/__tests__/flows.test.ts
@@ -188,10 +188,16 @@ describe('verifyLicenseJWT — negative cases', () => {
 
     const now = Math.floor(Date.now() / 1000);
     const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
-    // No exp claim
-    const payloadB64 = Buffer.from(JSON.stringify({ tier: 'enterprise', iat: now })).toString(
-      'base64url',
-    );
+    // No exp claim (perpetual). Include required iss/aud/jti to match issuer output.
+    const payloadB64 = Buffer.from(
+      JSON.stringify({
+        tier: 'enterprise',
+        iat: now,
+        iss: 'https://revealui.com',
+        aud: 'revealui-license',
+        jti: 'test-perpetual-fixture',
+      }),
+    ).toString('base64url');
     const message = `${header}.${payloadB64}`;
     const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');
 

--- a/packages/daemon/src/__tests__/license-crypto.test.ts
+++ b/packages/daemon/src/__tests__/license-crypto.test.ts
@@ -1,0 +1,117 @@
+import { generateKeyPairSync, sign } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isRevokedJti, verifyLicenseJWT } from '../license-crypto.js';
+
+function makeToken(
+  payload: Record<string, unknown>,
+  privateKey: string,
+  header: Record<string, unknown> = { alg: 'EdDSA', typ: 'JWT' },
+): string {
+  const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const message = `${headerB64}.${payloadB64}`;
+  const signatureB64 = sign(null, Buffer.from(message, 'utf-8'), privateKey).toString('base64url');
+  return `${headerB64}.${payloadB64}.${signatureB64}`;
+}
+
+const { privateKey, publicKey } = generateKeyPairSync('ed25519', {
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const NOW_S = Math.floor(Date.now() / 1000);
+
+const VALID_PAYLOAD: Record<string, unknown> = {
+  tier: 'pro',
+  iss: 'https://revealui.com',
+  aud: 'revealui-license',
+  jti: 'test-jti-0000',
+  nbf: NOW_S - 10,
+  iat: NOW_S - 10,
+};
+
+beforeEach(() => {
+  process.env.REVDEV_LICENSE_PUBLIC_KEY = publicKey;
+});
+
+afterEach(() => {
+  delete process.env.REVDEV_LICENSE_PUBLIC_KEY;
+  vi.restoreAllMocks();
+});
+
+describe('verifyLicenseJWT — valid token', () => {
+  it('accepts a fully-formed valid token', () => {
+    const token = makeToken(VALID_PAYLOAD, privateKey);
+    const result = verifyLicenseJWT(token, publicKey);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.tier).toBe('pro');
+    }
+  });
+});
+
+describe('verifyLicenseJWT — iss check', () => {
+  it('rejects token with wrong iss', () => {
+    const token = makeToken({ ...VALID_PAYLOAD, iss: 'https://evil.com' }, privateKey);
+    const result = verifyLicenseJWT(token, publicKey);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toContain('invalid iss');
+    }
+  });
+
+  it('rejects token with missing iss', () => {
+    const { iss: _iss, ...rest } = VALID_PAYLOAD;
+    const token = makeToken(rest, privateKey);
+    const result = verifyLicenseJWT(token, publicKey);
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('verifyLicenseJWT — aud check', () => {
+  it('rejects token with wrong aud', () => {
+    const token = makeToken({ ...VALID_PAYLOAD, aud: 'other-service' }, privateKey);
+    const result = verifyLicenseJWT(token, publicKey);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toContain('invalid aud');
+    }
+  });
+});
+
+describe('verifyLicenseJWT — nbf check', () => {
+  it('rejects token with nbf in the future', () => {
+    const futureNbf = NOW_S + 3600;
+    const token = makeToken({ ...VALID_PAYLOAD, nbf: futureNbf }, privateKey);
+    const result = verifyLicenseJWT(token, publicKey);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toContain('nbf');
+    }
+  });
+
+  it('accepts token whose nbf is in the past', () => {
+    const token = makeToken({ ...VALID_PAYLOAD, nbf: NOW_S - 60 }, privateKey);
+    const result = verifyLicenseJWT(token, publicKey);
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts token with no nbf claim (backwards compat)', () => {
+    const { nbf: _nbf, ...rest } = VALID_PAYLOAD;
+    const token = makeToken(rest, privateKey);
+    const result = verifyLicenseJWT(token, publicKey);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('verifyLicenseJWT — jti revocation hook', () => {
+  it('stub always returns false (hook is unwired)', () => {
+    expect(isRevokedJti('any-jti')).toBe(false);
+  });
+
+  it('accepts token when jti is not revoked', () => {
+    const token = makeToken({ ...VALID_PAYLOAD, jti: 'clean-jti-1234' }, privateKey);
+    const result = verifyLicenseJWT(token, publicKey);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/daemon/src/license-crypto.ts
+++ b/packages/daemon/src/license-crypto.ts
@@ -43,6 +43,14 @@ export function getVendorPublicKey(): string {
 
 const VALID_TIERS = new Set(['pro', 'max', 'enterprise']);
 
+const EXPECTED_ISS = 'https://revealui.com';
+const EXPECTED_AUD = 'revealui-license';
+
+// hook for future revocation channel
+export function isRevokedJti(_jti: string): boolean {
+  return false;
+}
+
 export interface LicenseJWTResult {
   tier: 'pro' | 'max' | 'enterprise';
   expiresAt: number; // unix seconds, 0 = perpetual
@@ -137,6 +145,36 @@ export function verifyLicenseJWT(
 
     if (!isValid) {
       return { tier: 'free', valid: false, reason: 'invalid signature' };
+    }
+
+    // Validate iss
+    if (payload.iss !== EXPECTED_ISS) {
+      return { tier: 'free', valid: false, reason: `invalid iss: ${String(payload.iss)}` };
+    }
+
+    // Validate aud (jose sets aud as an array or scalar; issuer uses scalar)
+    const aud = payload.aud;
+    const audValue = Array.isArray(aud) ? aud[0] : aud;
+    if (audValue !== EXPECTED_AUD) {
+      return { tier: 'free', valid: false, reason: `invalid aud: ${String(aud)}` };
+    }
+
+    // Validate nbf if present
+    const nbf = payload.nbf;
+    if (nbf !== undefined) {
+      if (typeof nbf !== 'number') {
+        return { tier: 'free', valid: false, reason: 'invalid nbf claim' };
+      }
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      if (nowSeconds < nbf) {
+        return { tier: 'free', valid: false, reason: 'token not yet valid (nbf)' };
+      }
+    }
+
+    // Check jti revocation
+    const jti = payload.jti;
+    if (typeof jti === 'string' && isRevokedJti(jti)) {
+      return { tier: 'free', valid: false, reason: 'token has been revoked' };
     }
 
     // expiresAt: 0 = perpetual (mirrors dotted-v2 semantics)


### PR DESCRIPTION
## Summary

- The daemon's `verifyLicenseJWT` verified `alg`, `tier`, `exp`, and signature but ignored `iss`, `aud`, `nbf`, and `jti` — wrong-audience tokens passed, and per-token revocation was structurally impossible.
- This adds the missing claim checks and exports a `isRevokedJti` stub as the revocation hook point.

## Changes

- `packages/daemon/src/license-crypto.ts` — add `EXPECTED_ISS` / `EXPECTED_AUD` constants; reject on mismatch; check `nbf` when present (absence is OK for backwards compat); call `isRevokedJti(jti)` before returning success; export the stub.
- `packages/daemon/src/__tests__/license-crypto.test.ts` — new test file: 9 tests covering the valid path, wrong `iss`, wrong `aud`, future `nbf`, past `nbf`, absent `nbf`, and `isRevokedJti` stub contract.
- `packages/daemon/src/__tests__/flows.test.ts` — update the hand-rolled perpetual-JWT fixture to include `iss`/`aud`/`jti` (matching issuer output); the old fixture omitted them and now correctly fails the new checks.

## Test plan

- [x] `pnpm --filter @revdev/daemon exec vitest run src/__tests__/license-crypto.test.ts` — 9/9 pass
- [x] `pnpm --filter @revdev/daemon exec vitest run src/__tests__/flows.test.ts` — 20/20 pass
- [x] `pnpm --filter @revdev/daemon build` — clean
- [x] Biome format — no changes applied

Audit reference: internal lane (2026-05-16 schemas + validation fleet audit, §P0-1)
