### PR TITLE
chore(release): promote test to main

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -10,5 +10,8 @@ on:
 
 jobs:
   backflow:
-    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@main
+    # Pinned to an immutable SHA (RevealUIStudio/.github main @ 2026-05-30) so a
+    # later push to the shared repo cannot silently change this production gate.
+    # Bump via Dependabot (github-actions) like every other pinned ref.
+    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@3626bec684c4e98db506cf3a0c973dea58ed0cc4
     secrets: inherit

--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -20,10 +20,20 @@ jobs:
   promotion-gate:
     runs-on: ubuntu-latest
     steps:
-      - name: Verify head branch is 'test'
+      - name: Verify head branch is 'test' from the canonical repo
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
+          # A fork can name a branch 'test' and open a PR to main; head_ref alone
+          # ('test') would pass, and the ancestry check below only proves the fork
+          # branch contains main — not that the changes were promoted through THIS
+          # repo's test branch. Require the PR to originate from this repository.
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error title=Cross-repo promotion::Promotion PRs to main must come from '$BASE_REPO' (this repo's 'test' branch), not a fork. Got head repo: '$HEAD_REPO'."
+            exit 1
+          fi
           if [ "$HEAD_REF" != "test" ]; then
             echo "::error title=Wrong head branch::Promotion PRs to main must come from 'test'. Got: '$HEAD_REF'."
             echo ""


### PR DESCRIPTION
Routine promotion of all merged `test` content to `main` (production release).

Carries the work accumulated on `test` since the last promotion. Every included
change was individually reviewed and CI-gated when it merged to `test`; this PR
re-runs the full required-check suite against `main` plus the `promotion-gate`.

Merge method: merge commit (preserves the test→main lineage; `backflow-main-into-test`
re-syncs `test` afterward).
