### PR TITLE
ci(backflow): retry PR-open on transient permission/API blips

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -90,8 +90,6 @@ jobs:
           BEHIND: ${{ steps.check.outputs.behind }}
           REPO: ${{ github.repository }}
         run: |
-          existing=$(gh pr list --repo "$REPO" --base test --head chore/backflow-main-into-test --json number --jq '.[0].number // empty')
-
           title="chore(test): backflow main into test ($BEHIND commit(s) behind)"
           {
             echo "## Summary"
@@ -119,10 +117,33 @@ jobs:
             echo "_Per \`feedback_no_auto_merge\`: manual merge only — no \`--auto\`._"
           } > /tmp/pr-body.md
 
-          if [ -n "$existing" ]; then
-            gh pr edit "$existing" --repo "$REPO" --title "$title" --body-file /tmp/pr-body.md
-            echo "Updated existing backflow PR #$existing"
-          else
-            gh pr create --repo "$REPO" --base test --head chore/backflow-main-into-test --title "$title" --body-file /tmp/pr-body.md
-            echo "Created new backflow PR"
-          fi
+          # Idempotent open-or-update: re-checks for an existing backflow PR on each
+          # call, so a retry after a failed attempt edits rather than double-creates.
+          open_or_update_pr() {
+            local existing
+            existing=$(gh pr list --repo "$REPO" --base test --head chore/backflow-main-into-test --json number --jq '.[0].number // empty') || return 1
+            if [ -n "$existing" ]; then
+              gh pr edit "$existing" --repo "$REPO" --title "$title" --body-file /tmp/pr-body.md || return 1
+              echo "Updated existing backflow PR #$existing"
+            else
+              gh pr create --repo "$REPO" --base test --head chore/backflow-main-into-test --title "$title" --body-file /tmp/pr-body.md || return 1
+              echo "Created new backflow PR"
+            fi
+          }
+
+          # Retry with backoff. "GitHub Actions is not permitted to create or approve
+          # pull requests" (and transient API 5xx) can fire right after a promotion
+          # while the org→repo PR-creation permission propagates; a retry lets the
+          # blip self-heal without a manual rerun. A persistent failure still exits
+          # non-zero so genuinely-unhealed staleness stays visible (red), not silent.
+          attempt=0
+          max=4
+          until open_or_update_pr; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge "$max" ]; then
+              echo "::error title=Backflow PR open failed::Could not open/update the backflow PR after $max attempts. The chore/backflow-main-into-test branch is already pushed (it carries the main→test merge), so recovery is just opening the PR. If the cause is 'GitHub Actions is not permitted to create or approve pull requests', enable Settings → Actions → General → Workflow permissions → 'Allow GitHub Actions to create and approve pull requests', then re-run this job."
+              exit 1
+            fi
+            echo "::warning::backflow PR open attempt $attempt/$max failed; retrying in $((attempt * 15))s..."
+            sleep "$((attempt * 15))"
+          done


### PR DESCRIPTION
## Summary

Hardens the `Open or update backflow PR` step in `.github/workflows/backflow-main-into-test.yml` so a transient blip no longer reds the backflow job and forces a manual re-run.

## Problem

The step runs `gh pr create` / `gh pr edit` with `GITHUB_TOKEN`. Immediately after a `test`→`main` promotion it can fail with:

> GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)

— an org→repo PR-creation-permission propagation blip — or a transient API 5xx. The merge step has already pushed `chore/backflow-main-into-test`, but without the PR the staleness isn't healed and the job goes red, needing a manual re-run.

## Fix

- Extract the open/update into an idempotent `open_or_update_pr()` that re-checks for an existing backflow PR on each call, so a retry **edits** rather than double-creates.
- Retry up to 4 attempts with 15/30/45s backoff — a propagation blip self-heals without intervention.
- A persistent failure still `exit 1`s, so a genuine misconfiguration (e.g. the "Allow GitHub Actions to create and approve pull requests" toggle actually disabled) stays **visible** (red) with an actionable error message, rather than being silently swallowed.

Happy-path behavior is unchanged.

## Verification

The backflow workflow only triggers on `push: main`, so it can't be exercised from this PR. The retry control-flow was unit-tested locally under `bash -eo pipefail` with a mocked `gh`: succeeds immediately (0 failures), self-heals after 2 blips, and gives up with `exit 1` on persistent failure. YAML validated via `yaml.safe_load`.

This workflow is byte-identical across the fleet repos; the same change is being applied to each as a sweep.

_Manual merge only — no `--auto`._
