### PR TITLE
ci(studio): typecheck frontend on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,35 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
 
+  typecheck-studio:
+    name: Typecheck (studio)
+    runs-on: ubuntu-latest
+    needs: quality
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install Linux system dependencies (Tauri toolchain for ts-rs binding generation)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - name: Rust cache
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: apps/studio/src-tauri -> target
+      - run: pnpm install --frozen-lockfile
+      # Studio frontend `tsc -b` imports ./generated/* (ts-rs bindings, gitignored),
+      # so regenerate them from the Rust source before typechecking.
+      - run: bash apps/studio/scripts/generate-types.sh
+      - run: pnpm typecheck:studio
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The **studio frontend was never typechecked in CI.** The root `pnpm typecheck` script filters it out (`pnpm -r --filter=!studio typecheck`), and the `Test` job (vitest) transpiles without type-checking. There is a `typecheck:studio` script, but no CI job ran it.

This let **#143** (which added `StudioSettings.localMode`) pass CI fully green while breaking the studio frontend build: three test files (`apps/studio/src/__tests__/components/Dashboard.test.tsx`, `.../hooks/use-health.test.ts`, `.../hooks/use-subscription.test.ts`) constructed settings literals without the new required field, so `tsc -b` failed. It only surfaced when `build-windows.ps1` failed at the frontend step, and was hotfixed in **#148**.

## Change

Adds a dedicated **`Typecheck (studio)`** job to `ci.yml` that runs on every PR.

Studio's frontend `tsc -b` imports `./generated/*` — the ts-rs TypeScript bindings that are **gitignored** and produced by `cargo` (ts-rs `cargo test --lib`). A fresh CI checkout has no `src/generated/`, so a naive `pnpm typecheck:studio` would fail on missing modules. The job therefore mirrors the Tauri toolchain setup already proven in `studio-release.yml`:

1. install the Tauri Linux system deps + Rust stable + rust-cache,
2. regenerate the bindings via `apps/studio/scripts/generate-types.sh`,
3. run `pnpm typecheck:studio` (`tsc -b --noEmit`).

As a side benefit this also catches **binding drift** (Rust structs changing without the frontend keeping up), since it regenerates from the current Rust source each run.

## Notes

- The job is `needs: quality`, consistent with the existing `Typecheck` and `Test` jobs.
- The `Typecheck (studio)` context is being added to the required status checks (managed as code in a separate internal repo) so it blocks merges.
- Manual merge only — no auto-merge.
