### PR TITLE
fix(ci): resolve codex P1 review findings (promotion gate + backflow pin)

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -10,5 +10,8 @@ on:
 
 jobs:
   backflow:
-    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@main
+    # Pinned to an immutable SHA (RevealUIStudio/.github main @ 2026-05-30) so a
+    # later push to the shared repo cannot silently change this production gate.
+    # Bump via Dependabot (github-actions) like every other pinned ref.
+    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@3626bec684c4e98db506cf3a0c973dea58ed0cc4
     secrets: inherit

--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -20,10 +20,20 @@ jobs:
   promotion-gate:
     runs-on: ubuntu-latest
     steps:
-      - name: Verify head branch is 'test'
+      - name: Verify head branch is 'test' from the canonical repo
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
+          # A fork can name a branch 'test' and open a PR to main; head_ref alone
+          # ('test') would pass, and the ancestry check below only proves the fork
+          # branch contains main — not that the changes were promoted through THIS
+          # repo's test branch. Require the PR to originate from this repository.
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error title=Cross-repo promotion::Promotion PRs to main must come from '$BASE_REPO' (this repo's 'test' branch), not a fork. Got head repo: '$HEAD_REPO'."
+            exit 1
+          fi
           if [ "$HEAD_REF" != "test" ]; then
             echo "::error title=Wrong head branch::Promotion PRs to main must come from 'test'. Got: '$HEAD_REF'."
             echo ""


### PR DESCRIPTION
## Summary

revdev had 30 P1 `chatgpt-codex-connector` comments across 24 PRs; deduped and validated against current `test`. This PR fixes the two cross-cutting CI findings that are verifiable without a build. The rest are categorized below (most were already fixed).

## Fixed here

- **Promotion gate trusted the branch name alone** (codex on #79): a fork could open a PR to `main` from a branch named `test` and pass. Now also requires `head.repo == this repository`.
- **Backflow caller used a mutable `@main` ref**: pinned to an immutable `.github` SHA (fleet-wide hardening). codex #91's caller-`permissions` concern is **moot** — the reusable workflow auths via a GitHub App token (`create-github-app-token`), not `GITHUB_TOKEN`, so caller token scopes don't gate the push.

## Still present — handed to a WSL-terminal session (need daemon test-suite / cargo / studio typecheck)

- **#1 bridge socket identity** (`packages/bridge/src/client.ts`): fresh socket per RPC + no `actorAgentId` injection → non-exempt calls after `session_register` hit `-32002`. *(daemon test-suite)*
- **#2 files.reserve TOCTOU** (`server.ts` reserve): the unconditional-overwrite is fixed, but SELECT-then-upsert isn't atomic → a narrow reservation-steal race remains. *(daemon test-suite)*
- **#5 session staleness** (`server.ts` prune): keys off `started_at`, so a re-registered long-lived session is force-ended; should use `updated_at`. *(daemon test-suite)*
- **#10 Tauri `daemon_stop` PID ownership** + **#11 reap-zombie** (`daemon_ctl.rs`): SIGTERMs any PID-file PID without verifying it's `revdev-daemon`, and never reaps the child so a zombie reads as alive. *(cargo)*
- **#12 StepEmail persist** (`StepEmail.tsx`): `Next` is gated on local input state, not persisted config — can advance/deploy with unsaved Gmail creds. *(studio typecheck)*

## Validated as already fixed (no action)

`session.attach` + `memory.store` schemas (accept `agentId` / aligned on `memoryType`+`content`), `maxLineBytes` (checked post-split), signature-identity reset (cleared in `verifyOrWarn`, the #61 fix), `revvault-client` missing-CLI (handles the async `error` event), `daemon_start` readiness (returns `Err`), `rotate-license` (`execFileSync` argv + malformed-JWT fail-loud), `issue-license` (`--help` before `--generate-keypair`), license-crypto verify-before-expired (shipped via #94), `security.yml` gitleaks (SHA256-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
