### PR TITLE
ci(studio): build frontend (tsc + vite) in the studio gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,12 @@ jobs:
         with:
           workspaces: apps/studio/src-tauri -> target
       - run: pnpm install --frozen-lockfile
-      # Studio frontend `tsc -b` imports ./generated/* (ts-rs bindings, gitignored),
-      # so regenerate them from the Rust source before typechecking.
+      # Studio frontend build imports ./generated/* (ts-rs bindings, gitignored),
+      # so regenerate them from the Rust source first. `build` runs `tsc -b` (the
+      # #143 failure mode) then `vite build`, mirroring build-windows.ps1's frontend
+      # step, catching type errors AND bundling errors on every PR.
       - run: bash apps/studio/scripts/generate-types.sh
-      - run: pnpm typecheck:studio
+      - run: pnpm --filter studio build
 
   test:
     name: Test


### PR DESCRIPTION
## What

Extends the `Typecheck (studio)` job's final step from `pnpm typecheck:studio` (`tsc -b --noEmit`) to **`pnpm --filter studio build`** (`tsc -b && vite build`).

## Why

The gate added in #151 catches the exact #143 failure mode (`tsc -b`), but not the second half of studio's frontend build (`vite build`). A bundling-only break (bad import vite resolves but tsc doesn't, asset/config error, etc.) would still pass the gate and only surface in `build-windows.ps1`. This makes the CI job mirror what `build-windows.ps1` does at the frontend step.

## Notes

- Bindings are still regenerated first (`generate-types.sh`), so the gitignored `src/generated/*` exist before the build.
- **Job name unchanged** (`Typecheck (studio)`), so the required status check stays bound — no branch-protection change needed.
- Marginal extra cost: `vite build` is fast (no additional cargo); the heavy step remains the cached Rust binding generation.
- Manual merge only.
