### PR TITLE
Promote test to main: localMode test-literal build hotfix

### DIFF
--- a/apps/studio/src/__tests__/components/Dashboard.test.tsx
+++ b/apps/studio/src/__tests__/components/Dashboard.test.tsx
@@ -43,6 +43,7 @@ const defaultSettings = {
     pollingIntervalMs: 30_000,
     solanaWalletAddress: '',
     solanaNetwork: 'devnet' as const,
+    localMode: false,
   },
   updateSettings: vi.fn(),
   resetSettings: vi.fn(),

--- a/apps/studio/src/__tests__/hooks/use-health.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-health.test.ts
@@ -44,6 +44,7 @@ const DEFAULT_SETTINGS: SettingsContextValue = {
     pollingIntervalMs: 30_000,
     solanaWalletAddress: '',
     solanaNetwork: 'devnet',
+    localMode: false,
   },
   updateSettings: vi.fn(),
   resetSettings: vi.fn(),

--- a/apps/studio/src/__tests__/hooks/use-subscription.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-subscription.test.ts
@@ -42,6 +42,7 @@ const DEFAULT_SETTINGS: SettingsContextValue = {
     pollingIntervalMs: 30_000,
     solanaWalletAddress: '',
     solanaNetwork: 'devnet',
+    localMode: false,
   },
   updateSettings: vi.fn(),
   resetSettings: vi.fn(),


### PR DESCRIPTION
Promotes the #148 hotfix (adds localMode to 3 studio test settings literals) to main so build-windows.ps1 passes the frontend tsc step. revdev has no deploy; no live impact. Verified locally with tsc -b (exit 0).