### PR TITLE
Promote test to main: Studio local mode + vendor-neutral naming + lint cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Per the fleet [agnosticism principle](https://github.com/RevealUIStudio/revealui
 └──────┬───────┘
        │ Unix socket JSON-RPC
        ▼
-  Claude Code hooks + other agent runtimes
+  AI coding tool hooks + other agent runtimes
 ```
 
 Studio talks to the daemon; the daemon coordinates agents and tools. Console talks to the RevealUI API directly for payment + licensing — it doesn't need the daemon hop.

--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -6,7 +6,7 @@
 //  3. Connects to WS /api/terminal/ws/:id
 //  4. Pipes SSH I/O ↔ WebSocket I/O bidirectionally
 //
-// This enables controlling Claude Code agents from any SSH client (iPhone, iPad, etc.).
+// This enables controlling AI coding tool sessions from any SSH client (iPhone, iPad, etc.).
 package proxy
 
 import (
@@ -90,7 +90,7 @@ func (p *Proxy) listSessions() ([]SessionInfo, error) {
 	return sessions, nil
 }
 
-// spawnSession creates a new Claude Code session via the API.
+// spawnSession creates a new agent session via the API.
 func (p *Proxy) spawnSession(name string) (string, error) {
 	body := fmt.Sprintf(`{"name":"%s","cols":120,"rows":30}`, name)
 	endpoint := fmt.Sprintf("%s/api/terminal/sessions", p.apiURL)

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -21,7 +21,7 @@ import TunnelPanel from './components/tunnel/TunnelPanel';
 import VaultPanel from './components/vault/VaultPanel';
 import { AuthContext, useAuth } from './hooks/use-auth';
 import { useConfig } from './hooks/use-config';
-import { SettingsContext, useSettings } from './hooks/use-settings';
+import { SettingsContext, useSettings, useSettingsContext } from './hooks/use-settings';
 import type { Page } from './types';
 
 interface EditorTarget {
@@ -40,8 +40,8 @@ export default function App() {
 }
 
 function AuthGatedApp() {
-  const { settings } = useSettings();
-  const auth = useAuth(settings.apiUrl);
+  const { settings } = useSettingsContext();
+  const auth = useAuth(settings.apiUrl, settings.localMode);
 
   return (
     <AuthContext.Provider value={auth}>

--- a/apps/studio/src/__tests__/components/IntentScreen.test.tsx
+++ b/apps/studio/src/__tests__/components/IntentScreen.test.tsx
@@ -2,6 +2,13 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import IntentScreen from '../../components/intent/IntentScreen';
 
+/** Click the <button> ancestor of a heading, failing loudly if absent. */
+function clickHeadingButton(name: string): void {
+  const button = screen.getByRole('heading', { name }).closest('button');
+  if (!button) throw new Error(`No <button> ancestor for heading "${name}"`);
+  fireEvent.click(button);
+}
+
 describe('IntentScreen', () => {
   it('renders welcome heading and description', () => {
     render(<IntentScreen onSelect={vi.fn()} />);
@@ -26,7 +33,7 @@ describe('IntentScreen', () => {
   it('enables Continue after selecting Deploy', () => {
     render(<IntentScreen onSelect={vi.fn()} />);
 
-    fireEvent.click(screen.getByRole('heading', { name: 'Deploy' }).closest('button')!);
+    clickHeadingButton('Deploy');
     expect(screen.getByText('Continue')).not.toBeDisabled();
   });
 
@@ -34,7 +41,7 @@ describe('IntentScreen', () => {
     const onSelect = vi.fn();
     render(<IntentScreen onSelect={onSelect} />);
 
-    fireEvent.click(screen.getByRole('heading', { name: 'Deploy' }).closest('button')!);
+    clickHeadingButton('Deploy');
     fireEvent.click(screen.getByText('Continue'));
     expect(onSelect).toHaveBeenCalledWith('deploy');
   });
@@ -43,7 +50,7 @@ describe('IntentScreen', () => {
     const onSelect = vi.fn();
     render(<IntentScreen onSelect={onSelect} />);
 
-    fireEvent.click(screen.getByRole('heading', { name: 'Develop' }).closest('button')!);
+    clickHeadingButton('Develop');
     fireEvent.click(screen.getByText('Continue'));
     expect(onSelect).toHaveBeenCalledWith('develop');
   });

--- a/apps/studio/src/__tests__/hooks/use-auth.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-auth.test.ts
@@ -1,0 +1,67 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuth } from '../../hooks/use-auth';
+
+// Local mode must never touch the API or the vault. Mock both so any call
+// is observable and can be asserted against.
+vi.mock('../../lib/auth-api', () => ({
+  checkStatus: vi.fn(),
+  linkDevice: vi.fn(),
+  refreshToken: vi.fn(),
+  revokeToken: vi.fn(),
+  verifyDevice: vi.fn(),
+}));
+
+vi.mock('../../lib/invoke', () => ({
+  vaultGet: vi.fn(),
+  vaultSet: vi.fn(),
+}));
+
+const { checkStatus } = await import('../../lib/auth-api');
+const { vaultGet } = await import('../../lib/invoke');
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+describe('useAuth — local mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('authenticates a synthetic local user without calling the API or vault', async () => {
+    const { result } = renderHook(() => useAuth('https://api.example.com', true));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(result.current.step).toBe('authenticated');
+    expect(result.current.user?.email).toBe('local@localhost');
+    expect(result.current.user?.role).toBe('local');
+    expect(result.current.getToken()).toBeNull();
+    expect(vi.mocked(checkStatus)).not.toHaveBeenCalled();
+    expect(vi.mocked(vaultGet)).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the email step when local mode is off and no token is stored', async () => {
+    vi.mocked(vaultGet).mockRejectedValue(new Error('vault unavailable'));
+
+    const { result } = renderHook(() => useAuth('https://api.example.com', false));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(result.current.step).toBe('email');
+    expect(result.current.user).toBeNull();
+    expect(vi.mocked(checkStatus)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/studio/src/__tests__/hooks/use-devbox.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-devbox.test.ts
@@ -110,7 +110,7 @@ describe('useDevBox', () => {
 
     const { result } = renderHook(() => useDevBox());
 
-    let mountPromise: Promise<void>;
+    let mountPromise: Promise<void> | undefined;
     act(() => {
       mountPromise = result.current.mount();
     });
@@ -120,7 +120,7 @@ describe('useDevBox', () => {
 
     await act(async () => {
       resolveMount('Done');
-      await mountPromise!;
+      await mountPromise;
     });
 
     expect(result.current.operating).toBe(false);

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -1,7 +1,7 @@
 /**
  * AgentPanel — workboard-aware change review (Pro)
  *
- * Left pane:  active Claude Code sessions, parsed from a configurable workboard.md
+ * Left pane:  active agent sessions, parsed from a configurable workboard.md
  * Right pane: pending git changes with per-file stage / discard and bulk actions
  */
 

--- a/apps/studio/src/components/auth/LoginScreen.tsx
+++ b/apps/studio/src/components/auth/LoginScreen.tsx
@@ -16,7 +16,7 @@ import Input from '../ui/Input';
 
 export default function LoginScreen() {
   const { step, loading, error, sendOtp, submitOtp } = useAuthContext();
-  const { settings } = useSettingsContext();
+  const { settings, updateSettings } = useSettingsContext();
   const [email, setEmail] = useState('');
   const [code, setCode] = useState('');
   const [otpSent, setOtpSent] = useState(false);
@@ -132,6 +132,23 @@ export default function LoginScreen() {
             </div>
           </form>
         ) : null}
+
+        {/* Local mode escape hatch (email step only) */}
+        {showOtp ? null : (
+          <div className="space-y-2 border-t border-neutral-800 pt-4">
+            <button
+              type="button"
+              onClick={() => updateSettings({ localMode: true })}
+              className="w-full rounded-md border border-neutral-700 px-3 py-2 text-sm text-neutral-300 transition-colors hover:border-neutral-500 hover:text-neutral-100"
+            >
+              Continue in local mode
+            </button>
+            <p className="text-center text-[11px] text-neutral-600">
+              Use local tools (terminal, shell, git) without signing in. Account
+              features stay disabled until you sign in.
+            </p>
+          </div>
+        )}
 
         {/* Footer */}
         <p className="text-center text-[11px] text-neutral-600">Connecting to {settings.apiUrl}</p>

--- a/apps/studio/src/components/auth/LoginScreen.tsx
+++ b/apps/studio/src/components/auth/LoginScreen.tsx
@@ -144,8 +144,8 @@ export default function LoginScreen() {
               Continue in local mode
             </button>
             <p className="text-center text-[11px] text-neutral-600">
-              Use local tools (terminal, shell, git) without signing in. Account
-              features stay disabled until you sign in.
+              Use local tools (terminal, shell, git) without signing in. Account features stay
+              disabled until you sign in.
             </p>
           </div>
         )}

--- a/apps/studio/src/components/settings/SettingsPanel.tsx
+++ b/apps/studio/src/components/settings/SettingsPanel.tsx
@@ -20,6 +20,11 @@ const POLLING_OPTIONS = [
   { label: '5m', value: 300_000 },
 ];
 
+const LOCAL_MODE_OPTIONS = [
+  { label: 'On', value: true },
+  { label: 'Off', value: false },
+];
+
 export default function SettingsPanel() {
   const [activeTab, setActiveTab] = useState<SettingsTab>('appearance');
   const [appVersion, setAppVersion] = useState('dev');
@@ -124,6 +129,29 @@ export default function SettingsPanel() {
                   </button>
                 ))}
               </div>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm text-neutral-400">Local mode</span>
+              <div className="flex gap-2">
+                {LOCAL_MODE_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.label}
+                    type="button"
+                    onClick={() => updateSettings({ localMode: opt.value })}
+                    className={`rounded-md px-4 py-2 text-sm transition-colors ${
+                      settings.localMode === opt.value
+                        ? 'bg-orange-600 text-white'
+                        : 'bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-200'
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+              <span className="text-xs text-neutral-500">
+                Skip sign-in and use local tools (terminal, shell, git) offline. Account
+                and API-backed features stay disabled until you sign in.
+              </span>
             </div>
           </div>
         </Card>

--- a/apps/studio/src/components/settings/SettingsPanel.tsx
+++ b/apps/studio/src/components/settings/SettingsPanel.tsx
@@ -149,8 +149,8 @@ export default function SettingsPanel() {
                 ))}
               </div>
               <span className="text-xs text-neutral-500">
-                Skip sign-in and use local tools (terminal, shell, git) offline. Account
-                and API-backed features stay disabled until you sign in.
+                Skip sign-in and use local tools (terminal, shell, git) offline. Account and
+                API-backed features stay disabled until you sign in.
               </span>
             </div>
           </div>

--- a/apps/studio/src/hooks/use-auth.ts
+++ b/apps/studio/src/hooks/use-auth.ts
@@ -91,7 +91,15 @@ export function useAuthContext(): AuthContextValue {
 
 // ── Hook ────────────────────────────────────────────────────────────────────
 
-export function useAuth(apiUrl: string): AuthContextValue {
+/** Synthetic identity used in local mode (no API account, no token). */
+const LOCAL_USER: AuthUser = {
+  id: 'local',
+  email: 'local@localhost',
+  name: 'Local',
+  role: 'local',
+};
+
+export function useAuth(apiUrl: string, localMode = false): AuthContextValue {
   const [step, setStep] = useState<AuthStep>('idle');
   const [user, setUser] = useState<AuthUser | null>(null);
   const [tokenExpiresAt, setTokenExpiresAt] = useState<string | null>(null);
@@ -102,6 +110,22 @@ export function useAuth(apiUrl: string): AuthContextValue {
   // Check stored token on mount
   useEffect(() => {
     let cancelled = false;
+
+    // Local mode: skip the API entirely and present a synthetic local
+    // identity. Unlocks Studio's self-contained local tools (terminal,
+    // shell, git) offline. Account and API features stay disabled until
+    // the user signs in (which they can do by turning local mode off).
+    if (localMode) {
+      setUser(LOCAL_USER);
+      setTokenExpiresAt(null);
+      setError(null);
+      setStep('authenticated');
+      setLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
     (async () => {
       try {
         const token = await loadToken();
@@ -138,7 +162,7 @@ export function useAuth(apiUrl: string): AuthContextValue {
     return () => {
       cancelled = true;
     };
-  }, [apiUrl]);
+  }, [apiUrl, localMode]);
 
   // Auto-refresh token when it's within 7 days of expiry
   useEffect(() => {

--- a/apps/studio/src/hooks/use-settings.ts
+++ b/apps/studio/src/hooks/use-settings.ts
@@ -10,6 +10,12 @@ export interface StudioSettings {
   solanaWalletAddress: string;
   /** Solana network for RVUI queries. */
   solanaNetwork: 'devnet' | 'mainnet-beta';
+  /**
+   * Local mode: skip API sign-in and use Studio's local, self-contained
+   * tools (terminal, shell, git) offline. Off by default. Account and
+   * API-backed features stay disabled until you sign in.
+   */
+  localMode: boolean;
 }
 
 const DEFAULT_API_URL = import.meta.env.DEV ? 'http://localhost:3004' : 'https://api.revealui.com';
@@ -20,6 +26,7 @@ const DEFAULT_SETTINGS: StudioSettings = {
   pollingIntervalMs: 30_000,
   solanaWalletAddress: '',
   solanaNetwork: 'devnet',
+  localMode: false,
 };
 
 const STORAGE_KEY = 'revealui-studio-settings';
@@ -52,6 +59,8 @@ function loadSettings(): StudioSettings {
         obj.solanaNetwork === 'devnet' || obj.solanaNetwork === 'mainnet-beta'
           ? obj.solanaNetwork
           : DEFAULT_SETTINGS.solanaNetwork,
+      localMode:
+        typeof obj.localMode === 'boolean' ? obj.localMode : DEFAULT_SETTINGS.localMode,
     };
   } catch {
     return { ...DEFAULT_SETTINGS };

--- a/apps/studio/src/hooks/use-settings.ts
+++ b/apps/studio/src/hooks/use-settings.ts
@@ -59,8 +59,7 @@ function loadSettings(): StudioSettings {
         obj.solanaNetwork === 'devnet' || obj.solanaNetwork === 'mainnet-beta'
           ? obj.solanaNetwork
           : DEFAULT_SETTINGS.solanaNetwork,
-      localMode:
-        typeof obj.localMode === 'boolean' ? obj.localMode : DEFAULT_SETTINGS.localMode,
+      localMode: typeof obj.localMode === 'boolean' ? obj.localMode : DEFAULT_SETTINGS.localMode,
     };
   } catch {
     return { ...DEFAULT_SETTINGS };

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -67,9 +67,9 @@ Register a new agent session. Returns a sessionId to use as identity.
 | Field | Type | Description |
 |-------|------|-------------|
 | `agentId` | string? | Stable ID (upserts if exists). Omit for ephemeral UUID. |
-| `agentName` | string? | Human-readable name (e.g., "claude-main") |
+| `agentName` | string? | Human-readable name (e.g., "agent-main") |
 | `workDir` | string? | Agent's working directory |
-| `backend` | string? | Agent backend type (e.g., "studio", "claude-code") |
+| `backend` | string? | Agent backend type (e.g., "studio", "mcp-agent") |
 
 **Response**: `{ sessionId: string }`
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -132,12 +132,12 @@ Once Studio is connected to the daemon:
 5. **Vault** — Secret management via revvault integration
 6. **Deploy** — Multi-step deployment wizard (Vercel, Neon, Stripe, Email)
 
-### Using with Claude Code
+### Using with an MCP-compatible AI coding tool
 
-RevDev's MCP Bridge exposes the daemon to Claude Code:
+RevDev's MCP Bridge exposes the daemon to any MCP-compatible AI coding tool (Claude Code, Codex, Cursor, Windsurf, or custom agents). For example, with Claude Code:
 
 ```json
-// In your Claude Code MCP config:
+// In your MCP client config (Claude Code shown as an example):
 {
   "revdev": {
     "command": "node",
@@ -146,7 +146,7 @@ RevDev's MCP Bridge exposes the daemon to Claude Code:
 }
 ```
 
-This gives Claude Code access to agent coordination, file reservations, and task management.
+This gives the tool access to agent coordination, file reservations, and task management.
 
 ---
 

--- a/docs/KEY_GENERATION.md
+++ b/docs/KEY_GENERATION.md
@@ -110,7 +110,7 @@ macOS-only (when ready for Apple distribution):
 
 ## After All Keys Are Set
 
-Tell Claude Code: "keys are generated" — it will:
+Tell your AI coding tool: "keys are generated" — it will:
 1. Wire Tauri public key into `tauri.conf.json`
 2. Tag `studio-v0.1.0` for first signed release
 3. Verify CI builds succeed with signing

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -34,7 +34,7 @@ server.tool(
   'session_register',
   'Register this agent session with the harness daemon',
   {
-    agentName: z.string().describe('Name for this agent (e.g. "claude-main")'),
+    agentName: z.string().describe('Name for this agent (e.g. "agent-main")'),
     workDir: z.string().describe('Working directory for this session'),
     backend: z.string().optional().describe('Backend identifier (default: "mcp-agent")'),
   },

--- a/packages/daemon/src/__tests__/e2e-ipc.test.ts
+++ b/packages/daemon/src/__tests__/e2e-ipc.test.ts
@@ -10,11 +10,11 @@
  *   - Concurrent fresh-socket calls (stress test)
  */
 
-import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { startDaemon } from '../server.js';
 
 // Daemon startup (key generation + license guard + PGlite + socket bind)

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -149,7 +149,11 @@ if (args.includes('--detach')) {
   // stdout (1) and stderr (2). stdin is /dev/null.
   const logFd = openSync(logPath, 'a');
   const childArgs = args.filter((a) => a !== '--detach');
-  const child = spawn(process.execPath, [process.argv[1]!, ...childArgs], {
+  const entryScript = process.argv[1];
+  if (!entryScript) {
+    throw new Error('Cannot determine daemon entry script (process.argv[1] missing)');
+  }
+  const child = spawn(process.execPath, [entryScript, ...childArgs], {
     detached: true,
     stdio: ['ignore', logFd, logFd],
     env: process.env,

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -76,7 +76,7 @@ interface RpcRequest {
 export interface SocketContext {
   /** Agent identity for this socket. Null until session.register/attach succeeds. */
   agentId: string | null;
-  /** Human-readable agent name (e.g. "claude-main"). */
+  /** Human-readable agent name (e.g. "agent-main"). */
   agentName: string | null;
   /**
    * How `agentId` was bound to this socket:

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1347,7 +1347,7 @@ export async function startDaemon(
         // Validate params
         const validation = validateParams(req.method, req.params);
         if (!validation.valid) {
-          socket.write(`${invalidParamsResponse(req.id, validation.error!)}\n`);
+          socket.write(`${invalidParamsResponse(req.id, validation.error ?? 'Invalid params')}\n`);
           continue;
         }
 


### PR DESCRIPTION
## Promotion: test -> main

Promotes the current `test` to `main`. revdev ships no deployed service, so this has no live/runtime impact; it only makes `main` current so the desktop build (`build-windows.ps1`, which builds `origin/main`) includes the changes below.

### Included (all were CI-green on `test`)

- **feat(studio): local mode** — opt-in offline mode to skip the API sign-in and use Studio's local, self-contained tools (terminal/shell/git). Off by default. (#143)
- **chore: clear biome lint debt** — 6 noNonNullAssertion + 2 unused-import violations, no behavior change. (#145)
- **docs/chore: vendor-neutral naming** — comments, docs, and the README architecture diagram. (#142, #144)
- **main -> test backflow.** (#141)
