### PR TITLE
feat(daemon): versioned PGlite schema migrations (A2)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -47,7 +47,7 @@ Everything between today and the first commercial sale. Split agent-executable v
 | # | Task | Status (2026-06-11) | Notes |
 |---|---|---|---|
 | A1 | Zod input validation on RPC dispatch | ✅ **SHIPPED** | `packages/daemon/src/validation/schemas.ts`; invalid params → `-32602`. |
-| A2 | Versioned migration system for PGlite | **OPEN — P1** | Daemon still runs a single `SCHEMA_SQL` with `CREATE TABLE IF NOT EXISTS` (`src/storage/schema.ts`); no `migrations/` dir. Build: `schema_version` table, sequential `migrations/000N_*.sql`, fail-fast on error, `revdev-daemon migrate [--status]` subcommands. Verify: fresh DB applies all; existing DB applies only pending; bad SQL refuses to start. |
+| A2 | Versioned migration system for PGlite | ✅ **SHIPPED 2026-06-11** | `src/migrations/` registry (TS modules, not loose `.sql` — tsup bundles the daemon and runtime-loaded files don't survive the bundle) + `src/storage/migrate.ts` runner: `schema_version` table, ascending one-shot transactional application, fail-fast `MigrationError` (daemon refuses to start), future-schema refusal, pre-migration DBs adopt the `IF NOT EXISTS` baseline as a recorded no-op. `revdev-daemon migrate [--status]` subcommand (PGlite is single-process — stop the daemon first). Covered by `__tests__/migrate.test.ts`. |
 | A3 | HTTP gateway for remote daemon access | **SUPERSEDED by W3 design** | Tracked as [#2](https://github.com/RevealUIStudio/revdev/issues/2). The GAP-154 Phase 5 design recommends a *server-mediated* cross-machine path rather than every daemon hosting public HTTP — do not implement a daemon-hosted gateway before the W3 architecture decision is ratified. |
 | A4 | Studio UI for daemon status + lifecycle | ✅ **SHIPPED** | `apps/studio/src/components/infrastructure/{DaemonPanel,InfrastructurePanel}.tsx`. Before closing permanently, confirm start/stop/restart controls cover the systemd-managed case. |
 | A5 | Rust integration tests (Tauri bridge ↔ real daemon) | **OPEN — P2** | `apps/studio/src-tauri/tests/` does not exist. Build: round-trip, timeout-when-unreachable, retry-on-transient, daemon start/stop lifecycle; add `cargo test` to CI. |
@@ -80,7 +80,7 @@ Everything between today and the first commercial sale. Split agent-executable v
 - [ ] CI secrets configured; first signed Studio build published (H5 + release)
 - [ ] Customer can purchase and receive a license (H9)
 - [ ] Minimum customer docs exist: install + activate + troubleshoot (H10)
-- [ ] Database migrations work so the schema can evolve post-launch (A2)
+- [x] Database migrations work so the schema can evolve post-launch (A2, 2026-06-11)
 
 ### W2 — Daemon identity: DID + Ed25519 per-RPC signing (Phases 2–4)
 

--- a/packages/daemon/src/__tests__/migrate.test.ts
+++ b/packages/daemon/src/__tests__/migrate.test.ts
@@ -17,12 +17,7 @@ import { PGlite } from '@electric-sql/pglite';
 import { afterEach, describe, expect, it } from 'vitest';
 import { MIGRATIONS } from '../migrations/index.js';
 import { startDaemon } from '../server.js';
-import {
-  type Migration,
-  MigrationError,
-  migrate,
-  migrationStatus,
-} from '../storage/migrate.js';
+import { type Migration, MigrationError, migrate, migrationStatus } from '../storage/migrate.js';
 import { SCHEMA_SQL } from '../storage/schema.js';
 
 /** Cold PGlite WASM init is seconds, not milliseconds — see header. */

--- a/packages/daemon/src/__tests__/migrate.test.ts
+++ b/packages/daemon/src/__tests__/migrate.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Migration runner tests — fresh DB, idempotent re-run, pre-migration
+ * baseline adoption, sequential pending application, transactional
+ * rollback on bad SQL, future-schema refusal, registry validation, and
+ * the startDaemon() wiring.
+ *
+ * Every case boots its own PGlite instance (migration state must be
+ * isolated), and a cold PGlite WASM init costs seconds — so each test
+ * carries an explicit timeout instead of vitest's 5s default. CI absorbs
+ * this easily; low-memory dev boxes stay green instead of flaking.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGlite } from '@electric-sql/pglite';
+import { afterEach, describe, expect, it } from 'vitest';
+import { MIGRATIONS } from '../migrations/index.js';
+import { startDaemon } from '../server.js';
+import {
+  type Migration,
+  MigrationError,
+  migrate,
+  migrationStatus,
+} from '../storage/migrate.js';
+import { SCHEMA_SQL } from '../storage/schema.js';
+
+/** Cold PGlite WASM init is seconds, not milliseconds — see header. */
+const DB_TEST_TIMEOUT = 60_000;
+/** The wiring test boots the full daemon (PGlite + socket + license guard). */
+const DAEMON_TEST_TIMEOUT = 120_000;
+
+const first = MIGRATIONS[0];
+if (!first) throw new Error('migration registry is empty — baseline expected');
+const BASELINE = first;
+
+function probeMigration(version: number, table: string): Migration {
+  return {
+    version,
+    name: `probe-${table}`,
+    sql: `CREATE TABLE ${table} (id INTEGER PRIMARY KEY);`,
+  };
+}
+
+async function tableExists(db: PGlite, table: string): Promise<boolean> {
+  const result = await db.query<{ n: number }>(
+    `SELECT COUNT(*)::int AS n FROM information_schema.tables
+     WHERE table_schema = 'public' AND table_name = $1`,
+    [table],
+  );
+  return (result.rows[0]?.n ?? 0) > 0;
+}
+
+describe('migrate()', () => {
+  let db: PGlite;
+
+  afterEach(async () => {
+    await db.close().catch(() => {});
+  });
+
+  it(
+    'applies the baseline on a fresh database and records version 1',
+    async () => {
+      db = new PGlite();
+      const result = await migrate(db);
+
+      expect(result.applied).toEqual([1]);
+      expect(result.current).toBe(1);
+      expect(await tableExists(db, 'agent_sessions')).toBe(true);
+      expect(await tableExists(db, 'agent_identity_nonces')).toBe(true);
+
+      const rows = await db.query<{ version: number; name: string }>(
+        'SELECT version, name FROM schema_version ORDER BY version',
+      );
+      expect(rows.rows).toEqual([{ version: 1, name: 'initial-schema' }]);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'is a no-op when already at the latest version',
+    async () => {
+      db = new PGlite();
+      await migrate(db);
+      const second = await migrate(db);
+
+      expect(second.applied).toEqual([]);
+      expect(second.current).toBe(1);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'adopts a pre-migration database (baseline SQL already executed)',
+    async () => {
+      db = new PGlite();
+      // Simulate a deployment created before the migration system existed.
+      await db.exec(SCHEMA_SQL);
+      await db.query(`INSERT INTO agent_sessions (id) VALUES ('pre-existing')`);
+
+      const result = await migrate(db);
+
+      expect(result.applied).toEqual([1]);
+      const session = await db.query<{ id: string }>('SELECT id FROM agent_sessions');
+      expect(session.rows).toEqual([{ id: 'pre-existing' }]);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'applies only pending migrations, in order',
+    async () => {
+      db = new PGlite();
+      await migrate(db); // at version 1
+
+      const registry: Migration[] = [
+        BASELINE,
+        probeMigration(2, 'probe_two'),
+        probeMigration(3, 'probe_three'),
+      ];
+      const result = await migrate(db, registry);
+
+      expect(result.applied).toEqual([2, 3]);
+      expect(result.current).toBe(3);
+      expect(await tableExists(db, 'probe_two')).toBe(true);
+      expect(await tableExists(db, 'probe_three')).toBe(true);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'rolls back a failed migration and leaves schema_version untouched',
+    async () => {
+      db = new PGlite();
+      await migrate(db);
+
+      const broken: Migration = {
+        version: 2,
+        name: 'broken',
+        sql: 'CREATE TABLE rollback_probe (id INTEGER PRIMARY KEY); SELECT * FROM not_a_table;',
+      };
+
+      await expect(migrate(db, [BASELINE, broken])).rejects.toThrowError(MigrationError);
+      await expect(migrate(db, [BASELINE, broken])).rejects.toThrowError(/migration 2 \(broken\)/);
+
+      // Transaction rolled back: neither the table nor the version row survived.
+      expect(await tableExists(db, 'rollback_probe')).toBe(false);
+      const status = await migrationStatus(db);
+      expect(status.current).toBe(1);
+
+      // A corrected migration with the same version then applies cleanly.
+      const fixed = probeMigration(2, 'rollback_probe_fixed');
+      const result = await migrate(db, [BASELINE, fixed]);
+      expect(result.applied).toEqual([2]);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'refuses to run against a schema newer than the registry',
+    async () => {
+      db = new PGlite();
+      await migrate(db);
+      await db.query(`INSERT INTO schema_version (version, name) VALUES (99, 'from-the-future')`);
+
+      await expect(migrate(db)).rejects.toThrowError(/newer than this daemon/);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'rejects malformed registries before touching the database',
+    async () => {
+      db = new PGlite();
+
+      const duplicate = [BASELINE, probeMigration(1, 'dup')];
+      await expect(migrate(db, duplicate)).rejects.toThrowError(/unique and ascending/);
+
+      const descending = [probeMigration(2, 'two'), probeMigration(1, 'one')];
+      await expect(migrate(db, descending)).rejects.toThrowError(/unique and ascending/);
+
+      const nonInteger = [{ version: 1.5, name: 'half', sql: 'SELECT 1;' }];
+      await expect(migrate(db, nonInteger)).rejects.toThrowError(/positive integers/);
+
+      const empty = [{ version: 1, name: ' ', sql: 'SELECT 1;' }];
+      await expect(migrate(db, empty)).rejects.toThrowError(/empty name or empty sql/);
+    },
+    DB_TEST_TIMEOUT,
+  );
+});
+
+describe('migrationStatus()', () => {
+  let db: PGlite;
+
+  afterEach(async () => {
+    await db.close().catch(() => {});
+  });
+
+  it(
+    'reports current 0 with the baseline pending, then no pending once applied',
+    async () => {
+      db = new PGlite();
+
+      const before = await migrationStatus(db);
+      expect(before.current).toBe(0);
+      expect(before.latest).toBe(1);
+      expect(before.pending).toEqual([{ version: 1, name: 'initial-schema' }]);
+
+      await migrate(db);
+
+      const after = await migrationStatus(db);
+      expect(after.current).toBe(1);
+      expect(after.pending).toEqual([]);
+    },
+    DB_TEST_TIMEOUT,
+  );
+});
+
+describe('startDaemon() migration wiring', () => {
+  it(
+    'boots a fresh data dir through the migration runner',
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'revdev-mig-'));
+      const socketPath = join(dir, 'mig.sock');
+      const d = await startDaemon({ socketPath, dataDir: join(dir, 'db'), pruneIntervalMs: 0 });
+      try {
+        const rows = await d._db.query<{ version: number }>(
+          'SELECT version FROM schema_version ORDER BY version',
+        );
+        expect(rows.rows).toEqual([{ version: 1 }]);
+      } finally {
+        await d.close();
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+    DAEMON_TEST_TIMEOUT,
+  );
+});

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -44,6 +44,14 @@ RevDev Daemon — AI agent coordination runtime
 
 Usage:
   revdev-daemon [options]
+  revdev-daemon migrate [--status]
+
+Commands:
+  migrate        Apply pending schema migrations and exit (non-zero on
+                 failure). With --status, report current/latest/pending
+                 versions without applying anything. PGlite allows one
+                 process per data dir — stop the daemon first, or point
+                 REVDEV_DAEMON_DATA at the target copy.
 
 Options:
   --help, -h     Show this help message
@@ -78,6 +86,55 @@ License tiers:
 if (args.includes('--version') || args.includes('-v')) {
   console.log('revdev-daemon 0.1.0');
   process.exit(0);
+}
+
+// `migrate` subcommand — bring the schema to the latest version (or report
+// status) without starting the daemon. PGlite is single-process per data
+// dir: if the daemon currently holds it, this fails loudly instead of
+// corrupting anything — stop the daemon first.
+if (args[0] === 'migrate') {
+  const dataDir = process.env.REVDEV_DAEMON_DATA ?? DAEMON_DEFAULTS.dataDir;
+  const { PGlite } = await import('@electric-sql/pglite');
+  const { MigrationError, migrate, migrationStatus } = await import('./storage/migrate.js');
+  let db: InstanceType<typeof PGlite> | undefined;
+  try {
+    db = new PGlite(dataDir);
+    if (args.includes('--status')) {
+      const status = await migrationStatus(db);
+      console.log(`[migrate] data dir: ${dataDir}`);
+      console.log(`[migrate] schema version: ${status.current} (latest known: ${status.latest})`);
+      if (status.pending.length === 0) {
+        console.log('[migrate] pending: none');
+      } else {
+        for (const m of status.pending) {
+          console.log(`[migrate] pending: ${m.version} (${m.name})`);
+        }
+      }
+    } else {
+      const result = await migrate(db);
+      if (result.applied.length === 0) {
+        console.log(`[migrate] schema already at version ${result.current} — nothing to apply`);
+      } else {
+        console.log(
+          `[migrate] applied migration(s) ${result.applied.join(', ')} — schema now at version ${result.current}`,
+        );
+      }
+    }
+    await db.close();
+    process.exit(0);
+  } catch (err) {
+    if (db) {
+      await db.close().catch(() => {});
+    }
+    if (err instanceof MigrationError) {
+      console.error(`[migrate] ${err.message}`);
+    } else {
+      console.error(
+        `[migrate] failed: ${String(err)} — if the daemon is running it holds the PGlite data dir; stop it first (systemctl --user stop revdev-daemon)`,
+      );
+    }
+    process.exit(1);
+  }
 }
 
 // --detach: re-spawn ourselves in a new session, redirect stdio to a log,

--- a/packages/daemon/src/migrations/0001-initial-schema.ts
+++ b/packages/daemon/src/migrations/0001-initial-schema.ts
@@ -1,0 +1,17 @@
+/**
+ * Migration 0001 — frozen baseline.
+ *
+ * Wraps the original SCHEMA_SQL (12 tables + indexes, everything
+ * IF NOT EXISTS) so databases created before the migration system adopt
+ * it as a no-op that records version 1. Do not edit the baseline —
+ * schema changes are new migrations.
+ */
+
+import type { Migration } from '../storage/migrate.js';
+import { SCHEMA_SQL } from '../storage/schema.js';
+
+export const MIGRATION_0001: Migration = {
+  version: 1,
+  name: 'initial-schema',
+  sql: SCHEMA_SQL,
+};

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -15,7 +15,7 @@
  * bundle (they would need a postbuild copy step that drifts).
  */
 
-import { MIGRATION_0001 } from './0001-initial-schema.js';
 import type { Migration } from '../storage/migrate.js';
+import { MIGRATION_0001 } from './0001-initial-schema.js';
 
 export const MIGRATIONS: readonly Migration[] = [MIGRATION_0001];

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Migration registry — the ordered list of every schema migration this
+ * daemon build knows about.
+ *
+ * Adding a schema change:
+ *   1. Create `src/migrations/000N-<kebab-name>.ts` exporting a
+ *      `Migration` with the next version number.
+ *   2. Append it to MIGRATIONS below (ascending order — the runner
+ *      validates and refuses out-of-order or duplicate versions).
+ *   3. Never edit an already-shipped migration; ship a corrective
+ *      migration instead.
+ *
+ * Migrations are TS modules (not .sql files) deliberately: tsup bundles
+ * the daemon, and files loaded from disk at runtime do not survive the
+ * bundle (they would need a postbuild copy step that drifts).
+ */
+
+import { MIGRATION_0001 } from './0001-initial-schema.js';
+import type { Migration } from '../storage/migrate.js';
+
+export const MIGRATIONS: readonly Migration[] = [MIGRATION_0001];

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -55,7 +55,7 @@ import {
 } from './neon.js';
 import { initObservability, onConnect, onDisconnect, trackRpcCall } from './observability.js';
 import { revvaultSet } from './revvault-client.js';
-import { SCHEMA_SQL } from './storage/schema.js';
+import { migrate } from './storage/migrate.js';
 import { invalidParamsResponse, validateParams } from './validation/index.js';
 
 const log = createLogger({ service: 'revdev-daemon' });
@@ -1138,11 +1138,16 @@ export async function startDaemon(
   await mkdir(cfg.dataDir, { recursive: true });
   await mkdir(dirname(cfg.socketPath), { recursive: true });
 
-  // Initialize PGlite
+  // Initialize PGlite and bring the schema to the latest version. A failed
+  // or future-version migration throws MigrationError — the daemon refuses
+  // to start rather than run on a half-migrated schema (fail-fast).
   log.info('initializing database', { dataDir: cfg.dataDir });
   const db = new PGlite(cfg.dataDir);
-  await db.exec(SCHEMA_SQL);
-  log.info('schema initialized');
+  const migration = await migrate(db);
+  log.info('schema migrated', {
+    version: migration.current,
+    applied: migration.applied.length > 0 ? migration.applied : 'none',
+  });
 
   // Initialize observability (metrics + health checks)
   initObservability(db);

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -3,3 +3,11 @@
  */
 
 export { SCHEMA_SQL } from './schema.js';
+export {
+  type Migration,
+  MigrationError,
+  type MigrationStatus,
+  migrate,
+  migrationStatus,
+} from './migrate.js';
+export { MIGRATIONS } from '../migrations/index.js';

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -2,7 +2,7 @@
  * Storage layer — PGlite-backed daemon state.
  */
 
-export { SCHEMA_SQL } from './schema.js';
+export { MIGRATIONS } from '../migrations/index.js';
 export {
   type Migration,
   MigrationError,
@@ -10,4 +10,4 @@ export {
   migrate,
   migrationStatus,
 } from './migrate.js';
-export { MIGRATIONS } from '../migrations/index.js';
+export { SCHEMA_SQL } from './schema.js';

--- a/packages/daemon/src/storage/migrate.ts
+++ b/packages/daemon/src/storage/migrate.ts
@@ -1,0 +1,158 @@
+/**
+ * Versioned schema migrations for the daemon's PGlite database.
+ *
+ * The registry lives in `src/migrations/` (TS modules, not loose .sql
+ * files — tsup bundles the daemon into dist/, and runtime-loaded files
+ * would be dropped from the bundle). Each migration runs exactly once,
+ * inside a transaction, in ascending version order; the applied set is
+ * recorded in the `schema_version` table.
+ *
+ * Failure policy is fail-fast: a failed migration rolls back its own
+ * transaction, leaves `schema_version` untouched, and throws
+ * MigrationError — callers (startDaemon, the `migrate` CLI subcommand)
+ * refuse to proceed rather than run on a half-migrated schema.
+ */
+
+import type { PGlite } from '@electric-sql/pglite';
+import { MIGRATIONS } from '../migrations/index.js';
+
+/** One schema migration. Registered in `src/migrations/index.ts`. */
+export interface Migration {
+  /** Strictly increasing positive integer; 1 is the frozen baseline. */
+  version: number;
+  /** Kebab-case label, recorded in `schema_version.name`. */
+  name: string;
+  /** SQL applied inside a single transaction. */
+  sql: string;
+}
+
+/** Pending/current snapshot returned by {@link migrationStatus}. */
+export interface MigrationStatus {
+  /** Highest applied version (0 = nothing recorded yet). */
+  current: number;
+  /** Highest version known to this daemon build. */
+  latest: number;
+  /** Migrations this daemon would apply, in order. */
+  pending: ReadonlyArray<{ version: number; name: string }>;
+}
+
+export class MigrationError extends Error {
+  readonly version: number | undefined;
+
+  constructor(message: string, version?: number, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'MigrationError';
+    this.version = version;
+  }
+}
+
+const SCHEMA_VERSION_SQL = `
+  CREATE TABLE IF NOT EXISTS schema_version (
+    version     INTEGER PRIMARY KEY,
+    name        TEXT NOT NULL,
+    applied_at  TIMESTAMP NOT NULL DEFAULT NOW()
+  );
+`;
+
+/**
+ * Reject malformed registries before touching the database: versions must
+ * be positive integers, unique, and listed in ascending order; every entry
+ * needs a name and non-empty SQL.
+ */
+function validateRegistry(migrations: readonly Migration[]): void {
+  let prev = 0;
+  for (const m of migrations) {
+    if (!Number.isInteger(m.version) || m.version <= 0) {
+      throw new MigrationError(
+        `invalid migration version ${String(m.version)} (${m.name}) — versions are positive integers`,
+        m.version,
+      );
+    }
+    if (m.version <= prev) {
+      throw new MigrationError(
+        `migration registry out of order at version ${m.version} (${m.name}) — versions must be unique and ascending`,
+        m.version,
+      );
+    }
+    if (!m.name.trim() || !m.sql.trim()) {
+      throw new MigrationError(`migration ${m.version} has an empty name or empty sql`, m.version);
+    }
+    prev = m.version;
+  }
+}
+
+async function currentVersion(db: PGlite): Promise<number> {
+  await db.exec(SCHEMA_VERSION_SQL);
+  const result = await db.query<{ v: number }>(
+    'SELECT COALESCE(MAX(version), 0)::int AS v FROM schema_version',
+  );
+  return result.rows[0]?.v ?? 0;
+}
+
+/** Report current/latest/pending without applying anything. */
+export async function migrationStatus(
+  db: PGlite,
+  migrations: readonly Migration[] = MIGRATIONS,
+): Promise<MigrationStatus> {
+  validateRegistry(migrations);
+  const current = await currentVersion(db);
+  const latest = migrations.at(-1)?.version ?? 0;
+  const pending = migrations
+    .filter((m) => m.version > current)
+    .map((m) => ({ version: m.version, name: m.name }));
+  return { current, latest, pending };
+}
+
+/**
+ * Apply every pending migration in ascending order. Each migration's SQL
+ * and its `schema_version` insert share one transaction, so a failure
+ * rolls back cleanly and the next attempt resumes at the failed version.
+ *
+ * A database whose recorded version is NEWER than this build's registry
+ * is refused outright — running old code against a future schema is the
+ * one corruption mode a version table cannot repair.
+ *
+ * Pre-migration databases (created when startup ran the baseline SQL
+ * directly) adopt cleanly: the baseline migration is idempotent
+ * (IF NOT EXISTS throughout), so applying it over existing tables is a
+ * no-op that simply records version 1.
+ */
+export async function migrate(
+  db: PGlite,
+  migrations: readonly Migration[] = MIGRATIONS,
+): Promise<{ current: number; applied: number[] }> {
+  validateRegistry(migrations);
+  let current = await currentVersion(db);
+  const latest = migrations.at(-1)?.version ?? 0;
+
+  if (current > latest) {
+    throw new MigrationError(
+      `database schema version ${current} is newer than this daemon's latest known migration (${latest}) — refusing to start against a future schema; upgrade the daemon instead`,
+      current,
+    );
+  }
+
+  const applied: number[] = [];
+  for (const m of migrations) {
+    if (m.version <= current) continue;
+    try {
+      await db.transaction(async (tx) => {
+        await tx.exec(m.sql);
+        await tx.query('INSERT INTO schema_version (version, name) VALUES ($1, $2)', [
+          m.version,
+          m.name,
+        ]);
+      });
+    } catch (err) {
+      throw new MigrationError(
+        `migration ${m.version} (${m.name}) failed and was rolled back: ${String(err)}`,
+        m.version,
+        { cause: err },
+      );
+    }
+    applied.push(m.version);
+    current = m.version;
+  }
+
+  return { current, applied };
+}

--- a/packages/daemon/src/storage/schema.ts
+++ b/packages/daemon/src/storage/schema.ts
@@ -3,9 +3,15 @@
  *
  * Uses raw SQL (no ORM) for minimal dependencies.
  * PGlite runs in-process — no external database needed.
+ *
+ * FROZEN BASELINE — this SQL ships as migration 0001
+ * (`src/migrations/0001-initial-schema.ts`). Do not edit it for schema
+ * changes; add a new migration in `src/migrations/` instead. Everything
+ * here is IF NOT EXISTS so pre-migration databases adopt the baseline
+ * as a no-op.
  */
 
-/** SQL statements to initialize the daemon database. */
+/** SQL statements to initialize the daemon database (migration 0001). */
 export const SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS agent_sessions (
     id            TEXT PRIMARY KEY,


### PR DESCRIPTION
## What

Closes launch-plan task **A2 — versioned migration system for PGlite**. The daemon previously ran one big `SCHEMA_SQL` exec on every boot; schema evolution post-launch had no story. Now:

- **`src/migrations/`** — ordered registry. Migrations are TS modules, deliberately **not** loose `.sql` files: tsup bundles the daemon into `dist/`, and files loaded from disk at runtime don't survive the bundle. `0001-initial-schema` wraps the existing `SCHEMA_SQL` as the frozen baseline (schema.ts marked FROZEN with add-a-migration guidance).
- **`src/storage/migrate.ts`** — `schema_version` table; pending migrations applied in ascending order, each one's SQL + version insert in a **single transaction** (failed migration rolls back fully and the daemon refuses to start — fail-fast); registry validation; **future-schema refusal** (a DB stamped newer than the running build is refused, since old code on a future schema is the one mode a version table can't repair).
- **Existing deployments adopt cleanly** — the baseline is `IF NOT EXISTS` throughout, so a pre-migration data dir applies 0001 as a no-op and gets recorded at version 1 (covered by a dedicated test).
- **CLI** — `revdev-daemon migrate` / `migrate --status`, with the PGlite single-process caveat made loud (stop the daemon first or point `REVDEV_DAEMON_DATA` elsewhere).
- **Exports** — `@revdev/daemon/storage` now exposes `migrate`, `migrationStatus`, `MigrationError`, `MIGRATIONS` + types.

## Tests

New `__tests__/migrate.test.ts` (9 cases): fresh DB, idempotent re-run, pre-migration adoption, sequential pending application, bad-SQL transactional rollback + corrected re-apply, future-schema refusal, registry validation (duplicate/descending/non-integer/empty), status reporting, and a `startDaemon()` wiring smoke against a real temp data dir. Each case boots an isolated PGlite (migration state must be isolated), so the tests carry explicit timeouts — cold PGlite WASM init is seconds, not ms.

**Local verification scope (honest):** Biome clean + `tsc --noEmit` clean on the package; the new migrate suite is green in isolation (9/9, 57s). The FULL daemon suite is delegated to this PR's CI Test job — the local 4GB WSL box thrashes running all suites in parallel (pre-existing wall-clock assertions in `shutdown-drain.test.ts` flake under swap there; they are green in CI, which has run the full suite at ~90s on every recent PR).

## Plan

`docs/PLAN.md`: A2 → ✅ SHIPPED 2026-06-11; definition-of-done “database migrations work” ticked. Remaining open W1 agent task is A5 (Rust integration tests), next up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
