### PR TITLE
feat(studio): add local mode to skip API sign-in for local tools

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -21,7 +21,7 @@ import TunnelPanel from './components/tunnel/TunnelPanel';
 import VaultPanel from './components/vault/VaultPanel';
 import { AuthContext, useAuth } from './hooks/use-auth';
 import { useConfig } from './hooks/use-config';
-import { SettingsContext, useSettings } from './hooks/use-settings';
+import { SettingsContext, useSettings, useSettingsContext } from './hooks/use-settings';
 import type { Page } from './types';
 
 interface EditorTarget {
@@ -40,8 +40,8 @@ export default function App() {
 }
 
 function AuthGatedApp() {
-  const { settings } = useSettings();
-  const auth = useAuth(settings.apiUrl);
+  const { settings } = useSettingsContext();
+  const auth = useAuth(settings.apiUrl, settings.localMode);
 
   return (
     <AuthContext.Provider value={auth}>

--- a/apps/studio/src/__tests__/hooks/use-auth.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-auth.test.ts
@@ -1,0 +1,67 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuth } from '../../hooks/use-auth';
+
+// Local mode must never touch the API or the vault. Mock both so any call
+// is observable and can be asserted against.
+vi.mock('../../lib/auth-api', () => ({
+  checkStatus: vi.fn(),
+  linkDevice: vi.fn(),
+  refreshToken: vi.fn(),
+  revokeToken: vi.fn(),
+  verifyDevice: vi.fn(),
+}));
+
+vi.mock('../../lib/invoke', () => ({
+  vaultGet: vi.fn(),
+  vaultSet: vi.fn(),
+}));
+
+const { checkStatus } = await import('../../lib/auth-api');
+const { vaultGet } = await import('../../lib/invoke');
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+describe('useAuth — local mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('authenticates a synthetic local user without calling the API or vault', async () => {
+    const { result } = renderHook(() => useAuth('https://api.example.com', true));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(result.current.step).toBe('authenticated');
+    expect(result.current.user?.email).toBe('local@localhost');
+    expect(result.current.user?.role).toBe('local');
+    expect(result.current.getToken()).toBeNull();
+    expect(vi.mocked(checkStatus)).not.toHaveBeenCalled();
+    expect(vi.mocked(vaultGet)).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the email step when local mode is off and no token is stored', async () => {
+    vi.mocked(vaultGet).mockRejectedValue(new Error('vault unavailable'));
+
+    const { result } = renderHook(() => useAuth('https://api.example.com', false));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(result.current.step).toBe('email');
+    expect(result.current.user).toBeNull();
+    expect(vi.mocked(checkStatus)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/studio/src/components/auth/LoginScreen.tsx
+++ b/apps/studio/src/components/auth/LoginScreen.tsx
@@ -16,7 +16,7 @@ import Input from '../ui/Input';
 
 export default function LoginScreen() {
   const { step, loading, error, sendOtp, submitOtp } = useAuthContext();
-  const { settings } = useSettingsContext();
+  const { settings, updateSettings } = useSettingsContext();
   const [email, setEmail] = useState('');
   const [code, setCode] = useState('');
   const [otpSent, setOtpSent] = useState(false);
@@ -132,6 +132,23 @@ export default function LoginScreen() {
             </div>
           </form>
         ) : null}
+
+        {/* Local mode escape hatch (email step only) */}
+        {showOtp ? null : (
+          <div className="space-y-2 border-t border-neutral-800 pt-4">
+            <button
+              type="button"
+              onClick={() => updateSettings({ localMode: true })}
+              className="w-full rounded-md border border-neutral-700 px-3 py-2 text-sm text-neutral-300 transition-colors hover:border-neutral-500 hover:text-neutral-100"
+            >
+              Continue in local mode
+            </button>
+            <p className="text-center text-[11px] text-neutral-600">
+              Use local tools (terminal, shell, git) without signing in. Account
+              features stay disabled until you sign in.
+            </p>
+          </div>
+        )}
 
         {/* Footer */}
         <p className="text-center text-[11px] text-neutral-600">Connecting to {settings.apiUrl}</p>

--- a/apps/studio/src/components/auth/LoginScreen.tsx
+++ b/apps/studio/src/components/auth/LoginScreen.tsx
@@ -144,8 +144,8 @@ export default function LoginScreen() {
               Continue in local mode
             </button>
             <p className="text-center text-[11px] text-neutral-600">
-              Use local tools (terminal, shell, git) without signing in. Account
-              features stay disabled until you sign in.
+              Use local tools (terminal, shell, git) without signing in. Account features stay
+              disabled until you sign in.
             </p>
           </div>
         )}

--- a/apps/studio/src/components/settings/SettingsPanel.tsx
+++ b/apps/studio/src/components/settings/SettingsPanel.tsx
@@ -20,6 +20,11 @@ const POLLING_OPTIONS = [
   { label: '5m', value: 300_000 },
 ];
 
+const LOCAL_MODE_OPTIONS = [
+  { label: 'On', value: true },
+  { label: 'Off', value: false },
+];
+
 export default function SettingsPanel() {
   const [activeTab, setActiveTab] = useState<SettingsTab>('appearance');
   const [appVersion, setAppVersion] = useState('dev');
@@ -124,6 +129,29 @@ export default function SettingsPanel() {
                   </button>
                 ))}
               </div>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm text-neutral-400">Local mode</span>
+              <div className="flex gap-2">
+                {LOCAL_MODE_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.label}
+                    type="button"
+                    onClick={() => updateSettings({ localMode: opt.value })}
+                    className={`rounded-md px-4 py-2 text-sm transition-colors ${
+                      settings.localMode === opt.value
+                        ? 'bg-orange-600 text-white'
+                        : 'bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-200'
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+              <span className="text-xs text-neutral-500">
+                Skip sign-in and use local tools (terminal, shell, git) offline. Account
+                and API-backed features stay disabled until you sign in.
+              </span>
             </div>
           </div>
         </Card>

--- a/apps/studio/src/components/settings/SettingsPanel.tsx
+++ b/apps/studio/src/components/settings/SettingsPanel.tsx
@@ -149,8 +149,8 @@ export default function SettingsPanel() {
                 ))}
               </div>
               <span className="text-xs text-neutral-500">
-                Skip sign-in and use local tools (terminal, shell, git) offline. Account
-                and API-backed features stay disabled until you sign in.
+                Skip sign-in and use local tools (terminal, shell, git) offline. Account and
+                API-backed features stay disabled until you sign in.
               </span>
             </div>
           </div>

--- a/apps/studio/src/hooks/use-auth.ts
+++ b/apps/studio/src/hooks/use-auth.ts
@@ -91,7 +91,15 @@ export function useAuthContext(): AuthContextValue {
 
 // ── Hook ────────────────────────────────────────────────────────────────────
 
-export function useAuth(apiUrl: string): AuthContextValue {
+/** Synthetic identity used in local mode (no API account, no token). */
+const LOCAL_USER: AuthUser = {
+  id: 'local',
+  email: 'local@localhost',
+  name: 'Local',
+  role: 'local',
+};
+
+export function useAuth(apiUrl: string, localMode = false): AuthContextValue {
   const [step, setStep] = useState<AuthStep>('idle');
   const [user, setUser] = useState<AuthUser | null>(null);
   const [tokenExpiresAt, setTokenExpiresAt] = useState<string | null>(null);
@@ -102,6 +110,22 @@ export function useAuth(apiUrl: string): AuthContextValue {
   // Check stored token on mount
   useEffect(() => {
     let cancelled = false;
+
+    // Local mode: skip the API entirely and present a synthetic local
+    // identity. Unlocks Studio's self-contained local tools (terminal,
+    // shell, git) offline. Account and API features stay disabled until
+    // the user signs in (which they can do by turning local mode off).
+    if (localMode) {
+      setUser(LOCAL_USER);
+      setTokenExpiresAt(null);
+      setError(null);
+      setStep('authenticated');
+      setLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
     (async () => {
       try {
         const token = await loadToken();
@@ -138,7 +162,7 @@ export function useAuth(apiUrl: string): AuthContextValue {
     return () => {
       cancelled = true;
     };
-  }, [apiUrl]);
+  }, [apiUrl, localMode]);
 
   // Auto-refresh token when it's within 7 days of expiry
   useEffect(() => {

--- a/apps/studio/src/hooks/use-settings.ts
+++ b/apps/studio/src/hooks/use-settings.ts
@@ -10,6 +10,12 @@ export interface StudioSettings {
   solanaWalletAddress: string;
   /** Solana network for RVUI queries. */
   solanaNetwork: 'devnet' | 'mainnet-beta';
+  /**
+   * Local mode: skip API sign-in and use Studio's local, self-contained
+   * tools (terminal, shell, git) offline. Off by default. Account and
+   * API-backed features stay disabled until you sign in.
+   */
+  localMode: boolean;
 }
 
 const DEFAULT_API_URL = import.meta.env.DEV ? 'http://localhost:3004' : 'https://api.revealui.com';
@@ -20,6 +26,7 @@ const DEFAULT_SETTINGS: StudioSettings = {
   pollingIntervalMs: 30_000,
   solanaWalletAddress: '',
   solanaNetwork: 'devnet',
+  localMode: false,
 };
 
 const STORAGE_KEY = 'revealui-studio-settings';
@@ -52,6 +59,8 @@ function loadSettings(): StudioSettings {
         obj.solanaNetwork === 'devnet' || obj.solanaNetwork === 'mainnet-beta'
           ? obj.solanaNetwork
           : DEFAULT_SETTINGS.solanaNetwork,
+      localMode:
+        typeof obj.localMode === 'boolean' ? obj.localMode : DEFAULT_SETTINGS.localMode,
     };
   } catch {
     return { ...DEFAULT_SETTINGS };

--- a/apps/studio/src/hooks/use-settings.ts
+++ b/apps/studio/src/hooks/use-settings.ts
@@ -59,8 +59,7 @@ function loadSettings(): StudioSettings {
         obj.solanaNetwork === 'devnet' || obj.solanaNetwork === 'mainnet-beta'
           ? obj.solanaNetwork
           : DEFAULT_SETTINGS.solanaNetwork,
-      localMode:
-        typeof obj.localMode === 'boolean' ? obj.localMode : DEFAULT_SETTINGS.localMode,
+      localMode: typeof obj.localMode === 'boolean' ? obj.localMode : DEFAULT_SETTINGS.localMode,
     };
   } catch {
     return { ...DEFAULT_SETTINGS };


### PR DESCRIPTION
## Summary

Adds an opt-in **local mode** so Studio can run as an offline local toolbox (terminal, shell, git) without an API sign-in. Off by default; account and API-backed features still require signing in.

This makes Studio usable as a daily-driver terminal host (its local terminal already defaults to `wsl.exe` on Windows, landing in the user's WSL shell) without first completing a device OTP login.

## Changes

- `StudioSettings` gains a persisted `localMode` flag (default `false`).
- `useAuth` short-circuits to a synthetic local identity when `localMode` is on, skipping the token load and all API calls.
- `AuthGatedApp` now reads settings from context. It previously called `useSettings()` directly (a separate state instance), so a settings change from `LoginScreen` or the Settings panel would not have reached the auth gate. This also removes that duplicate-state smell.
- `LoginScreen` gains a "Continue in local mode" escape hatch on the email step.
- Settings -> Connection gains a Local mode On/Off toggle to leave local mode.
- Adds a `useAuth` local-mode test.

## Security posture

Local mode is **opt-in and off by default**. It only unlocks Studio's self-contained local tools. Server-side and paid features remain gated independently: the harness daemon enforces its own license, and API calls still require a bearer token, which local mode does not mint.

## Verification

- Diff reviewed locally; no unrelated changes.
- Lint, typecheck, and tests run in CI for this branch (the local WSL environment has no installed dependencies by design).
