### PR TITLE
chore(studio): match revealui stripe-env cache path move

### DIFF
--- a/apps/studio/src-tauri/src/commands/deploy/stripe.rs
+++ b/apps/studio/src-tauri/src/commands/deploy/stripe.rs
@@ -16,8 +16,10 @@ pub async fn stripe_validate_keys(secret_key: String) -> Result<bool, StudioErro
 }
 
 /// Run stripe:seed script (creates products, prices, webhook, billing portal).
-/// After seed completes, reads `.revealui/stripe-env.json` which contains
+/// After seed completes, reads `node_modules/.cache/revealui-stripe-env.json`
+/// which contains
 /// `{ envVars: { STRIPE_WEBHOOK_SECRET, NEXT_PUBLIC_STRIPE_*_PRICE_ID, ... }, catalogEntries }`.
+/// Path MUST match revealui's scripts/setup/stripe-env-cache-path.ts.
 #[tauri::command]
 pub async fn stripe_run_seed(repo_path: String) -> Result<String, StudioError> {
     let output = Command::new("pnpm")
@@ -32,8 +34,9 @@ pub async fn stripe_run_seed(repo_path: String) -> Result<String, StudioError> {
         ));
     }
 
-    // Read .revealui/stripe-env.json which contains envVars + catalogEntries
-    let env_file = std::path::Path::new(&repo_path).join(".revealui/stripe-env.json");
+    // Read node_modules/.cache/revealui-stripe-env.json which contains envVars + catalogEntries
+    let env_file = std::path::Path::new(&repo_path)
+        .join("node_modules/.cache/revealui-stripe-env.json");
     match std::fs::read_to_string(&env_file) {
         Ok(contents) => Ok(contents),
         Err(_) => {


### PR DESCRIPTION
## Summary

Paired with the revealui-side cache path move. revealui's `pnpm stripe:seed`
now writes to `node_modules/.cache/revealui-stripe-env.json` instead of
`.revealui/stripe-env.json` — the latter sat in the same namespace as
revvault's `~/.revealui/passage-store/` and was deletable as collateral
from any clean-shell `find ~/.revealui -delete`.

Studio's `stripe_run_seed` Tauri command reads that file post-seed; this
PR updates the hardcoded path.

## File

- `apps/studio/src-tauri/src/commands/deploy/stripe.rs` (3 lines updated: comment + comment + path)

## Why now

Until both PRs ship together, Studio's "deploy → Stripe seed" command will
fail to find the cache file on local dev. The revealui PR is in flight; this
matches.

## Test plan

- [ ] CI green
- [ ] Manual smoke (Studio dev mode → Stripe seed → check stdout) — owner verifies once paired PR lands
