### PR TITLE
chore: use vendor-neutral naming in comments and docs

### DIFF
--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -6,7 +6,7 @@
 //  3. Connects to WS /api/terminal/ws/:id
 //  4. Pipes SSH I/O ↔ WebSocket I/O bidirectionally
 //
-// This enables controlling Claude Code agents from any SSH client (iPhone, iPad, etc.).
+// This enables controlling AI coding tool sessions from any SSH client (iPhone, iPad, etc.).
 package proxy
 
 import (
@@ -90,7 +90,7 @@ func (p *Proxy) listSessions() ([]SessionInfo, error) {
 	return sessions, nil
 }
 
-// spawnSession creates a new Claude Code session via the API.
+// spawnSession creates a new agent session via the API.
 func (p *Proxy) spawnSession(name string) (string, error) {
 	body := fmt.Sprintf(`{"name":"%s","cols":120,"rows":30}`, name)
 	endpoint := fmt.Sprintf("%s/api/terminal/sessions", p.apiURL)

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -1,7 +1,7 @@
 /**
  * AgentPanel — workboard-aware change review (Pro)
  *
- * Left pane:  active Claude Code sessions, parsed from a configurable workboard.md
+ * Left pane:  active agent sessions, parsed from a configurable workboard.md
  * Right pane: pending git changes with per-file stage / discard and bulk actions
  */
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -67,9 +67,9 @@ Register a new agent session. Returns a sessionId to use as identity.
 | Field | Type | Description |
 |-------|------|-------------|
 | `agentId` | string? | Stable ID (upserts if exists). Omit for ephemeral UUID. |
-| `agentName` | string? | Human-readable name (e.g., "claude-main") |
+| `agentName` | string? | Human-readable name (e.g., "agent-main") |
 | `workDir` | string? | Agent's working directory |
-| `backend` | string? | Agent backend type (e.g., "studio", "claude-code") |
+| `backend` | string? | Agent backend type (e.g., "studio", "mcp-agent") |
 
 **Response**: `{ sessionId: string }`
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -132,12 +132,12 @@ Once Studio is connected to the daemon:
 5. **Vault** — Secret management via revvault integration
 6. **Deploy** — Multi-step deployment wizard (Vercel, Neon, Stripe, Email)
 
-### Using with Claude Code
+### Using with an MCP-compatible AI coding tool
 
-RevDev's MCP Bridge exposes the daemon to Claude Code:
+RevDev's MCP Bridge exposes the daemon to any MCP-compatible AI coding tool (Claude Code, Codex, Cursor, Windsurf, or custom agents). For example, with Claude Code:
 
 ```json
-// In your Claude Code MCP config:
+// In your MCP client config (Claude Code shown as an example):
 {
   "revdev": {
     "command": "node",
@@ -146,7 +146,7 @@ RevDev's MCP Bridge exposes the daemon to Claude Code:
 }
 ```
 
-This gives Claude Code access to agent coordination, file reservations, and task management.
+This gives the tool access to agent coordination, file reservations, and task management.
 
 ---
 

--- a/docs/KEY_GENERATION.md
+++ b/docs/KEY_GENERATION.md
@@ -110,7 +110,7 @@ macOS-only (when ready for Apple distribution):
 
 ## After All Keys Are Set
 
-Tell Claude Code: "keys are generated" — it will:
+Tell your AI coding tool: "keys are generated" — it will:
 1. Wire Tauri public key into `tauri.conf.json`
 2. Tag `studio-v0.1.0` for first signed release
 3. Verify CI builds succeed with signing

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -34,7 +34,7 @@ server.tool(
   'session_register',
   'Register this agent session with the harness daemon',
   {
-    agentName: z.string().describe('Name for this agent (e.g. "claude-main")'),
+    agentName: z.string().describe('Name for this agent (e.g. "agent-main")'),
     workDir: z.string().describe('Working directory for this session'),
     backend: z.string().optional().describe('Backend identifier (default: "mcp-agent")'),
   },

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -76,7 +76,7 @@ interface RpcRequest {
 export interface SocketContext {
   /** Agent identity for this socket. Null until session.register/attach succeeds. */
   agentId: string | null;
-  /** Human-readable agent name (e.g. "claude-main"). */
+  /** Human-readable agent name (e.g. "agent-main"). */
   agentName: string | null;
   /**
    * How `agentId` was bound to this socket:


### PR DESCRIPTION
## What

Vendor-neutral naming pass across RevDev comments and docs. RevDev's runtime is vendor-agnostic by design, but several comments, example values, and worked tutorials still framed usage around one specific AI coding tool where neutral language belongs.

**No behavior change** — comments, JSDoc, markdown, and one MCP tool parameter description only. Two commits: incidental comment/example fixes, then genericized "using with" tutorials.

## Changes (7 files)

| File | Change |
|------|--------|
| `apps/console/proxy/proxy.go` | package doc: "controlling Claude Code agents" → "controlling AI coding tool sessions" |
| `apps/console/proxy/proxy.go` | `spawnSession` comment: "Claude Code session" → "agent session" |
| `packages/bridge/src/index.ts` | `session_register` `agentName` example: `"claude-main"` → `"agent-main"` |
| `packages/daemon/src/server.ts` | `SocketContext.agentName` doc example: `"claude-main"` → `"agent-main"` |
| `docs/API_REFERENCE.md` | `agentName` example → `"agent-main"`; `backend` example → `"mcp-agent"` (the bridge's actual default) |
| `apps/studio/src/components/agent/AgentPanel.tsx` | doc comment: "active Claude Code sessions" → "active agent sessions" (panel parses a generic `workboard.md`) |
| `docs/GETTING_STARTED.md` | "Using with Claude Code" → "Using with an MCP-compatible AI coding tool"; intro now lists the compatible tools and the config block is labeled as a Claude Code **example** rather than the assumed default |
| `docs/KEY_GENERATION.md` | "Tell Claude Code" → "Tell your AI coding tool" |

## Deliberately left untouched (legitimate references)

A full repo grep surfaced other vendor mentions that are **not** violations and were intentionally kept:

- **README agnosticism statement** — names Anthropic/OpenAI as vendors explicitly *not* baked into the runtime (the entire point of that section).
- **README architecture diagram** — "Claude Code hooks + other agent runtimes" is an inclusive enumeration (one example + "other runtimes"), same principle as the bridge's "works with any MCP-compatible tool (Claude Code, Codex, Cursor, Windsurf …)" comment.
- **`spawner.rs` "OpenAI-compatible API"** — industry-standard technical term for the local inference-snap endpoint, not a vendor endorsement.
- **Agent-context filenames / config paths** — references to the agent-context markdown file and the agent config directory are real paths.
- **PR-review bot finding attributions** — historical "P1/P2 finding" provenance in test comments.
- **Test fixtures** — backend/name values in `*_test.go` / `*.test.ts` are test data, not docs.

## Verification

- `go build ./...` (apps/console) passes; `gofmt` clean.
- TS / markdown edits are comment / JSDoc / markdown / `.describe()`-string only (non-semantic); CI typecheck covers them.

Base branch: `test`, per fleet branch policy.
