### PR TITLE
chore(docs): add YAML frontmatter to MASTER_PLAN + MASTER_SPEC

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -1,3 +1,11 @@
+---
+type: master-plan
+repo: revdev
+last-updated: 2026-05-10
+owner: RevealUI Studio
+staleness-status: FRESH
+---
+
 # RevDev — Master Plan
 
 **Last Updated:** 2026-05-10

--- a/docs/MASTER_SPEC.md
+++ b/docs/MASTER_SPEC.md
@@ -1,3 +1,11 @@
+---
+type: master-spec
+repo: revdev
+last-updated: 2026-05-10
+owner: RevealUI Studio
+staleness-status: FRESH
+---
+
 # RevDev — Master Spec
 
 **Last Updated:** 2026-05-10


### PR DESCRIPTION
## Summary

- Add YAML frontmatter (`type`, `repo`, `last-updated`, `owner`, `staleness-status`) to `docs/MASTER_PLAN.md` and `docs/MASTER_SPEC.md`.
- Matches the canonical fleet per-product schema (see revealcoin's MASTER_PLAN.md / MASTER_SPEC.md).
- Restores compatibility with internal docs frontmatter detection — the 2026-05-17 MASTER_INDEX regen pass flagged both docs as "no frontmatter".

## Test plan

- [ ] revdev CI green
- [ ] Frontmatter schema visually matches revealcoin's MASTER_PLAN.md / MASTER_SPEC.md
- [ ] Next internal docs --apply` run no longer flags revdev as "no frontmatter"
