### PR TITLE
feat(studio): Phase 2 PR-2 — shim Tooltip + ErrorAlert + Badge via @revealui/presentation

### DIFF
--- a/apps/studio/src/__tests__/components/Badge.test.tsx
+++ b/apps/studio/src/__tests__/components/Badge.test.tsx
@@ -11,38 +11,38 @@ describe('Badge', () => {
   it('applies default variant styles', () => {
     render(<Badge>Default</Badge>);
     const badge = screen.getByText('Default');
-    expect(badge.className).toContain('bg-neutral-800');
-    expect(badge.className).toContain('text-neutral-300');
+    expect(badge.className).toContain('bg-zinc-600/10');
+    expect(badge.className).toContain('text-zinc-700');
   });
 
   it('applies success variant styles', () => {
     render(<Badge variant="success">OK</Badge>);
     const badge = screen.getByText('OK');
-    expect(badge.className).toContain('text-green-400');
+    expect(badge.className).toContain('text-green-700');
   });
 
   it('applies warning variant styles', () => {
     render(<Badge variant="warning">Warn</Badge>);
     const badge = screen.getByText('Warn');
-    expect(badge.className).toContain('text-yellow-400');
+    expect(badge.className).toContain('text-yellow-700');
   });
 
   it('applies error variant styles', () => {
     render(<Badge variant="error">Fail</Badge>);
     const badge = screen.getByText('Fail');
-    expect(badge.className).toContain('text-red-400');
+    expect(badge.className).toContain('text-red-700');
   });
 
   it('applies info variant styles', () => {
     render(<Badge variant="info">Info</Badge>);
     const badge = screen.getByText('Info');
-    expect(badge.className).toContain('text-blue-400');
+    expect(badge.className).toContain('text-blue-700');
   });
 
   it('applies brand variant styles', () => {
     render(<Badge variant="brand">Pro</Badge>);
     const badge = screen.getByText('Pro');
-    expect(badge.className).toContain('text-orange-400');
+    expect(badge.className).toContain('text-emerald-700');
   });
 
   it('applies sm size styles', () => {

--- a/apps/studio/src/__tests__/components/Badge.test.tsx
+++ b/apps/studio/src/__tests__/components/Badge.test.tsx
@@ -11,38 +11,38 @@ describe('Badge', () => {
   it('applies default variant styles', () => {
     render(<Badge>Default</Badge>);
     const badge = screen.getByText('Default');
-    expect(badge.className).toContain('bg-zinc-600/10');
-    expect(badge.className).toContain('text-zinc-700');
+    expect(badge.className).toContain('bg-white/5');
+    expect(badge.className).toContain('text-zinc-400');
   });
 
   it('applies success variant styles', () => {
     render(<Badge variant="success">OK</Badge>);
     const badge = screen.getByText('OK');
-    expect(badge.className).toContain('text-green-700');
+    expect(badge.className).toContain('text-green-400');
   });
 
   it('applies warning variant styles', () => {
     render(<Badge variant="warning">Warn</Badge>);
     const badge = screen.getByText('Warn');
-    expect(badge.className).toContain('text-yellow-700');
+    expect(badge.className).toContain('text-yellow-300');
   });
 
   it('applies error variant styles', () => {
     render(<Badge variant="error">Fail</Badge>);
     const badge = screen.getByText('Fail');
-    expect(badge.className).toContain('text-red-700');
+    expect(badge.className).toContain('text-red-400');
   });
 
   it('applies info variant styles', () => {
     render(<Badge variant="info">Info</Badge>);
     const badge = screen.getByText('Info');
-    expect(badge.className).toContain('text-blue-700');
+    expect(badge.className).toContain('text-blue-400');
   });
 
   it('applies brand variant styles', () => {
     render(<Badge variant="brand">Pro</Badge>);
     const badge = screen.getByText('Pro');
-    expect(badge.className).toContain('text-emerald-700');
+    expect(badge.className).toContain('text-emerald-400');
   });
 
   it('applies sm size styles', () => {

--- a/apps/studio/src/components/ui/Badge.tsx
+++ b/apps/studio/src/components/ui/Badge.tsx
@@ -1,21 +1,21 @@
 import type { ReactNode } from 'react';
 
-const variantStyles = {
-  default: 'bg-neutral-800 text-neutral-300',
-  success: 'bg-green-900/40 text-green-400',
-  warning: 'bg-yellow-900/40 text-yellow-400',
-  error: 'bg-red-900/40 text-red-400',
-  info: 'bg-blue-900/40 text-blue-400',
-  brand: 'bg-orange-900/40 text-orange-400',
+const variantClasses = {
+  default: 'bg-zinc-600/10 text-zinc-700 dark:bg-white/5 dark:text-zinc-400',
+  success: 'bg-green-500/15 text-green-700 dark:bg-green-500/10 dark:text-green-400',
+  warning: 'bg-yellow-400/20 text-yellow-700 dark:bg-yellow-400/10 dark:text-yellow-300',
+  error: 'bg-red-500/15 text-red-700 dark:bg-red-500/10 dark:text-red-400',
+  info: 'bg-blue-500/15 text-blue-700 dark:text-blue-400',
+  brand: 'bg-emerald-500/15 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-400',
 } as const;
 
-const sizeStyles = {
+const sizeClasses = {
   sm: 'px-1.5 py-0.5 text-[10px]',
   md: 'px-2 py-0.5 text-xs',
 } as const;
 
-export type BadgeVariant = keyof typeof variantStyles;
-export type BadgeSize = keyof typeof sizeStyles;
+export type BadgeVariant = keyof typeof variantClasses;
+export type BadgeSize = keyof typeof sizeClasses;
 
 interface BadgeProps {
   variant?: BadgeVariant;
@@ -32,7 +32,12 @@ export default function Badge({
 }: BadgeProps) {
   return (
     <span
-      className={`inline-flex items-center rounded-full font-medium ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
+      className={`inline-flex items-center rounded-full font-medium ${variantClasses[variant]} ${sizeClasses[size]} ${className}`}
+      style={{
+        borderRadius: 'var(--rvui-radius-full, 9999px)',
+        transition:
+          'background-color var(--rvui-duration-fast, 120ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1))',
+      }}
     >
       {children}
     </span>

--- a/apps/studio/src/components/ui/Badge.tsx
+++ b/apps/studio/src/components/ui/Badge.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode } from 'react';
 
 const variantClasses = {
-  default: 'bg-zinc-600/10 text-zinc-700 dark:bg-white/5 dark:text-zinc-400',
-  success: 'bg-green-500/15 text-green-700 dark:bg-green-500/10 dark:text-green-400',
-  warning: 'bg-yellow-400/20 text-yellow-700 dark:bg-yellow-400/10 dark:text-yellow-300',
-  error: 'bg-red-500/15 text-red-700 dark:bg-red-500/10 dark:text-red-400',
-  info: 'bg-blue-500/15 text-blue-700 dark:text-blue-400',
-  brand: 'bg-emerald-500/15 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-400',
+  default: 'bg-white/5 text-zinc-400',
+  success: 'bg-green-500/10 text-green-400',
+  warning: 'bg-yellow-400/10 text-yellow-300',
+  error: 'bg-red-500/10 text-red-400',
+  info: 'bg-blue-500/15 text-blue-400',
+  brand: 'bg-emerald-500/10 text-emerald-400',
 } as const;
 
 const sizeClasses = {

--- a/apps/studio/src/components/ui/ErrorAlert.tsx
+++ b/apps/studio/src/components/ui/ErrorAlert.tsx
@@ -8,7 +8,7 @@ export default function ErrorAlert({ message, className = '' }: ErrorAlertProps)
 
   return (
     <div
-      className={`rounded-md border border-red-900/50 bg-red-950/30 px-4 py-3 text-sm text-red-400 ${className}`}
+      className={`rounded-md border border-[var(--rvui-error)]/30 bg-[var(--rvui-error-subtle)] px-4 py-3 text-sm text-[var(--rvui-error)] ${className}`}
       role="alert"
     >
       {message}

--- a/apps/studio/src/components/ui/Tooltip.tsx
+++ b/apps/studio/src/components/ui/Tooltip.tsx
@@ -1,13 +1,7 @@
+import { Tooltip as PresentationTooltip } from '@revealui/presentation';
 import type { ReactNode } from 'react';
 
-const positionStyles = {
-  top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
-  bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
-  left: 'right-full top-1/2 -translate-y-1/2 mr-2',
-  right: 'left-full top-1/2 -translate-y-1/2 ml-2',
-} as const;
-
-export type TooltipPosition = keyof typeof positionStyles;
+export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
 
 interface TooltipProps {
   content: string;
@@ -17,14 +11,8 @@ interface TooltipProps {
 
 export default function Tooltip({ content, position = 'top', children }: TooltipProps) {
   return (
-    <div className="group relative inline-flex">
+    <PresentationTooltip content={content} side={position}>
       {children}
-      <div
-        role="tooltip"
-        className={`pointer-events-none absolute z-50 whitespace-nowrap rounded-md bg-neutral-800 px-2.5 py-1.5 text-xs text-neutral-200 opacity-0 shadow-lg transition-opacity group-hover:opacity-100 ${positionStyles[position]}`}
-      >
-        {content}
-      </div>
-    </div>
+    </PresentationTooltip>
   );
 }


### PR DESCRIPTION
## Phase 2 PR-2: shim Tooltip + ErrorAlert + Badge via @revealui/presentation

Continues the Studio dogfood lane. Three shadow UI primitives in
apps/studio/src/components/ui/ become thin wrappers that consume
@revealui/presentation token vocabulary, advancing the fleet
brand-emerald convergence and RevealUI-native compliance posture
(per internal ADRs sealed 2026-05-16).

### Per-component shim choices

**Tooltip** (0 importers)
Thin wrapper around @revealui/presentation Tooltip. Maps Studio's
position prop to presentation's side, preserves the default export
and content: string type. No API change at any call-site.

**ErrorAlert** (13 importers)
@revealui/presentation Alert is an alertdialog modal — wrong surface
for an inline error banner. No equivalent exists. Shim stays standalone
but migrates the three hard-coded palette classes to --rvui-error and
--rvui-error-subtle token references (already defined in tokens.css
imported by Phase 1 PR-1). role=alert and className passthrough
preserved; all 5 tests pass unchanged.

**Badge** (1 non-test importer: SshBookmarkSidebar — variant=info,
variant=warning, size=sm)
Presentation Badge uses a color palette-name prop; Studio API uses
semantic variant names. Shim maps variant to presentation color class
vocabulary internally. brand variant migrated from orange-400 to
emerald (fleet brand-emerald convergence ADR 2026-05-16). size prop
handled in the shim (presentation Badge has no size prop). Adds
--rvui-radius-full and --rvui-duration-fast token-backed style block
matching presentation Badge rendering contract. Test assertions updated
from old palette classes to new presentation-aligned classes; all 10
tests pass.

### Importer counts
| Component | Non-test importers |
|---|---|
| Tooltip | 0 |
| ErrorAlert | 13 |
| Badge | 1 |

### Verification
- 61 test files, 536 tests: all passed
- Zero errors in shim files under typecheck
- Zero stale orange tokens in the three shim files
- Pre-existing tsc failures (AgentPanel, GitPanel, TunnelPanel,
  src/types.ts generated bindings) are unchanged baseline requiring
  cargo ts-rs output, gated by studio-release.yml CI, not this PR

### API-shape tradeoffs
- ErrorAlert: no presentation equivalent for inline error banners;
  shim stays standalone with token migration only. Future InlineAlert
  in presentation makes this a one-line wrapper.
- Badge: presentation Badge has no size prop; shim handles sm/md via
  direct padding classes. All existing variant + size call-sites compile.

### Part of
Phase 2 PR-2 of the Studio dogfood lane. Predecessor: revdev#71
(PR-1: StatusDot + PanelHeader, squash f914b84 on test).
Next: PR-3 (Modal + Dialog).
