### PR TITLE
fix(daemon): verify license signature before expiration check

### DIFF
--- a/packages/daemon/src/__tests__/flows.test.ts
+++ b/packages/daemon/src/__tests__/flows.test.ts
@@ -169,8 +169,17 @@ describe('verifyLicenseJWT — negative cases', () => {
 
     const now = Math.floor(Date.now() / 1000);
     const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
+    // iss/aud required: temporal expiry now runs AFTER signature + iss + aud
+    // verification (see verifyLicenseJWT comments). Without them this would
+    // fall through to 'invalid iss' before the expiry check.
     const payloadB64 = Buffer.from(
-      JSON.stringify({ tier: 'pro', iat: now - 7200, exp: now - 3600 }),
+      JSON.stringify({
+        tier: 'pro',
+        iat: now - 7200,
+        exp: now - 3600,
+        iss: 'https://revealui.com',
+        aud: 'revealui-license',
+      }),
     ).toString('base64url');
     const message = `${header}.${payloadB64}`;
     const sig = sign(null, Buffer.from(message), privateKey).toString('base64url');

--- a/packages/daemon/src/__tests__/license-expiry.test.ts
+++ b/packages/daemon/src/__tests__/license-expiry.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { initLicenseGuard } from '../guard.js';
+import { verifyLicenseJWT } from '../license-crypto.js';
 import {
   checkLicense,
   evaluateLicense,
@@ -172,6 +173,53 @@ describe('initLicenseGuard — fail-closed + warnings', () => {
     const state = initLicenseGuard();
     expect(state.valid).toBe(false);
     expect(state.tier).toBe('free');
+  });
+});
+
+describe('verifyLicenseJWT — signature precedes expiration check (Codex P1 #93)', () => {
+  // A forged token with a past `exp` must classify as `invalid-signature`
+  // (degrade-to-free), NOT `expired` (which the daemon maps to fail-closed
+  // startup). If signature verification happened AFTER the expiry check, a
+  // mistyped or attacker-supplied stale JWT would crash the daemon on boot
+  // instead of falling back to free tier.
+
+  it('forged token with past exp → code: "invalid-signature" (NOT "expired")', () => {
+    // Real signer + a separate keypair acting as the daemon's vendor key
+    const signer = generateTestLicense('enterprise', false, { daysUntilExpiry: -1 });
+    const vendor = generateTestLicense('enterprise', true);
+
+    // Verifying signer's expired token against vendor's PUBLIC key — signature mismatch
+    const result = verifyLicenseJWT(signer.licenseKey, vendor.publicKey);
+
+    expect(result.valid).toBe(false);
+    if (result.valid) return; // type narrow
+    expect(result.code).toBe('invalid-signature');
+    // expiresAt must NOT leak through on a signature failure
+    expect(result.expiresAt).toBeUndefined();
+  });
+
+  it('forged token with future exp → code: "invalid-signature" (regression)', () => {
+    const signer = generateTestLicense('pro', false, { daysUntilExpiry: 30 });
+    const vendor = generateTestLicense('pro', true);
+
+    const result = verifyLicenseJWT(signer.licenseKey, vendor.publicKey);
+
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.code).toBe('invalid-signature');
+  });
+
+  it('properly-signed expired token → code: "expired" (preserved)', () => {
+    // Sanity: the original fail-closed path still triggers for legitimate
+    // signed-but-expired tokens.
+    const kit = generateTestLicense('enterprise', false, { daysUntilExpiry: -1 });
+
+    const result = verifyLicenseJWT(kit.licenseKey, kit.publicKey);
+
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.code).toBe('expired');
+    expect(result.expiresAt).toBeGreaterThan(0);
   });
 });
 

--- a/packages/daemon/src/__tests__/license-expiry.test.ts
+++ b/packages/daemon/src/__tests__/license-expiry.test.ts
@@ -10,7 +10,6 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { initLicenseGuard } from '../guard.js';
-import { verifyLicenseJWT } from '../license-crypto.js';
 import {
   checkLicense,
   evaluateLicense,
@@ -18,6 +17,7 @@ import {
   LicenseExpiredError,
   loadLicenseKey,
 } from '../license.js';
+import { verifyLicenseJWT } from '../license-crypto.js';
 import {
   clearTestLicenseEnv,
   generateTestLicense,

--- a/packages/daemon/src/license-crypto.ts
+++ b/packages/daemon/src/license-crypto.ts
@@ -149,26 +149,14 @@ export function verifyLicenseJWT(
       };
     }
 
-    // Validate exp (absent = perpetual; present = must be a number)
+    // Validate exp claim shape (absent = perpetual; present = must be a number).
+    // The temporal `now > exp` comparison is deferred until AFTER signature
+    // verification so a forged token with a past `exp` returns 'invalid-signature'
+    // (degrade-to-free) rather than 'expired' (which the daemon maps to
+    // fail-closed startup). See evaluateLicense() in license.ts.
     const exp = payload.exp;
     if (exp !== undefined && typeof exp !== 'number') {
       return { tier: 'free', valid: false, reason: 'invalid exp claim', code: 'invalid-claim' };
-    }
-
-    // Check expiration if exp is present
-    if (typeof exp === 'number') {
-      const nowSeconds = Math.floor(Date.now() / 1000);
-      if (nowSeconds > exp) {
-        // Carry expiresAt so callers can compute time-since-expiry + drive
-        // fail-closed / telemetry without re-decoding the token.
-        return {
-          tier: 'free',
-          valid: false,
-          reason: 'license expired',
-          code: 'expired',
-          expiresAt: exp,
-        };
-      }
     }
 
     if (!publicKey) {
@@ -239,6 +227,24 @@ export function verifyLicenseJWT(
     const jti = payload.jti;
     if (typeof jti === 'string' && isRevokedJti(jti)) {
       return { tier: 'free', valid: false, reason: 'token has been revoked', code: 'revoked' };
+    }
+
+    // Temporal expiration check — performed AFTER signature + iss + aud + nbf
+    // verification so forged tokens can't trigger the daemon's
+    // fail-closed-on-expired path via a backdated `exp` claim.
+    if (typeof exp === 'number') {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      if (nowSeconds > exp) {
+        // Carry expiresAt so callers can compute time-since-expiry + drive
+        // fail-closed / telemetry without re-decoding the token.
+        return {
+          tier: 'free',
+          valid: false,
+          reason: 'license expired',
+          code: 'expired',
+          expiresAt: exp,
+        };
+      }
     }
 
     // expiresAt: 0 = perpetual (mirrors dotted-v2 semantics)


### PR DESCRIPTION
## What
Reorder `verifyLicenseJWT` so signature verification happens **before** the temporal `now > exp` comparison. The cheap syntactic `exp`-claim-type validation stays where it is.

## Why
Codex P1 on PR #93 (Verify signature before returning `expired`):

> Move the expiration classification behind signature verification, otherwise any syntactically valid JWT with a past `exp` is treated as `code: 'expired'` even when the signature is invalid. In this commit, `evaluateLicense()` maps `expired` to fail-closed startup behavior, so a mistyped/forged token with stale claims now prevents daemon startup instead of falling back to degraded free mode (the documented behavior for invalid signatures).

This is real — verified by reading `packages/daemon/src/license-crypto.ts` (expiry check at the old line ~158 fired before the signature check at the old line ~188) and `packages/daemon/src/license.ts` (`evaluateLicense()` maps `code === 'expired'` to fail-closed via `LicenseExpiredError`).

## Change

`packages/daemon/src/license-crypto.ts`:
- `exp`-claim **type** validation stays early (returns `invalid-claim` for non-numeric exp).
- `now > exp` **temporal** check moved to after signature + iss + aud + nbf + revocation.
- Added inline comments explaining both halves so a future reader doesn't re-flatten them.

`packages/daemon/src/__tests__/license-expiry.test.ts`:
- New `describe('verifyLicenseJWT — signature precedes expiration check ...')`:
  - forged token + past exp → `code: 'invalid-signature'` (proves the fix)
  - forged token + future exp → `code: 'invalid-signature'` (regression)
  - properly-signed expired token → `code: 'expired'` (preserved)

## Validation
- All existing tests use the matching signer/vendor keypair (helper at `test-license-helper.ts`), so they continue to hit the legitimate `'expired'` path.
- New tests directly exercise the forged-expired class that motivates the reorder.
- Local typecheck/test deferred to CI (constrained workstation per fleet practice).

## Out of scope
- The other early-return codes (`invalid-format`, `unsupported-algorithm`, `invalid-tier`, `invalid-claim`) are syntactic and don't leak license state — they stay early. Codex's concern was specifically about `expired` reaching callers ahead of signature verification.
