### PR TITLE
feat(studio): reusable ConfirmDialog + gate vault secret delete (audit item 5, part 1)

### DIFF
--- a/apps/studio/src/__tests__/components/ConfirmDialog.test.tsx
+++ b/apps/studio/src/__tests__/components/ConfirmDialog.test.tsx
@@ -19,7 +19,13 @@ describe('ConfirmDialog', () => {
 
   it('enables confirm immediately when no type-to-confirm is required', () => {
     render(
-      <ConfirmDialog open title="Stop daemon" body="Sessions end." onConfirm={vi.fn()} onClose={vi.fn()} />,
+      <ConfirmDialog
+        open
+        title="Stop daemon"
+        body="Sessions end."
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
     );
     expect(screen.getByText('Delete').closest('button')).not.toBeDisabled();
   });
@@ -67,9 +73,7 @@ describe('ConfirmDialog', () => {
 
   it('calls onClose when Cancel is clicked', () => {
     const onClose = vi.fn();
-    render(
-      <ConfirmDialog open title="Delete" body="x" onConfirm={vi.fn()} onClose={onClose} />,
-    );
+    render(<ConfirmDialog open title="Delete" body="x" onConfirm={vi.fn()} onClose={onClose} />);
     fireEvent.click(screen.getByText('Cancel'));
     expect(onClose).toHaveBeenCalledOnce();
   });

--- a/apps/studio/src/__tests__/components/ConfirmDialog.test.tsx
+++ b/apps/studio/src/__tests__/components/ConfirmDialog.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ConfirmDialog from '../../components/ui/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  it('renders the title and body when open', () => {
+    render(
+      <ConfirmDialog
+        open
+        title="Delete secret"
+        body="This cannot be undone."
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Delete secret')).toBeInTheDocument();
+    expect(screen.getByText('This cannot be undone.')).toBeInTheDocument();
+  });
+
+  it('enables confirm immediately when no type-to-confirm is required', () => {
+    render(
+      <ConfirmDialog open title="Stop daemon" body="Sessions end." onConfirm={vi.fn()} onClose={vi.fn()} />,
+    );
+    expect(screen.getByText('Delete').closest('button')).not.toBeDisabled();
+  });
+
+  it('keeps confirm disabled until the exact phrase is typed', () => {
+    render(
+      <ConfirmDialog
+        open
+        title="Delete secret"
+        body="Irreversible."
+        typeToConfirm="stripe/api_key"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const confirm = screen.getByText('Delete').closest('button');
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'wrong' } });
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'stripe/api_key' } });
+    expect(confirm).not.toBeDisabled();
+  });
+
+  it('calls onConfirm only after the phrase matches', () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        title="Discard all"
+        body="Throws away edits."
+        typeToConfirm="discard"
+        onConfirm={onConfirm}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'discard' } });
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when Cancel is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <ConfirmDialog open title="Delete" body="x" onConfirm={vi.fn()} onClose={onClose} />,
+    );
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('lists affected items when provided', () => {
+    render(
+      <ConfirmDialog
+        open
+        title="Discard all"
+        body="These files:"
+        affectedItems={['src/a.ts', 'src/b.ts']}
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('src/a.ts')).toBeInTheDocument();
+    expect(screen.getByText('src/b.ts')).toBeInTheDocument();
+  });
+});

--- a/apps/studio/src/__tests__/components/SecretList.test.tsx
+++ b/apps/studio/src/__tests__/components/SecretList.test.tsx
@@ -43,13 +43,18 @@ describe('SecretList', () => {
     expect(onSelect).toHaveBeenCalledWith('stripe/secret_key');
   });
 
-  it('calls onDelete when delete button is clicked', () => {
+  it('does not call onDelete until the confirm dialog is confirmed', () => {
     const onDelete = vi.fn();
     render(
       <SecretList secrets={SECRETS} selectedPath={null} onSelect={vi.fn()} onDelete={onDelete} />,
     );
-    const deleteButton = screen.getByLabelText('Delete stripe/secret_key');
-    fireEvent.click(deleteButton);
+    // Clicking the trash icon opens the confirm dialog — it must NOT delete yet.
+    fireEvent.click(screen.getByLabelText('Delete stripe/secret_key'));
+    expect(onDelete).not.toHaveBeenCalled();
+
+    // Type-to-confirm uses the secret key name; confirm only fires after it matches.
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'secret_key' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Delete secret' }));
     expect(onDelete).toHaveBeenCalledWith('stripe/secret_key');
   });
 

--- a/apps/studio/src/components/ui/ConfirmDialog.tsx
+++ b/apps/studio/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,118 @@
+import { type ReactNode, useId, useState } from 'react';
+import Modal from './Modal';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  /** Explanation of what will happen. Keep it concrete and honest. */
+  body: ReactNode;
+  /** Optional list of the exact items that will be destroyed. */
+  affectedItems?: string[];
+  /** Label for the destructive confirm button (default "Delete"). */
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /**
+   * When set, the user must type this exact string before the confirm button
+   * enables. Use for the truly irreversible actions (vault secret delete, git
+   * discard-all, seeding a database with existing data).
+   */
+  typeToConfirm?: string;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+/**
+ * A single reusable confirmation gate for destructive actions. Routes every
+ * irreversible click (delete a secret, discard working-tree edits, stop the
+ * daemon, remove a multi-GB model…) through one explicit, clearly-worded
+ * dialog instead of firing on a single hover-click. The optional
+ * `typeToConfirm` adds a type-the-name guard for the unrecoverable ones.
+ */
+export default function ConfirmDialog({
+  open,
+  title,
+  body,
+  affectedItems,
+  confirmLabel = 'Delete',
+  cancelLabel = 'Cancel',
+  typeToConfirm,
+  onConfirm,
+  onClose,
+}: ConfirmDialogProps) {
+  const [typed, setTyped] = useState('');
+  const inputId = useId();
+
+  const needsTyping = typeToConfirm != null && typeToConfirm.length > 0;
+  const confirmDisabled = needsTyping && typed !== typeToConfirm;
+
+  function handleClose(): void {
+    setTyped('');
+    onClose();
+  }
+
+  function handleConfirm(): void {
+    if (confirmDisabled) return;
+    setTyped('');
+    onConfirm();
+  }
+
+  return (
+    <Modal
+      title={title}
+      open={open}
+      onClose={handleClose}
+      maxWidth="sm"
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-md px-3 py-1.5 text-sm font-medium text-neutral-300 hover:bg-neutral-800"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={confirmDisabled}
+            className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {confirmLabel}
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-3 text-sm text-neutral-300">
+        <div>{body}</div>
+
+        {affectedItems && affectedItems.length > 0 && (
+          <ul className="max-h-40 list-inside list-disc overflow-y-auto rounded bg-neutral-900/60 p-2 font-mono text-xs text-neutral-400">
+            {affectedItems.map((item) => (
+              <li key={item} className="truncate">
+                {item}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {needsTyping && (
+          <label htmlFor={inputId} className="block space-y-1">
+            <span className="text-xs text-neutral-400">
+              Type <span className="font-mono text-neutral-200">{typeToConfirm}</span> to confirm:
+            </span>
+            <input
+              id={inputId}
+              type="text"
+              value={typed}
+              onChange={(e) => setTyped(e.target.value)}
+              autoComplete="off"
+              // biome-ignore lint/a11y/noAutofocus: focusing the gate input is the expected UX
+              autoFocus
+              className="w-full rounded border border-neutral-700 bg-neutral-900 px-2 py-1 font-mono text-sm text-neutral-100 outline-none focus:border-red-500"
+            />
+          </label>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/apps/studio/src/components/vault/SecretList.tsx
+++ b/apps/studio/src/components/vault/SecretList.tsx
@@ -34,7 +34,11 @@ export default function SecretList({ secrets, selectedPath, onSelect, onDelete }
                 : 'text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200'
             }`}
           >
-            <button type="button" className="flex-1 text-left" onClick={() => onSelect(secret.path)}>
+            <button
+              type="button"
+              className="flex-1 text-left"
+              onClick={() => onSelect(secret.path)}
+            >
               <p className="truncate text-sm font-medium">{secret.path.split('/').pop()}</p>
               <p className="truncate text-xs text-neutral-500">{secret.path}</p>
             </button>
@@ -67,9 +71,8 @@ export default function SecretList({ secrets, selectedPath, onSelect, onDelete }
         title="Delete secret"
         body={
           <>
-            Permanently delete{' '}
-            <span className="font-mono text-neutral-100">{pendingDelete}</span>? This destroys the
-            stored value with no undo.
+            Permanently delete <span className="font-mono text-neutral-100">{pendingDelete}</span>?
+            This destroys the stored value with no undo.
           </>
         }
         confirmLabel="Delete secret"

--- a/apps/studio/src/components/vault/SecretList.tsx
+++ b/apps/studio/src/components/vault/SecretList.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import type { SecretInfo } from '../../types';
+import ConfirmDialog from '../ui/ConfirmDialog';
 
 interface SecretListProps {
   secrets: SecretInfo[];
@@ -8,6 +10,10 @@ interface SecretListProps {
 }
 
 export default function SecretList({ secrets, selectedPath, onSelect, onDelete }: SecretListProps) {
+  // The hover trash icon used to delete a stored secret on a single click with
+  // no undo. Gate it behind a type-to-confirm dialog (the secret key name).
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+
   if (secrets.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center text-sm text-neutral-500">
@@ -17,42 +23,63 @@ export default function SecretList({ secrets, selectedPath, onSelect, onDelete }
   }
 
   return (
-    <div className="flex flex-1 flex-col gap-0.5 overflow-y-auto">
-      {secrets.map((secret) => (
-        <div
-          key={secret.path}
-          className={`group flex items-center justify-between rounded px-3 py-2 transition-colors ${
-            selectedPath === secret.path
-              ? 'bg-neutral-800 text-neutral-100'
-              : 'text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200'
-          }`}
-        >
-          <button type="button" className="flex-1 text-left" onClick={() => onSelect(secret.path)}>
-            <p className="truncate text-sm font-medium">{secret.path.split('/').pop()}</p>
-            <p className="truncate text-xs text-neutral-500">{secret.path}</p>
-          </button>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete(secret.path);
-            }}
-            className="ml-2 hidden rounded p-1 text-neutral-600 transition-colors hover:bg-red-950/50 hover:text-red-400 group-hover:flex"
-            aria-label={`Delete ${secret.path}`}
+    <>
+      <div className="flex flex-1 flex-col gap-0.5 overflow-y-auto">
+        {secrets.map((secret) => (
+          <div
+            key={secret.path}
+            className={`group flex items-center justify-between rounded px-3 py-2 transition-colors ${
+              selectedPath === secret.path
+                ? 'bg-neutral-800 text-neutral-100'
+                : 'text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200'
+            }`}
           >
-            <svg
-              className="size-3.5"
-              aria-hidden="true"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
+            <button type="button" className="flex-1 text-left" onClick={() => onSelect(secret.path)}>
+              <p className="truncate text-sm font-medium">{secret.path.split('/').pop()}</p>
+              <p className="truncate text-xs text-neutral-500">{secret.path}</p>
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setPendingDelete(secret.path);
+              }}
+              className="ml-2 hidden rounded p-1 text-neutral-600 transition-colors hover:bg-red-950/50 hover:text-red-400 group-hover:flex"
+              aria-label={`Delete ${secret.path}`}
             >
-              <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
-            </svg>
-          </button>
-        </div>
-      ))}
-    </div>
+              <svg
+                className="size-3.5"
+                aria-hidden="true"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+              </svg>
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete secret"
+        body={
+          <>
+            Permanently delete{' '}
+            <span className="font-mono text-neutral-100">{pendingDelete}</span>? This destroys the
+            stored value with no undo.
+          </>
+        }
+        confirmLabel="Delete secret"
+        typeToConfirm={pendingDelete?.split('/').pop() ?? undefined}
+        onConfirm={() => {
+          if (pendingDelete) onDelete(pendingDelete);
+          setPendingDelete(null);
+        }}
+        onClose={() => setPendingDelete(null)}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Item 5 (part 1) of the 2026-06-23 UX + durability audit remediation

Establishes the **reusable destructive-confirmation primitive** for Theme 3 and wires the **highest-blast-radius critical** through it: vault secret delete. Base `test`.

### `ConfirmDialog` — one gate for every destructive action
`components/ui/ConfirmDialog.tsx` (built on the existing `Modal`): title + concrete body, an optional `affectedItems` list, and an optional **type-to-confirm** guard (`typeToConfirm`) that keeps the destructive button disabled until the user types the exact phrase. This is the single primitive the rest of Theme 3 (git discard-all, daemon stop/restart, snap/model delete, SSH bookmark delete, DB migrate/seed, SetupWizard dismiss) will route through. 6 unit tests cover the gate, the phrase match, affected-items, and cancel.

### Vault secret delete — gated with type-to-confirm (critical)
`components/vault/SecretList.tsx`: the hover trash icon deleted a stored secret (API key, token, credential) on a single mis-aimed click with **no confirm and no undo**. It now opens `ConfirmDialog` requiring the user to type the secret's key name before deleting; the delete only fires on confirm. Existing test updated to the confirm flow.

### Verification
- `pnpm --filter studio typecheck` clean.
- `pnpm --filter studio exec vitest run` (ConfirmDialog + SecretList) → **12/12**.
- `biome check` clean.

### Remaining Theme 3 sites (follow-up — same `ConfirmDialog` pattern)
git Discard All / per-file discard (`AgentPanel.tsx`, `GitPanel.tsx`, type-to-confirm), daemon Stop/Restart (`DaemonPanel.tsx`), SSH bookmark delete (`SshBookmarkSidebar.tsx`/`ConnectForm.tsx`), snap/model delete (`InferencePanel.tsx`), agent Stop/Remove (`SpawnerPanel.tsx`), DB migrate/seed (`StepDatabase.tsx`, type-to-confirm), and separating SetupWizard dismiss from setup-complete (`SetupWizard.tsx`/`App.tsx`). The primitive here makes each a mechanical wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
