### PR TITLE
docs: neutralize remaining vendor name in README architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Per the fleet [agnosticism principle](https://github.com/RevealUIStudio/revealui
 └──────┬───────┘
        │ Unix socket JSON-RPC
        ▼
-  Claude Code hooks + other agent runtimes
+  AI coding tool hooks + other agent runtimes
 ```
 
 Studio talks to the daemon; the daemon coordinates agents and tools. Console talks to the RevealUI API directly for payment + licensing — it doesn't need the daemon hop.


### PR DESCRIPTION
## What

Final vendor-neutral cleanup: the README architecture diagram still headlined one specific AI coding tool despite the "Vendor-agnostic by design" section directly above it.

`Claude Code hooks + other agent runtimes` → `AI coding tool hooks + other agent runtimes`

Docs-only, no behavior change. Follow-up to #142 (merged), which left this line as a borderline "inclusive enumeration"; neutralized here for full consistency with the README's own agnosticism framing.

## Verification

Markdown-only single-line change; renders identically in the ASCII diagram (line length is below the box, so no alignment impact).

Base branch: `test`, per fleet branch policy.
