### PR TITLE
chore(ci): replace licensed gitleaks-action with gitleaks CLI

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,6 +36,9 @@ jobs:
       # gitleaks CLI binary (MIT, free). The gitleaks-action wrapper requires a
       # paid license for organization accounts and fails on Dependabot PRs.
       GITLEAKS_VERSION: "8.30.0"
+      # SHA256 of gitleaks_<ver>_linux_x64.tar.gz (from gitleaks_<ver>_checksums.txt);
+      # verified before install to close the curl|tar supply-chain gap. Bump with VERSION.
+      GITLEAKS_SHA256: "79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -43,8 +46,10 @@ jobs:
       - name: Install gitleaks
         run: |
           set -euo pipefail
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xz -C /tmp gitleaks
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}" -o "/tmp/${tarball}"
+          echo "${GITLEAKS_SHA256}  /tmp/${tarball}" | sha256sum -c -
+          tar -xzf "/tmp/${tarball}" -C /tmp gitleaks
           sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
           gitleaks version
       - name: Run gitleaks

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,13 +32,26 @@ jobs:
     name: Secret Scanning (Gitleaks)
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      # gitleaks CLI binary (MIT, free). The gitleaks-action wrapper requires a
+      # paid license for organization accounts and fails on Dependabot PRs.
+      GITLEAKS_VERSION: "8.30.0"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+      - name: Run gitleaks
+        run: |
+          gitleaks detect --no-banner --redact \
+            --config .gitleaks.toml \
+            --report-path /tmp/gitleaks-report.json --report-format json
 
   codeql:
     name: CodeQL


### PR DESCRIPTION
## What

Replace the licensed `gitleaks/gitleaks-action@v2` with the free, MIT-licensed gitleaks **CLI binary** (pinned `8.30.0`) for secret scanning.

## Why

`gitleaks-action@v2` requires a **paid license for organization accounts**. On Dependabot PRs its license/account check fails with `Bad credentials` (Dependabot runs use a restricted token + a separate secrets store) and the job dies with `🛑 missing gitleaks license` — independent of branch protection. It also emits a Node-20 deprecation warning.

The gitleaks **CLI** is MIT-licensed and free: it does no license check and no GitHub API call, so it runs identically on pushes and Dependabot PRs. This mirrors the pattern already shipped in `revealui`'s `security.yml`.

## Notes

- Job `name:` is unchanged, so any required-status-check-by-name stays satisfied.
- Full history preserved via `fetch-depth: 0`.
- Pre-flighted `gitleaks 8.30.0` against this repo's full history → **clean, no findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
