### PR TITLE
feat(studio): Phase 2 PR-1 — shim PanelHeader + StatusDot via presentation

### DIFF
--- a/apps/studio/src/__tests__/components/StatusDot.test.tsx
+++ b/apps/studio/src/__tests__/components/StatusDot.test.tsx
@@ -8,24 +8,24 @@ describe('StatusDot', () => {
     expect(container.querySelector('span')).not.toBeNull();
   });
 
-  it('applies green color for ok status', () => {
+  it('applies --rvui-success token for ok status', () => {
     const { container } = render(<StatusDot status="ok" />);
-    expect(container.querySelector('span')?.className).toContain('bg-green-500');
+    expect(container.querySelector('span')?.className).toContain('bg-[var(--rvui-success)]');
   });
 
-  it('applies yellow color for warn status', () => {
+  it('applies --rvui-warning token for warn status', () => {
     const { container } = render(<StatusDot status="warn" />);
-    expect(container.querySelector('span')?.className).toContain('bg-yellow-500');
+    expect(container.querySelector('span')?.className).toContain('bg-[var(--rvui-warning)]');
   });
 
-  it('applies red color for error status', () => {
+  it('applies --rvui-error token for error status', () => {
     const { container } = render(<StatusDot status="error" />);
-    expect(container.querySelector('span')?.className).toContain('bg-red-500');
+    expect(container.querySelector('span')?.className).toContain('bg-[var(--rvui-error)]');
   });
 
-  it('applies neutral color for off status', () => {
+  it('applies --rvui-text-2 token for off status', () => {
     const { container } = render(<StatusDot status="off" />);
-    expect(container.querySelector('span')?.className).toContain('bg-neutral-600');
+    expect(container.querySelector('span')?.className).toContain('bg-[var(--rvui-text-2)]');
   });
 
   it('defaults to sm size', () => {

--- a/apps/studio/src/components/ui/PanelHeader.tsx
+++ b/apps/studio/src/components/ui/PanelHeader.tsx
@@ -1,3 +1,4 @@
+import { Heading } from '@revealui/presentation';
 import type { ReactNode } from 'react';
 
 interface PanelHeaderProps {
@@ -5,10 +6,22 @@ interface PanelHeaderProps {
   action?: ReactNode;
 }
 
+/**
+ * Studio panel header — title + optional right-aligned action slot.
+ *
+ * Phase 2 PR-1 (2026-05-16): shimmed to render `@revealui/presentation`'s
+ * `Heading` for the title element. Consumer API (default export, `title`,
+ * `action`) unchanged. Heading defaults to `level={1}` so the rendered
+ * element is still `<h1>` — existing tests asserting role=heading level=1
+ * continue to pass.
+ *
+ * See `~/revfleet/.jv/docs/lanes/studio-dogfood/plan.md` and ADR
+ * `2026-05-16-fleet-revealui-native-compliance.md`.
+ */
 export default function PanelHeader({ title, action }: PanelHeaderProps) {
   return (
     <div className="flex items-center justify-between">
-      <h1 className="text-xl font-semibold">{title}</h1>
+      <Heading level={1}>{title}</Heading>
       {action}
     </div>
   );

--- a/apps/studio/src/components/ui/PanelHeader.tsx
+++ b/apps/studio/src/components/ui/PanelHeader.tsx
@@ -15,8 +15,9 @@ interface PanelHeaderProps {
  * element is still `<h1>` — existing tests asserting role=heading level=1
  * continue to pass.
  *
- * See `~/revfleet/.jv/docs/lanes/studio-dogfood/plan.md` and ADR
- * `2026-05-16-fleet-revealui-native-compliance.md`.
+ * Sequencing tracked in the internal Studio dogfood lane plan;
+ * design rule codified in the internal fleet RevealUI-native
+ * compliance ADR.
  */
 export default function PanelHeader({ title, action }: PanelHeaderProps) {
   return (

--- a/apps/studio/src/components/ui/StatusDot.tsx
+++ b/apps/studio/src/components/ui/StatusDot.tsx
@@ -9,12 +9,12 @@
  *
  * StatusDot itself has no `@revealui/presentation` equivalent yet
  * (presentation has `Badge` for text content, but no pure decorative dot
- * primitive). It is named as a promotion candidate in Phase 5 of the
- * studio-dogfood lane plan. For Phase 2 PR-1, the dot is token-backed but
- * still lives in Studio.
+ * primitive). It is named as a future promotion candidate. For Phase 2
+ * PR-1, the dot is token-backed but still lives in Studio.
  *
- * See `~/revfleet/.jv/docs/lanes/studio-dogfood/plan.md` and ADR
- * `2026-05-16-fleet-revealui-native-compliance.md`.
+ * Sequencing tracked in the internal Studio dogfood lane plan;
+ * design rule codified in the internal fleet RevealUI-native
+ * compliance ADR.
  */
 
 const colorMap = {

--- a/apps/studio/src/components/ui/StatusDot.tsx
+++ b/apps/studio/src/components/ui/StatusDot.tsx
@@ -1,8 +1,27 @@
+/**
+ * Studio status indicator — a small decorative colored dot.
+ *
+ * Phase 2 PR-1 (2026-05-16): status colors migrated from hardcoded
+ * Tailwind palette classes (`bg-green-500`, `bg-yellow-500`, `bg-red-500`,
+ * `bg-neutral-600`) to `--rvui-success/warning/error/text-2` design tokens
+ * defined in `@revealui/presentation/tokens.css`. Consumer API
+ * (default export, `status`, `size`, `pulse`, `className`) unchanged.
+ *
+ * StatusDot itself has no `@revealui/presentation` equivalent yet
+ * (presentation has `Badge` for text content, but no pure decorative dot
+ * primitive). It is named as a promotion candidate in Phase 5 of the
+ * studio-dogfood lane plan. For Phase 2 PR-1, the dot is token-backed but
+ * still lives in Studio.
+ *
+ * See `~/revfleet/.jv/docs/lanes/studio-dogfood/plan.md` and ADR
+ * `2026-05-16-fleet-revealui-native-compliance.md`.
+ */
+
 const colorMap = {
-  ok: 'bg-green-500',
-  warn: 'bg-yellow-500',
-  error: 'bg-red-500',
-  off: 'bg-neutral-600',
+  ok: 'bg-[var(--rvui-success)]',
+  warn: 'bg-[var(--rvui-warning)]',
+  error: 'bg-[var(--rvui-error)]',
+  off: 'bg-[var(--rvui-text-2)]',
 } as const;
 
 const sizeMap = {


### PR DESCRIPTION
## Summary

Phase 2 PR-1 of Studio's `@revealui/presentation` dogfood — first shim of the shadow primitives in `apps/studio/src/components/ui/`.

- **PanelHeader** — internal `<h1>` swapped for `@revealui/presentation`'s `Heading` component. Default export + `title` + `action` props unchanged so all 8 importers continue to work without changes.
- **StatusDot** — status colors migrated from hardcoded Tailwind palette classes to `--rvui-success` / `--rvui-warning` / `--rvui-error` / `--rvui-text-2` design tokens from `@revealui/presentation/tokens.css` (token foundation added in #67). Default export + `status` / `size` / `pulse` / `className` props unchanged so all 10 importers continue to work without changes.

## Why these two first

Lowest fan-out of the 10 shadow primitives (PanelHeader 8 importers, StatusDot 10). De-risks the shim pattern before touching higher-traffic components (Button 33, ErrorAlert 13, Input 12, Card 6).

## Why StatusDot doesn't import @revealui/presentation

`@revealui/presentation`'s `Badge` is a text-padded pill primitive, not a decorative dot. There is no `Dot` / `StatusDot` primitive in presentation yet. For this PR, StatusDot's COLOR system is migrated to design tokens (true semantic migration); a future PR will promote StatusDot back to `@revealui/presentation` as a new primitive.

## Verification

- 536/536 studio vitest pass in worktree
- PanelHeader 4/4 pass (default export, role=heading level=1, action slot, no-action)
- StatusDot 11/11 pass with updated `bg-[var(--rvui-success)]` etc class-name assertions
- Zero sibling-test regressions
- Studio typecheck + vite build fail with pre-existing `ts-rs generated/*` errors (require cargo to materialize; CI handles via `studio-release.yml` not `ci.yml` per the `Studio is excluded from gate` comment in `ci.yml`)

## Test plan

- [x] Vitest pass in worktree
- [ ] `studio-release.yml` artifact green on PR
- [ ] Visual inspection of any panel using PanelHeader or StatusDot — emerald success-dot looks correct (the change cascades through every running Studio panel)

## Lane

Phase 2 of the Studio dogfood lane. Phase 1 (token foundation, #67) shipped 2026-05-16. Next planned PR-2 shims Tooltip + ErrorAlert + Badge — though pre-audit showed Tooltip + Dialog have zero importers and can be deleted outright in Phase 4 rather than shimmed.
