### PR TITLE
feat(scripts): license rotation script + weekly systemd timer

### DIFF
--- a/packages/daemon/systemd/install.sh
+++ b/packages/daemon/systemd/install.sh
@@ -69,3 +69,26 @@ systemctl --user status revdev-daemon --no-pager | head -10 || true
 echo
 echo "Tail logs with: journalctl --user-unit revdev-daemon -f"
 echo "If on WSL and you want survival across logouts: sudo loginctl enable-linger \$(whoami)"
+
+# --- License rotation timer (calendar, weekly) ----------------------------
+# Additive: installs the rotation oneshot + timer using the same NODE_PATH +
+# repo resolution as the daemon unit above. A second daemon-reload is harmless.
+ROTATION_SERVICE_TEMPLATE=$(dirname "$0")/revdev-license-rotation.service
+ROTATION_TIMER_TEMPLATE=$(dirname "$0")/revdev-license-rotation.timer
+ROTATION_SCRIPT=$REPO_ROOT/scripts/rotate-license.ts
+ESCAPED_SCRIPT=$(printf '%s\n' "$ROTATION_SCRIPT" | sed 's/[&"]/\\&/g')
+
+if [ -f "$ROTATION_SERVICE_TEMPLATE" ] && [ -f "$ROTATION_TIMER_TEMPLATE" ]; then
+  sed "s|/usr/bin/env node --import tsx %h/revfleet/revdev/scripts/rotate-license.ts|\"$ESCAPED_NODE\" --import tsx \"$ESCAPED_SCRIPT\"|" \
+    "$ROTATION_SERVICE_TEMPLATE" > "$UNIT_DIR/revdev-license-rotation.service"
+  cp "$ROTATION_TIMER_TEMPLATE" "$UNIT_DIR/revdev-license-rotation.timer"
+  systemctl --user daemon-reload
+  systemctl --user enable --now revdev-license-rotation.timer
+  echo
+  echo "license-rotation timer installed at $UNIT_DIR/revdev-license-rotation.timer"
+  echo "Next run:"
+  systemctl --user list-timers revdev-license-rotation.timer --no-pager | head -3 || true
+else
+  echo
+  echo "note: license-rotation unit templates not found alongside this script; skipped"
+fi

--- a/packages/daemon/systemd/revdev-license-rotation.service
+++ b/packages/daemon/systemd/revdev-license-rotation.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=RevDev license rotation (calendar)
+Documentation=https://github.com/RevealUIStudio/revdev
+
+[Service]
+Type=oneshot
+# install.sh substitutes the resolved node binary + absolute script path (the
+# %h template default is the contributor checkout). Runs with no args, so the
+# script's built-in defaults apply (rotate revdev/licenses/founder-jwt as
+# enterprise/RevealUIStudio/90d when within 14d of expiry). Override the
+# target by editing this line or adding a drop-in with a different ExecStart.
+#
+# Requires `tsx` to be resolvable by the node binary below (the scripts/ tools
+# run via tsx, matching issue-license.ts). If your node lacks a global tsx,
+# install it (npm i -g tsx) or point ExecStart at a built JS equivalent.
+ExecStart=/usr/bin/env node --import tsx %h/revfleet/revdev/scripts/rotate-license.ts
+# Keep a tracked rotation audit log by pointing this at it:
+# Environment=LICENSE_ROTATION_LOG=%h/.local/share/revealui/license-rotation-log.md
+# Optional: POST a rotation summary to a webhook:
+# Environment=LICENSE_ROTATION_ALERT_WEBHOOK=https://…

--- a/packages/daemon/systemd/revdev-license-rotation.timer
+++ b/packages/daemon/systemd/revdev-license-rotation.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Weekly RevDev license rotation check
+Documentation=https://github.com/RevealUIStudio/revdev
+
+[Timer]
+# Weekly, Sunday 04:00 local (after the 03:00 WSL backup window). The rotation
+# script is a no-op until the license is within its threshold window, so a
+# weekly cadence comfortably stages a replacement before the daemon's
+# fail-closed expiry fires (14-day default warning window).
+OnCalendar=Sun *-*-* 04:00:00
+Persistent=true
+RandomizedDelaySec=30min
+
+[Install]
+WantedBy=timers.target

--- a/scripts/issue-license.ts
+++ b/scripts/issue-license.ts
@@ -19,13 +19,19 @@
  * Output: Ed25519-signed JWT (RFC 7519). Header: { alg: "EdDSA", typ: "JWT" }.
  * Payload: { tier, iat, iss, aud, customerId?, exp? }.
  * Format matches the RevealUI license API issuer (revealui#735, Phase A).
+ *
+ * The signing helpers (issueLicense / getPrivateKey / revvaultSet) are
+ * exported so sibling tooling (e.g. scripts/rotate-license.ts) can reuse the
+ * exact mint path. The CLI body only runs when this file is the entrypoint
+ * (import.meta main-guard), so importing it has no side effects.
  */
 
 import { execSync } from 'node:child_process';
 import { createPrivateKey, generateKeyPairSync, sign } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
-interface Options {
+export interface Options {
   tier: 'pro' | 'max' | 'enterprise';
   customer?: string;
   days?: number;
@@ -78,7 +84,7 @@ Output format: Ed25519-signed JWT (RFC 7519). Set as REVEALUI_LICENSE_KEY on the
   return opts;
 }
 
-function getPrivateKey(): string {
+export function getPrivateKey(): string {
   // 1. Environment variable
   if (process.env.REVDEV_LICENSE_PRIVATE_KEY) {
     return process.env.REVDEV_LICENSE_PRIVATE_KEY;
@@ -110,7 +116,7 @@ function getPrivateKey(): string {
   process.exit(1);
 }
 
-function issueLicense(opts: Options): string {
+export function issueLicense(opts: Options): string {
   const privateKeyPem = getPrivateKey();
   const privateKey = createPrivateKey(privateKeyPem);
 
@@ -139,7 +145,7 @@ function issueLicense(opts: Options): string {
   return `${message}.${signature}`;
 }
 
-function revvaultSet(path: string, value: string): void {
+export function revvaultSet(path: string, value: string): void {
   try {
     execSync(`revvault set --force ${path}`, {
       input: value,
@@ -174,32 +180,47 @@ function generateKeypair(): void {
   console.log(publicKey);
 }
 
-// --- Main ---
-// Honor --help before any state-changing action: --generate-keypair writes to
-// revvault, so a `--generate-keypair --help` call must NOT rotate keys.
-if (process.argv.includes('--help') || process.argv.includes('-h')) {
-  parseArgs(); // prints help and exits
+/** True when this file is the process entrypoint (not imported). */
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
 }
 
-if (process.argv.includes('--generate-keypair')) {
-  generateKeypair();
-  process.exit(0);
+// --- CLI ---
+// Only runs when invoked directly; importing this module is side-effect-free
+// so rotate-license.ts can reuse issueLicense()/getPrivateKey()/revvaultSet().
+if (isMainModule()) {
+  // Honor --help before any state-changing action: --generate-keypair writes to
+  // revvault, so a `--generate-keypair --help` call must NOT rotate keys.
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    parseArgs(); // prints help and exits
+  }
+
+  if (process.argv.includes('--generate-keypair')) {
+    generateKeypair();
+    process.exit(0);
+  }
+
+  const opts = parseArgs();
+  const key = issueLicense(opts);
+
+  console.log('');
+  console.log('  License Key Issued');
+  console.log('  ──────────────────');
+  console.log(`  Tier:     ${opts.tier.toUpperCase()}`);
+  console.log(`  Customer: ${opts.customer ?? '(not specified)'}`);
+  console.log(`  Expires:  ${opts.perpetual ? 'Never (perpetual)' : `${opts.days ?? 365} days`}`);
+  console.log(`  Format:   Ed25519-signed JWT (RFC 7519)`);
+  console.log('');
+  console.log('  Key:');
+  console.log(`  ${key}`);
+  console.log('');
+  console.log('  Deliver this key to the customer. They set it as:');
+  console.log('  REVEALUI_LICENSE_KEY=<key>');
+  console.log('');
 }
-
-const opts = parseArgs();
-const key = issueLicense(opts);
-
-console.log('');
-console.log('  License Key Issued');
-console.log('  ──────────────────');
-console.log(`  Tier:     ${opts.tier.toUpperCase()}`);
-console.log(`  Customer: ${opts.customer ?? '(not specified)'}`);
-console.log(`  Expires:  ${opts.perpetual ? 'Never (perpetual)' : `${opts.days ?? 365} days`}`);
-console.log(`  Format:   Ed25519-signed JWT (RFC 7519)`);
-console.log('');
-console.log('  Key:');
-console.log(`  ${key}`);
-console.log('');
-console.log('  Deliver this key to the customer. They set it as:');
-console.log('  REVEALUI_LICENSE_KEY=<key>');
-console.log('');

--- a/scripts/issue-license.ts
+++ b/scripts/issue-license.ts
@@ -26,7 +26,7 @@
  * (import.meta main-guard), so importing it has no side effects.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { createPrivateKey, generateKeyPairSync, sign } from 'node:crypto';
 import { readFileSync, realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -92,7 +92,7 @@ export function getPrivateKey(): string {
 
   // 2. Revvault
   try {
-    const key = execSync('revvault get revdev/license-signing-private-key', {
+    const key = execFileSync('revvault', ['get', 'revdev/license-signing-private-key'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
@@ -147,7 +147,7 @@ export function issueLicense(opts: Options): string {
 
 export function revvaultSet(path: string, value: string): void {
   try {
-    execSync(`revvault set --force ${path}`, {
+    execFileSync('revvault', ['set', '--force', path], {
       input: value,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/scripts/rotate-license.ts
+++ b/scripts/rotate-license.ts
@@ -1,0 +1,313 @@
+#!/usr/bin/env -S node --import=tsx
+
+/**
+ * Rotate a RevDev license stored in revvault.
+ *
+ * Calendar rotation (default): mints a replacement when the current license
+ * is within --threshold-days of expiry (default 14), so the new key is staged
+ * BEFORE the daemon's fail-closed expiry fires. Idempotent — exits 0 with no
+ * change when the license is still outside the window.
+ *
+ * Emergency rotation: --emergency --reason "<why>" rotates immediately
+ * regardless of remaining time (laptop theft, vault anomaly, key exposure …).
+ *
+ * Designed to run unattended on a weekly systemd-user timer
+ * (systemd/revdev-license-rotation.{service,timer}).
+ *
+ *   # founder license, calendar rotation (no-op unless within 14d of expiry)
+ *   npx tsx scripts/rotate-license.ts \
+ *     --vault-path revdev/licenses/founder-jwt --tier enterprise \
+ *     --customer RevealUIStudio --days 90
+ *
+ *   # emergency rotation
+ *   npx tsx scripts/rotate-license.ts --vault-path revdev/licenses/founder-jwt \
+ *     --tier enterprise --customer RevealUIStudio --days 90 \
+ *     --emergency --reason "laptop-theft 2026-05-24"
+ *
+ * Audit log: every rotation appends a row to $LICENSE_ROTATION_LOG (default
+ * ~/.local/share/revealui/license-rotation-log.md). Operators who keep a
+ * tracked rotation log point that env var at it.
+ *
+ * Optional alert: if $LICENSE_ROTATION_ALERT_WEBHOOK is set, a JSON summary is
+ * POSTed there best-effort after a successful rotation.
+ *
+ * Reuses the exact mint path from issue-license.ts (issueLicense/revvaultSet).
+ */
+
+import { execSync } from 'node:child_process';
+import { appendFileSync, mkdirSync, realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { issueLicense, revvaultSet } from './issue-license.js';
+
+const DAY_SECONDS = 86_400;
+
+interface RotateConfig {
+  vaultPath: string;
+  tier: 'pro' | 'max' | 'enterprise';
+  customer?: string;
+  days: number;
+  thresholdDays: number;
+  emergency: boolean;
+  reason?: string;
+  auditLogPath: string;
+}
+
+/** Subset of license claims needed for the rotation decision + audit row. */
+export interface DecodedLicense {
+  exp: number | null; // unix seconds; null = perpetual / absent
+  customerId: string | null;
+  jti: string | null;
+  tier: string | null;
+}
+
+/**
+ * Decode (NOT verify) a license JWT to read its claims. We are reading our own
+ * vault copy purely to decide whether to rotate + to record the prior identity
+ * in the audit log; signature verification is the daemon's job at load time.
+ */
+export function decodeLicense(jwt: string): DecodedLicense {
+  const parts = jwt.trim().split('.');
+  if (parts.length !== 3) {
+    return { exp: null, customerId: null, jti: null, tier: null };
+  }
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1] as string, 'base64url').toString('utf-8'),
+    ) as Record<string, unknown>;
+    return {
+      exp: typeof payload.exp === 'number' ? payload.exp : null,
+      customerId: typeof payload.customerId === 'string' ? payload.customerId : null,
+      jti: typeof payload.jti === 'string' ? payload.jti : null,
+      tier: typeof payload.tier === 'string' ? payload.tier : null,
+    };
+  } catch {
+    return { exp: null, customerId: null, jti: null, tier: null };
+  }
+}
+
+/**
+ * Rotation decision. Emergency always rotates. Otherwise rotate only when a
+ * dated license is within the threshold window; a perpetual license (exp null)
+ * never calendar-rotates.
+ */
+export function shouldRotate(
+  exp: number | null,
+  nowSeconds: number,
+  thresholdDays: number,
+  emergency: boolean,
+): boolean {
+  if (emergency) return true;
+  if (exp === null) return false;
+  return exp - nowSeconds <= thresholdDays * DAY_SECONDS;
+}
+
+function parseArgs(): RotateConfig {
+  const args = process.argv.slice(2);
+  const cfg: RotateConfig = {
+    vaultPath: 'revdev/licenses/founder-jwt',
+    tier: 'enterprise',
+    customer: 'RevealUIStudio',
+    days: 90,
+    thresholdDays: 14,
+    emergency: false,
+    auditLogPath:
+      process.env.LICENSE_ROTATION_LOG ??
+      join(homedir(), '.local', 'share', 'revealui', 'license-rotation-log.md'),
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--vault-path':
+        cfg.vaultPath = args[++i] ?? cfg.vaultPath;
+        break;
+      case '--tier':
+        cfg.tier = args[++i] as RotateConfig['tier'];
+        break;
+      case '--customer':
+        cfg.customer = args[++i];
+        break;
+      case '--days':
+        cfg.days = Number.parseInt(args[++i] ?? '', 10) || cfg.days;
+        break;
+      case '--threshold-days':
+        cfg.thresholdDays = Number.parseInt(args[++i] ?? '', 10) || cfg.thresholdDays;
+        break;
+      case '--emergency':
+        cfg.emergency = true;
+        break;
+      case '--reason':
+        cfg.reason = args[++i];
+        break;
+      case '--help':
+      case '-h':
+        console.log(`
+Rotate a RevDev license stored in revvault.
+
+Usage:
+  npx tsx scripts/rotate-license.ts [options]
+
+Options:
+  --vault-path <path>     revvault path of the license to rotate
+                          (default: revdev/licenses/founder-jwt)
+  --tier <pro|max|enterprise>   tier for the replacement (default: enterprise)
+  --customer <name>       customer id for the replacement (default: RevealUIStudio)
+  --days <n>              expiry of the replacement, in days (default: 90)
+  --threshold-days <n>    rotate when within N days of expiry (default: 14)
+  --emergency             rotate now regardless of remaining time
+  --reason "<why>"        required with --emergency; recorded in the audit log
+  --help, -h              show this help
+
+Env:
+  LICENSE_ROTATION_LOG            audit-log path (default: ~/.local/share/revealui/license-rotation-log.md)
+  LICENSE_ROTATION_ALERT_WEBHOOK  optional URL to POST a JSON rotation summary to
+`);
+        process.exit(0);
+    }
+  }
+
+  return cfg;
+}
+
+function readCurrentLicense(vaultPath: string): string {
+  try {
+    return execSync(`revvault get ${vaultPath}`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function appendAuditLog(
+  auditLogPath: string,
+  row: {
+    timestamp: string;
+    trigger: 'calendar' | 'emergency';
+    reason: string;
+    tier: string;
+    customer: string;
+    priorJti: string;
+    priorExp: string;
+    newExp: string;
+    kid: string;
+  },
+): void {
+  mkdirSync(dirname(auditLogPath), { recursive: true });
+  const line =
+    `| ${row.timestamp} | ${row.trigger} | ${row.reason} | ${row.tier} | ${row.customer} ` +
+    `| ${row.priorJti} | ${row.priorExp} | ${row.newExp} | ${row.kid} |\n`;
+  appendFileSync(auditLogPath, line);
+}
+
+async function postAlert(payload: Record<string, unknown>): Promise<void> {
+  const url = process.env.LICENSE_ROTATION_ALERT_WEBHOOK;
+  if (!url) return;
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    console.error(`[rotate] alert webhook failed (non-fatal): ${String(err)}`);
+  }
+}
+
+function isoOrPerpetual(exp: number | null): string {
+  return exp === null ? 'perpetual' : new Date(exp * 1000).toISOString();
+}
+
+async function main(): Promise<void> {
+  const cfg = parseArgs();
+
+  if (cfg.emergency && !cfg.reason) {
+    console.error('[rotate] --emergency requires --reason "<why>"');
+    process.exit(1);
+  }
+
+  const current = readCurrentLicense(cfg.vaultPath);
+  if (!current) {
+    console.error(
+      `[rotate] no current license found at revvault path "${cfg.vaultPath}" ` +
+        '(is revvault unlocked + the path correct?)',
+    );
+    process.exit(1);
+  }
+
+  const prior = decodeLicense(current);
+  const nowSeconds = Math.floor(Date.now() / 1000);
+
+  if (!shouldRotate(prior.exp, nowSeconds, cfg.thresholdDays, cfg.emergency)) {
+    console.log(
+      `[rotate] no rotation needed — ${cfg.vaultPath} expires ${isoOrPerpetual(prior.exp)} ` +
+        `(> ${cfg.thresholdDays}d away).`,
+    );
+    process.exit(0);
+  }
+
+  const newJwt = issueLicense({ tier: cfg.tier, customer: cfg.customer, days: cfg.days });
+  revvaultSet(cfg.vaultPath, newJwt);
+  const next = decodeLicense(newJwt);
+
+  const timestamp = new Date().toISOString();
+  const trigger: 'calendar' | 'emergency' = cfg.emergency ? 'emergency' : 'calendar';
+  appendAuditLog(cfg.auditLogPath, {
+    timestamp,
+    trigger,
+    reason: cfg.reason ?? (trigger === 'calendar' ? 'within-threshold' : '(unspecified)'),
+    tier: cfg.tier,
+    customer: cfg.customer ?? '(none)',
+    priorJti: prior.jti ?? 'n/a',
+    priorExp: isoOrPerpetual(prior.exp),
+    newExp: isoOrPerpetual(next.exp),
+    // No `kid` claim is minted yet (single signing key); recorded as n/a so the
+    // column is ready when multi-key rotation lands.
+    kid: 'n/a (single-key)',
+  });
+
+  console.log('');
+  console.log('  License ROTATED');
+  console.log('  ───────────────');
+  console.log(`  Vault path: ${cfg.vaultPath}`);
+  console.log(`  Trigger:    ${trigger}${cfg.reason ? ` (${cfg.reason})` : ''}`);
+  console.log(`  Tier:       ${cfg.tier}   Customer: ${cfg.customer ?? '(none)'}`);
+  console.log(`  Prior exp:  ${isoOrPerpetual(prior.exp)}`);
+  console.log(`  New exp:    ${isoOrPerpetual(next.exp)}`);
+  console.log(`  Audit log:  ${cfg.auditLogPath}`);
+  console.log('');
+  console.log('  ACTION: restart any daemon/Studio consuming this license so it');
+  console.log('  reloads the rotated key (the new key is already in revvault).');
+  console.log('');
+
+  await postAlert({
+    event: 'license.rotated',
+    timestamp,
+    trigger,
+    reason: cfg.reason ?? null,
+    vaultPath: cfg.vaultPath,
+    tier: cfg.tier,
+    customer: cfg.customer ?? null,
+    priorExp: isoOrPerpetual(prior.exp),
+    newExp: isoOrPerpetual(next.exp),
+  });
+
+  process.exit(0);
+}
+
+/** True when this file is the process entrypoint (not imported). */
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  void main();
+}

--- a/scripts/rotate-license.ts
+++ b/scripts/rotate-license.ts
@@ -34,7 +34,7 @@
  * Reuses the exact mint path from issue-license.ts (issueLicense/revvaultSet).
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { appendFileSync, mkdirSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -60,6 +60,9 @@ export interface DecodedLicense {
   customerId: string | null;
   jti: string | null;
   tier: string | null;
+  /** True when the token could not be parsed (corrupt/truncated) — distinct
+   *  from a valid perpetual license (exp null, malformed false). */
+  malformed: boolean;
 }
 
 /**
@@ -70,7 +73,7 @@ export interface DecodedLicense {
 export function decodeLicense(jwt: string): DecodedLicense {
   const parts = jwt.trim().split('.');
   if (parts.length !== 3) {
-    return { exp: null, customerId: null, jti: null, tier: null };
+    return { exp: null, customerId: null, jti: null, tier: null, malformed: true };
   }
   try {
     const payload = JSON.parse(
@@ -81,9 +84,10 @@ export function decodeLicense(jwt: string): DecodedLicense {
       customerId: typeof payload.customerId === 'string' ? payload.customerId : null,
       jti: typeof payload.jti === 'string' ? payload.jti : null,
       tier: typeof payload.tier === 'string' ? payload.tier : null,
+      malformed: false,
     };
   } catch {
-    return { exp: null, customerId: null, jti: null, tier: null };
+    return { exp: null, customerId: null, jti: null, tier: null, malformed: true };
   }
 }
 
@@ -172,7 +176,7 @@ Env:
 
 function readCurrentLicense(vaultPath: string): string {
   try {
-    return execSync(`revvault get ${vaultPath}`, {
+    return execFileSync('revvault', ['get', vaultPath], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
@@ -238,6 +242,14 @@ async function main(): Promise<void> {
   }
 
   const prior = decodeLicense(current);
+  if (prior.malformed && !cfg.emergency) {
+    console.error(
+      `[rotate] current license at "${cfg.vaultPath}" is not a parseable JWT — refusing to ` +
+        'silently skip rotation. Investigate the vault entry, or force-replace it with ' +
+        '--emergency --reason "<why>".',
+    );
+    process.exit(1);
+  }
   const nowSeconds = Math.floor(Date.now() / 1000);
 
   if (!shouldRotate(prior.exp, nowSeconds, cfg.thresholdDays, cfg.emergency)) {


### PR DESCRIPTION
## Summary

Adds calendar + emergency license rotation for licenses stored in revvault, plus a weekly systemd-user timer. Pairs with the daemon-side expiry warnings / fail-closed work — rotation stages a replacement key *before* the daemon's fail-closed expiry fires.

## Changes

- **`scripts/rotate-license.ts`** — mints a replacement when the current license is within `--threshold-days` of expiry (default 14); idempotent (no-op outside the window). `--emergency --reason "<why>"` rotates immediately (theft / vault anomaly / key exposure). Appends an audit row to `$LICENSE_ROTATION_LOG` (default `~/.local/share/revealui/license-rotation-log.md`) and optionally POSTs a JSON summary to `$LICENSE_ROTATION_ALERT_WEBHOOK`. Defaults target the founder license but `--vault-path` / `--tier` / `--customer` / `--days` generalize it to any license.
- **`scripts/issue-license.ts`** — exports `issueLicense` / `getPrivateKey` / `revvaultSet` behind an `import.meta` main-guard so the rotate script reuses the exact mint path with zero duplication; the CLI is unchanged when run directly.
- **`systemd/revdev-license-rotation.{service,timer}`** — weekly oneshot (Sun 04:00, `Persistent=true`), wired into `pnpm --filter @revdev/daemon setup:systemd` via an additive block in `install.sh`.

## Design notes

- The audit-log path is **env-configurable**, not hardcoded — the operator points `LICENSE_ROTATION_LOG` at a tracked log if they keep one. (No internal paths baked into this public framework repo.)
- The rotation decision (`decodeLicense` + `shouldRotate`) is exported as pure functions for testability; a perpetual license never calendar-rotates (only `--emergency` does).
- `kid` is recorded as `n/a (single-key)` in the audit row — the column is ready for multi-key (`kid`-based) signing-key rotation when that lands.

## Verification

- biome clean (`biome check`)
- `decodeLicense` + `shouldRotate` logic checks pass (decode of valid/perpetual/garbage JWTs; threshold + emergency + perpetual decision matrix)
- both `rotate-license.ts --help` and `issue-license.ts --help` work (refactor's main-guard intact)
- `install.sh` passes `bash -n`

A live rotation smoke (mint a near-expiry license → run the script → confirm replacement) is owner-runnable — it touches the real signing key + revvault and would rotate an actual license, so it isn't run in CI.
