### PR TITLE
Promote test -> main: studio gate now runs full frontend build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,12 @@ jobs:
         with:
           workspaces: apps/studio/src-tauri -> target
       - run: pnpm install --frozen-lockfile
-      # Studio frontend `tsc -b` imports ./generated/* (ts-rs bindings, gitignored),
-      # so regenerate them from the Rust source before typechecking.
+      # Studio frontend build imports ./generated/* (ts-rs bindings, gitignored),
+      # so regenerate them from the Rust source first. `build` runs `tsc -b` (the
+      # #143 failure mode) then `vite build`, mirroring build-windows.ps1's frontend
+      # step, catching type errors AND bundling errors on every PR.
       - run: bash apps/studio/scripts/generate-types.sh
-      - run: pnpm typecheck:studio
+      - run: pnpm --filter studio build
 
   test:
     name: Test


### PR DESCRIPTION
Promotes #154 — the Typecheck (studio) job now runs pnpm --filter studio build (tsc -b + vite build) instead of typecheck-only, mirroring build-windows.ps1 frontend step. Merge commit to keep test/main convergent.