### PR TITLE
Promote test -> main: studio frontend typecheck CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,35 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
 
+  typecheck-studio:
+    name: Typecheck (studio)
+    runs-on: ubuntu-latest
+    needs: quality
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install Linux system dependencies (Tauri toolchain for ts-rs binding generation)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - name: Rust cache
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: apps/studio/src-tauri -> target
+      - run: pnpm install --frozen-lockfile
+      # Studio frontend `tsc -b` imports ./generated/* (ts-rs bindings, gitignored),
+      # so regenerate them from the Rust source before typechecking.
+      - run: bash apps/studio/scripts/generate-types.sh
+      - run: pnpm typecheck:studio
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Promotes `test` → `main`.

Carries:
- **#151** — new `Typecheck (studio)` CI job. Gates the studio frontend `tsc -b` on every PR by regenerating the gitignored ts-rs bindings (`generate-types.sh`) then running `pnpm typecheck:studio`. Closes the gap that let #143 merge green while breaking the studio frontend build.
- the #150 backflow (main→test) reconciliation.

Merge commit (not squash) to keep `test`/`main` histories convergent.
