### PR TITLE
chore(deps): add Dependabot version-update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,96 @@
+version: 2
+updates:
+  # npm workspace (pnpm monorepo: root + apps/studio + packages/*)
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - automated
+    groups:
+      patch-and-minor:
+        update-types: ["patch", "minor"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # Rust crate behind the Tauri Studio app.
+  # NOTE: apps/studio/src-tauri is NOT compiled in PR CI (only studio-release.yml).
+  # Cargo bumps have no PR safety net -- verify locally with `cargo check` before merge.
+  - package-ecosystem: cargo
+    directory: /apps/studio/src-tauri
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - automated
+    groups:
+      patch-and-minor:
+        update-types: ["patch", "minor"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # Go module (Console)
+  - package-ecosystem: gomod
+    directory: /apps/console
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - automated
+    groups:
+      patch-and-minor:
+        update-types: ["patch", "minor"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - github-actions
+      - automated
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # Docker base image (Console)
+  - package-ecosystem: docker
+    directory: /apps/console
+    schedule:
+      interval: monthly
+      timezone: UTC
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - docker
+      - automated


### PR DESCRIPTION
Adds `.github/dependabot.yml` enabling weekly version-update PRs for revdev.

**Ecosystems:** npm (pnpm monorepo `/`), cargo (`/apps/studio/src-tauri`), gomod (`/apps/console`), github-actions (`/`), docker (`/apps/console`, monthly).

**Noise control:** patch+minor grouped per ecosystem; semver-major ignored.

**Heads-up for reviewers:** `apps/studio/src-tauri` is not compiled in PR CI (only `studio-release.yml`), so any cargo bump from Dependabot must be `cargo check`-verified locally before merge.

Part of the fleet-wide Dependabot enablement (security-updates auto-fix enabled fleet-wide same change-set). Base is `test` per the test->main promotion flow.