### PR TITLE
feat(studio+console): persistent degraded/mock-mode banner + no fake secrets (audit item 4)

### DIFF
--- a/apps/console/tui/model.go
+++ b/apps/console/tui/model.go
@@ -55,6 +55,11 @@ type Model struct {
 	tiers  []Tier
 	cursor int
 
+	// pricingOffline is true while the displayed tiers are the hardcoded
+	// fallback (API not yet loaded or fetch failed) rather than live pricing,
+	// so the view can warn the operator the prices may be out of date.
+	pricingOffline bool
+
 	selected *Tier
 	qrCode   string
 	qrURL    string
@@ -120,15 +125,16 @@ func NewModel(s ssh.Session, client *api.Client) Model {
 	}
 
 	return Model{
-		session:     s,
-		client:      client,
-		fingerprint: fp,
-		view:        ViewLoading,
-		tiers:       fallbackTiers(),
-		loading:     true,
-		loadingMsg:  "Loading pricing…",
-		width:       80,
-		height:      24,
+		session:        s,
+		client:         client,
+		fingerprint:    fp,
+		view:           ViewLoading,
+		tiers:          fallbackTiers(),
+		pricingOffline: true,
+		loading:        true,
+		loadingMsg:     "Loading pricing…",
+		width:          80,
+		height:         24,
 	}
 }
 
@@ -160,6 +166,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case pricingMsg:
 		if len(msg.tiers) > 0 {
 			m.tiers = msg.tiers
+			m.pricingOffline = false
 		}
 		// If still on loading view, transition to tiers
 		if m.view == ViewLoading {
@@ -199,8 +206,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case errMsg:
 		m.loading = false
 		m.err = msg.err
-		// If we were on loading, show tiers with fallback data
+		// An error during the initial load means pricing never arrived, so the
+		// tiers on screen are stale fallback data. Only flag offline here (not
+		// for later checkout/lookup errors, which don't touch pricing).
 		if m.view == ViewLoading {
+			m.pricingOffline = true
 			m.view = ViewTiers
 		}
 		return m, nil
@@ -469,9 +479,9 @@ var (
 			Bold(true)
 
 	highlightBorder = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("#3B82F6")).
-				Padding(0, 1)
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("#3B82F6")).
+			Padding(0, 1)
 
 	badgeStyle = lipgloss.NewStyle().
 			Background(lipgloss.Color("#7C3AED")).
@@ -492,6 +502,11 @@ func (m Model) viewLoading() string {
 
 func (m Model) viewTiers() string {
 	s := titleStyle.Render("RevealUI — Choose Your Plan") + "\n"
+
+	// Warn when the displayed prices are stale fallback data, not live pricing.
+	if m.pricingOffline {
+		s += errorStyle.Render("  ⚠ Offline pricing — may be out of date") + "\n"
+	}
 
 	// Show current user info if known
 	if m.currentUser != nil {

--- a/apps/studio/src/__tests__/lib/degraded-mode.test.ts
+++ b/apps/studio/src/__tests__/lib/degraded-mode.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { __resetDegradedModeForTests, isDegradedMode, markDegraded } from '../../lib/degraded-mode';
+
+type Win = Record<string, unknown>;
+
+function setTauri(on: boolean): void {
+  if (on) {
+    (window as unknown as Win).__TAURI_INTERNALS__ = {};
+  } else {
+    delete (window as unknown as Win).__TAURI_INTERNALS__;
+  }
+  __resetDegradedModeForTests();
+}
+
+describe('degraded-mode', () => {
+  afterEach(() => {
+    setTauri(false);
+  });
+
+  it('is degraded when not running under Tauri (browser preview)', () => {
+    setTauri(false);
+    expect(isDegradedMode()).toBe(true);
+  });
+
+  it('is not degraded under Tauri until a runtime fallback fires', () => {
+    setTauri(true);
+    expect(isDegradedMode()).toBe(false);
+
+    markDegraded('mock fired');
+    expect(isDegradedMode()).toBe(true);
+  });
+
+  it('stays degraded after repeated markDegraded calls', () => {
+    setTauri(true);
+    markDegraded('reason-a');
+    markDegraded('reason-a');
+    markDegraded('reason-b');
+    expect(isDegradedMode()).toBe(true);
+  });
+});

--- a/apps/studio/src/__tests__/lib/deploy.test.ts
+++ b/apps/studio/src/__tests__/lib/deploy.test.ts
@@ -105,22 +105,26 @@ describe('deploy bridge (browser mocks)', () => {
 
   // ── Secrets ───────────────────────────────────────────────────────────────
 
-  it('generateSecret returns string of requested length', async () => {
+  it('generateSecret returns an obviously-fake secret of the requested length', async () => {
     const result = await generateSecret(48);
     expect(result).toHaveLength(48);
-    expect(result).toBe('x'.repeat(48));
+    // Must NOT look like a real secret — it should scream MOCK so it can't be
+    // mistaken for or copied into a real env (see audit Theme 2).
+    expect(result.startsWith('MOCK_SECRET')).toBe(true);
+    expect(result).not.toBe('x'.repeat(48));
   });
 
-  it('generateKek returns 64-char string', async () => {
+  it('generateKek returns an obviously-fake 64-char value', async () => {
     const result = await generateKek();
     expect(result).toHaveLength(64);
-    expect(result).toBe('a'.repeat(64));
+    expect(result.startsWith('MOCK_KEK')).toBe(true);
+    expect(result).not.toBe('a'.repeat(64));
   });
 
-  it('generateRsaKeypair returns PEM key tuple', async () => {
+  it('generateRsaKeypair returns obviously-fake key sentinels', async () => {
     const [priv, pub] = await generateRsaKeypair();
-    expect(priv).toBe('MOCK_PRIVATE_KEY_PEM');
-    expect(pub).toBe('MOCK_PUBLIC_KEY_PEM');
+    expect(priv).toBe('MOCK_PRIVATE_KEY_DO_NOT_USE');
+    expect(pub).toBe('MOCK_PUBLIC_KEY_DO_NOT_USE');
   });
 
   // ── Health ────────────────────────────────────────────────────────────────

--- a/apps/studio/src/components/layout/AppShell.tsx
+++ b/apps/studio/src/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useState } from 'react';
 import { StatusContext, useStatus } from '../../hooks/use-status';
 import type { Page } from '../../types';
+import DegradedBanner from './DegradedBanner';
 import Sidebar from './Sidebar';
 import StatusBar from './StatusBar';
 

--- a/apps/studio/src/components/layout/AppShell.tsx
+++ b/apps/studio/src/components/layout/AppShell.tsx
@@ -45,6 +45,9 @@ export default function AppShell({ currentPage, onNavigate, children, padless }:
         </div>
 
         <div className="flex flex-1 flex-col overflow-hidden">
+          {/* Persistent banner whenever the app is showing mock/degraded data */}
+          <DegradedBanner />
+
           {/* Mobile top bar with hamburger */}
           <div className="flex items-center gap-3 border-b border-neutral-800 bg-neutral-900 px-3 py-2 md:hidden">
             <button

--- a/apps/studio/src/components/layout/DegradedBanner.tsx
+++ b/apps/studio/src/components/layout/DegradedBanner.tsx
@@ -1,0 +1,37 @@
+import { useDegradedMode } from '../../lib/degraded-mode';
+
+/**
+ * Persistent banner shown whenever the app is in degraded/mock mode (see
+ * `lib/degraded-mode`). Deliberately not dismissible: it must stay visible as
+ * long as the surfaces below it are showing fabricated data.
+ */
+export default function DegradedBanner() {
+  const { degraded, reason } = useDegradedMode();
+  if (!degraded) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center gap-2 border-b border-amber-500/40 bg-amber-500/15 px-3 py-1.5 text-xs font-medium text-amber-200"
+    >
+      <svg
+        className="size-4 shrink-0"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 9v3.75m0 3.75h.008M10.34 3.94l-7.5 12.99A1.5 1.5 0 004.14 19.5h15.72a1.5 1.5 0 001.3-2.57l-7.5-12.99a1.5 1.5 0 00-2.6 0z"
+        />
+      </svg>
+      <span>{reason ?? 'Demo data — not connected to a real system.'}</span>
+    </div>
+  );
+}

--- a/apps/studio/src/lib/degraded-mode.ts
+++ b/apps/studio/src/lib/degraded-mode.ts
@@ -1,0 +1,93 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Global "degraded mode" signal.
+ *
+ * Degraded mode means the app is showing mocked / fabricated / offline-default
+ * data instead of real system state. The app shell renders one persistent
+ * banner whenever it is active, so an operator can never mistake demo data for
+ * a real system (e.g. a fabricated "deployment is live" with placeholder
+ * secrets, or green "running" service cards that reflect nothing).
+ *
+ * Today the dominant trigger is running outside the Tauri desktop app (browser
+ * preview): every `!isTauri()` fallback — `invoke()` MOCK_DATA, the deploy-lib
+ * mocks, the browser config short-circuit — is degraded by definition. A
+ * mutable `markDegraded()` escalation hook is also provided so any genuinely
+ * runtime fallback (e.g. a remote daemon going unreachable) can flip the flag.
+ *
+ * Backed by useSyncExternalStore so React re-renders when the flag changes.
+ */
+
+function isTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+}
+
+const BROWSER_REASON =
+  'Demo data — not connected to a real system (running outside the desktop app).';
+
+export interface DegradedState {
+  degraded: boolean;
+  reason: string | null;
+}
+
+let runtimeDegraded = false;
+let runtimeReason: string | null = null;
+const listeners = new Set<() => void>();
+
+function compute(): DegradedState {
+  if (!isTauri()) {
+    return { degraded: true, reason: BROWSER_REASON };
+  }
+  if (runtimeDegraded) {
+    return { degraded: true, reason: runtimeReason };
+  }
+  return { degraded: false, reason: null };
+}
+
+// useSyncExternalStore requires a referentially-stable snapshot between
+// changes, so cache it and only rebuild when the state actually moves.
+let snapshot: DegradedState = compute();
+
+/**
+ * Escalate into degraded mode at runtime with a human-readable reason.
+ * Idempotent for the same reason (no spurious re-renders).
+ */
+export function markDegraded(reason: string): void {
+  if (runtimeDegraded && runtimeReason === reason) {
+    return;
+  }
+  runtimeDegraded = true;
+  runtimeReason = reason;
+  snapshot = compute();
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** Imperative read for non-React callers. */
+export function isDegradedMode(): boolean {
+  return compute().degraded;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): DegradedState {
+  return snapshot;
+}
+
+/** React hook — reactive degraded-mode state for the shell banner. */
+export function useDegradedMode(): DegradedState {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/** Test-only reset of the runtime escalation (does not affect isTauri()). */
+export function __resetDegradedModeForTests(): void {
+  runtimeDegraded = false;
+  runtimeReason = null;
+  snapshot = compute();
+}

--- a/apps/studio/src/lib/deploy.ts
+++ b/apps/studio/src/lib/deploy.ts
@@ -1,5 +1,6 @@
 import { invoke as tauriInvoke } from '@tauri-apps/api/core';
 import type { VercelDeployment, VercelProject } from '../types';
+import { markDegraded } from './degraded-mode';
 
 function isTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
@@ -122,18 +123,38 @@ export async function smtpSendTest(
 
 // ── Secrets ────────────────────────────────────────────────────────────────
 
+/**
+ * An obviously-fake secret of the requested length. Browser mode has no real
+ * crypto backend; the previous mocks (`'x'.repeat(n)`, `'a'.repeat(64)`)
+ * looked like real secrets and could be copied into a real env. This screams
+ * MOCK while keeping the length the UI expects.
+ */
+function mockSecret(label: string, length: number): string {
+  const marker = `MOCK_${label}_DO_NOT_USE_`;
+  return marker.repeat(Math.ceil(Math.max(length, marker.length) / marker.length)).slice(0, length);
+}
+
 export async function generateSecret(length: number): Promise<string> {
-  if (!isTauri()) return 'x'.repeat(length);
+  if (!isTauri()) {
+    markDegraded('Demo mode — generated secrets are fake placeholders, not real keys.');
+    return mockSecret('SECRET', length);
+  }
   return tauriInvoke<string>('generate_secret', { length });
 }
 
 export async function generateKek(): Promise<string> {
-  if (!isTauri()) return 'a'.repeat(64);
+  if (!isTauri()) {
+    markDegraded('Demo mode — generated secrets are fake placeholders, not real keys.');
+    return mockSecret('KEK', 64);
+  }
   return tauriInvoke<string>('generate_kek');
 }
 
 export async function generateRsaKeypair(): Promise<[string, string]> {
-  if (!isTauri()) return ['MOCK_PRIVATE_KEY_PEM', 'MOCK_PUBLIC_KEY_PEM'];
+  if (!isTauri()) {
+    markDegraded('Demo mode — generated secrets are fake placeholders, not real keys.');
+    return ['MOCK_PRIVATE_KEY_DO_NOT_USE', 'MOCK_PUBLIC_KEY_DO_NOT_USE'];
+  }
   return tauriInvoke<[string, string]>('generate_rsa_keypair');
 }
 

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -1,4 +1,5 @@
 import { invoke as tauriInvoke } from '@tauri-apps/api/core';
+import { markDegraded } from './degraded-mode';
 
 const MOCK_COMMIT_RECENT_S = 300; // 5 minutes ago
 const MOCK_COMMIT_OLDER_S = 3600; // 1 hour ago
@@ -476,8 +477,10 @@ function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
     return httpRpc<T>(rpcMethod, params);
   }
 
-  // Fallback: mock data for non-harness commands
+  // Fallback: mock data for non-harness commands. Serving fabricated system
+  // state — flag degraded mode so the shell banner stays visible.
   if (cmd in MOCK_DATA) {
+    markDegraded('Demo data — showing mocked system state, not a real daemon.');
     return Promise.resolve(MOCK_DATA[cmd] as T);
   }
   return Promise.reject(new Error(`No mock data for command: ${cmd}`));


### PR DESCRIPTION
## Item 4 of the 2026-06-23 UX + durability audit remediation

Closes **Theme 2 — Mock/degraded modes indistinguishable from production** (1 critical, 2 high, 1 medium). Base `test`. Fourth of the ordered 12 items.

The worst case: the deploy wizard (and dashboards) render fabricated "live" state with placeholder secrets in browser mode, with no signal it isn't real — an operator can believe a real deployment happened and push placeholder secrets into a real env.

### One global degraded signal + one persistent banner (Studio)
- `lib/degraded-mode.ts` — a `useSyncExternalStore`-backed flag. Degraded ≡ running outside the Tauri app (every `!isTauri()` fallback is mock/fabricated by definition), plus a `markDegraded(reason)` escalation hook for any runtime fallback. `useDegradedMode()` hook + imperative `isDegradedMode()`.
- `components/layout/DegradedBanner.tsx`, wired into `AppShell` above the content area → **one persistent, non-dismissible banner across every page** ("Demo data — not connected to a real system").
- `lib/invoke.ts` — flags degraded on the `MOCK_DATA` fallback (fabricated WSL/tier status).

### Stop emitting realistic-looking mock secrets (Studio)
- `lib/deploy.ts` — `generateSecret`/`generateKek` returned `'x'.repeat(n)` / `'a'.repeat(64)` (real-looking) and `generateRsaKeypair` returned `MOCK_*_PEM`. Now all return obviously-fake `MOCK_*_DO_NOT_USE` sentinels (length-preserving) and flag degraded mode. Tests updated to assert the values are *not* realistic.

### Console offline-pricing indicator
- `tui/model.go` — a `pricingOffline` flag (true until live pricing loads, set on fetch failure) renders "⚠ Offline pricing — may be out of date" in the tiers view, instead of silently showing stale fallback tiers as real. Scoped to the initial-load failure so later checkout/lookup errors don't false-flag it.

### Verification
- `pnpm --filter studio typecheck` clean.
- `pnpm --filter studio exec vitest run` → **541/541** across 63 files (incl. 3 new `degraded-mode` tests; updated deploy mock-secret assertions).
- Console: `go vet ./...` / `go build` / `go test ./...` all clean.
- `biome check` clean on changed TS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
