### PR TITLE
fix(ci): split dependency-review into PR-only workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,36 @@
+name: Dependency Review
+
+# Blocks PRs that introduce dependencies with high-severity CVEs.
+#
+# Split out of security.yml on 2026-05-19. security.yml triggers on
+# push/pull_request/schedule, but actions/dependency-review-action
+# only works on pull_request events — so push and schedule runs
+# marked the job SKIPPED while pull_request runs marked it SUCCESS.
+# Both shared the "Dependency Review" context, and GitHub treats a
+# SKIPPED required check as not-succeeded, blocking merge.
+#
+# Branch protection on main + test requires "Dependency Review" by
+# context name only (app_id 15368), so the rename to a dedicated
+# file required no protection-rule change.
+
+on:
+  pull_request:
+    branches: [main, test]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,11 @@ name: Security
 # Ports the portable jobs from RevealUI's Security workflow:
 #   gitleaks       — full-history secret scanning
 #   codeql         — TypeScript + Go static analysis (Rust uses clippy in ci.yml)
-#   dependency-review — blocks PRs that introduce high-severity CVEs
+#
+# Dependency Review used to live here too, but was split into
+# .github/workflows/dependency-review.yml on 2026-05-19 because
+# the dual-trigger pattern (push + pull_request + schedule) caused
+# SKIPPED/SUCCESS check dupes — see that file's header for context.
 #
 # The revealui-specific `security-gate` job (which runs `pnpm gate:security`)
 # is not ported because its underlying scripts live in the revealui repo.
@@ -85,13 +89,3 @@ jobs:
         with:
           category: /language:${{ matrix.language }}
 
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
-        with:
-          fail-on-severity: high


### PR DESCRIPTION
## Summary

- Split `dependency-review` out of `security.yml` into its own `dependency-review.yml` workflow with `on: pull_request` only.
- `security.yml` keeps `gitleaks` + `codeql` (which legitimately want `push` + `pull_request` + `schedule` triggers).

## Why

`security.yml` triggers on `push: [main, test]` + `pull_request: [main, test]` + `schedule`. The `dependency-review` job had `if: github.event_name == 'pull_request'`, so push and schedule runs marked the job SKIPPED while pull_request runs marked it SUCCESS. Both share the `Dependency Review` check context, and GitHub treats a SKIPPED required status check as not-succeeded — blocking merge of PRs that should have been mergeable.

Precedent: commit `3d1d2d9` on `chore/backflow-main-into-test` was titled `trigger: force re-run required checks (Dependency Review SKIPPED dupe)` — a workaround that forced a re-run to clear the stuck check.

Pattern recorded in memory `feedback_main_promotion_skipped_required_checks`.

## Branch protection safety

Both `main` and `test` require the check by **context name only** (`Dependency Review`, `app_id: 15368`), per `gh api repos/RevealUIStudio/revdev/branches/{main,test}/protection`. No workflow-file binding in the protection rule, so the move to a separate workflow file requires no rule update.

## Test plan

- [ ] CI green on this PR — single `Dependency Review` check shows SUCCESS, no SKIPPED dupe.
- [ ] After merge, open a follow-up feature → test PR and confirm one `Dependency Review` check (PR-only trigger).
- [ ] On the next backflow main → test PR, confirm `security.yml` no longer emits a SKIPPED `Dependency Review` check.
