### PR TITLE
chore: promote test → main

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -1,0 +1,128 @@
+name: backflow-main-into-test
+
+# After main moves (test→main promotion or direct push), automatically
+# open or update a "backflow main into test" PR if test is behind main.
+# Companion to promotion-gate.yml — that workflow REJECTS stale promotions;
+# this one PROACTIVELY heals the staleness gap.
+#
+# Permissions:
+#   contents: write — push to the chore/backflow-main-into-test branch
+#   pull-requests: write — open/update the backflow PR
+#
+# Known limitation: PRs opened by GITHUB_TOKEN don't trigger other
+# workflows (anti-loop guard built into GitHub Actions). The auto-opened
+# backflow PR will have empty CI. Close + reopen via gh CLI (or the web
+# UI button) to fire CI, then merge.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (resolved 2026-05-19)
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if test needs backflow
+        id: check
+        run: |
+          if ! git fetch origin test 2>/dev/null; then
+            echo "::warning::No 'test' branch on origin — skipping backflow"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git merge-base --is-ancestor origin/main origin/test; then
+            echo "test already contains main — no backflow needed ✓"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            behind=$(git rev-list --count origin/test..origin/main)
+            echo "test is $behind commit(s) behind main"
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "behind=$behind" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure git identity
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Attempt backflow merge
+        if: steps.check.outputs.needed == 'true'
+        id: merge
+        run: |
+          git checkout -B chore/backflow-main-into-test origin/test
+
+          missing=$(git log --oneline origin/test..origin/main | head -20)
+          {
+            echo "Merge main into test"
+            echo ""
+            echo "Auto-opened by .github/workflows/backflow-main-into-test.yml"
+            echo "after main moved forward. Merge commit (no squash) per"
+            echo "feedback_merge_main_into_test_must_use_merge_commit so main's"
+            echo "parentage is preserved and the next promotion-gate check passes."
+            echo ""
+            echo "Missing commits backflowed:"
+            echo "$missing"
+          } > /tmp/merge-msg.txt
+
+          if git merge --no-ff -F /tmp/merge-msg.txt origin/main; then
+            git push origin chore/backflow-main-into-test --force-with-lease
+            echo "merged=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error title=Backflow merge conflict::Auto-backflow hit content conflicts. Resolve manually: git checkout test && git fetch origin && git merge --no-ff origin/main && resolve && git push origin test"
+            exit 1
+          fi
+
+      - name: Open or update backflow PR
+        if: steps.check.outputs.needed == 'true' && steps.merge.outputs.merged == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BEHIND: ${{ steps.check.outputs.behind }}
+          REPO: ${{ github.repository }}
+        run: |
+          existing=$(gh pr list --repo "$REPO" --base test --head chore/backflow-main-into-test --json number --jq '.[0].number // empty')
+
+          title="chore(test): backflow main into test ($BEHIND commit(s) behind)"
+          {
+            echo "## Summary"
+            echo ""
+            echo "Auto-opened by \`.github/workflows/backflow-main-into-test.yml\` because \`main\` moved forward and \`test\` is $BEHIND commit(s) behind."
+            echo ""
+            echo "## Why this exists"
+            echo ""
+            echo "Without backflow, the next \`test\` → \`main\` promotion fails the \`promotion-gate\` check (it requires test to contain all of main). This PR catches \`test\` up so the next promotion lands cleanly."
+            echo ""
+            echo "## Merge instructions"
+            echo ""
+            echo "**Merge as a merge commit (NOT squash) per \`feedback_merge_main_into_test_must_use_merge_commit\`:**"
+            echo ""
+            echo '```'
+            echo "gh pr merge <PR#> --merge --delete-branch --repo $REPO"
+            echo '```'
+            echo ""
+            echo "Squash strips \`main\`'s parentage — \`promotion-gate\` will re-flag the same condition on the next push to main, and another backflow PR will auto-open."
+            echo ""
+            echo "## CI on this PR"
+            echo ""
+            echo "GitHub blocks workflows triggered by \`GITHUB_TOKEN\` from triggering other workflows (anti-loop guard). If CI is empty, **close and reopen the PR via the web UI or \`gh pr close <PR#> && gh pr reopen <PR#>\`** to fire CI."
+            echo ""
+            echo "_Per \`feedback_no_auto_merge\`: manual merge only — no \`--auto\`._"
+          } > /tmp/pr-body.md
+
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --repo "$REPO" --title "$title" --body-file /tmp/pr-body.md
+            echo "Updated existing backflow PR #$existing"
+          else
+            gh pr create --repo "$REPO" --base test --head chore/backflow-main-into-test --title "$title" --body-file /tmp/pr-body.md
+            echo "Created new backflow PR"
+          fi

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,36 @@
+name: Dependency Review
+
+# Blocks PRs that introduce dependencies with high-severity CVEs.
+#
+# Split out of security.yml on 2026-05-19. security.yml triggers on
+# push/pull_request/schedule, but actions/dependency-review-action
+# only works on pull_request events — so push and schedule runs
+# marked the job SKIPPED while pull_request runs marked it SUCCESS.
+# Both shared the "Dependency Review" context, and GitHub treats a
+# SKIPPED required check as not-succeeded, blocking merge.
+#
+# Branch protection on main + test requires "Dependency Review" by
+# context name only (app_id 15368), so the rename to a dedicated
+# file required no protection-rule change.
+
+on:
+  pull_request:
+    branches: [main, test]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -1,0 +1,63 @@
+name: promotion-gate
+
+# Fires on PRs targeting main. Enforces:
+#   1. Head branch is 'test' (no feature → main promotion).
+#   2. test contains all of main (covers "test behind main" and
+#      "main was squash-merged into test instead of merge-committed").
+#
+# Pairs with branch protection requiring this check to pass on
+# public repos. On private repos (free plan), enforcement is by
+# convention — the visible red X surfaces the gap.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  promotion-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify head branch is 'test'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ "$HEAD_REF" != "test" ]; then
+            echo "::error title=Wrong head branch::Promotion PRs to main must come from 'test'. Got: '$HEAD_REF'."
+            echo ""
+            echo "Feature branches must merge to 'test' first, then 'test' promotes to 'main'."
+            exit 1
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (resolved 2026-05-19)
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Verify test contains all of main
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=200
+          base_sha=$(git rev-parse "origin/$BASE_REF")
+
+          if git merge-base --is-ancestor "$base_sha" HEAD; then
+            echo "test contains all of $BASE_REF ✓"
+            exit 0
+          fi
+
+          behind=$(git rev-list --count "HEAD..origin/$BASE_REF")
+          echo "::error title=test is behind main::test is $behind commit(s) behind '$BASE_REF'. Backflow main into test using a merge commit (NOT squash):"
+          echo ""
+          echo "  git checkout test"
+          echo "  git fetch origin"
+          echo "  git merge --no-ff origin/$BASE_REF"
+          echo "  git push origin test"
+          echo ""
+          echo "Squash-merging main into test produces the same red X — main's parentage isn't preserved."
+          echo ""
+          echo "Missing commits:"
+          git log --oneline -20 "HEAD..origin/$BASE_REF"
+          exit 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,11 @@ name: Security
 # Ports the portable jobs from RevealUI's Security workflow:
 #   gitleaks       — full-history secret scanning
 #   codeql         — TypeScript + Go static analysis (Rust uses clippy in ci.yml)
-#   dependency-review — blocks PRs that introduce high-severity CVEs
+#
+# Dependency Review used to live here too, but was split into
+# .github/workflows/dependency-review.yml on 2026-05-19 because
+# the dual-trigger pattern (push + pull_request + schedule) caused
+# SKIPPED/SUCCESS check dupes — see that file's header for context.
 #
 # The revealui-specific `security-gate` job (which runs `pnpm gate:security`)
 # is not ported because its underlying scripts live in the revealui repo.
@@ -85,13 +89,3 @@ jobs:
         with:
           category: /language:${{ matrix.language }}
 
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
-        with:
-          fail-on-severity: high

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,13 +32,31 @@ jobs:
     name: Secret Scanning (Gitleaks)
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      # gitleaks CLI binary (MIT, free). The gitleaks-action wrapper requires a
+      # paid license for organization accounts and fails on Dependabot PRs.
+      GITLEAKS_VERSION: "8.30.0"
+      # SHA256 of gitleaks_<ver>_linux_x64.tar.gz (from gitleaks_<ver>_checksums.txt);
+      # verified before install to close the curl|tar supply-chain gap. Bump with VERSION.
+      GITLEAKS_SHA256: "79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}" -o "/tmp/${tarball}"
+          echo "${GITLEAKS_SHA256}  /tmp/${tarball}" | sha256sum -c -
+          tar -xzf "/tmp/${tarball}" -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+      - name: Run gitleaks
+        run: |
+          gitleaks detect --no-banner --redact \
+            --config .gitleaks.toml \
+            --report-path /tmp/gitleaks-report.json --report-format json
 
   codeql:
     name: CodeQL


### PR DESCRIPTION
## Promote `test` → `main`

Routine promotion bringing the current `test` delta to `main`. Highlights:

- **Security**: gitleaks-action → free gitleaks **CLI** migration + **SHA256 supply-chain verification** (the Codex P1 fix), now consistent across the fleet.
- **CI plumbing**: `promotion-gate` + `auto-backflow` workflows.
- Plus this repo's other merged-to-`test` changes — see the commit list below.

`promotion-gate` enforces head=`test` and that `test` contains all of `main`. Merge with a **merge commit** (not squash) to preserve parentage for the backflow cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
