### PR TITLE
docs(readme): sync READMEs with current code

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ Studio talks to the daemon; the daemon coordinates agents and tools. Console tal
 ```
 revdev/
 ├── apps/studio/          # Tauri 2 desktop app (Studio UI)
-├── apps/console/         # Go TUI (Console — SSH ops cockpit)
+├── apps/console/         # Go TUI (Console — SSH billing/ops cockpit)
 ├── packages/daemon/      # Harness daemon (agent coordination, PTY, tools)
 ├── packages/protocol/    # JSON-RPC types shared across all apps
-├── packages/bridge/      # Thin adapter layer between daemon + apps
 └── packages/theme/       # Console theme tokens
 ```
 
@@ -98,6 +97,6 @@ pnpm test
 
 | Component | License |
 |---|---|
-| Studio | MIT |
+| Studio | LicenseRef-RevealUI-Commercial |
 | Console | MIT |
 | Harness Daemon | FSL-1.1-MIT (Fair Source, converts to MIT after 2 years) |

--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -2,10 +2,14 @@
 
 > **Status: Experimental** — Not production-deployed. Functional prototype.
 
-SSH-delivered TUI ops cockpit for RevealUI. Read-mostly view of agent health,
-deploys, billing, and alerts; fast keyboard ops for rollback, approve, rotate,
-ack, and credit purchases. Runs anywhere there's SSH — phone, borrowed laptop,
-server — and is explicitly **not** for editing code (that's Studio's job).
+SSH-delivered TUI for RevealUI account management and licensing. Runs anywhere
+there's SSH — phone, borrowed laptop, server — and is explicitly **not** for
+editing code (that's Studio's job).
+
+The TUI walks users through: browsing subscription tiers, initiating checkout
+(Stripe-hosted URL + QR code), entering a license key, and linking/verifying an
+email account via OTP. It can also proxy raw SSH sessions to the RevealUI agent
+API (pass `agents` as the SSH command, or set `TERMINAL_MODE=agents`).
 
 Built with the [Charm](https://charm.sh/) ecosystem:
 
@@ -18,7 +22,8 @@ Built with the [Charm](https://charm.sh/) ecosystem:
 The intended entry point — once hosted deployment ships — is a single SSH command:
 
 ```bash
-ssh console.revealui.com    # planned — hosted endpoint not yet live
+ssh terminal.revealui.com           # planned — hosted endpoint not yet live
+ssh terminal.revealui.com -t agents # agent proxy mode
 ```
 
 Until then, run locally via the [Development](#development) section.

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -8,12 +8,20 @@ Built with Tauri 2 + React 19 + Tailwind CSS v4.
 
 ## Features
 
-- **Dashboard** — Service status overview with tier badge
+- **Dashboard** — Service status overview with tier badge and mount status
 - **Vault** — Secret management via Revvault (age encryption), namespace filtering, clipboard integration
-- **Infrastructure** — App launcher (start/stop/open 5 apps by port) + DevPod mount/unmount
+- **Infrastructure** — App launcher (start/stop/read logs) + DevPod mount/unmount
 - **Sync** — Repository sync across locations (WSL, LTS, DevPod)
 - **Tunnel** — Tailscale status, connect/disconnect, peer list with 10s polling
-- **Setup** — First-run wizard (environment check, vault init, Tailscale, project setup)
+- **Setup** — First-run wizard (environment check, vault init, Tailscale, git identity)
+- **SSH** — SSH client with password/key auth, bookmarks (save/list/delete), interactive terminal
+- **Terminal** — Local PTY shell sessions (open/send/resize/close) + terminal emulator detection/install
+- **Git** — Full git workflow: status, diff, stage/unstage, discard, commit, branch management (create/switch/delete), push/pull, log, read/write files, diff content
+- **Deploy** — One-click deploy pipeline: Vercel (project create, env set, deploy, deployment status, blob token validate), Neon DB (test connection, migrate, seed), Stripe (validate keys, seed, run keys, catalog sync), email (Resend + SMTP test), health check, secret generation (KEK, RSA keypair)
+- **Harness** — Harness daemon coordination: ping, sessions, inbox, send/broadcast messages, mark-read, tasks (create/claim/complete/release), file reservations (reserve/check)
+- **Agent Spawner** — Spawn/stop/list/remove agent PTY sessions with input/resize
+- **Inference** — Ollama management (status, models, pull, delete, start, stop) + Ubuntu Snap inference (status, list, install, remove)
+- **Daemon Control** — Start/stop/restart/status of the harness daemon process
 
 ## Stack
 
@@ -45,24 +53,26 @@ pnpm build:windows
 apps/studio/
 ├── src/                    # React frontend
 │   ├── App.tsx
-│   ├── components/
-│   │   ├── apps/           # App launcher
-│   │   ├── dashboard/      # Dashboard + service cards
-│   │   ├── devbox/         # DevPod manager
-│   │   ├── infrastructure/ # Infrastructure panel (apps + devbox)
-│   │   ├── layout/         # AppShell, Sidebar, StatusBar
-│   │   ├── setup/          # Setup wizard + setup page
-│   │   ├── sync/           # Repo sync panel
-│   │   ├── tunnel/         # Tailscale tunnel panel
-│   │   └── vault/          # Secret vault UI
-│   ├── hooks/              # React hooks (use-apps, use-devbox, use-setup, use-status, use-sync, use-tunnel, use-vault)
-│   ├── lib/invoke.ts       # Typed Tauri command wrappers
-│   └── types.ts            # Shared TypeScript types
+│   ├── generated/          # ts-rs bindings (Git*, Harness*, Ollama*, Snap*, Ssh*, Deploy*, Agent*, …)
+│   └── lib/invoke.ts       # Typed Tauri command wrappers
 ├── src-tauri/              # Rust backend
 │   ├── src/
-│   │   ├── commands/       # Tauri commands (apps, devbox, sync, vault, tunnel)
+│   │   ├── commands/       # Tauri commands (agent, apps, config, deploy, git, harness,
+│   │   │                   #   inference, launcher, local_shell, mount, setup, spawner,
+│   │   │                   #   ssh, status, sync, terminal, tunnel, vault)
 │   │   ├── platform/       # PlatformOps trait + OS implementations
-│   │   └── lib.rs          # Plugin registration
+│   │   ├── config.rs       # App config state
+│   │   ├── daemon_ctl.rs   # Harness daemon process control
+│   │   ├── harness.rs      # Harness connection state
+│   │   ├── harness_watcher.rs # Daemon health watcher
+│   │   ├── inference.rs    # Ollama + Snap inference management
+│   │   ├── local_shell.rs  # Local PTY shell sessions
+│   │   ├── spawner.rs      # Agent spawner (PTY per agent)
+│   │   ├── ssh.rs          # SSH client (russh)
+│   │   ├── state.rs        # Managed AppState
+│   │   ├── tray.rs         # System tray
+│   │   ├── updater.rs      # Auto-updater (tauri-plugin-updater)
+│   │   └── lib.rs          # Plugin registration + invoke_handler
 │   └── Cargo.toml
 └── package.json
 ```
@@ -76,6 +86,8 @@ The Rust backend uses a `PlatformOps` trait for cross-platform operations:
 
 App management uses `ss -tlnp` for status detection and `fuser -k PORT/tcp` for stopping.
 
+Key Rust crates: `russh` 0.60 (SSH client), `portable-pty` (PTY sessions), `git2` 0.20 (vendored, git operations), `revvault-core` (vault), `age` 0.11 + `secrecy` (encryption), `lettre` (SMTP email), `ts-rs` (TypeScript binding generation), `tauri-plugin-updater` (auto-update), `reqwest` with rustls (HTTP).
+
 ## Related
 
 - [Architecture Guide](../../docs/ARCHITECTURE.md)
@@ -83,4 +95,4 @@ App management uses `ss -tlnp` for status detection and `fuser -k PORT/tcp` for 
 
 ## License
 
-MIT
+LicenseRef-RevealUI-Commercial (see `src-tauri/Cargo.toml`)

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -117,7 +117,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"ping"}' | \
 ## Architecture pointers
 
 - `src/server.ts` — JSON-RPC dispatch, license guard, RPC handler registry, periodic stale-session prune (GAP-153).
-- `src/storage/schema.ts` — PGlite schema (8 tables: agent_sessions, agent_messages, file_reservations, tasks, events, worktrees, agent_memory, merge_requests).
+- `src/storage/schema.ts` — PGlite schema (11 tables: agent_sessions, agent_messages, file_reservations, tasks, events, worktrees, agent_memory, merge_requests, agent_identity, agent_identity_keys, agent_identity_nonces).
 - `src/neon.ts` — daemon → Neon dual-write helpers (GAP-154 Phases 2 + 3). Best-effort, no-op when `POSTGRES_URL` unset.
 - `src/guard.ts` — license tier check at RPC dispatch time.
 - `systemd/revdev-daemon.service` — systemd-user unit template.

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -4,19 +4,19 @@ JSON-RPC 2.0 type definitions shared between Studio, Terminal, and the Harness D
 
 ## Methods
 
-| Method | Description |
-|--------|-------------|
-| `agent.list` | List active agent sessions |
-| `agent.spawn` | Start a new agent session |
-| `agent.stop` | Stop an agent session |
-| `agent.input` | Send input to agent PTY |
-| `agent.resize` | Resize agent terminal |
-| `tasks.create` | Create a coordination task |
-| `tasks.claim` | Claim a task (atomic CAS) |
-| `tasks.complete` | Mark task complete |
-| `tasks.release` | Release task ownership |
-| `tasks.list` | List tasks with filters |
-| `messages.send` | Send inter-agent message |
-| `messages.list` | List messages for agent |
-| `files.reserve` | Reserve file for editing |
-| `files.release` | Release file reservation |
+All method name constants are exported as `RPC_METHODS` from `src/methods.ts`.
+
+| Namespace | Methods |
+|-----------|---------|
+| System | `ping` |
+| Harness | `harness.list`, `harness.execute`, `harness.info`, `harness.listRunning`, `harness.syncConfig`, `harness.diffConfig`, `harness.health`, `harness.prune` |
+| Sessions | `session.register`, `session.attach`, `session.update`, `session.end`, `session.list`, `session.history` |
+| Messaging | `mail.send`, `mail.broadcast`, `mail.inbox`, `mail.markRead` |
+| Files | `files.reserve`, `files.check`, `files.release`, `files.list` |
+| Tasks | `tasks.create`, `tasks.claim`, `tasks.complete`, `tasks.release`, `tasks.list` |
+| Events | `events.log`, `events.query` |
+| Agents | `agent.spawn`, `agent.stop`, `agent.input`, `agent.resize` |
+| Inference | `inference.status`, `inference.pull`, `inference.start`, `inference.stop` |
+| Worktrees | `worktree.create`, `worktree.list`, `worktree.remove` |
+| Merge pipeline | `merge.request`, `merge.status`, `merge.list`, `merge.update` |
+| Memory | `memory.store`, `memory.query` |


### PR DESCRIPTION
## Summary

Updates the repo READMEs to reflect the current code. Docs only; every change is justified by source, not other documentation (notably, several stale claims in `CLAUDE.md` were *not* used — code won).

## What changed (verified against source)

- **`README.md`** — removed `packages/bridge/` from the layout (no such package); corrected Studio's license to `LicenseRef-RevealUI-Commercial` (`apps/studio/src-tauri/Cargo.toml`).
- **`apps/console/README.md`** — rewrote the description: per `tui/model.go` the views are `ViewTiers/ViewCheckout/ViewLicense/ViewLinkEmail/ViewLinkOTP`, i.e. a subscription/licensing/account-linking SSH TUI (Stripe checkout + QR), with an agent-proxy mode (`main.go`: `agents` command / `TERMINAL_MODE=agents`). Fixed the SSH endpoint to `terminal.revealui.com` (`main.go` header + listen banner).
- **`apps/studio/README.md`** — expanded the feature/command surface from `src-tauri/src/lib.rs` (SSH, local shell/PTY, Git, Deploy, Harness, Agent spawner, Inference, Daemon control, updater); corrected the architecture tree and listed the backing crates (`russh`, `portable-pty`, `git2`, `lettre`, `ts-rs`, `tauri-plugin-updater`, `reqwest`); license corrected to commercial.
- **`packages/daemon/README.md`** — storage schema is 11 tables (`src/storage/schema.ts`), not 8 (added the three `agent_identity*` tables).
- **`packages/protocol/README.md`** — replaced the JSON-RPC method table with the actual namespaces from `src/methods.ts` (`session.*`, `mail.*`, harness/inference/worktree/merge/memory/event); the old table referenced nonexistent `agent.list`/`messages.*`.
- **`packages/theme/README.md`** — unchanged (already accurate per `src/index.ts`/`src/colors.ts`).

## Test plan

Docs-only; no code paths affected.
