### PR TITLE
chore(studio,daemon): clear biome noNonNullAssertion and unused-import debt

### DIFF
--- a/apps/studio/src/__tests__/components/IntentScreen.test.tsx
+++ b/apps/studio/src/__tests__/components/IntentScreen.test.tsx
@@ -2,6 +2,13 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import IntentScreen from '../../components/intent/IntentScreen';
 
+/** Click the <button> ancestor of a heading, failing loudly if absent. */
+function clickHeadingButton(name: string): void {
+  const button = screen.getByRole('heading', { name }).closest('button');
+  if (!button) throw new Error(`No <button> ancestor for heading "${name}"`);
+  fireEvent.click(button);
+}
+
 describe('IntentScreen', () => {
   it('renders welcome heading and description', () => {
     render(<IntentScreen onSelect={vi.fn()} />);
@@ -26,7 +33,7 @@ describe('IntentScreen', () => {
   it('enables Continue after selecting Deploy', () => {
     render(<IntentScreen onSelect={vi.fn()} />);
 
-    fireEvent.click(screen.getByRole('heading', { name: 'Deploy' }).closest('button')!);
+    clickHeadingButton('Deploy');
     expect(screen.getByText('Continue')).not.toBeDisabled();
   });
 
@@ -34,7 +41,7 @@ describe('IntentScreen', () => {
     const onSelect = vi.fn();
     render(<IntentScreen onSelect={onSelect} />);
 
-    fireEvent.click(screen.getByRole('heading', { name: 'Deploy' }).closest('button')!);
+    clickHeadingButton('Deploy');
     fireEvent.click(screen.getByText('Continue'));
     expect(onSelect).toHaveBeenCalledWith('deploy');
   });
@@ -43,7 +50,7 @@ describe('IntentScreen', () => {
     const onSelect = vi.fn();
     render(<IntentScreen onSelect={onSelect} />);
 
-    fireEvent.click(screen.getByRole('heading', { name: 'Develop' }).closest('button')!);
+    clickHeadingButton('Develop');
     fireEvent.click(screen.getByText('Continue'));
     expect(onSelect).toHaveBeenCalledWith('develop');
   });

--- a/apps/studio/src/__tests__/hooks/use-devbox.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-devbox.test.ts
@@ -110,7 +110,7 @@ describe('useDevBox', () => {
 
     const { result } = renderHook(() => useDevBox());
 
-    let mountPromise: Promise<void>;
+    let mountPromise: Promise<void> | undefined;
     act(() => {
       mountPromise = result.current.mount();
     });
@@ -120,7 +120,7 @@ describe('useDevBox', () => {
 
     await act(async () => {
       resolveMount('Done');
-      await mountPromise!;
+      await mountPromise;
     });
 
     expect(result.current.operating).toBe(false);

--- a/packages/daemon/src/__tests__/e2e-ipc.test.ts
+++ b/packages/daemon/src/__tests__/e2e-ipc.test.ts
@@ -10,11 +10,11 @@
  *   - Concurrent fresh-socket calls (stress test)
  */
 
-import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { startDaemon } from '../server.js';
 
 // Daemon startup (key generation + license guard + PGlite + socket bind)

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -149,7 +149,11 @@ if (args.includes('--detach')) {
   // stdout (1) and stderr (2). stdin is /dev/null.
   const logFd = openSync(logPath, 'a');
   const childArgs = args.filter((a) => a !== '--detach');
-  const child = spawn(process.execPath, [process.argv[1]!, ...childArgs], {
+  const entryScript = process.argv[1];
+  if (!entryScript) {
+    throw new Error('Cannot determine daemon entry script (process.argv[1] missing)');
+  }
+  const child = spawn(process.execPath, [entryScript, ...childArgs], {
     detached: true,
     stdio: ['ignore', logFd, logFd],
     env: process.env,

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1347,7 +1347,7 @@ export async function startDaemon(
         // Validate params
         const validation = validateParams(req.method, req.params);
         if (!validation.valid) {
-          socket.write(`${invalidParamsResponse(req.id, validation.error!)}\n`);
+          socket.write(`${invalidParamsResponse(req.id, validation.error ?? 'Invalid params')}\n`);
           continue;
         }
 


### PR DESCRIPTION
## Summary

Clears the biome lint debt on the tree: 6 `noNonNullAssertion` and 2 `noUnusedImports` violations.

These currently pass push CI (reported as warnings) but fail pull_request CI (reported as errors), which blocks unrelated PRs because the Typecheck and Test jobs are gated behind Quality (`needs: quality`).

## Changes (no behavior change)

- `IntentScreen.test.tsx`: extract a `clickHeadingButton` helper that throws if the `<button>` ancestor is missing, replacing three `.closest('button')!` assertions.
- `use-devbox.test.ts`: type `mountPromise` as optional and drop the `!`.
- `e2e-ipc.test.ts`: drop unused `stat` and `afterEach` imports.
- `daemon/cli.ts`: guard `process.argv[1]` with a clear error instead of asserting it.
- `daemon/server.ts`: fall back to `'Invalid params'` instead of asserting `validation.error`, which is always set inside the `!validation.valid` branch.

## Verification

Lint, typecheck, and tests run in CI for this branch.
