### PR TITLE
feat(daemon): license expiry warnings + fail-closed start + KEY_FILE support

### DIFF
--- a/packages/daemon/src/__tests__/license-expiry.test.ts
+++ b/packages/daemon/src/__tests__/license-expiry.test.ts
@@ -1,0 +1,193 @@
+/**
+ * GAP-184 — daemon license-expiry warn/fail behavior + REVEALUI_LICENSE_KEY_FILE.
+ *
+ * Covers: expiry status buckets (14d/7d/1d), fail-closed on expired, the
+ * file-based key source, and the loud config error when KEY_FILE is broken.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initLicenseGuard } from '../guard.js';
+import {
+  checkLicense,
+  evaluateLicense,
+  LicenseConfigError,
+  LicenseExpiredError,
+  loadLicenseKey,
+} from '../license.js';
+import {
+  clearTestLicenseEnv,
+  generateTestLicense,
+  setTestLicenseEnv,
+} from './test-license-helper.js';
+
+/** Mint + install a license expiring `days` from now (negative = expired). */
+function installLicense(days: number, tier: 'pro' | 'max' | 'enterprise' = 'enterprise') {
+  const kit = generateTestLicense(tier, false, { daysUntilExpiry: days });
+  setTestLicenseEnv(kit);
+  return kit;
+}
+
+beforeEach(() => {
+  clearTestLicenseEnv();
+  delete process.env.REVEALUI_LICENSE_KEY_FILE;
+});
+
+afterEach(() => {
+  clearTestLicenseEnv();
+  delete process.env.REVEALUI_LICENSE_KEY_FILE;
+  vi.restoreAllMocks();
+});
+
+describe('evaluateLicense — expiry status buckets', () => {
+  it('15 days out → ok (no warning bucket)', () => {
+    installLicense(15);
+    const ev = evaluateLicense();
+    expect(ev.valid).toBe(true);
+    expect(ev.status).toBe('ok');
+    expect(ev.tier).toBe('enterprise');
+  });
+
+  it('13 days out → expiring-14d (info)', () => {
+    installLicense(13);
+    expect(evaluateLicense().status).toBe('expiring-14d');
+  });
+
+  it('6 days out → expiring-7d (warn)', () => {
+    installLicense(6);
+    expect(evaluateLicense().status).toBe('expiring-7d');
+  });
+
+  it('12 hours out → expiring-1d (critical)', () => {
+    installLicense(0.5);
+    const ev = evaluateLicense();
+    expect(ev.status).toBe('expiring-1d');
+    expect(ev.valid).toBe(true);
+    expect(ev.secondsRemaining).toBeGreaterThan(0);
+  });
+
+  it('1 hour ago → expired (fail-closed signal)', () => {
+    installLicense(-1 / 24);
+    const ev = evaluateLicense();
+    expect(ev.valid).toBe(false);
+    expect(ev.status).toBe('expired');
+    expect(ev.present).toBe(true);
+    expect(ev.secondsRemaining).toBeLessThan(0);
+  });
+
+  it('perpetual (no exp) → perpetual', () => {
+    const kit = generateTestLicense('enterprise', true);
+    setTestLicenseEnv(kit);
+    const ev = evaluateLicense();
+    expect(ev.valid).toBe(true);
+    expect(ev.status).toBe('perpetual');
+    expect(ev.expiresAt).toBeNull();
+  });
+
+  it('no key set → absent (free/degraded)', () => {
+    const ev = evaluateLicense();
+    expect(ev.present).toBe(false);
+    expect(ev.valid).toBe(false);
+    expect(ev.status).toBe('absent');
+  });
+});
+
+describe('loadLicenseKey — env / file priority', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'revdev-lic-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads REVEALUI_LICENSE_KEY_FILE when KEY is unset', () => {
+    const kit = generateTestLicense('pro', true);
+    const file = join(dir, 'license.jwt');
+    writeFileSync(file, `${kit.licenseKey}\n`);
+    process.env.REVEALUI_LICENSE_KEY_FILE = file;
+    process.env.REVDEV_LICENSE_PUBLIC_KEY = kit.publicKey;
+
+    const loaded = loadLicenseKey();
+    expect(loaded.source).toBe('file');
+    expect(loaded.key).toBe(kit.licenseKey);
+
+    const ev = evaluateLicense();
+    expect(ev.valid).toBe(true);
+    expect(ev.source).toBe('file');
+    expect(ev.tier).toBe('pro');
+  });
+
+  it('inline KEY takes priority over KEY_FILE', () => {
+    const inline = generateTestLicense('max', true);
+    const fileKit = generateTestLicense('pro', true);
+    const file = join(dir, 'license.jwt');
+    writeFileSync(file, fileKit.licenseKey);
+    setTestLicenseEnv(inline);
+    process.env.REVEALUI_LICENSE_KEY_FILE = file;
+
+    const loaded = loadLicenseKey();
+    expect(loaded.source).toBe('env');
+    expect(loaded.key).toBe(inline.licenseKey);
+  });
+
+  it('throws LicenseConfigError when KEY_FILE points at a missing path', () => {
+    process.env.REVEALUI_LICENSE_KEY_FILE = join(dir, 'does-not-exist.jwt');
+    expect(() => loadLicenseKey()).toThrow(LicenseConfigError);
+  });
+
+  it('throws LicenseConfigError when KEY_FILE is empty', () => {
+    const file = join(dir, 'empty.jwt');
+    writeFileSync(file, '   \n');
+    process.env.REVEALUI_LICENSE_KEY_FILE = file;
+    expect(() => loadLicenseKey()).toThrow(LicenseConfigError);
+  });
+});
+
+describe('initLicenseGuard — fail-closed + warnings', () => {
+  it('FAILS CLOSED (throws LicenseExpiredError) on an expired license', () => {
+    installLicense(-1 / 24);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => initLicenseGuard()).toThrow(LicenseExpiredError);
+    expect(errSpy).toHaveBeenCalled(); // CRITICAL line emitted before throw
+  });
+
+  it('does NOT throw, and logs CRITICAL, at <= 1 day', () => {
+    installLicense(0.5);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const state = initLicenseGuard();
+    expect(state.valid).toBe(true);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it('does NOT throw on a healthy (15d) license', () => {
+    installLicense(15);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => initLicenseGuard()).not.toThrow();
+  });
+
+  it('does NOT throw, runs degraded, when no license is set', () => {
+    const state = initLicenseGuard();
+    expect(state.valid).toBe(false);
+    expect(state.tier).toBe('free');
+  });
+});
+
+describe('checkLicense — backward-compatible {tier, valid}', () => {
+  it('returns valid Pro+ for a perpetual license', () => {
+    const kit = generateTestLicense('pro', true);
+    setTestLicenseEnv(kit);
+    expect(checkLicense()).toEqual({ tier: 'pro', valid: true });
+  });
+
+  it('returns free/invalid for an expired license (degraded at the RPC layer)', () => {
+    installLicense(-1 / 24);
+    expect(checkLicense()).toEqual({ tier: 'free', valid: false });
+  });
+
+  it('returns free/invalid when no key is set', () => {
+    expect(checkLicense()).toEqual({ tier: 'free', valid: false });
+  });
+});

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -27,6 +27,7 @@ import { dirname, join } from 'node:path';
 import './inference.js';
 import './vcs.js';
 import { DAEMON_DEFAULTS } from './config.js';
+import { LicenseConfigError, LicenseExpiredError } from './license.js';
 import { startDaemon } from './server.js';
 
 // Default log path for --detach mode. Use the user's data dir (mode 0700,
@@ -71,6 +72,11 @@ License tiers:
   max          + inference management, advanced coordination
   enterprise   Full access, all features
 `);
+  process.exit(0);
+}
+
+if (args.includes('--version') || args.includes('-v')) {
+  console.log('revdev-daemon 0.1.0');
   process.exit(0);
 }
 
@@ -120,7 +126,22 @@ console.log('');
 console.log('  RevDev Daemon v0.1.0');
 console.log('  ────────────────────');
 
-const daemon = await startDaemon(config);
+let daemon: Awaited<ReturnType<typeof startDaemon>>;
+try {
+  daemon = await startDaemon(config);
+} catch (err) {
+  // Fail-closed license errors are operator-actionable, not crashes:
+  // initLicenseGuard already logged the CRITICAL detail for an expired
+  // license; surface a config error then exit non-zero with no stack trace.
+  if (err instanceof LicenseExpiredError) {
+    process.exit(1);
+  }
+  if (err instanceof LicenseConfigError) {
+    console.error(`[license] ${err.message}`);
+    process.exit(1);
+  }
+  throw err;
+}
 
 // Write PID file so supervisors and Studio can find us
 await mkdir(dirname(pidFile), { recursive: true });

--- a/packages/daemon/src/guard.ts
+++ b/packages/daemon/src/guard.ts
@@ -6,9 +6,25 @@
  *
  * This is the runtime enforcement layer. The FSL-1.1-MIT license provides
  * legal protection; this guard provides operational protection.
+ *
+ * Expiry behavior (GAP-184): initLicenseGuard() warns at 14d/7d/1d before
+ * expiry and FAILS CLOSED (throws LicenseExpiredError) when a present
+ * license is already expired — the daemon refuses to start. A license that
+ * expires *while the daemon is running* is reported loudly via
+ * runtimeLicenseRecheck() but does NOT tear down active sessions; the next
+ * restart fails closed.
  */
 
-import { checkLicense, isExemptMethod, type LicenseTier } from './license.js';
+import {
+  checkLicense,
+  evaluateLicense,
+  isExemptMethod,
+  type LicenseEvaluation,
+  LicenseExpiredError,
+  LICENSE_HELP_URL,
+  type LicenseTier,
+} from './license.js';
+import { recordLicenseMetrics } from './observability.js';
 
 export interface RpcGuardResult {
   allowed: boolean;
@@ -19,15 +35,69 @@ export interface RpcGuardResult {
 /** Cached license state — checked once at startup, refreshable on demand. */
 let cachedLicense: { tier: LicenseTier; valid: boolean } | null = null;
 
+/** Render a signed seconds delta as a compact human duration ("12d 3h"). */
+function humanizeSeconds(seconds: number): string {
+  const abs = Math.abs(seconds);
+  const days = Math.floor(abs / 86_400);
+  const hours = Math.floor((abs % 86_400) / 3_600);
+  if (days > 0) return `${days}d ${hours}h`;
+  const minutes = Math.floor((abs % 3_600) / 60);
+  return `${hours}h ${minutes}m`;
+}
+
+/** Log the expiry warning appropriate to a valid-but-expiring license. */
+function logExpiryWarning(ev: LicenseEvaluation): void {
+  if (ev.secondsRemaining === null || ev.expiresAt === null) return;
+  const at = new Date(ev.expiresAt * 1000).toISOString();
+  const ttl = humanizeSeconds(ev.secondsRemaining);
+  const tail = `(expires ${at}, ${ttl} remaining) — rotate per ${LICENSE_HELP_URL}`;
+  switch (ev.status) {
+    case 'expiring-1d':
+      console.error(`[license] CRITICAL: license expires in <= 1 day ${tail}`);
+      break;
+    case 'expiring-7d':
+      console.warn(`[license] WARNING: license expires in <= 7 days ${tail}`);
+      break;
+    case 'expiring-14d':
+      console.info(`[license] notice: license expires in <= 14 days ${tail}`);
+      break;
+    default:
+      break;
+  }
+}
+
 /**
  * Initialize license state. Call once at daemon startup.
- * Logs the detected tier as a startup banner.
+ *
+ * Logs the detected tier as a startup banner, records license metrics, warns
+ * on approaching expiry, and FAILS CLOSED (throws LicenseExpiredError) when a
+ * present license is already expired. Because startDaemon() calls this before
+ * binding the socket or opening the database, the throw aborts startup with
+ * nothing to tear down.
  */
 export function initLicenseGuard(): { tier: LicenseTier; valid: boolean } {
-  cachedLicense = checkLicense();
+  const ev = evaluateLicense();
+  cachedLicense = { tier: ev.tier, valid: ev.valid };
+  recordLicenseMetrics(ev);
 
-  if (cachedLicense.valid) {
-    console.log(`[license] RevDev daemon running with ${cachedLicense.tier.toUpperCase()} license`);
+  // Fail-closed: a present-but-expired credential is a security event, not
+  // the same as running unlicensed (free/degraded) mode.
+  if (ev.status === 'expired') {
+    const ago = ev.secondsRemaining === null ? 'some time' : humanizeSeconds(ev.secondsRemaining);
+    const at = ev.expiresAt ? new Date(ev.expiresAt * 1000).toISOString() : 'unknown';
+    console.error(
+      `[license] CRITICAL: license EXPIRED ${ago} ago (expired ${at}) — refusing to start. ` +
+        `Rotate the license per ${LICENSE_HELP_URL}, then restart the daemon.`,
+    );
+    throw new LicenseExpiredError(
+      `RevDev daemon license expired (${at}); refusing to start`,
+      ev.expiresAt,
+    );
+  }
+
+  if (ev.valid) {
+    console.log(`[license] RevDev daemon running with ${ev.tier.toUpperCase()} license`);
+    logExpiryWarning(ev);
   } else {
     console.log('[license] RevDev daemon running in FREE (degraded) mode');
     console.log('[license] Set REVEALUI_LICENSE_KEY to unlock Pro features');
@@ -35,6 +105,30 @@ export function initLicenseGuard(): { tier: LicenseTier; valid: boolean } {
   }
 
   return cachedLicense;
+}
+
+/**
+ * Re-evaluate the license while the daemon is running (called on a daily
+ * timer). Refreshes metrics and logs warnings, but intentionally does NOT
+ * tear down the running daemon or downgrade the cached tier — a license that
+ * crosses expiry mid-session is reported loudly and fails closed on the next
+ * restart, rather than disrupting in-flight agent work. Returns the fresh
+ * evaluation so the caller can emit telemetry events.
+ */
+export function runtimeLicenseRecheck(): LicenseEvaluation {
+  const ev = evaluateLicense();
+  recordLicenseMetrics(ev);
+  if (ev.status === 'expired') {
+    const at = ev.expiresAt ? new Date(ev.expiresAt * 1000).toISOString() : 'unknown';
+    console.error(
+      `[license] CRITICAL: license has EXPIRED while running (expired ${at}). ` +
+        `Pro features remain served until restart, which will fail closed. ` +
+        `Rotate per ${LICENSE_HELP_URL}.`,
+    );
+  } else {
+    logExpiryWarning(ev);
+  }
+  return ev;
 }
 
 /** Force a license recheck (e.g. if env var was updated). */

--- a/packages/daemon/src/guard.ts
+++ b/packages/daemon/src/guard.ts
@@ -19,9 +19,9 @@ import {
   checkLicense,
   evaluateLicense,
   isExemptMethod,
+  LICENSE_HELP_URL,
   type LicenseEvaluation,
   LicenseExpiredError,
-  LICENSE_HELP_URL,
   type LicenseTier,
 } from './license.js';
 import { recordLicenseMetrics } from './observability.js';

--- a/packages/daemon/src/license-crypto.ts
+++ b/packages/daemon/src/license-crypto.ts
@@ -51,6 +51,24 @@ export function isRevokedJti(_jti: string): boolean {
   return false;
 }
 
+/**
+ * Machine-readable reason a verification failed. Lets callers branch on
+ * the failure class (e.g. fail-closed on `expired` while degrading to free
+ * tier on `invalid-signature`) without string-matching the human `reason`.
+ */
+export type LicenseFailureCode =
+  | 'invalid-format'
+  | 'unsupported-algorithm'
+  | 'invalid-tier'
+  | 'invalid-claim'
+  | 'expired'
+  | 'not-yet-valid'
+  | 'no-public-key'
+  | 'invalid-signature'
+  | 'invalid-issuer'
+  | 'invalid-audience'
+  | 'revoked';
+
 export interface LicenseJWTResult {
   tier: 'pro' | 'max' | 'enterprise';
   expiresAt: number; // unix seconds, 0 = perpetual
@@ -61,6 +79,13 @@ export interface LicenseJWTFailure {
   tier: 'free';
   valid: false;
   reason: string;
+  code: LicenseFailureCode;
+  /**
+   * Present when the token parsed far enough to read its `exp` claim — set
+   * on the `expired` failure so callers can report time-since-expiry and
+   * drive expiry telemetry without re-decoding the token.
+   */
+  expiresAt?: number;
 }
 
 function decodeBase64url(input: string): Buffer {
@@ -70,8 +95,8 @@ function decodeBase64url(input: string): Buffer {
 /**
  * Verify an Ed25519-signed JWT license key.
  *
- * Returns the tier + expiration if valid, or { valid: false, reason } if not.
- * Never throws — all parse/verify errors are returned as failures.
+ * Returns the tier + expiration if valid, or { valid: false, reason, code }
+ * if not. Never throws — all parse/verify errors are returned as failures.
  */
 export function verifyLicenseJWT(
   token: string,
@@ -80,7 +105,7 @@ export function verifyLicenseJWT(
   try {
     const parts = token.split('.');
     if (parts.length !== 3) {
-      return { tier: 'free', valid: false, reason: 'invalid format' };
+      return { tier: 'free', valid: false, reason: 'invalid format', code: 'invalid-format' };
     }
 
     const [headerB64, payloadB64, signatureB64] = parts as [string, string, string];
@@ -90,11 +115,16 @@ export function verifyLicenseJWT(
     try {
       header = JSON.parse(decodeBase64url(headerB64).toString('utf-8')) as Record<string, unknown>;
     } catch {
-      return { tier: 'free', valid: false, reason: 'invalid format' };
+      return { tier: 'free', valid: false, reason: 'invalid format', code: 'invalid-format' };
     }
 
     if (header.alg !== 'EdDSA') {
-      return { tier: 'free', valid: false, reason: 'unsupported algorithm' };
+      return {
+        tier: 'free',
+        valid: false,
+        reason: 'unsupported algorithm',
+        code: 'unsupported-algorithm',
+      };
     }
 
     // Decode + parse payload
@@ -105,26 +135,39 @@ export function verifyLicenseJWT(
         unknown
       >;
     } catch {
-      return { tier: 'free', valid: false, reason: 'invalid format' };
+      return { tier: 'free', valid: false, reason: 'invalid format', code: 'invalid-format' };
     }
 
     // Validate tier
     const tier = payload.tier;
     if (typeof tier !== 'string' || !VALID_TIERS.has(tier)) {
-      return { tier: 'free', valid: false, reason: `invalid tier: ${String(tier)}` };
+      return {
+        tier: 'free',
+        valid: false,
+        reason: `invalid tier: ${String(tier)}`,
+        code: 'invalid-tier',
+      };
     }
 
     // Validate exp (absent = perpetual; present = must be a number)
     const exp = payload.exp;
     if (exp !== undefined && typeof exp !== 'number') {
-      return { tier: 'free', valid: false, reason: 'invalid exp claim' };
+      return { tier: 'free', valid: false, reason: 'invalid exp claim', code: 'invalid-claim' };
     }
 
     // Check expiration if exp is present
     if (typeof exp === 'number') {
       const nowSeconds = Math.floor(Date.now() / 1000);
       if (nowSeconds > exp) {
-        return { tier: 'free', valid: false, reason: 'license expired' };
+        // Carry expiresAt so callers can compute time-since-expiry + drive
+        // fail-closed / telemetry without re-decoding the token.
+        return {
+          tier: 'free',
+          valid: false,
+          reason: 'license expired',
+          code: 'expired',
+          expiresAt: exp,
+        };
       }
     }
 
@@ -133,6 +176,7 @@ export function verifyLicenseJWT(
         tier: 'free',
         valid: false,
         reason: 'REVDEV_LICENSE_PUBLIC_KEY not set — cannot verify signature',
+        code: 'no-public-key',
       };
     }
 
@@ -144,37 +188,57 @@ export function verifyLicenseJWT(
     const isValid = verify(null, Buffer.from(message, 'utf-8'), publicKey, signatureBuffer);
 
     if (!isValid) {
-      return { tier: 'free', valid: false, reason: 'invalid signature' };
+      return {
+        tier: 'free',
+        valid: false,
+        reason: 'invalid signature',
+        code: 'invalid-signature',
+      };
     }
 
     // Validate iss
     if (payload.iss !== EXPECTED_ISS) {
-      return { tier: 'free', valid: false, reason: `invalid iss: ${String(payload.iss)}` };
+      return {
+        tier: 'free',
+        valid: false,
+        reason: `invalid iss: ${String(payload.iss)}`,
+        code: 'invalid-issuer',
+      };
     }
 
     // Validate aud (jose sets aud as an array or scalar; issuer uses scalar)
     const aud = payload.aud;
     const audValue = Array.isArray(aud) ? aud[0] : aud;
     if (audValue !== EXPECTED_AUD) {
-      return { tier: 'free', valid: false, reason: `invalid aud: ${String(aud)}` };
+      return {
+        tier: 'free',
+        valid: false,
+        reason: `invalid aud: ${String(aud)}`,
+        code: 'invalid-audience',
+      };
     }
 
     // Validate nbf if present
     const nbf = payload.nbf;
     if (nbf !== undefined) {
       if (typeof nbf !== 'number') {
-        return { tier: 'free', valid: false, reason: 'invalid nbf claim' };
+        return { tier: 'free', valid: false, reason: 'invalid nbf claim', code: 'invalid-claim' };
       }
       const nowSeconds = Math.floor(Date.now() / 1000);
       if (nowSeconds < nbf) {
-        return { tier: 'free', valid: false, reason: 'token not yet valid (nbf)' };
+        return {
+          tier: 'free',
+          valid: false,
+          reason: 'token not yet valid (nbf)',
+          code: 'not-yet-valid',
+        };
       }
     }
 
     // Check jti revocation
     const jti = payload.jti;
     if (typeof jti === 'string' && isRevokedJti(jti)) {
-      return { tier: 'free', valid: false, reason: 'token has been revoked' };
+      return { tier: 'free', valid: false, reason: 'token has been revoked', code: 'revoked' };
     }
 
     // expiresAt: 0 = perpetual (mirrors dotted-v2 semantics)
@@ -186,6 +250,6 @@ export function verifyLicenseJWT(
       valid: true,
     };
   } catch {
-    return { tier: 'free', valid: false, reason: 'invalid format' };
+    return { tier: 'free', valid: false, reason: 'invalid format', code: 'invalid-format' };
   }
 }

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -6,20 +6,59 @@
  * exempt to allow daemon lifecycle management without a license check.
  *
  * When running as a standalone daemon (outside the RevealUI monorepo),
- * license validation is done via the REVEALUI_LICENSE_KEY env var.
+ * license validation is done via the REVEALUI_LICENSE_KEY env var, or
+ * REVEALUI_LICENSE_KEY_FILE (a path whose contents hold the key — lets a
+ * systemd-user unit decrypt the JWT to a tmpfs file + shred it post-stop,
+ * avoiding env-var persistence in the process environment).
  *
  * License format: Ed25519-signed JWT (RFC 7519) — keys start with "eyJ".
  * Issued by the RevealUI license API or `revdev/scripts/issue-license.ts`.
  *
  * Legacy formats (RVUI.v2.*, RVUI-*) are rejected per CR8-P0-01 Q2
  * (immediate dotted-v2 removal, no deprecation window, 2026-05-04).
+ *
+ * Expiry posture (GAP-184):
+ *   - No license at all      → FREE (degraded) mode. The daemon runs;
+ *     session management works, Pro features are gated. (Unchanged.)
+ *   - Present + valid         → licensed; warn at 14d / 7d / 1d to expiry.
+ *   - Present + EXPIRED       → fail-closed: the daemon refuses to start.
+ *     An expired credential is a security event, not "no license."
+ *   - Present + invalid sig   → FREE (degraded). Could be a typo; loud log.
+ *   - KEY_FILE set but unread → LicenseConfigError (operator pointed at a
+ *     broken path — surface it loudly, don't silently degrade).
  */
 
+import { readFileSync } from 'node:fs';
 // Import statically — same ESM module, no circular risk.
 import { getVendorPublicKey, verifyLicenseJWT } from './license-crypto.js';
 
 export const LICENSE_TIERS = ['free', 'pro', 'max', 'enterprise'] as const;
 export type LicenseTier = (typeof LICENSE_TIERS)[number];
+
+/**
+ * Customer-facing pointer for expiry/rotation guidance. Kept generic (no
+ * internal repo paths) because the daemon is a source-visible Pro artifact
+ * that customers self-host.
+ */
+export const LICENSE_HELP_URL = 'https://revealui.com/docs/licensing';
+
+/** Thrown when REVEALUI_LICENSE_KEY_FILE is set but its contents are unusable. */
+export class LicenseConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LicenseConfigError';
+  }
+}
+
+/** Thrown at startup when a license is present but its `exp` is in the past. */
+export class LicenseExpiredError extends Error {
+  readonly expiresAt: number | null;
+  constructor(message: string, expiresAt: number | null) {
+    super(message);
+    this.name = 'LicenseExpiredError';
+    this.expiresAt = expiresAt;
+  }
+}
 
 const EXEMPT_METHODS = new Set([
   'ping',
@@ -29,15 +68,57 @@ const EXEMPT_METHODS = new Set([
   'session.list',
 ]);
 
+const DAY_SECONDS = 86_400;
+
+export type LicenseKeySource = 'env' | 'file' | 'none';
+
+/**
+ * Resolve the license key from the environment.
+ *
+ * Priority: REVEALUI_LICENSE_KEY (inline) > REVEALUI_LICENSE_KEY_FILE (path).
+ * Returns { key: null } when neither is set (→ free/degraded mode). Throws
+ * LicenseConfigError when KEY_FILE is set but its contents can't be read or
+ * are empty — a configured-but-broken file is an operator error, not the
+ * same as "no license."
+ */
+export function loadLicenseKey(): { key: string | null; source: LicenseKeySource } {
+  const inline = process.env.REVEALUI_LICENSE_KEY;
+  if (inline) {
+    return { key: inline, source: 'env' };
+  }
+
+  const filePath = process.env.REVEALUI_LICENSE_KEY_FILE;
+  if (filePath) {
+    let contents: string;
+    try {
+      contents = readFileSync(filePath, 'utf-8').trim();
+    } catch (err) {
+      throw new LicenseConfigError(
+        `REVEALUI_LICENSE_KEY_FILE is set to "${filePath}" but could not be read: ` +
+          (err instanceof Error ? err.message : String(err)),
+      );
+    }
+    if (!contents) {
+      throw new LicenseConfigError(`REVEALUI_LICENSE_KEY_FILE ("${filePath}") is empty`);
+    }
+    return { key: contents, source: 'file' };
+  }
+
+  return { key: null, source: 'none' };
+}
+
 /**
  * Check whether the current license allows daemon operation.
  *
  * Returns the detected tier, or 'free' if no valid license is found.
  * The daemon runs in degraded mode on free tier: session management
  * works, but spawning, inference, and merge pipeline are gated.
+ *
+ * Kept as the stable {tier, valid} shape consumed by the RPC guard. The
+ * richer expiry-aware view is `evaluateLicense()`.
  */
 export function checkLicense(): { tier: LicenseTier; valid: boolean } {
-  const key = process.env.REVEALUI_LICENSE_KEY;
+  const { key } = loadLicenseKey();
 
   if (!key) {
     return { tier: 'free', valid: false };
@@ -56,7 +137,7 @@ export function checkLicense(): { tier: LicenseTier; valid: boolean } {
   }
 
   // Legacy formats — REJECTED outright per CR8-P0-01 Q2
-  if (key.startsWith('RVUI.v2.') || key.match(/^RVUI-/i)) {
+  if (key.startsWith('RVUI.v2.') || key.toUpperCase().startsWith('RVUI-')) {
     process.stderr.write(
       '[revdev] Legacy license formats (RVUI.v2.*, RVUI-*) are no longer accepted. ' +
         'Mint an Ed25519-signed JWT via the RevealUI license API or ' +
@@ -66,6 +147,126 @@ export function checkLicense(): { tier: LicenseTier; valid: boolean } {
   }
 
   return { tier: 'free', valid: false };
+}
+
+/** Coarse lifecycle status of the resolved license, expiry-aware. */
+export type LicenseStatus =
+  | 'absent' // no key set → free/degraded
+  | 'invalid' // key present but failed verification (not expiry)
+  | 'expired' // key present, parsed, past its exp → fail-closed
+  | 'perpetual' // valid, no exp claim
+  | 'ok' // valid, > 14 days to expiry
+  | 'expiring-14d' // valid, <= 14 days to expiry
+  | 'expiring-7d' // valid, <= 7 days to expiry
+  | 'expiring-1d'; // valid, <= 1 day to expiry
+
+export interface LicenseEvaluation {
+  tier: LicenseTier;
+  valid: boolean;
+  /** A key was resolved from env or file (vs. none set). */
+  present: boolean;
+  source: LicenseKeySource;
+  status: LicenseStatus;
+  /** Unix seconds; null = perpetual or not determinable. */
+  expiresAt: number | null;
+  /** Seconds until expiry (negative if expired); null = perpetual/unknown. */
+  secondsRemaining: number | null;
+  reason?: string;
+}
+
+/**
+ * Full expiry-aware evaluation of the resolved license. Single source of
+ * truth for the startup guard's warn/fail-closed decisions + telemetry.
+ *
+ * `nowMs` is injectable for deterministic tests.
+ */
+export function evaluateLicense(nowMs: number = Date.now()): LicenseEvaluation {
+  const { key, source } = loadLicenseKey(); // may throw LicenseConfigError
+  const nowSeconds = Math.floor(nowMs / 1000);
+
+  if (!key) {
+    return {
+      tier: 'free',
+      valid: false,
+      present: false,
+      source,
+      status: 'absent',
+      expiresAt: null,
+      secondsRemaining: null,
+    };
+  }
+
+  // Only Ed25519 JWTs are honored; anything else (legacy RVUI.*, garbage)
+  // is invalid — mirrors checkLicense()'s acceptance gate.
+  if (!key.startsWith('eyJ')) {
+    return {
+      tier: 'free',
+      valid: false,
+      present: true,
+      source,
+      status: 'invalid',
+      expiresAt: null,
+      secondsRemaining: null,
+      reason: 'unrecognized license format (expected Ed25519 JWT)',
+    };
+  }
+
+  const result = verifyLicenseJWT(key, getVendorPublicKey());
+
+  if (result.valid) {
+    const expiresAt = result.expiresAt > 0 ? result.expiresAt : null;
+    if (expiresAt === null) {
+      return {
+        tier: result.tier,
+        valid: true,
+        present: true,
+        source,
+        status: 'perpetual',
+        expiresAt: null,
+        secondsRemaining: null,
+      };
+    }
+    const secondsRemaining = expiresAt - nowSeconds;
+    let status: LicenseStatus = 'ok';
+    if (secondsRemaining <= DAY_SECONDS) status = 'expiring-1d';
+    else if (secondsRemaining <= 7 * DAY_SECONDS) status = 'expiring-7d';
+    else if (secondsRemaining <= 14 * DAY_SECONDS) status = 'expiring-14d';
+    return {
+      tier: result.tier,
+      valid: true,
+      present: true,
+      source,
+      status,
+      expiresAt,
+      secondsRemaining,
+    };
+  }
+
+  // Failure. Distinguish expired (fail-closed) from other invalidity (degrade).
+  if (result.code === 'expired') {
+    const expiresAt = result.expiresAt ?? null;
+    return {
+      tier: 'free',
+      valid: false,
+      present: true,
+      source,
+      status: 'expired',
+      expiresAt,
+      secondsRemaining: expiresAt === null ? null : expiresAt - nowSeconds,
+      reason: result.reason,
+    };
+  }
+
+  return {
+    tier: 'free',
+    valid: false,
+    present: true,
+    source,
+    status: 'invalid',
+    expiresAt: null,
+    secondsRemaining: null,
+    reason: result.reason,
+  };
 }
 
 /** Returns true if the given RPC method is exempt from license checks. */

--- a/packages/daemon/src/observability.ts
+++ b/packages/daemon/src/observability.ts
@@ -14,6 +14,7 @@ import {
   startMemoryMonitoring,
   updateActiveConnections,
 } from '@revealui/core/observability';
+import type { LicenseEvaluation } from './license.js';
 
 // ---------------------------------------------------------------------------
 // Daemon-specific metrics
@@ -46,6 +47,22 @@ export const activeSessions = metrics.gauge(
   'Registered agent sessions',
 );
 
+/** 1 when a valid Pro+ license is active, 0 otherwise (free/expired/invalid). */
+export const licenseValid = metrics.gauge(
+  'revdev_daemon_license_valid',
+  'Whether a valid Pro+ license is active (1) or not (0)',
+);
+
+/**
+ * License expiry as an absolute unix timestamp (seconds). 0 = perpetual or
+ * no license. Prometheus-idiomatic: alerting computes time-to-expiry as
+ * `revdev_daemon_license_expires_timestamp_seconds - time()`.
+ */
+export const licenseExpiresTimestamp = metrics.gauge(
+  'revdev_daemon_license_expires_timestamp_seconds',
+  'License expiry as a unix timestamp in seconds (0 = perpetual/none)',
+);
+
 // ---------------------------------------------------------------------------
 // Health checks
 // ---------------------------------------------------------------------------
@@ -76,6 +93,15 @@ export function initObservability(db: PGlite): void {
 
   // Start background memory usage tracking (every 30s)
   startMemoryMonitoring(30_000);
+}
+
+/**
+ * Record license state into metrics gauges. Boot-safe — gauges are in-memory
+ * and registered at module load, so this can run before initObservability().
+ */
+export function recordLicenseMetrics(ev: LicenseEvaluation): void {
+  licenseValid.set(ev.valid ? 1 : 0);
+  licenseExpiresTimestamp.set(ev.expiresAt ?? 0);
 }
 
 /**

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -29,7 +29,12 @@ import {
   verifyEnvelope,
 } from './agent-identity-crypto.js';
 import { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
-import { guardRpcMethod, initLicenseGuard, licenseErrorResponse } from './guard.js';
+import {
+  guardRpcMethod,
+  initLicenseGuard,
+  licenseErrorResponse,
+  runtimeLicenseRecheck,
+} from './guard.js';
 import {
   initNeonSync,
   isNeonSyncActive,
@@ -1177,6 +1182,39 @@ export async function startDaemon(
   );
   nonceSweepTimer.unref();
 
+  // License expiry re-check (GAP-184). Daily while running: refresh metrics,
+  // log expiry warnings, and record a license.* event so Studio can surface
+  // expiry status in its dashboard. Startup is the fail-closed gate
+  // (initLicenseGuard above); this timer never tears the daemon down — it
+  // reports loudly and lets the next restart fail closed.
+  const licenseRecheckTimer = setInterval(
+    () => {
+      let ev: ReturnType<typeof runtimeLicenseRecheck>;
+      try {
+        ev = runtimeLicenseRecheck();
+      } catch (err) {
+        log.warn('license recheck failed', { error: String(err) });
+        return;
+      }
+      if (ev.status === 'expired' || ev.status.startsWith('expiring-')) {
+        const eventType =
+          ev.status === 'expired' ? 'license.expired' : 'license.expiry-approaching';
+        db.query(`INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`, [
+          'revdev-daemon',
+          eventType,
+          JSON.stringify({
+            status: ev.status,
+            tier: ev.tier,
+            expiresAt: ev.expiresAt,
+            secondsRemaining: ev.secondsRemaining,
+          }),
+        ]).catch((err) => log.warn('license event log failed', { error: String(err) }));
+      }
+    },
+    24 * 60 * 60 * 1000,
+  );
+  licenseRecheckTimer.unref();
+
   // Remove stale socket
   const { unlink, chmod } = await import('node:fs/promises');
   await unlink(cfg.socketPath).catch(() => {});
@@ -1468,6 +1506,7 @@ export async function startDaemon(
           _shutdownController = null;
           if (pruneTimer) clearInterval(pruneTimer);
           clearInterval(nonceSweepTimer);
+          clearInterval(licenseRecheckTimer);
           server.close();
           for (const s of openSockets) {
             s.destroy();

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1199,16 +1199,22 @@ export async function startDaemon(
       if (ev.status === 'expired' || ev.status.startsWith('expiring-')) {
         const eventType =
           ev.status === 'expired' ? 'license.expired' : 'license.expiry-approaching';
+        const payload = {
+          status: ev.status,
+          tier: ev.tier,
+          expiresAt: ev.expiresAt,
+          secondsRemaining: ev.secondsRemaining,
+        };
+        // Local insert + best-effort Neon mirror (coordination_events), matching
+        // the events.log handler's dual-write, so fleet/admin dashboards see
+        // license telemetry when POSTGRES_URL is configured.
         db.query(`INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`, [
           'revdev-daemon',
           eventType,
-          JSON.stringify({
-            status: ev.status,
-            tier: ev.tier,
-            expiresAt: ev.expiresAt,
-            secondsRemaining: ev.secondsRemaining,
-          }),
-        ]).catch((err) => log.warn('license event log failed', { error: String(err) }));
+          JSON.stringify(payload),
+        ])
+          .then(() => syncEventLog({ agentId: 'revdev-daemon', type: eventType, payload }))
+          .catch((err) => log.warn('license event log failed', { error: String(err) }));
       }
     },
     24 * 60 * 60 * 1000,

--- a/packages/daemon/systemd/license-file.conf.example
+++ b/packages/daemon/systemd/license-file.conf.example
@@ -1,0 +1,40 @@
+# revdev-daemon — license-file drop-in (EXAMPLE; copy + adapt, do not symlink)
+# =============================================================================
+# Loads the daemon's license JWT from a FILE instead of an inline env var, so
+# the secret never persists in the daemon's process environment (where any
+# `cat /proc/<pid>/environ` or crash dump would expose it). The plaintext key
+# is written to the service-private /tmp (tmpfs, via PrivateTmp=true in the
+# base unit), then shredded when the service stops.
+#
+# The daemon resolves its license in this priority order (packages/daemon/src/
+# license.ts → loadLicenseKey):
+#     1. REVEALUI_LICENSE_KEY        (inline — must be UNSET to use the file)
+#     2. REVEALUI_LICENSE_KEY_FILE   (this pattern)
+#
+# Install:
+#     mkdir -p ~/.config/systemd/user/revdev-daemon.service.d
+#     cp packages/daemon/systemd/license-file.conf.example \
+#        ~/.config/systemd/user/revdev-daemon.service.d/license-file.conf
+#     # edit the revvault path + binary paths below, then:
+#     systemctl --user daemon-reload && systemctl --user restart revdev-daemon
+#
+# Requirements / caveats:
+#   - revvault must be resolvable. systemd-user units run with a minimal PATH
+#     that usually excludes ~/.local/bin, so use an ABSOLUTE path to revvault
+#     below (find yours with `command -v revvault`).
+#   - The base unit sets PrivateTmp=true, so /tmp here is private to this
+#     service and torn down on stop; the ExecStopPost shred is belt-and-braces.
+#   - If `revvault get ... --full` writes an empty file (a known quirk inside
+#     some non-interactive shells), use the JSON form instead:
+#       revvault --json get revdev/licenses/founder-jwt | jq -r .value > "$F"
+#   - Ensure REVEALUI_LICENSE_KEY is NOT exported in the daemon's environment,
+#     or it will win over this file.
+
+[Service]
+# Materialize the license into the service-private tmpfs at start. umask 077
+# so the file is owner-only.
+ExecStartPre=/bin/sh -c 'umask 077; /usr/local/bin/revvault get revdev/licenses/founder-jwt --full > /tmp/revdev-license.jwt'
+Environment=REVEALUI_LICENSE_KEY_FILE=/tmp/revdev-license.jwt
+
+# Shred the plaintext key on stop (best-effort; PrivateTmp also discards it).
+ExecStopPost=/bin/sh -c 'shred -u /tmp/revdev-license.jwt 2>/dev/null || rm -f /tmp/revdev-license.jwt'


### PR DESCRIPTION
## Summary

Hardens the RevDev daemon's license lifecycle: expiry warnings, fail-closed startup on an expired license, and file-based license loading.

## Changes

- **`REVEALUI_LICENSE_KEY_FILE`** — load the license JWT from a file path (priority: inline `REVEALUI_LICENSE_KEY` > file). Lets a systemd-user unit decrypt the key to tmpfs and shred it post-stop instead of persisting it in the process environment. A file that is set-but-unreadable/empty fails loudly (`LicenseConfigError`).
- **Expiry warnings** — warns at 14d (info) / 7d (warning) / 1d (critical) before expiry, on startup and on a daily re-check while running.
- **Fail-closed start** — a present-but-expired license makes the daemon refuse to start (clean non-zero exit, no stack trace). See the design note below.
- **Telemetry** — `license_valid` + `license_expires_timestamp_seconds` Prometheus gauges; `license.expiry-approaching` / `license.expired` events recorded for the dashboard.
- **`--version`** flag on the daemon CLI.
- **`systemd/license-file.conf.example`** — documented secure file-load drop-in (decrypt to `PrivateTmp`, shred on stop).
- **Structured failure `code`** on the JWT verifier so callers branch on `expired` without string-matching the human-readable reason.

## Design note (reviewer input welcome)

Fail-closed is scoped to a **present-but-expired** license — a security event. An **absent** license intentionally still runs in free/degraded mode (session management only), because that unlicensed path is load-bearing across the guard and the existing test suite. (A literal "fail if neither key is set" would have broken free-tier operation.)

## Verification

- typecheck clean
- `guard` + `flows` + new `license-expiry` suites: **71/71** pass (no regression)
- `shutdown-drain`: **10/10** (the new daily-recheck interval is cleared in `close()`)
- package build OK

18 new test cases cover the expiry thresholds (15d/13d/6d/12h/-1h), the fail-closed throw, file-based load, and the config-error path.
