### PR TITLE
feat(studio): configure Tauri updater signing (H1)

### DIFF
--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
   "plugins": {
     "updater": {
       "endpoints": ["https://releases.revealui.com/studio/{{target}}/{{arch}}/latest.json"],
-      "pubkey": ""
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEUwMjEwREREQjBBRTEwNjEKUldSaEVLNnczUTBoNExmOEowekdCckdwUGhKQm5kS3dEMGRKU0V4OUhwS1pDb0FrYTc3NmlTTUMK"
     }
   },
   "bundle": {

--- a/docs/KEY_GENERATION.md
+++ b/docs/KEY_GENERATION.md
@@ -9,27 +9,36 @@ All keys are stored in revvault (encrypted at rest).
 
 Signs Studio desktop binaries for auto-update verification.
 
+> **STATUS: DONE 2026-06-11.** The keypair exists. Private key, password, and public key live in revvault at `revdev/tauri-signing-{private-key,private-key-password,public-key}`; the public key is embedded in `apps/studio/src-tauri/tauri.conf.json` → `plugins.updater.pubkey`; the `TAURI_SIGNING_PRIVATE_KEY{,_PASSWORD}` repo secrets are set.
+>
+> **Re-running this section ROTATES the key.** Installed Studio builds verify updates against the embedded public key — a new keypair orphans every existing install until it manually reinstalls. Only rotate on compromise, and treat it as a breaking release event.
+
 ```bash
-# Generate keypair (prompts for a password)
-cd ~/revfleet/revdev/apps/studio/src-tauri
-npx @tauri-apps/cli signer generate -w ~/.tauri/revdev-studio.key
+# Generate in tmpfs so the private key never lands on persistent disk,
+# with a random password (no interactive prompt):
+D=/dev/shm/h1-tauri && mkdir -m 700 "$D"
+openssl rand -base64 24 > "$D/pw"
+cd ~/revfleet/revdev/apps/studio
+node_modules/.bin/tauri signer generate -w "$D/revdev-studio.key" --password "$(cat "$D/pw")"
 
-# Store in revvault
-revvault set revdev/tauri-signing-private-key < ~/.tauri/revdev-studio.key
-revvault set revdev/tauri-signing-password
-# ^ enter the password you chose during generation
+# Vault all three (revvault set reads stdin)
+revvault set revdev/tauri-signing-private-key          < "$D/revdev-studio.key"
+revvault set revdev/tauri-signing-private-key-password < "$D/pw"
+revvault set revdev/tauri-signing-public-key           < "$D/revdev-studio.key.pub"
 
-# Copy the PUBLIC KEY printed during generation — needed for tauri.conf.json
-# It looks like: dW50cnVzdGVkIGNvbW1lbnQ6...
+# Mirror to CI secrets, then shred
+gh secret set TAURI_SIGNING_PRIVATE_KEY          -R RevealUIStudio/revdev < "$D/revdev-studio.key"
+gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD -R RevealUIStudio/revdev < "$D/pw"
+shred -u "$D/pw" "$D/revdev-studio.key" && rm -rf "$D"
 ```
 
-**After**: Give the public key to Claude Code to wire into `tauri.conf.json`.
+**After**: wire the public key (`revdev-studio.key.pub` content) into `tauri.conf.json` → `plugins.updater.pubkey`.
 
 ---
 
 ## 2. License Signing Key (Ed25519)
 
-Signs customer license keys (RVUI.v2 format) so the daemon can verify them.
+Signs customer license keys (Ed25519-signed JWTs — the daemon rejects legacy `RVUI.v2.*` / `RVUI-*` formats) so the daemon can verify them.
 
 ```bash
 # Mint Ed25519 keypair; auto-stores both halves in revvault at
@@ -83,10 +92,10 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tasks.create","params":{"title":"test ta
 
 Add these to RevealUIStudio/revdev → Settings → Secrets → Actions:
 
-| Secret | Value Source |
-|--------|-------------|
-| `TAURI_SIGNING_PRIVATE_KEY` | `revvault get --full revdev/tauri-signing-private-key` |
-| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | `revvault get --full revdev/tauri-signing-password` |
+| Secret | Value Source | Status |
+|--------|-------------|--------|
+| `TAURI_SIGNING_PRIVATE_KEY` | `revvault get --full revdev/tauri-signing-private-key` | ✅ set 2026-06-11 |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | `revvault get --full revdev/tauri-signing-private-key-password` | ✅ set 2026-06-11 |
 
 macOS-only (when ready for Apple distribution):
 | Secret | Value Source |

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -20,7 +20,7 @@ staleness-status: FRESH
 
 | Component | Status | How to get it today |
 |---|---|---|
-| Studio | Buildable, unsigned | `pnpm --filter studio tauri build` — local binary. `studio-release.yml` defined; no public releases cut (updater pubkey not yet configured). |
+| Studio | Buildable; signing configured | `pnpm --filter studio tauri build` — local binary. `studio-release.yml` defined; updater pubkey + signing secrets configured 2026-06-11 (H1); no public releases cut yet — remaining gates are the H4 release endpoint + first `studio-v*` tag. |
 | Console | Buildable | `cd apps/console && go build -o ../../rvui .` — no root `go.mod`; module lives under `apps/console/`. `console-release.yml` defined; no releases cut. |
 | Harness daemon | Buildable, not published | `pnpm --filter @revdev/daemon build`; CLI at `packages/daemon/dist/cli.js`. Runs locally under systemd-user. |
 
@@ -57,11 +57,11 @@ Everything between today and the first commercial sale. Split agent-executable v
 
 | # | Task | Status (2026-06-11) | Notes |
 |---|---|---|---|
-| H1 | Generate Tauri updater signing keypair | **OPEN — P0, blocks auto-update** | `tauri.conf.json` → `plugins.updater.pubkey` is still `""`. `pnpm tauri signer generate -w ~/.tauri/revdev-studio.key`; public key into `tauri.conf.json`; private key into the vault; add `TAURI_SIGNING_PRIVATE_KEY{,_PASSWORD}` repo secrets. |
+| H1 | Generate Tauri updater signing keypair | ✅ **DONE 2026-06-11** | Keypair generated in tmpfs (never on persistent disk) and vaulted at `revdev/tauri-signing-{private-key,private-key-password,public-key}`; public key embedded in `tauri.conf.json` → `plugins.updater.pubkey`; `TAURI_SIGNING_PRIVATE_KEY{,_PASSWORD}` repo secrets set. Re-running the generator ROTATES the key — existing installs would reject updates signed by a new key, so don't regenerate casually. Runbook: [`KEY_GENERATION.md`](./KEY_GENERATION.md) §1. |
 | H2 | Generate license signing keypair (Ed25519) | ✅ **DONE 2026-06-10** | Canonical pair lives at `revdev/license-signing-{private,public}-key`; prod env carries it. Remaining tail: embed the public key in the Studio binary (resource or `tauri.conf.json`) and mirror to CI if integration tests need Pro+ gating. Runbook: [`KEY_GENERATION.md`](./KEY_GENERATION.md). |
 | H3 | Issue first customer licenses | **READY — awaiting first sale** | `pnpm exec tsx scripts/issue-license.ts --tier pro --customer "<name>" --days 365` (or `--perpetual`). Output is an Ed25519-signed JWT; customer sets it as `REVEALUI_LICENSE_KEY`. (The old `RVUI.v2.…` wording in the retired launch plan was wrong — the daemon rejects that format.) |
 | H4 | Release endpoint for auto-update | **OPEN — P1** | Pick GitHub Releases (simplest) vs S3/CloudFront vs edge proxy; `tauri.conf.json` already points at `releases.revealui.com/studio/{{target}}/{{arch}}/latest.json`. |
-| H5 | CI secrets for signed builds | **OPEN — P1** | `TAURI_SIGNING_PRIVATE_KEY{,_PASSWORD}` (from H1) + Apple cert/notarization set (from H7). Linux/Windows builds work without the Apple set. |
+| H5 | CI secrets for signed builds | **PARTIAL — Tauri set done 2026-06-11** | `TAURI_SIGNING_PRIVATE_KEY{,_PASSWORD}` set (H1). Remaining: the Apple cert/notarization set (from H7) for macOS builds. Linux/Windows signed builds work today. |
 | H6 | Daemon service on dev machine | ✅ **DONE** | systemd-user unit installed + running (closed 2026-04-28 via [#27](https://github.com/RevealUIStudio/revdev/pull/27) + [#23](https://github.com/RevealUIStudio/revdev/pull/23)). |
 | H7 | Apple Developer account + certs | **OPEN — P2, blocks macOS distribution** | Developer ID cert, app-specific password, .p12 into the vault. |
 | H8 | Windows code-signing certificate | **OPEN — P2, blocks Windows distribution** | EV vs OV vs Azure Trusted Signing; store cert + password in the vault. |
@@ -74,7 +74,7 @@ Everything between today and the first commercial sale. Split agent-executable v
 - [x] Daemon running as a service on the dev machine, dogfooded (H6)
 - [x] RPC params validated — no unbounded-input attacks (A1)
 - [x] Daemon restarts automatically after crash (systemd `Restart=on-failure`)
-- [ ] Tauri signing keypair generated + in repo secrets (H1)
+- [x] Tauri signing keypair generated + in repo secrets (H1, 2026-06-11)
 - [ ] Customer license key verifiably unlocks Pro features end-to-end (H3 dry-run)
 - [ ] Auto-update endpoint serves `latest.json` (H4) and an update verifiably applies (v0.1.0 → v0.1.1)
 - [ ] CI secrets configured; first signed Studio build published (H5 + release)
@@ -154,12 +154,11 @@ Carve-outs that stay: `codemirror`/`@codemirror/*` (editor) and `@xterm/*` (term
 
 | # | Item | Unblocks | Priority |
 |---|---|---|---|
-| 1 | H1 Tauri updater keypair | Auto-update, W6 | **P0** |
-| 2 | H4 release-endpoint decision + H5 CI secrets | First signed release | P1 |
-| 3 | H9 pricing + purchase flow decision | Revenue | P1 (owner-gated) |
-| 4 | W3 architecture ratification (server-mediated) | Cross-machine coordination | On demand |
-| 5 | H7 Apple / H8 Windows certs | Platform distribution | P2 |
-| 6 | W5 Console-home decision | Console productization | P3 |
+| 1 | H4 release-endpoint decision (GitHub Releases is the low-friction default) | First signed release + auto-update (H1 keypair done 2026-06-11) | **P1** |
+| 2 | H9 pricing + purchase flow decision | Revenue | P1 (owner-gated) |
+| 3 | W3 architecture ratification (server-mediated) | Cross-machine coordination | On demand |
+| 4 | H7 Apple / H8 Windows certs (completes H5) | Platform distribution | P2 |
+| 5 | W5 Console-home decision | Console productization | P3 |
 
 ## References
 


### PR DESCRIPTION
## What

Closes out **H1 — Tauri updater signing keypair** (was the P0 blocker for auto-update and any signed Studio release).

- `tauri.conf.json` → `plugins.updater.pubkey` now carries the real public key (was `""`).
- Keypair generated 2026-06-11 **in tmpfs** (private material never touched persistent disk), random password, non-interactive.
- Private key + password + public key vaulted at `revdev/tauri-signing-{private-key,private-key-password,public-key}`.
- `TAURI_SIGNING_PRIVATE_KEY` + `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` repo secrets set (mirrored from the vault — matches the env names `studio-release.yml` already reads).
- Temp files shredded; only the public key ever printed.

## Docs

- **PLAN.md** — H1 → ✅ DONE; H5 → PARTIAL (Tauri set done, Apple set remains for macOS); DoD checkbox ticked; owner queue re-ranked: **H4 (release endpoint) is now the top owner action**; Studio verified-state row updated.
- **KEY_GENERATION.md** — §1 rewritten to the vault-first tmpfs flow actually used, with a prominent **rotation warning** (re-generating the key orphans every installed build); fixed the password vault-path mismatch (`tauri-signing-password` → `tauri-signing-private-key-password`, matching what is actually stored); §2 stale "RVUI.v2 format" claim corrected to Ed25519 JWT; §5 secret table updated with statuses.

## Verify

- `jq .plugins.updater.pubkey apps/studio/src-tauri/tauri.conf.json` → non-empty minisign key.
- `gh secret list -R RevealUIStudio/revdev` → both TAURI_SIGNING secrets present.
- First signed release now gates only on H4 (endpoint) + a `studio-v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
