### PR TITLE
docs(plan): record DID+Ed25519 ADR acceptance; P2 clear to start

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -84,12 +84,12 @@ Everything between today and the first commercial sale. Split agent-executable v
 
 ### W2 — Daemon identity: DID + Ed25519 per-RPC signing (Phases 2–4)
 
-Decision record: internal ADR `2026-05-16-revdev-did-ed25519-rpc-signing` (the public security-limitations disclosure names this work as the planned remediation for socket-bound identity).
+Decision record: internal ADR `2026-05-16-revdev-did-ed25519-rpc-signing` — **accepted by the owner 2026-06-11** (the public security-limitations disclosure names this work as the planned remediation for socket-bound identity; that disclosure retires when P3 enforcement ships).
 
 | Phase | Scope | Status |
 |---|---|---|
 | P1 | Identity tables, DID bootstrap on register, vault-backed keys, accept-if-present verification | ✅ **SHIPPED** (in daemon since 2026-05-16; on `main` via promotion #97) |
-| P2 | Telemetry: per-RPC signature-status events; observe ≥95% valid-signature rate across 7 days | **NEXT** |
+| P2 | Telemetry: per-RPC signature-status events; observe ≥95% valid-signature rate across 7 days | **NEXT — clear to start** (ADR accepted 2026-06-11) |
 | P3 | Enforce: non-exempt RPCs without a valid signature fail (`-32099`); revertible via `REVDEV_REQUIRE_SIGNATURE` | Pending P2 acceptance |
 | P4 | Remove legacy socket-bound identity fallback | Pending 30 days clean P3 |
 


### PR DESCRIPTION
Owner accepted the internal DID + Ed25519 per-RPC signing decision record on 2026-06-11 (it had been proposed-pending-sign-off since 2026-05-16).

Two-line PLAN.md §W2 update:

- Decision record marked **accepted 2026-06-11**.
- P2 (per-RPC signature-status telemetry) marked **clear to start** — it was already sequenced as NEXT; acceptance removes the gate. P3 (enforce) / P4 (remove socket-bound fallback) acceptance criteria unchanged.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
