### PR TITLE
feat(daemon): P0 — file.*/git.* RPC surface + tier exemptions + signature enforcement

### DIFF
--- a/packages/daemon/src/__tests__/filegit.test.ts
+++ b/packages/daemon/src/__tests__/filegit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Path-containment unit tests for the file.* / git.* surface (ADR zero-9P P0).
+ *
+ * These cover the third security barrier in isolation — the registered-root
+ * allowlist + realpath descendant check — without standing up a daemon or
+ * signing envelopes (the signed-RPC round-trip tests live in P5). The point
+ * is that neither a `..` traversal nor a symlink can escape a registered
+ * project root to reach `~/.ssh`, `~/.age-identity`, etc.
+ */
+
+import { mkdir, mkdtemp, realpath, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  _addRootForTest,
+  _clearRegisteredRootsForTest,
+  _gitRelPathForTest,
+  _resolveInRootForTest,
+} from '../filegit.js';
+
+describe('filegit path containment', () => {
+  let root: string;
+  let outside: string;
+
+  beforeEach(async () => {
+    _clearRegisteredRootsForTest();
+    // realpath so macOS /var -> /private/var symlink doesn't break `within`.
+    root = await realpath(await mkdtemp(join(tmpdir(), 'revdev-root-')));
+    outside = await realpath(await mkdtemp(join(tmpdir(), 'revdev-out-')));
+    _addRootForTest(root);
+  });
+
+  afterEach(() => {
+    _clearRegisteredRootsForTest();
+  });
+
+  describe('resolveInRoot (realpath descendant check)', () => {
+    it('resolves an existing file inside the root', async () => {
+      await writeFile(join(root, 'a.txt'), 'hi');
+      const resolved = await _resolveInRootForTest(root, 'a.txt', true);
+      expect(resolved).toBe(join(root, 'a.txt'));
+    });
+
+    it('resolves a new file in an existing subdir (mustExist=false)', async () => {
+      await mkdir(join(root, 'sub'));
+      const resolved = await _resolveInRootForTest(root, 'sub/new.txt', false);
+      expect(resolved).toBe(join(root, 'sub', 'new.txt'));
+    });
+
+    it('rejects a ../ traversal escape', async () => {
+      await expect(_resolveInRootForTest(root, '../escape.txt', false)).rejects.toThrow(
+        'escapes project root',
+      );
+    });
+
+    it('rejects an absolute path outside the root', async () => {
+      await writeFile(join(outside, 'secret'), 'x');
+      await expect(_resolveInRootForTest(root, join(outside, 'secret'), true)).rejects.toThrow(
+        'escapes project root',
+      );
+    });
+
+    it('rejects a symlink that points outside the root', async () => {
+      await writeFile(join(outside, 'secret'), 'x');
+      await symlink(join(outside, 'secret'), join(root, 'link'));
+      // realpath resolves the link to its outside target → escape.
+      await expect(_resolveInRootForTest(root, 'link', true)).rejects.toThrow(
+        'escapes project root',
+      );
+    });
+
+    it('rejects a path whose parent escapes via symlinked dir', async () => {
+      await symlink(outside, join(root, 'linkdir'));
+      await expect(_resolveInRootForTest(root, 'linkdir/file.txt', false)).rejects.toThrow(
+        'escapes project root',
+      );
+    });
+  });
+
+  describe('gitRelPath (lexical pathspec check)', () => {
+    it('returns a clean repo-relative path', () => {
+      expect(_gitRelPathForTest(root, 'src/x.ts')).toBe(join('src', 'x.ts'));
+    });
+
+    it('rejects ../ escape', () => {
+      expect(() => _gitRelPathForTest(root, '../x.ts')).toThrow('escapes project root');
+    });
+
+    it('rejects an absolute path outside the root', () => {
+      expect(() => _gitRelPathForTest(root, join(outside, 'x.ts'))).toThrow('escapes project root');
+    });
+
+    it('rejects the repo root itself as a pathspec', () => {
+      expect(() => _gitRelPathForTest(root, '.')).toThrow('escapes project root');
+    });
+  });
+});

--- a/packages/daemon/src/__tests__/guard.test.ts
+++ b/packages/daemon/src/__tests__/guard.test.ts
@@ -124,6 +124,61 @@ describe('guardRpcMethod', () => {
     });
   });
 
+  // ADR zero-9P P0: all single-repo file/git I/O is FREE; only multi-agent
+  // coordination stays Pro. This locks the boundary so a future EXEMPT_METHODS
+  // edit can't accidentally exempt a Pro method or re-gate a free one.
+  describe('file/git tier boundary (zero-9P P0)', () => {
+    const freeFileGitMethods = [
+      'project.open',
+      'file.read',
+      'file.write',
+      'file.delete',
+      'file.stat',
+      'git.status',
+      'git.diffFile',
+      'git.diffContent',
+      'git.stageFile',
+      'git.unstageFile',
+      'git.discardFile',
+      'git.listBranches',
+      'git.createBranch',
+      'git.switchBranch',
+      'git.deleteBranch',
+      'git.log',
+      'git.commit',
+      'git.push',
+      'git.pull',
+      'git.readBlobAtHead',
+      'git.readBlobAtIndex',
+    ];
+
+    for (const method of freeFileGitMethods) {
+      it(`allows "${method}" on free tier (not -32001)`, () => {
+        const result = guardRpcMethod(method);
+        expect(result.allowed).toBe(true);
+        expect(result.tier).toBe('free');
+      });
+    }
+
+    const proCoordinationMethods = [
+      'agent.spawn',
+      'merge.request',
+      'mail.send',
+      'tasks.create',
+      'files.reserve',
+      'memory.store',
+      'inference.status',
+    ];
+
+    for (const method of proCoordinationMethods) {
+      it(`still blocks Pro method "${method}" on free tier`, () => {
+        const result = guardRpcMethod(method);
+        expect(result.allowed).toBe(false);
+        expect(result.tier).toBe('free');
+      });
+    }
+  });
+
   describe('invalid license keys', () => {
     it('treats malformed key as free tier', () => {
       process.env.REVEALUI_LICENSE_KEY = 'not-a-valid-key';

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Locks the signature-enforcement set against drift (zero-9P security review).
+ *
+ * Every file/git method that WRITES or returns file CONTENT must be in
+ * MUTATING_OR_CONTENT_METHODS so the dispatch loop requires a valid signature
+ * (-32003 otherwise). Adding a new content/mutation handler without adding it
+ * here would silently let an unsigned caller invoke it — this test fails the
+ * build in that case. The Rust client's `requires_signature` set
+ * (apps/studio/src-tauri/src/signing.rs) must be kept in lockstep with this
+ * list.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { MUTATING_OR_CONTENT_METHODS } from '../server.js';
+
+const SIGNED = [
+  'file.read',
+  'file.write',
+  'file.delete',
+  'file.stat',
+  'git.stageFile',
+  'git.unstageFile',
+  'git.discardFile',
+  'git.createBranch',
+  'git.switchBranch',
+  'git.deleteBranch',
+  'git.commit',
+  'git.push',
+  'git.pull',
+  'git.diffFile',
+  'git.diffContent',
+  'git.readBlobAtHead',
+  'git.readBlobAtIndex',
+];
+
+// Payload-free coordination reads (and setup) stay signature-OPTIONAL.
+const OPTIONAL = [
+  'project.open',
+  'git.status',
+  'git.listBranches',
+  'git.log',
+  'ping',
+  'session.list',
+];
+
+describe('signature-required method set (zero-9P)', () => {
+  for (const m of SIGNED) {
+    it(`requires a signature for "${m}"`, () => {
+      expect(MUTATING_OR_CONTENT_METHODS.has(m)).toBe(true);
+    });
+  }
+
+  for (const m of OPTIONAL) {
+    it(`does not require a signature for "${m}"`, () => {
+      expect(MUTATING_OR_CONTENT_METHODS.has(m)).toBe(false);
+    });
+  }
+
+  it('is EXACTLY the enumerated set (no silent additions)', () => {
+    expect([...MUTATING_OR_CONTENT_METHODS].sort()).toEqual([...SIGNED].sort());
+  });
+});

--- a/packages/daemon/src/__tests__/validation.test.ts
+++ b/packages/daemon/src/__tests__/validation.test.ts
@@ -381,6 +381,40 @@ describe('inference.status validation', () => {
   });
 });
 
+describe('git option-injection rejection (zero-9P)', () => {
+  it('rejects a branch name starting with "-"', () => {
+    expect(validateParams('git.switchBranch', { repoPath: '/r', name: '--orphan' }).valid).toBe(
+      false,
+    );
+    expect(validateParams('git.createBranch', { repoPath: '/r', name: '-D' }).valid).toBe(false);
+    expect(validateParams('git.deleteBranch', { repoPath: '/r', name: '--force' }).valid).toBe(
+      false,
+    );
+  });
+
+  it('rejects a push/pull remote starting with "-" (--receive-pack / --upload-pack)', () => {
+    expect(
+      validateParams('git.push', {
+        repoPath: '/r',
+        remote: '--receive-pack=touch /tmp/x',
+        branch: 'main',
+      }).valid,
+    ).toBe(false);
+    expect(validateParams('git.pull', { repoPath: '/r', remote: '--upload-pack=evil' }).valid).toBe(
+      false,
+    );
+  });
+
+  it('accepts ordinary branch and remote names', () => {
+    expect(validateParams('git.switchBranch', { repoPath: '/r', name: 'feature/x' }).valid).toBe(
+      true,
+    );
+    expect(
+      validateParams('git.push', { repoPath: '/r', remote: 'origin', branch: 'main' }).valid,
+    ).toBe(true);
+  });
+});
+
 describe('No-schema methods (pass-through)', () => {
   it('ping passes through with empty payload', () => {
     expect(validateParams('ping', {}).valid).toBe(true);

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -68,6 +68,23 @@ export interface DaemonConfig {
    */
   gitTimeoutMs: number;
   /**
+   * Maximum size in UTF-8 bytes of file/blob CONTENT returned inline by a
+   * content-returning read (`file.read`, `git.diffContent`,
+   * `git.readBlobAtHead`, `git.readBlobAtIndex`). The inbound `maxLineBytes`
+   * cap only guards request frames; it does NOT bound a response the daemon
+   * writes back. Without this, a multi-MB file would be serialized into a
+   * single JSON-RPC response frame and shipped over the relay, blowing the
+   * client's reassembly buffer.
+   *
+   * Above the cap the handler returns `{ tooLarge: true, bytes }` instead of
+   * `content`; the editor falls back to a streamed / read-only view (P1/P2).
+   * Measured pre-serialize on the raw bytes (JSON escaping can roughly double
+   * the wire size, so this sits comfortably under `maxLineBytes`).
+   *
+   * 768 KiB default is generous for any source file an editor opens inline.
+   */
+  maxInlineReadBytes: number;
+  /**
    * Maximum wall-clock time (in ms) the daemon's `close()` waits for
    * in-flight RPC handlers to complete before tearing down PGlite and
    * the Unix socket. Pre-this-flag, `db.close()` raced with active
@@ -107,5 +124,6 @@ export const DAEMON_DEFAULTS: DaemonConfig = {
   pruneIntervalMs: 60 * 60 * 1000, // 1 hour
   maxLineBytes: 1_048_576, // 1 MiB
   gitTimeoutMs: 60_000, // 60 s
+  maxInlineReadBytes: 786_432, // 768 KiB
   shutdownGracePeriodMs: 5_000, // 5 s
 };

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -24,7 +24,8 @@
  * traversal nor a symlink can escape to `~/.ssh`, `~/.age-identity`, etc.
  */
 
-import { readFile, realpath, stat, unlink, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { open, readFile, realpath, stat, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { getDaemonConfig, registerHandler } from './server.js';
@@ -222,7 +223,20 @@ registerHandler('file.write', async (params) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), false);
   const content = str(params.content) ?? '';
-  await writeFile(target, content, 'utf8');
+  // Open with O_NOFOLLOW so a symlink swapped in at the FINAL component between
+  // resolveInRoot's parent-realpath check and the write (leaf TOCTOU) is
+  // refused (ELOOP) — a write can't be redirected outside the registered root.
+  const handle = await open(
+    target,
+    // eslint-disable-next-line no-bitwise
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW,
+    0o644,
+  );
+  try {
+    await handle.writeFile(content, 'utf8');
+  } finally {
+    await handle.close();
+  }
   return { success: true, bytes: Buffer.byteLength(content, 'utf8') };
 });
 

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -1,0 +1,422 @@
+/**
+ * file.* / git.* handlers — daemon-owned ext4 file and git I/O (ADR
+ * 2026-06-23, "RevDev as a zero-9P WSL-native dev surface", P0).
+ *
+ * The daemon runs as a Linux process on the WSL ext4 filesystem, so every
+ * read/write/commit it performs is coherent. Studio (Windows) becomes a pure
+ * RPC client and never touches a project path through the 9P (`\\wsl$`)
+ * redirector, eliminating the stale-read / phantom-git-metadata failure
+ * class by construction rather than guarding it per call.
+ *
+ * Three layered barriers gate this surface (the 0600 socket alone is NOT
+ * sufficient — any host process can `wsl.exe` in as the WSL user and reach
+ * the socket):
+ *   1. Socket + parent-dir mode (0600 / 0700) — see server.ts.
+ *   2. Required Ed25519 signature on every mutation + content read — enforced
+ *      at the dispatch site via MUTATING_OR_CONTENT_METHODS (server.ts).
+ *   3. Registered-project-roots allowlist + realpath descendant check in
+ *      EVERY handler below — implemented here.
+ *
+ * Path handling: `~` is expanded against the DAEMON's $HOME (Studio passes
+ * paths verbatim and never resolves them). A repo path must have been
+ * registered via `project.open`; every file target is realpath-resolved and
+ * confirmed to be a descendant of the registered root, so neither a `..`
+ * traversal nor a symlink can escape to `~/.ssh`, `~/.age-identity`, etc.
+ */
+
+import { readFile, realpath, stat, unlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { getDaemonConfig, registerHandler } from './server.js';
+import { runGit, type ShellResult } from './vcs.js';
+
+// ---------------------------------------------------------------------------
+// Registered project roots
+// ---------------------------------------------------------------------------
+
+/**
+ * realpath-resolved absolute paths registered via `project.open`. Module-level
+ * by design — the daemon is a singleton (mirrors pruneState in server.ts).
+ * A handler rejects any repoPath whose realpath is not in this set.
+ */
+const registeredRoots = new Set<string>();
+
+/** @internal — test seam: clear the allowlist between test cases. */
+export function _clearRegisteredRootsForTest(): void {
+  registeredRoots.clear();
+}
+
+/** @internal — test seam: register an already-realpath'd root directly. */
+export function _addRootForTest(realRoot: string): void {
+  registeredRoots.add(realRoot);
+}
+
+/** @internal — test seam: exercise the realpath descendant resolver. */
+export function _resolveInRootForTest(
+  repoReal: string,
+  filePathRaw: string,
+  mustExist: boolean,
+): Promise<string> {
+  return resolveInRoot(repoReal, filePathRaw, mustExist);
+}
+
+/** @internal — test seam: exercise the lexical git-pathspec escape check. */
+export function _gitRelPathForTest(repoReal: string, filePathRaw: string): string {
+  return gitRelPath(repoReal, filePathRaw);
+}
+
+// ---------------------------------------------------------------------------
+// Param + path helpers
+// ---------------------------------------------------------------------------
+
+function str(v: unknown): string | null {
+  return typeof v === 'string' ? v : null;
+}
+
+function requireStr(v: unknown, name: string): string {
+  const s = str(v);
+  if (s === null || s.length === 0) throw new Error(`missing required string param: ${name}`);
+  return s;
+}
+
+/** Expand a leading `~` against the daemon's own $HOME. */
+function expandTilde(p: string): string {
+  if (p === '~') return homedir();
+  if (p.startsWith('~/')) return join(homedir(), p.slice(2));
+  return p;
+}
+
+/** True when `target` is `root` itself or a descendant of it. */
+function within(root: string, target: string): boolean {
+  return target === root || target.startsWith(root + sep);
+}
+
+/**
+ * Resolve a raw repoPath to its realpath and assert it is a registered root.
+ * Throws if the path does not exist or was never registered via project.open.
+ */
+async function requireRoot(repoPathRaw: string): Promise<string> {
+  const expanded = expandTilde(repoPathRaw);
+  let real: string;
+  try {
+    real = await realpath(expanded);
+  } catch {
+    throw new Error(`project root does not exist: ${repoPathRaw}`);
+  }
+  if (!registeredRoots.has(real)) {
+    throw new Error(`project root not registered: ${repoPathRaw} (call project.open first)`);
+  }
+  return real;
+}
+
+/**
+ * Resolve a file path against an already-validated repo root, confirming via
+ * realpath that it cannot escape the root through `..` or a symlink.
+ *
+ *  - mustExist=true:  realpath the target itself (read / delete / stat).
+ *  - mustExist=false: realpath the PARENT directory (write / create a
+ *    possibly-new file), then join the basename — the parent must itself be
+ *    a real descendant of the root.
+ */
+async function resolveInRoot(
+  repoReal: string,
+  filePathRaw: string,
+  mustExist: boolean,
+): Promise<string> {
+  const expanded = expandTilde(filePathRaw);
+  const abs = isAbsolute(expanded) ? expanded : resolve(repoReal, expanded);
+
+  if (mustExist) {
+    let real: string;
+    try {
+      real = await realpath(abs);
+    } catch {
+      throw new Error(`file not found: ${filePathRaw}`);
+    }
+    if (!within(repoReal, real)) throw new Error(`path escapes project root: ${filePathRaw}`);
+    return real;
+  }
+
+  const parent = dirname(abs);
+  let parentReal: string;
+  try {
+    parentReal = await realpath(parent);
+  } catch {
+    throw new Error(`parent directory does not exist: ${filePathRaw}`);
+  }
+  if (!within(repoReal, parentReal)) throw new Error(`path escapes project root: ${filePathRaw}`);
+  return join(parentReal, basename(abs));
+}
+
+/**
+ * Lexical repo-relative path for a git pathspec argument. The repo root is
+ * already a realpath'd registered root, and git itself confines pathspecs to
+ * the work tree, so a lexical `..`/absolute-escape check is sufficient here
+ * (no filesystem hit). Always passed after a `--` separator by callers.
+ */
+function gitRelPath(repoReal: string, filePathRaw: string): string {
+  const expanded = expandTilde(filePathRaw);
+  const abs = isAbsolute(expanded) ? expanded : resolve(repoReal, expanded);
+  const rel = relative(repoReal, abs);
+  if (rel === '' || rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw new Error(`path escapes project root: ${filePathRaw}`);
+  }
+  return rel;
+}
+
+/**
+ * Wrap content in an inline-or-tooLarge envelope. The inbound maxLineBytes
+ * cap guards request frames only; a content-returning READ would otherwise
+ * serialize an unbounded file into a single response frame. Above the cap the
+ * caller gets `{ tooLarge: true, bytes }` and falls back to a streamed view.
+ */
+function inlineContent(
+  buf: Buffer,
+): { content: string; bytes: number } | { tooLarge: true; bytes: number } {
+  const bytes = buf.byteLength;
+  if (bytes > getDaemonConfig().maxInlineReadBytes) return { tooLarge: true, bytes };
+  return { content: buf.toString('utf8'), bytes };
+}
+
+/** Normalize a ShellResult from a mutating git op into a success/error shape. */
+function gitOutcome(r: ShellResult, what: string): Record<string, unknown> {
+  if (!r.ok) return { success: false, error: r.stderr || `${what} failed`, code: r.code };
+  return { success: true, stdout: r.stdout };
+}
+
+// ---------------------------------------------------------------------------
+// project.*
+// ---------------------------------------------------------------------------
+
+registerHandler('project.open', async (params) => {
+  const repoPathRaw = requireStr(params.repoPath, 'repoPath');
+  const expanded = expandTilde(repoPathRaw);
+  let real: string;
+  try {
+    real = await realpath(expanded);
+  } catch {
+    throw new Error(`project root does not exist: ${repoPathRaw}`);
+  }
+  // Confirm it is actually a git repository — registering a non-repo root
+  // would let file.* operate on an arbitrary directory tree.
+  const isRepo = await stat(join(real, '.git')).then(
+    () => true,
+    () => false,
+  );
+  registeredRoots.add(real);
+  return { success: true, root: real, isGitRepo: isRepo };
+});
+
+// ---------------------------------------------------------------------------
+// file.*
+// ---------------------------------------------------------------------------
+
+registerHandler('file.read', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), true);
+  const buf = await readFile(target);
+  return inlineContent(buf);
+});
+
+registerHandler('file.write', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), false);
+  const content = str(params.content) ?? '';
+  await writeFile(target, content, 'utf8');
+  return { success: true, bytes: Buffer.byteLength(content, 'utf8') };
+});
+
+registerHandler('file.delete', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), true);
+  await unlink(target);
+  return { success: true };
+});
+
+registerHandler('file.stat', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), false);
+  try {
+    const s = await stat(target);
+    return {
+      exists: true,
+      isFile: s.isFile(),
+      isDirectory: s.isDirectory(),
+      size: s.size,
+      mtimeMs: s.mtimeMs,
+    };
+  } catch {
+    return { exists: false };
+  }
+});
+
+// ---------------------------------------------------------------------------
+// git.* — reads
+// ---------------------------------------------------------------------------
+
+registerHandler('git.status', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const r = await runGit(['status', '--porcelain=v1', '--branch'], repoReal);
+  if (!r.ok) return { success: false, error: r.stderr || 'git status failed' };
+  let branch: string | null = null;
+  const files: Array<{ status: string; path: string }> = [];
+  for (const line of r.stdout.split('\n')) {
+    if (!line) continue;
+    if (line.startsWith('## ')) {
+      let head = line.slice(3);
+      const dots = head.indexOf('...');
+      if (dots >= 0) head = head.slice(0, dots);
+      const space = head.indexOf(' ');
+      if (space >= 0) head = head.slice(0, space);
+      branch = head;
+      continue;
+    }
+    files.push({ status: line.slice(0, 2), path: line.slice(3) });
+  }
+  return { success: true, branch, files, clean: files.length === 0 };
+});
+
+registerHandler('git.diffFile', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
+  const args = ['diff'];
+  if (params.staged === true) args.push('--cached');
+  args.push('--', rel);
+  const r = await runGit(args, repoReal);
+  if (!r.ok) return { success: false, error: r.stderr || 'git diff failed' };
+  return { success: true, diff: r.stdout };
+});
+
+registerHandler('git.diffContent', async (params) => {
+  // The working-tree ("after") content for a diff view. Read directly off
+  // ext4 (untrimmed, full fidelity) rather than via `git show`.
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), true);
+  const buf = await readFile(target);
+  return inlineContent(buf);
+});
+
+registerHandler('git.readBlobAtHead', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
+  // NOTE: runGit trims trailing whitespace on stdout, so a blob's final
+  // newline is not preserved here. Acceptable for the read-only "committed
+  // version" diff pane; full-fidelity working-tree content comes from
+  // file.read / git.diffContent (untrimmed fs reads).
+  const r = await runGit(['show', `HEAD:${rel}`], repoReal);
+  if (!r.ok) return { success: false, error: r.stderr || 'git show HEAD failed' };
+  return { success: true, ...inlineContent(Buffer.from(r.stdout, 'utf8')) };
+});
+
+registerHandler('git.readBlobAtIndex', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
+  const r = await runGit(['show', `:${rel}`], repoReal);
+  if (!r.ok) return { success: false, error: r.stderr || 'git show :index failed' };
+  return { success: true, ...inlineContent(Buffer.from(r.stdout, 'utf8')) };
+});
+
+registerHandler('git.listBranches', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const r = await runGit(['branch', '--format=%(refname:short)'], repoReal);
+  if (!r.ok) return { success: false, error: r.stderr || 'git branch failed' };
+  const branches = r.stdout.split('\n').filter(Boolean);
+  const cur = await runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoReal);
+  return { success: true, branches, current: cur.ok ? cur.stdout : null };
+});
+
+registerHandler('git.log', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const limit = typeof params.limit === 'number' ? Math.max(1, Math.floor(params.limit)) : 50;
+  // %x1f = ASCII unit separator, unambiguous against any commit subject text.
+  const r = await runGit(
+    ['log', '--pretty=format:%H%x1f%an%x1f%aI%x1f%s', '-n', String(limit)],
+    repoReal,
+  );
+  if (!r.ok) {
+    // An empty repo (no commits yet) is not an error for the editor.
+    if (r.stderr.includes('does not have any commits')) return { success: true, commits: [] };
+    return { success: false, error: r.stderr || 'git log failed' };
+  }
+  const commits = r.stdout
+    ? r.stdout.split('\n').map((l) => {
+        const [hash, author, date, subject] = l.split('\x1f');
+        return { hash, author, date, subject };
+      })
+    : [];
+  return { success: true, commits };
+});
+
+// ---------------------------------------------------------------------------
+// git.* — mutations
+// ---------------------------------------------------------------------------
+
+registerHandler('git.stageFile', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
+  return gitOutcome(await runGit(['add', '--', rel], repoReal), 'git add');
+});
+
+registerHandler('git.unstageFile', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
+  return gitOutcome(
+    await runGit(['restore', '--staged', '--', rel], repoReal),
+    'git restore --staged',
+  );
+});
+
+registerHandler('git.discardFile', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
+  // Restore the working-tree copy from the index (discard unstaged edits).
+  return gitOutcome(await runGit(['restore', '--', rel], repoReal), 'git restore');
+});
+
+registerHandler('git.createBranch', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const name = requireStr(params.name, 'name');
+  const args = ['branch', name];
+  const base = str(params.baseBranch);
+  if (base) args.push(base);
+  return gitOutcome(await runGit(args, repoReal), 'git branch');
+});
+
+registerHandler('git.switchBranch', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const name = requireStr(params.name, 'name');
+  return gitOutcome(await runGit(['switch', name], repoReal), 'git switch');
+});
+
+registerHandler('git.deleteBranch', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const name = requireStr(params.name, 'name');
+  const flag = params.force === true ? '-D' : '-d';
+  return gitOutcome(await runGit(['branch', flag, name], repoReal), 'git branch -d');
+});
+
+registerHandler('git.commit', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const message = requireStr(params.message, 'message');
+  return gitOutcome(await runGit(['commit', '-m', message], repoReal), 'git commit');
+});
+
+registerHandler('git.push', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const args = ['push'];
+  const remote = str(params.remote);
+  const branch = str(params.branch);
+  if (remote) args.push(remote);
+  if (branch) args.push(branch);
+  return gitOutcome(await runGit(args, repoReal), 'git push');
+});
+
+registerHandler('git.pull', async (params) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const args = ['pull'];
+  const remote = str(params.remote);
+  const branch = str(params.branch);
+  if (remote) args.push(remote);
+  if (branch) args.push(branch);
+  return gitOutcome(await runGit(args, repoReal), 'git pull');
+});

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -376,7 +376,9 @@ registerHandler('git.discardFile', async (params) => {
 registerHandler('git.createBranch', async (params) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const name = requireStr(params.name, 'name');
-  const args = ['branch', name];
+  // `--` so a name/base that slipped past validation can't be read as a flag
+  // (defense in depth; schema's gitRefArg already rejects a leading '-').
+  const args = ['branch', '--', name];
   const base = str(params.baseBranch);
   if (base) args.push(base);
   return gitOutcome(await runGit(args, repoReal), 'git branch');
@@ -385,14 +387,14 @@ registerHandler('git.createBranch', async (params) => {
 registerHandler('git.switchBranch', async (params) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const name = requireStr(params.name, 'name');
-  return gitOutcome(await runGit(['switch', name], repoReal), 'git switch');
+  return gitOutcome(await runGit(['switch', '--', name], repoReal), 'git switch');
 });
 
 registerHandler('git.deleteBranch', async (params) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const name = requireStr(params.name, 'name');
   const flag = params.force === true ? '-D' : '-d';
-  return gitOutcome(await runGit(['branch', flag, name], repoReal), 'git branch -d');
+  return gitOutcome(await runGit(['branch', flag, '--', name], repoReal), 'git branch -d');
 });
 
 registerHandler('git.commit', async (params) => {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -29,6 +29,7 @@ export { registerHandler, startDaemon } from './server.js';
 // Side-effect imports: register built-in handler groups.
 import './inference.js';
 import './vcs.js';
+import './filegit.js';
 
 export { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 export { SCHEMA_SQL } from './storage/schema.js';

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -66,6 +66,34 @@ const EXEMPT_METHODS = new Set([
   'session.update',
   'session.end',
   'session.list',
+  // Single-repo file + git I/O is FREE: RevDev is meant to be a usable daily
+  // driver and dogfood surface, so basic editing/committing of your own repo
+  // is never gated behind Pro. Only MULTI-AGENT COORDINATION stays Pro
+  // (agent.*, merge.*, mail.*, tasks.*, files.* reservations, memory.*,
+  // inference.*). Enumerated explicitly — NO wildcard — so a Pro method can
+  // never be exempted by accident; a CI test asserts each method below
+  // returns success on a free license and that the Pro methods still -32001.
+  'project.open',
+  'file.read',
+  'file.write',
+  'file.delete',
+  'file.stat',
+  'git.status',
+  'git.diffFile',
+  'git.diffContent',
+  'git.stageFile',
+  'git.unstageFile',
+  'git.discardFile',
+  'git.listBranches',
+  'git.createBranch',
+  'git.switchBranch',
+  'git.deleteBranch',
+  'git.log',
+  'git.commit',
+  'git.push',
+  'git.pull',
+  'git.readBlobAtHead',
+  'git.readBlobAtIndex',
 ]);
 
 const DAY_SECONDS = 86_400;

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -142,7 +142,7 @@ type VerificationResult = 'verified' | 'none' | 'invalid';
  * signature-OPTIONAL behind the `0600` boundary — they expose no file
  * content and registering a project root exfiltrates nothing on its own.
  */
-const MUTATING_OR_CONTENT_METHODS = new Set([
+export const MUTATING_OR_CONTENT_METHODS = new Set([
   // file surface — writes + content/metadata reads
   'file.read',
   'file.write',

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -119,6 +119,52 @@ const IDENTITY_EXEMPT = new Set([
   'inference.generate',
 ]);
 
+/**
+ * Result of the per-request signature check (`verifyOrWarn`).
+ *   - 'verified': a well-formed Ed25519 envelope passed every check and
+ *     `ctx.agentId` is now bound to the signer.
+ *   - 'none': no `x-revdev-signature` was present.
+ *   - 'invalid': a signature was present but failed a check (parse, unknown
+ *     key, bad signature, stale ts, method/params mismatch, nonce replay).
+ */
+type VerificationResult = 'verified' | 'none' | 'invalid';
+
+/**
+ * Methods that MUST carry a verified Ed25519 signature — every mutation and
+ * every content-returning read. The `0600` socket alone stops a hostile
+ * non-owner WSL process, but ANY host process can `wsl.exe` in as the WSL
+ * user and reach the socket; the signature is the real barrier that keeps
+ * such a process from reading project files (or `~/.ssh`, `~/.age-identity`
+ * via a traversal) or mutating the repo without Studio's per-install key.
+ *
+ * Payload-free coordination reads (`ping`, `session.*`, `git.status` /
+ * `git.listBranches` / `git.log` name+metadata lists, `project.open`) stay
+ * signature-OPTIONAL behind the `0600` boundary — they expose no file
+ * content and registering a project root exfiltrates nothing on its own.
+ */
+const MUTATING_OR_CONTENT_METHODS = new Set([
+  // file surface — writes + content/metadata reads
+  'file.read',
+  'file.write',
+  'file.delete',
+  'file.stat',
+  // git mutations
+  'git.stageFile',
+  'git.unstageFile',
+  'git.discardFile',
+  'git.createBranch',
+  'git.switchBranch',
+  'git.deleteBranch',
+  'git.commit',
+  'git.push',
+  'git.pull',
+  // git content-returning reads (diffFile/diffContent embed source lines)
+  'git.diffFile',
+  'git.diffContent',
+  'git.readBlobAtHead',
+  'git.readBlobAtIndex',
+]);
+
 // ---------------------------------------------------------------------------
 // Stale-session pruning state (GAP-153)
 //
@@ -231,6 +277,24 @@ export function getShutdownSignal(): AbortSignal | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// Active daemon config — set at startDaemon so handlers registered in other
+// modules (e.g. filegit.ts) can read effective limits like
+// `maxInlineReadBytes` without threading `cfg` through the handler signature.
+// Null before the first startDaemon call.
+// ---------------------------------------------------------------------------
+
+let _daemonConfig: DaemonConfig | null = null;
+
+/**
+ * Returns the effective config of the running daemon. Falls back to
+ * DAEMON_DEFAULTS when called before startDaemon (e.g. a handler invoked in
+ * a unit test that never started a server) so callers never see `null`.
+ */
+export function getDaemonConfig(): DaemonConfig {
+  return _daemonConfig ?? DAEMON_DEFAULTS;
+}
+
+// ---------------------------------------------------------------------------
 // In-flight handler counter + shutdown gate.
 //
 // `_activeHandlerCount` is incremented before each `await handler()` and
@@ -325,7 +389,11 @@ function asStringArray(v: unknown): string[] {
 const SIG_TS_WINDOW_SECS = 60;
 const NONCE_SWEEP_WINDOW_MINUTES = 10;
 
-async function verifyOrWarn(req: RpcRequest, db: PGlite, ctx: SocketContext): Promise<void> {
+async function verifyOrWarn(
+  req: RpcRequest,
+  db: PGlite,
+  ctx: SocketContext,
+): Promise<VerificationResult> {
   // Reset any prior signature binding on this socket before processing the
   // current request. Connection-level bindings (register/attach/param) are
   // restored from the pre-signature snapshot. Without this, a signed call
@@ -344,19 +412,19 @@ async function verifyOrWarn(req: RpcRequest, db: PGlite, ctx: SocketContext): Pr
   const envelopeStr = req['x-revdev-signature'];
   if (!envelopeStr) {
     log.debug('no signature', { method: req.method });
-    return;
+    return 'none';
   }
 
   const parsed = parseEnvelope(envelopeStr);
   if (!parsed) {
     log.warn('signature parse failed', { method: req.method });
-    return;
+    return 'invalid';
   }
 
   const didParsed = parseDid(parsed.payload.did);
   if (!didParsed) {
     log.warn('signature did unparseable', { did: parsed.payload.did });
-    return;
+    return 'invalid';
   }
 
   if (parsed.payload.kid !== didParsed.fingerprint) {
@@ -364,7 +432,7 @@ async function verifyOrWarn(req: RpcRequest, db: PGlite, ctx: SocketContext): Pr
       kid: parsed.payload.kid,
       fingerprint: didParsed.fingerprint,
     });
-    return;
+    return 'invalid';
   }
 
   const keyRow = await db.query<{ public_key_pem: string }>(
@@ -374,18 +442,18 @@ async function verifyOrWarn(req: RpcRequest, db: PGlite, ctx: SocketContext): Pr
   );
   if (keyRow.rows.length === 0) {
     log.warn('signature unknown key', { kid: parsed.payload.kid, agentId: didParsed.agentId });
-    return;
+    return 'invalid';
   }
 
   const publicKeyPem = keyRow.rows[0]?.public_key_pem;
   if (!publicKeyPem || !verifyEnvelope(parsed, publicKeyPem)) {
     log.warn('signature invalid', { kid: parsed.payload.kid });
-    return;
+    return 'invalid';
   }
 
   if (Math.abs(Date.now() / 1000 - parsed.payload.ts) > SIG_TS_WINDOW_SECS) {
     log.warn('signature ts outside window', { ts: parsed.payload.ts });
-    return;
+    return 'invalid';
   }
 
   if (parsed.payload.method !== req.method) {
@@ -393,12 +461,12 @@ async function verifyOrWarn(req: RpcRequest, db: PGlite, ctx: SocketContext): Pr
       payloadMethod: parsed.payload.method,
       reqMethod: req.method,
     });
-    return;
+    return 'invalid';
   }
 
   if (hashParams(req.method, req.params) !== parsed.payload.paramsHash) {
     log.warn('signature paramsHash mismatch', { method: req.method });
-    return;
+    return 'invalid';
   }
 
   try {
@@ -408,7 +476,7 @@ async function verifyOrWarn(req: RpcRequest, db: PGlite, ctx: SocketContext): Pr
     ]);
   } catch {
     log.warn('signature nonce replay', { nonce: parsed.payload.nonce, agentId: didParsed.agentId });
-    return;
+    return 'invalid';
   }
 
   // Snapshot the pre-signature connection identity so the NEXT request can
@@ -422,6 +490,7 @@ async function verifyOrWarn(req: RpcRequest, db: PGlite, ctx: SocketContext): Pr
   ctx.agentId = didParsed.agentId;
   ctx.boundVia = 'signature';
   ctx.verifiedSignature = { kid: parsed.payload.kid, nonce: parsed.payload.nonce };
+  return 'verified';
 }
 
 /** Accept either `paths: string[]` or `filePath: string` — normalize to array. */
@@ -1120,6 +1189,9 @@ export async function startDaemon(
   config: Partial<DaemonConfig> = {},
 ): Promise<{ close: () => Promise<void>; _db: PGlite }> {
   const cfg = { ...DAEMON_DEFAULTS, ...config };
+  // Publish the effective config so handlers in other modules (filegit.ts)
+  // can read limits like maxInlineReadBytes without a cfg parameter.
+  _daemonConfig = cfg;
 
   // Reset shutdown signal + closing gate for this daemon lifecycle.
   // _shutdownController is aborted in close(); _closing is set to true
@@ -1136,7 +1208,11 @@ export async function startDaemon(
 
   // Ensure data directory exists
   await mkdir(cfg.dataDir, { recursive: true });
-  await mkdir(dirname(cfg.socketPath), { recursive: true });
+  // Create the socket's parent dir with an explicit owner-only mode. Without
+  // `mode`, the dir inherits the umask; the socket itself is bound 0600 (see
+  // listen() below), but a world-traversable parent dir is an unnecessary
+  // weakening of the filesystem boundary that gates the Unix socket.
+  await mkdir(dirname(cfg.socketPath), { recursive: true, mode: 0o700 });
 
   // Initialize PGlite and bring the schema to the latest version. A failed
   // or future-version migration throws MigrationError — the daemon refuses
@@ -1364,10 +1440,33 @@ export async function startDaemon(
           continue;
         }
 
-        // Signature gate (accept-if-present, P1). Attempts to bind ctx.agentId
-        // from a verified Ed25519 envelope. Never rejects the request — invalid
-        // or missing signatures fall through to the identity gate below.
-        await verifyOrWarn(req, db, ctx);
+        // Signature gate. Attempts to bind ctx.agentId from a verified Ed25519
+        // envelope. For coordination methods this is accept-if-present (invalid
+        // or missing signatures fall through to the identity gate below). For
+        // MUTATING_OR_CONTENT_METHODS the signature is REQUIRED — anything other
+        // than a fully-verified envelope is rejected with -32003 before the
+        // handler runs, mirroring the license-guard block above.
+        const verification = await verifyOrWarn(req, db, ctx);
+        if (MUTATING_OR_CONTENT_METHODS.has(req.method) && verification !== 'verified') {
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: '2.0',
+              id: req.id,
+              error: {
+                code: -32003,
+                message: 'Signature required',
+                data: {
+                  method: req.method,
+                  reason:
+                    verification === 'none'
+                      ? 'missing Ed25519 signature'
+                      : 'invalid Ed25519 signature',
+                },
+              },
+            })}\n`,
+          );
+          continue;
+        }
 
         // Identity gate: most coordination calls need a registered agent.
         // Fallback: accept `actorAgentId` in params (requireAgent will validate).

--- a/packages/daemon/src/validation/limits.ts
+++ b/packages/daemon/src/validation/limits.ts
@@ -15,6 +15,13 @@ export const MAX_BODY_LENGTH = 50_000;
 /** Maximum file path length */
 export const MAX_PATH_LENGTH = 4096;
 
+/**
+ * Maximum bytes accepted by `file.write` content. 768 KiB — symmetric with the
+ * daemon's `maxInlineReadBytes` read cap, so the write surface is bounded
+ * explicitly (clean -32602) rather than only by the 1 MiB inbound frame cap.
+ */
+export const MAX_FILE_WRITE_BYTES = 786_432;
+
 /** Maximum number of paths in a batch operation */
 export const MAX_PATHS_BATCH = 100;
 

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -44,6 +44,21 @@ const safePath = z
     message: 'System paths not allowed',
   });
 
+/**
+ * A git ref / remote name argument (branch, remote). Must NOT start with '-':
+ * a leading dash is parsed by git as an option, so a value like
+ * `--receive-pack=…` / `--upload-pack=…` / `--orphan` would turn a branch or
+ * remote name into arbitrary git plumbing (option-injection, RCE-class on
+ * push/pull). The file/pathspec handlers neutralize this with `--`, but
+ * `git push`/`pull` don't accept `--` before the remote, so the leading-dash
+ * rejection is the load-bearing guard for those.
+ */
+const gitRefArg = z
+  .string()
+  .min(1)
+  .max(256)
+  .refine((s) => !s.startsWith('-'), { message: 'must not start with "-"' });
+
 // agentId must conform to the DID grammar (alphanumeric, _, -; 1-128 chars)
 // so it can be embedded in `did:revfleet:<agentId>:<fingerprint>`.
 // Pre-existing IDs that contained spaces, slashes, or colons are rejected
@@ -553,20 +568,18 @@ export const schemas: Record<string, z.ZodType> = {
   'git.createBranch': z
     .object({
       repoPath: safePath,
-      name: z.string().max(256),
-      baseBranch: z.string().max(256).optional(),
+      name: gitRefArg,
+      baseBranch: gitRefArg.optional(),
       actorAgentId,
     })
     .passthrough(),
 
-  'git.switchBranch': z
-    .object({ repoPath: safePath, name: z.string().max(256), actorAgentId })
-    .passthrough(),
+  'git.switchBranch': z.object({ repoPath: safePath, name: gitRefArg, actorAgentId }).passthrough(),
 
   'git.deleteBranch': z
     .object({
       repoPath: safePath,
-      name: z.string().max(256),
+      name: gitRefArg,
       force: z.boolean().optional(),
       actorAgentId,
     })
@@ -591,8 +604,8 @@ export const schemas: Record<string, z.ZodType> = {
   'git.push': z
     .object({
       repoPath: safePath,
-      remote: z.string().max(256).optional(),
-      branch: z.string().max(256).optional(),
+      remote: gitRefArg.optional(),
+      branch: gitRefArg.optional(),
       actorAgentId,
     })
     .passthrough(),
@@ -600,8 +613,8 @@ export const schemas: Record<string, z.ZodType> = {
   'git.pull': z
     .object({
       repoPath: safePath,
-      remote: z.string().max(256).optional(),
-      branch: z.string().max(256).optional(),
+      remote: gitRefArg.optional(),
+      branch: gitRefArg.optional(),
       actorAgentId,
     })
     .passthrough(),

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -460,4 +460,142 @@ export const schemas: Record<string, z.ZodType> = {
       actorAgentId,
     })
     .passthrough(),
+
+  // -- File surface (P0: daemon-owned ext4 I/O) -------------------------------
+  // `safePath` already rejects `..` traversal + system roots; the handler
+  // additionally realpath-checks every target is a descendant of a registered
+  // project root, so this is a first (cheap) line of defense, not the only one.
+  'project.open': z
+    .object({
+      repoPath: safePath,
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'file.read': z
+    .object({
+      repoPath: safePath,
+      filePath: safePath,
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'file.write': z
+    .object({
+      repoPath: safePath,
+      filePath: safePath,
+      // Content is bounded by the inbound `maxLineBytes` frame cap, not here —
+      // MAX_BODY_LENGTH (50k) is far too small for a legitimate source file.
+      content: z.string(),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'file.delete': z
+    .object({
+      repoPath: safePath,
+      filePath: safePath,
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'file.stat': z
+    .object({
+      repoPath: safePath,
+      filePath: safePath,
+      actorAgentId,
+    })
+    .passthrough(),
+
+  // -- Git surface (P0: daemon-owned, shells the git binary via vcs.ts) -------
+  'git.status': z.object({ repoPath: safePath, actorAgentId }).passthrough(),
+
+  'git.diffFile': z
+    .object({
+      repoPath: safePath,
+      filePath: safePath,
+      staged: z.boolean().optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'git.diffContent': z
+    .object({ repoPath: safePath, filePath: safePath, actorAgentId })
+    .passthrough(),
+
+  'git.stageFile': z.object({ repoPath: safePath, filePath: safePath, actorAgentId }).passthrough(),
+
+  'git.unstageFile': z
+    .object({ repoPath: safePath, filePath: safePath, actorAgentId })
+    .passthrough(),
+
+  'git.discardFile': z
+    .object({ repoPath: safePath, filePath: safePath, actorAgentId })
+    .passthrough(),
+
+  'git.listBranches': z.object({ repoPath: safePath, actorAgentId }).passthrough(),
+
+  'git.createBranch': z
+    .object({
+      repoPath: safePath,
+      name: z.string().max(256),
+      baseBranch: z.string().max(256).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'git.switchBranch': z
+    .object({ repoPath: safePath, name: z.string().max(256), actorAgentId })
+    .passthrough(),
+
+  'git.deleteBranch': z
+    .object({
+      repoPath: safePath,
+      name: z.string().max(256),
+      force: z.boolean().optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'git.log': z
+    .object({
+      repoPath: safePath,
+      limit: z.number().int().min(1).max(1000).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'git.commit': z
+    .object({
+      repoPath: safePath,
+      message: z.string().min(1).max(MAX_BODY_LENGTH),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'git.push': z
+    .object({
+      repoPath: safePath,
+      remote: z.string().max(256).optional(),
+      branch: z.string().max(256).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'git.pull': z
+    .object({
+      repoPath: safePath,
+      remote: z.string().max(256).optional(),
+      branch: z.string().max(256).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'git.readBlobAtHead': z
+    .object({ repoPath: safePath, filePath: safePath, actorAgentId })
+    .passthrough(),
+
+  'git.readBlobAtIndex': z
+    .object({ repoPath: safePath, filePath: safePath, actorAgentId })
+    .passthrough(),
 };

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -20,6 +20,7 @@ import { isValidAgentId } from '@revdev/protocol/did';
 import { z } from 'zod';
 import {
   MAX_BODY_LENGTH,
+  MAX_FILE_WRITE_BYTES,
   MAX_IDS_BATCH,
   MAX_MEMORY_LENGTH,
   MAX_NAME_LENGTH,
@@ -514,9 +515,10 @@ export const schemas: Record<string, z.ZodType> = {
     .object({
       repoPath: safePath,
       filePath: safePath,
-      // Content is bounded by the inbound `maxLineBytes` frame cap, not here —
-      // MAX_BODY_LENGTH (50k) is far too small for a legitimate source file.
-      content: z.string(),
+      // Bounded explicitly (symmetric with the read cap) rather than only by
+      // the inbound frame cap; MAX_BODY_LENGTH (50k) is too small for a source
+      // file, MAX_FILE_WRITE_BYTES (768 KiB) is the editor-write ceiling.
+      content: z.string().max(MAX_FILE_WRITE_BYTES),
       actorAgentId,
     })
     .passthrough(),

--- a/packages/daemon/src/vcs.ts
+++ b/packages/daemon/src/vcs.ts
@@ -144,7 +144,7 @@ export function runChild(
   });
 }
 
-function runGit(
+export function runGit(
   args: string[],
   cwd: string,
   opts?: Partial<RunChildOptions>,


### PR DESCRIPTION
Implements **P0** of the zero-9P ADR (#159 — `docs/decisions/2026-06-23-daemon-in-wsl-zero-9p.md`). Daemon-side only; no Studio changes yet (that's P1).

## What lands

**`filegit.ts`** (new handler group, side-effect imported in `index.ts`):
- `project.open` — registers a `realpath`'d project root into an allowlist.
- `file.read` / `file.write` / `file.delete` / `file.stat`.
- `git.status` / `diffFile` / `diffContent` / `stageFile` / `unstageFile` / `discardFile` / `listBranches` / `createBranch` / `switchBranch` / `deleteBranch` / `log` / `commit` / `push` / `pull` / `readBlobAtHead` / `readBlobAtIndex`, shelling the git binary via the existing `vcs.ts` `runGit` (now exported) — no JS git binding.

**Three security barriers** (barrier 1 = socket mode; 2 = signature; 3 = allowlist):
- Every handler enforces the registered-root allowlist **and** a `realpath` descendant check (`resolveInRoot`), so neither `..` nor a symlink can escape a root to reach `~/.ssh`, `~/.age-identity`, etc.
- `verifyOrWarn` now returns `VerificationResult` (`'verified' | 'none' | 'invalid'`); the dispatch loop rejects any `MUTATING_OR_CONTENT_METHODS` call that is not fully verified with **`-32003`**, mirroring the license-guard block.
- Socket parent dir is now created `mode 0o700`.

**Tier** (`license.ts`): all single-repo file/git I/O added to `EXEMPT_METHODS` (**FREE**); multi-agent coordination (`agent.*`, `merge.*`, `mail.*`, `tasks.*`, `files.*`, `memory.*`, `inference.*`) stays Pro. Enumerated, no wildcard.

**Frame cap** (`config.ts`): new `maxInlineReadBytes` (768 KiB); content reads return `{ tooLarge: true, bytes }` above it — the inbound `maxLineBytes` only guards request frames, not responses.

## Tests
- `filegit.test.ts` — path containment: `../`, symlink, symlinked-parent, and absolute-outside escapes all rejected; clean repo-relative paths resolved.
- `guard.test.ts` — free/Pro tier boundary locked: each new file/git method returns success on a free license; coordination methods still `-32001`.
- Zod schemas added for every new method.
- Full daemon suite green in isolation (coordination + e2e-ipc + validation = 99 tests pass; the two full-run timeouts are pre-existing PGlite-under-parallel-load flakes that pass alone).

## Not in this PR (per ADR sequencing)
P1 (Studio relay + Ed25519 signing client), P2 (delete Studio's ext4 path), P3 (systemd-user lifecycle), P4 (install pipeline), P5 (CI deny-list fence + signed-RPC round-trip integration tests over the relay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)