### PR TITLE
fix(studio): add localMode to test settings literals (unbreaks frontend build)

### DIFF
--- a/apps/studio/src/__tests__/components/Dashboard.test.tsx
+++ b/apps/studio/src/__tests__/components/Dashboard.test.tsx
@@ -43,6 +43,7 @@ const defaultSettings = {
     pollingIntervalMs: 30_000,
     solanaWalletAddress: '',
     solanaNetwork: 'devnet' as const,
+    localMode: false,
   },
   updateSettings: vi.fn(),
   resetSettings: vi.fn(),

--- a/apps/studio/src/__tests__/hooks/use-health.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-health.test.ts
@@ -44,6 +44,7 @@ const DEFAULT_SETTINGS: SettingsContextValue = {
     pollingIntervalMs: 30_000,
     solanaWalletAddress: '',
     solanaNetwork: 'devnet',
+    localMode: false,
   },
   updateSettings: vi.fn(),
   resetSettings: vi.fn(),

--- a/apps/studio/src/__tests__/hooks/use-subscription.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-subscription.test.ts
@@ -42,6 +42,7 @@ const DEFAULT_SETTINGS: SettingsContextValue = {
     pollingIntervalMs: 30_000,
     solanaWalletAddress: '',
     solanaNetwork: 'devnet',
+    localMode: false,
   },
   updateSettings: vi.fn(),
   resetSettings: vi.fn(),


### PR DESCRIPTION
## Summary

Hotfix: the `StudioSettings.localMode` field added in #143 made three test files type-invalid (they construct settings literals without `localMode`). This breaks `tsc -b` (the studio frontend build), so `build-windows.ps1` fails at the frontend step.

**Why CI did not catch it:** revdev CI does not typecheck the studio frontend. `pnpm typecheck` is filtered with `!studio`, and the Test job (vitest) transpiles without type-checking. So #143 was CI-green while the real Windows build fails.

## Fix

Add `localMode: false` to the settings literals in:
- `Dashboard.test.tsx`
- `use-health.test.ts`
- `use-subscription.test.ts`

Verified with `pnpm exec tsc -b` (exit 0) in a checkout with dependencies installed.

## Follow-up (not in this PR)

revdev CI should gate the studio frontend typecheck (`pnpm typecheck:studio`) so this class of break is caught in CI rather than at build time.
