### PR TITLE
promote: test -> main (Phase 2 PR-1 - PanelHeader + StatusDot shim)

### DIFF
--- a/apps/studio/src/__tests__/components/StatusDot.test.tsx
+++ b/apps/studio/src/__tests__/components/StatusDot.test.tsx
@@ -8,24 +8,24 @@ describe('StatusDot', () => {
     expect(container.querySelector('span')).not.toBeNull();
   });
 
-  it('applies green color for ok status', () => {
+  it('applies --rvui-success token for ok status', () => {
     const { container } = render(<StatusDot status="ok" />);
-    expect(container.querySelector('span')?.className).toContain('bg-green-500');
+    expect(container.querySelector('span')?.className).toContain('bg-[var(--rvui-success)]');
   });
 
-  it('applies yellow color for warn status', () => {
+  it('applies --rvui-warning token for warn status', () => {
     const { container } = render(<StatusDot status="warn" />);
-    expect(container.querySelector('span')?.className).toContain('bg-yellow-500');
+    expect(container.querySelector('span')?.className).toContain('bg-[var(--rvui-warning)]');
   });
 
-  it('applies red color for error status', () => {
+  it('applies --rvui-error token for error status', () => {
     const { container } = render(<StatusDot status="error" />);
-    expect(container.querySelector('span')?.className).toContain('bg-red-500');
+    expect(container.querySelector('span')?.className).toContain('bg-[var(--rvui-error)]');
   });
 
-  it('applies neutral color for off status', () => {
+  it('applies --rvui-text-2 token for off status', () => {
     const { container } = render(<StatusDot status="off" />);
-    expect(container.querySelector('span')?.className).toContain('bg-neutral-600');
+    expect(container.querySelector('span')?.className).toContain('bg-[var(--rvui-text-2)]');
   });
 
   it('defaults to sm size', () => {

--- a/apps/studio/src/components/ui/PanelHeader.tsx
+++ b/apps/studio/src/components/ui/PanelHeader.tsx
@@ -1,3 +1,4 @@
+import { Heading } from '@revealui/presentation';
 import type { ReactNode } from 'react';
 
 interface PanelHeaderProps {
@@ -5,10 +6,23 @@ interface PanelHeaderProps {
   action?: ReactNode;
 }
 
+/**
+ * Studio panel header — title + optional right-aligned action slot.
+ *
+ * Phase 2 PR-1 (2026-05-16): shimmed to render `@revealui/presentation`'s
+ * `Heading` for the title element. Consumer API (default export, `title`,
+ * `action`) unchanged. Heading defaults to `level={1}` so the rendered
+ * element is still `<h1>` — existing tests asserting role=heading level=1
+ * continue to pass.
+ *
+ * Sequencing tracked in the internal Studio dogfood lane plan;
+ * design rule codified in the internal fleet RevealUI-native
+ * compliance ADR.
+ */
 export default function PanelHeader({ title, action }: PanelHeaderProps) {
   return (
     <div className="flex items-center justify-between">
-      <h1 className="text-xl font-semibold">{title}</h1>
+      <Heading level={1}>{title}</Heading>
       {action}
     </div>
   );

--- a/apps/studio/src/components/ui/StatusDot.tsx
+++ b/apps/studio/src/components/ui/StatusDot.tsx
@@ -1,8 +1,27 @@
+/**
+ * Studio status indicator — a small decorative colored dot.
+ *
+ * Phase 2 PR-1 (2026-05-16): status colors migrated from hardcoded
+ * Tailwind palette classes (`bg-green-500`, `bg-yellow-500`, `bg-red-500`,
+ * `bg-neutral-600`) to `--rvui-success/warning/error/text-2` design tokens
+ * defined in `@revealui/presentation/tokens.css`. Consumer API
+ * (default export, `status`, `size`, `pulse`, `className`) unchanged.
+ *
+ * StatusDot itself has no `@revealui/presentation` equivalent yet
+ * (presentation has `Badge` for text content, but no pure decorative dot
+ * primitive). It is named as a future promotion candidate. For Phase 2
+ * PR-1, the dot is token-backed but still lives in Studio.
+ *
+ * Sequencing tracked in the internal Studio dogfood lane plan;
+ * design rule codified in the internal fleet RevealUI-native
+ * compliance ADR.
+ */
+
 const colorMap = {
-  ok: 'bg-green-500',
-  warn: 'bg-yellow-500',
-  error: 'bg-red-500',
-  off: 'bg-neutral-600',
+  ok: 'bg-[var(--rvui-success)]',
+  warn: 'bg-[var(--rvui-warning)]',
+  error: 'bg-[var(--rvui-error)]',
+  off: 'bg-[var(--rvui-text-2)]',
 } as const;
 
 const sizeMap = {


### PR DESCRIPTION
## Summary

Promote test → main: **Phase 2 PR-1 of Studio dogfood** ([#71](https://github.com/RevealUIStudio/revdev/pull/71)) — shims `PanelHeader` and `StatusDot` via `@revealui/presentation`.

- `PanelHeader` now renders `@revealui/presentation`'s `Heading` for the title; default-export + `title`/`action` props unchanged.
- `StatusDot` status colors migrated to `--rvui-success` / `--rvui-warning` / `--rvui-error` / `--rvui-text-2` design tokens (added in #67); default-export + `status`/`size`/`pulse`/`className` props unchanged.

## Verification (on the test branch, all 12 checks green)

Quality, Typecheck, Test, Build, CodeQL (js+go+top), Console (Go), Dependency Review, Private Leak Scan, Submodule Audit, Secret Scanning (Gitleaks) — all SUCCESS on the merged commit.

## Test plan

- [x] All 12 checks green on the source PR before merge to test
- [ ] Same 12 checks re-run green on this promo PR
- [ ] `studio-release.yml` artifact on production main visually inspected against any Studio panel using `PanelHeader` or `StatusDot`

## Lane

Phase 2 of the Studio dogfood arc. Phase 1 promoted via #68 on 2026-05-16.
