### PR TITLE
fix(daemon+console): events.log pre-auth DoS + Console panic cluster (audit item 3)

### DIFF
--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -175,7 +175,7 @@ func (p *Proxy) pickSession(s ssh.Session, sessions []SessionInfo) (string, erro
 		if err != nil {
 			return "", err
 		}
-		fmt.Fprintf(s, "  \033[32mSession created: %s\033[0m\r\n\r\n", sessionID[:8])
+		fmt.Fprintf(s, "  \033[32mSession created: %s\033[0m\r\n\r\n", short(sessionID))
 		return sessionID, nil
 	default:
 		// Try to parse as session index
@@ -194,7 +194,7 @@ func (p *Proxy) bridge(s ssh.Session, sessionID string) error {
 	wsURL = strings.Replace(wsURL, "http://", "ws://", 1)
 	wsURL = fmt.Sprintf("%s/api/terminal/ws/%s", wsURL, sessionID)
 
-	fmt.Fprintf(s, "  \033[90mConnecting to %s...\033[0m\r\n", sessionID[:8])
+	fmt.Fprintf(s, "  \033[90mConnecting to %s...\033[0m\r\n", short(sessionID))
 
 	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {

--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -111,11 +111,21 @@ func (p *Proxy) spawnSession(name string) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	// Check the status BEFORE decoding: an auth/server error returns an error
+	// body, not a session, and silently decoding it yields an empty SessionID
+	// that later panics at short()/slice sites or connects to ws/<empty>.
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("spawn failed: API returned %d", resp.StatusCode)
+	}
+
 	var result struct {
 		SessionID string `json:"sessionId"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", fmt.Errorf("decode spawn response: %w", err)
+	}
+	if result.SessionID == "" {
+		return "", fmt.Errorf("spawn response contained an empty session id")
 	}
 	return result.SessionID, nil
 }

--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -258,11 +258,7 @@ func (p *Proxy) bridge(s ssh.Session, sessionID string) error {
 
 			_, message, err := conn.ReadMessage()
 			if err != nil {
-				select {
-				case <-done:
-				default:
-					close(done)
-				}
+				closeDone()
 				return
 			}
 

--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -221,7 +221,7 @@ func (p *Proxy) bridge(s ssh.Session, sessionID string) error {
 		for {
 			n, err := s.Read(buf)
 			if err != nil {
-				close(done)
+				closeDone()
 				return
 			}
 			data := buf[:n]
@@ -229,7 +229,7 @@ func (p *Proxy) bridge(s ssh.Session, sessionID string) error {
 			// Ctrl+] (0x1D) = detach
 			for _, b := range data {
 				if b == 0x1D {
-					close(done)
+					closeDone()
 					return
 				}
 			}
@@ -239,7 +239,7 @@ func (p *Proxy) bridge(s ssh.Session, sessionID string) error {
 				"data": string(data),
 			}
 			if err := conn.WriteJSON(msg); err != nil {
-				close(done)
+				closeDone()
 				return
 			}
 		}

--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -90,6 +90,16 @@ func (p *Proxy) listSessions() ([]SessionInfo, error) {
 	return sessions, nil
 }
 
+// short truncates an ID for display. It returns the whole string when shorter
+// than 8 chars so a short or empty session ID never panics with a
+// slice-bounds-out-of-range error (which would kill the SSH session).
+func short(id string) string {
+	if len(id) < 8 {
+		return id
+	}
+	return id[:8]
+}
+
 // spawnSession creates a new agent session via the API.
 func (p *Proxy) spawnSession(name string) (string, error) {
 	body := fmt.Sprintf(`{"name":"%s","cols":120,"rows":30}`, name)

--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -146,7 +146,7 @@ func (p *Proxy) pickSession(s ssh.Session, sessions []SessionInfo) (string, erro
 		fmt.Fprintf(s, "  \033[1mActive sessions:\033[0m\r\n")
 		for i, sess := range ptySessions {
 			fmt.Fprintf(s, "    \033[36m%d)\033[0m %s \033[90m(%s)\033[0m\r\n",
-				i+1, sess.Name, sess.ID[:8])
+				i+1, sess.Name, short(sess.ID))
 		}
 		fmt.Fprintf(s, "\r\n")
 	} else {

--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -206,6 +206,12 @@ func (p *Proxy) bridge(s ssh.Session, sessionID string) error {
 
 	var wg sync.WaitGroup
 	done := make(chan struct{})
+	// Multiple goroutines (SSH→WS reader, WS→SSH reader, resize forwarder) race
+	// to signal teardown. Closing `done` more than once panics, and a panic in a
+	// goroutine is unrecoverable — it crashes the whole process. Gate every close
+	// behind a sync.Once so teardown is idempotent from any path.
+	var closeOnce sync.Once
+	closeDone := func() { closeOnce.Do(func() { close(done) }) }
 
 	// SSH → WebSocket (user input)
 	wg.Add(1)

--- a/apps/console/proxy/proxy_test.go
+++ b/apps/console/proxy/proxy_test.go
@@ -1,0 +1,79 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/RevealUIStudio/revdev/apps/console/api"
+)
+
+func TestShort(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},                     // empty must not panic
+		{"abc", "abc"},               // shorter than 8
+		{"12345678", "12345678"},     // exactly 8
+		{"123456789", "12345678"},    // longer than 8 → truncated
+		{"deadbeefcafe", "deadbeef"}, // long id
+	}
+	for _, c := range cases {
+		if got := short(c.in); got != c.want {
+			t.Errorf("short(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// newTestProxy wires a Proxy to an httptest server.
+func newTestProxy(serverURL string) *Proxy {
+	return New(api.NewClient(serverURL, "test-token"), serverURL)
+}
+
+func TestSpawnSession_RejectsNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := newTestProxy(srv.URL).spawnSession("agent")
+	if err == nil {
+		t.Fatal("expected an error on a 500 response, got nil")
+	}
+	if want := "API returned 500"; !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q should mention %q", err, want)
+	}
+}
+
+func TestSpawnSession_RejectsEmptyID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"sessionId":""}`)
+	}))
+	defer srv.Close()
+
+	_, err := newTestProxy(srv.URL).spawnSession("agent")
+	if err == nil {
+		t.Fatal("expected an error on an empty session id, got nil")
+	}
+	if want := "empty session id"; !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q should mention %q", err, want)
+	}
+}
+
+func TestSpawnSession_Succeeds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"sessionId":"abc123xyz"}`)
+	}))
+	defer srv.Close()
+
+	id, err := newTestProxy(srv.URL).spawnSession("agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "abc123xyz" {
+		t.Errorf("sessionID = %q, want %q", id, "abc123xyz")
+	}
+}

--- a/packages/daemon/src/__tests__/validation.test.ts
+++ b/packages/daemon/src/__tests__/validation.test.ts
@@ -393,9 +393,9 @@ describe('No-schema methods (pass-through)', () => {
 
 describe('events.log payload DoS guard', () => {
   it('accepts a small JSON-serializable payload', () => {
-    expect(
-      validateParams('events.log', { eventType: 'note', payload: { ok: true } }).valid,
-    ).toBe(true);
+    expect(validateParams('events.log', { eventType: 'note', payload: { ok: true } }).valid).toBe(
+      true,
+    );
   });
 
   it('accepts a missing (optional) payload', () => {
@@ -430,9 +430,9 @@ describe('events.log payload DoS guard', () => {
     expect(() =>
       validateParams('events.log', { eventType: 'note', payload: () => 'x' }),
     ).not.toThrow();
-    expect(
-      validateParams('events.log', { eventType: 'note', payload: () => 'x' }).valid,
-    ).toBe(false);
+    expect(validateParams('events.log', { eventType: 'note', payload: () => 'x' }).valid).toBe(
+      false,
+    );
   });
 
   it('rejects an oversize payload', () => {

--- a/packages/daemon/src/__tests__/validation.test.ts
+++ b/packages/daemon/src/__tests__/validation.test.ts
@@ -390,3 +390,54 @@ describe('No-schema methods (pass-through)', () => {
     expect(validateParams('not.a.method', { foo: 'bar' }).valid).toBe(true);
   });
 });
+
+describe('events.log payload DoS guard', () => {
+  it('accepts a small JSON-serializable payload', () => {
+    expect(
+      validateParams('events.log', { eventType: 'note', payload: { ok: true } }).valid,
+    ).toBe(true);
+  });
+
+  it('accepts a missing (optional) payload', () => {
+    expect(validateParams('events.log', { eventType: 'note' }).valid).toBe(true);
+  });
+
+  // The pre-fix refine called JSON.stringify, which throws on a BigInt — that
+  // throw escaped safeParse and crashed the per-socket handler (pre-auth DoS).
+  // It must now be rejected cleanly without throwing.
+  it('rejects a BigInt payload without throwing (returns invalid)', () => {
+    let result: ReturnType<typeof validateParams>;
+    expect(() => {
+      result = validateParams('events.log', { eventType: 'note', payload: { n: 1n } });
+    }).not.toThrow();
+    // biome-ignore lint/style/noNonNullAssertion: assigned in the callback above
+    expect(result!.valid).toBe(false);
+  });
+
+  it('rejects a circular payload without throwing (returns invalid)', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    let result: ReturnType<typeof validateParams>;
+    expect(() => {
+      result = validateParams('events.log', { eventType: 'note', payload: circular });
+    }).not.toThrow();
+    // biome-ignore lint/style/noNonNullAssertion: assigned in the callback above
+    expect(result!.valid).toBe(false);
+  });
+
+  it('rejects a non-JSON (function) payload without throwing', () => {
+    // JSON.stringify returns undefined here, so the pre-fix `.length` also threw.
+    expect(() =>
+      validateParams('events.log', { eventType: 'note', payload: () => 'x' }),
+    ).not.toThrow();
+    expect(
+      validateParams('events.log', { eventType: 'note', payload: () => 'x' }).valid,
+    ).toBe(false);
+  });
+
+  it('rejects an oversize payload', () => {
+    const huge = 'x'.repeat(200_000);
+    const result = validateParams('events.log', { eventType: 'note', payload: huge });
+    expect(result.valid).toBe(false);
+  });
+});

--- a/packages/daemon/src/validation/index.ts
+++ b/packages/daemon/src/validation/index.ts
@@ -30,7 +30,21 @@ export function validateParams(method: string, params: unknown): ValidationResul
     return { valid: true };
   }
 
-  const result = schema.safeParse(params ?? {});
+  // safeParse is documented not to throw on validation failure, but a custom
+  // `.refine()` predicate CAN throw (e.g. JSON.stringify on a BigInt/circular
+  // payload). Such a throw would escape here into the per-socket data handler
+  // as an unhandled rejection — a pre-auth remote DoS. Treat any throw as
+  // invalid params so the connection survives with a clean -32602. This guard
+  // protects every caller and any future schema, not just events.log.
+  let result: ReturnType<typeof schema.safeParse>;
+  try {
+    result = schema.safeParse(params ?? {});
+  } catch (err) {
+    return {
+      valid: false,
+      error: `params failed validation: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
   if (result.success) {
     return { valid: true };
   }

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -258,9 +258,24 @@ export const schemas: Record<string, z.ZodType> = {
       eventType: z.string().max(128),
       payload: z
         .unknown()
-        .refine((v) => JSON.stringify(v).length <= MAX_PAYLOAD_SIZE, {
-          message: `Event payload exceeds ${MAX_PAYLOAD_SIZE} bytes`,
-        })
+        .refine(
+          (v) => {
+            // This predicate MUST NEVER throw. JSON.stringify throws on BigInt
+            // and circular references, and returns `undefined` for a function /
+            // symbol value (so `.length` then throws too). A throw here escapes
+            // safeParse and surfaces as an unhandled rejection in the per-socket
+            // handler — a trivially reachable, pre-auth remote DoS. Treat any
+            // un-stringifiable payload as invalid rather than letting it throw.
+            try {
+              return JSON.stringify(v).length <= MAX_PAYLOAD_SIZE;
+            } catch {
+              return false;
+            }
+          },
+          {
+            message: `Event payload must be JSON-serializable and at most ${MAX_PAYLOAD_SIZE} bytes`,
+          },
+        )
         .optional(),
       // Handler accepts agentId override; falls back to ctx.agentId.
       agentId: z.string().max(MAX_NAME_LENGTH).optional(),


### PR DESCRIPTION
## Item 3 of the 2026-06-23 UX + durability audit remediation

Closes the remotely-reachable **pre-auth daemon DoS** plus the **Console Go panic cluster** (Theme 5). Base `test`. Third of the ordered 12 items.

### Daemon — events.log payload DoS (`packages/daemon/src/validation/`)
The `events.log` payload refine called `JSON.stringify(v).length`, which **throws** on a BigInt or circular payload (and `.length` throws when `stringify` returns `undefined` for a function/symbol). The throw escaped `safeParse` and surfaced as an **unhandled rejection in the per-socket data handler** — trivially reachable over the JSON-RPC socket **before the identity gate**.
- `schemas.ts`: guard the predicate so it never throws (un-stringifiable → invalid).
- `validation/index.ts`: harden `validateParams` to convert **any** `safeParse` throw into a clean `-32602` — protects every caller and any future schema, not just `events.log`.
- 6 new tests (BigInt, circular, function, oversize, + happy paths).

### Console — proxy panic cluster (`apps/console/proxy/proxy.go`)
- **done-channel double-close → process crash**: the SSH-reader and WS-reader goroutines both `close(done)` on teardown; concurrent close panics, and a panic in a goroutine is unrecoverable. Now routed through a `sync.Once` `closeDone()` so teardown is idempotent from any path.
- **`sessionID[:8]` slice panics** on short/empty IDs (3 sites) → new `short()` helper returns the whole string when `len < 8`.
- **error-response-as-success** in `spawnSession`: it decoded without checking `StatusCode`, returning an empty session id that then panicked at a slice site or connected to `ws/<empty>`. Now checks `StatusCode != 200` before decoding and rejects an empty id.
- First tests for the `proxy` package: `short()` across empty/short/exact/long IDs, and `spawnSession` rejecting non-200 + empty-id via `httptest`.

### Verification
- `pnpm --filter @revdev/daemon exec vitest run src/__tests__/validation.test.ts` → **68/68** (incl. 6 new DoS-guard tests).
- `go vet ./...` clean · `go build` OK · `go test ./...` all pass · `go test ./proxy/ -v` → **4/4** new tests.
- `biome check` clean on changed TS.

Out of scope (later items, deliberately not touched here): the `spawnSession` JSON injection via `fmt.Sprintf` (item 10) and the WS dial timeout/auth (item 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
