### PR TITLE
feat(studio): zero-9P P2 — delete Studio's git2/std::fs path

### DIFF
--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -2070,20 +2070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-sys",
- "url",
-]
-
-[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,19 +3060,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libgit2-sys"
-version = "0.18.3+1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,18 +3085,6 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3724,28 +3685,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-src"
-version = "300.6.0+3.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -4877,7 +4816,6 @@ dependencies = [
  "dirs",
  "dissimilar",
  "ed25519-dalek 2.2.0",
- "git2",
  "hex",
  "lettre",
  "libc",
@@ -7204,12 +7142,6 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -49,7 +49,8 @@ ed25519-dalek = "2"
 bs58 = "0.5"
 rsa = { version = "0.9", features = ["pem"] }
 lettre = { version = "0.11", features = ["tokio1-rustls-tls", "smtp-transport", "builder"], default-features = false }
-git2 = { version = "0.20", default-features = false, features = ["vendored-openssl", "vendored-libgit2"] }
+# git2 removed (zero-9P P2): all git/file I/O now routes through the WSL daemon
+# RPC surface; no in-process libgit2 / ext4 access from the Windows app.
 similar = "2"
 dissimilar = "1"
 ts-rs = { version = "10", features = ["serde-compat"] }

--- a/apps/studio/src-tauri/src/commands/agent.rs
+++ b/apps/studio/src-tauri/src/commands/agent.rs
@@ -1,15 +1,23 @@
-/// Reads a text file from the filesystem (tilde-expanded path).
-/// Used by the Agent panel to load workboard.md.
+use serde_json::{json, Value};
+
+/// Read a text file (e.g. the agent panel's workboard.md) through the WSL-side
+/// daemon — zero-9P (ADR P2), so no Windows process reads ext4 directly.
+///
+/// The daemon's `file.read` is repo-scoped, so the file's directory is
+/// registered as a project root and the basename is read within it. Paths are
+/// passed verbatim; the daemon expands `~` against its own (WSL) `$HOME`.
 #[tauri::command]
-pub fn agent_read_workboard(path: String) -> Result<String, String> {
-    let expanded = if path.starts_with("~/") {
-        if let Some(home) = dirs::home_dir() {
-            format!("{}/{}", home.display(), &path[2..])
-        } else {
-            path.clone()
-        }
-    } else {
-        path.clone()
+pub async fn agent_read_workboard(path: String) -> Result<String, String> {
+    let (dir, file) = match path.rfind('/') {
+        Some(i) => (path[..i].to_string(), path[i + 1..].to_string()),
+        None => (".".to_string(), path.clone()),
     };
-    std::fs::read_to_string(&expanded).map_err(|e| e.to_string())
+    let v: Value = crate::harness::repo_rpc("file.read", &dir, json!({ "filePath": file })).await?;
+    if v.get("tooLarge").and_then(Value::as_bool) == Some(true) {
+        return Err(format!("'{path}' is too large to open inline"));
+    }
+    v.get("content")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| format!("Cannot read '{path}'"))
 }

--- a/apps/studio/src-tauri/src/commands/git.rs
+++ b/apps/studio/src-tauri/src/commands/git.rs
@@ -1,10 +1,17 @@
-use std::path::Path;
+//! Git + file commands for the Studio editor.
+//!
+//! Zero-9P (ADR 2026-06-23, P2): every operation routes through the WSL-side
+//! daemon over `harness::repo_rpc`, so NO Windows process performs file or git
+//! I/O on an ext4 project path through the 9P redirector. The daemon owns all
+//! file/git I/O; this module is a thin typed adapter that maps the daemon's
+//! JSON responses onto the Tauri return contracts the frontend already binds.
 
-use git2::{DiffFormat, DiffOptions, Repository, Status, StatusOptions};
 use serde::Serialize;
+use serde_json::{json, Value};
 use ts_rs::TS;
 
 use super::error::StudioError;
+use crate::harness;
 
 // ── Branch / push / pull / log types ────────────────────────────────────────
 
@@ -60,111 +67,68 @@ pub struct GitStatusResult {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-/// Expand a leading `~/` to the home directory. Returns the path unchanged
-/// if it does not start with `~/` or if the home directory cannot be resolved.
-fn expand_tilde(path: &str) -> String {
-    if path.starts_with("~/") {
-        if let Some(home) = dirs::home_dir() {
-            return format!("{}/{}", home.display(), &path[2..]);
-        }
+/// Daemon git.*/file.* mutation handlers report failure as `{ success: false,
+/// error }` in the RESULT (not a JSON-RPC error). Surface that as an error so a
+/// failed stage/commit/etc. doesn't read as success.
+fn require_success(v: &Value) -> Result<(), StudioError> {
+    if v.get("success").and_then(Value::as_bool) == Some(false) {
+        let msg = v
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("git operation failed");
+        return Err(StudioError::Other(msg.to_string()));
     }
-    path.to_string()
+    Ok(())
 }
 
-fn open_repo(repo_path: &str) -> Result<Repository, StudioError> {
-    let expanded = expand_tilde(repo_path);
-    Repository::open(&expanded)
-        .map_err(|e| StudioError::Other(format!("Cannot open repository at {expanded}: {e}")))
+/// Map one porcelain status char (X = index side, Y = worktree side) to the
+/// frontend's friendly status string.
+fn map_status_char(code: u8) -> &'static str {
+    match code {
+        b'A' | b'C' => "new",
+        b'D' => "deleted",
+        b'R' => "renamed",
+        _ => "modified", // M, T, and any other change
+    }
+}
+
+/// Read a git blob (HEAD or index) via the daemon. `None` when the path is not
+/// present in that tree (or is too large) — the diff viewer treats that as an
+/// empty side, matching the previous git2 behavior.
+async fn read_blob(repo_path: &str, file_path: &str, method: &str) -> Option<String> {
+    let v = harness::repo_rpc(method, repo_path, json!({ "filePath": file_path }))
+        .await
+        .ok()?;
+    if v.get("success").and_then(Value::as_bool) == Some(false) {
+        return None;
+    }
+    if v.get("tooLarge").and_then(Value::as_bool) == Some(true) {
+        return None;
+    }
+    v.get("content").and_then(Value::as_str).map(str::to_string)
 }
 
 // ── Commands ─────────────────────────────────────────────────────────────────
 
 /// Return the current branch, staged/unstaged/untracked file lists.
 #[tauri::command]
-pub fn git_status(repo_path: String) -> Result<GitStatusResult, StudioError> {
-    let repo = open_repo(&repo_path)?;
+pub async fn git_status(repo_path: String) -> Result<GitStatusResult, StudioError> {
+    let v = harness::repo_rpc("git.status", &repo_path, json!({}))
+        .await
+        .map_err(StudioError::Other)?;
+    require_success(&v)?;
 
-    let branch = repo
-        .head()
-        .ok()
-        .as_ref()
-        .and_then(|h| h.shorthand().map(str::to_string))
-        .unwrap_or_else(|| "HEAD".to_string());
+    let branch = v
+        .get("branch")
+        .and_then(Value::as_str)
+        .unwrap_or("HEAD")
+        .to_string();
 
-    let mut opts = StatusOptions::new();
-    opts.include_untracked(true)
-        .recurse_untracked_dirs(true)
-        .include_ignored(false);
-
-    let statuses = repo
-        .statuses(Some(&mut opts))
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-
-    let mut staged: Vec<GitFileEntry> = Vec::new();
-    let mut unstaged: Vec<GitFileEntry> = Vec::new();
-    let mut untracked: Vec<GitFileEntry> = Vec::new();
-
-    for entry in statuses.iter() {
-        let path = entry.path().unwrap_or("").to_string();
-        let s = entry.status();
-
-        // Index (staged) changes
-        if s.intersects(
-            Status::INDEX_NEW
-                | Status::INDEX_MODIFIED
-                | Status::INDEX_DELETED
-                | Status::INDEX_RENAMED
-                | Status::INDEX_TYPECHANGE,
-        ) {
-            let status_str = if s.contains(Status::INDEX_NEW) {
-                "new"
-            } else if s.contains(Status::INDEX_DELETED) {
-                "deleted"
-            } else if s.contains(Status::INDEX_RENAMED) {
-                "renamed"
-            } else {
-                "modified"
-            };
-            staged.push(GitFileEntry {
-                path: path.clone(),
-                status: status_str.to_string(),
-            });
-        }
-
-        // Working tree (unstaged) changes
-        if s.intersects(
-            Status::WT_MODIFIED | Status::WT_DELETED | Status::WT_TYPECHANGE | Status::WT_RENAMED,
-        ) {
-            let status_str = if s.contains(Status::WT_DELETED) {
-                "deleted"
-            } else if s.contains(Status::WT_RENAMED) {
-                "renamed"
-            } else {
-                "modified"
-            };
-            unstaged.push(GitFileEntry {
-                path: path.clone(),
-                status: status_str.to_string(),
-            });
-        }
-
-        // Untracked new files
-        if s.contains(Status::WT_NEW) {
-            untracked.push(GitFileEntry {
-                path: path.clone(),
-                status: "untracked".to_string(),
-            });
-        }
-
-        // Merge conflicts
-        if s.contains(Status::CONFLICTED) {
-            unstaged.push(GitFileEntry {
-                path: path.clone(),
-                status: "conflicted".to_string(),
-            });
-        }
-    }
-
+    let (staged, unstaged, untracked) = bucket_porcelain(
+        v.get("files")
+            .and_then(Value::as_array)
+            .unwrap_or(&Vec::new()),
+    );
     Ok(GitStatusResult {
         branch,
         staged,
@@ -173,264 +137,291 @@ pub fn git_status(repo_path: String) -> Result<GitStatusResult, StudioError> {
     })
 }
 
+/// Sort the daemon's `git.status` entries (each `{ path, status: "XY" }`, where
+/// X is the index side and Y the worktree side of porcelain v1) into the
+/// staged / unstaged / untracked buckets the frontend renders.
+fn bucket_porcelain(files: &[Value]) -> (Vec<GitFileEntry>, Vec<GitFileEntry>, Vec<GitFileEntry>) {
+    let mut staged: Vec<GitFileEntry> = Vec::new();
+    let mut unstaged: Vec<GitFileEntry> = Vec::new();
+    let mut untracked: Vec<GitFileEntry> = Vec::new();
+
+    for f in files {
+        let path = f
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let st = f.get("status").and_then(Value::as_str).unwrap_or("  ");
+        let bytes = st.as_bytes();
+        let x = bytes.first().copied().unwrap_or(b' ');
+        let y = bytes.get(1).copied().unwrap_or(b' ');
+
+        if x == b'?' && y == b'?' {
+            untracked.push(GitFileEntry {
+                path,
+                status: "untracked".to_string(),
+            });
+            continue;
+        }
+        // Unmerged paths: any 'U', or both-added / both-deleted.
+        if x == b'U' || y == b'U' || (x == b'D' && y == b'D') || (x == b'A' && y == b'A') {
+            unstaged.push(GitFileEntry {
+                path,
+                status: "conflicted".to_string(),
+            });
+            continue;
+        }
+        if x != b' ' {
+            staged.push(GitFileEntry {
+                path: path.clone(),
+                status: map_status_char(x).to_string(),
+            });
+        }
+        if y != b' ' {
+            unstaged.push(GitFileEntry {
+                path,
+                status: map_status_char(y).to_string(),
+            });
+        }
+    }
+
+    (staged, unstaged, untracked)
+}
+
 /// Return a unified-diff patch for a single file.
 /// - `staged = true`:  diff HEAD → index (what will be committed)
 /// - `staged = false`: diff index → worktree (unstaged changes)
 #[tauri::command]
-pub fn git_diff_file(
+pub async fn git_diff_file(
     repo_path: String,
     file_path: String,
     staged: bool,
 ) -> Result<String, StudioError> {
-    let repo = open_repo(&repo_path)?;
-
-    let mut diff_opts = DiffOptions::new();
-    diff_opts.pathspec(&file_path);
-
-    let diff = if staged {
-        let head_tree = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
-        let index = repo
-            .index()
-            .map_err(|e| StudioError::Other(e.to_string()))?;
-        repo.diff_tree_to_index(head_tree.as_ref(), Some(&index), Some(&mut diff_opts))
-    } else {
-        repo.diff_index_to_workdir(None, Some(&mut diff_opts))
-    }
-    .map_err(|e| StudioError::Other(e.to_string()))?;
-
-    let mut patch = String::new();
-    diff.print(DiffFormat::Patch, |_delta, _hunk, line| {
-        let origin = line.origin();
-        let content = std::str::from_utf8(line.content()).unwrap_or("");
-        match origin {
-            '+' | '-' | ' ' => patch.push_str(&format!("{origin}{content}")),
-            _ => patch.push_str(content),
-        }
-        true
-    })
-    .map_err(|e| StudioError::Other(e.to_string()))?;
-
-    Ok(patch)
+    let v = harness::repo_rpc(
+        "git.diffFile",
+        &repo_path,
+        json!({ "filePath": file_path, "staged": staged }),
+    )
+    .await
+    .map_err(StudioError::Other)?;
+    require_success(&v)?;
+    Ok(v.get("diff")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string())
 }
 
-/// Stage a file (add to index). Handles deleted files by removing from index.
+/// Stage a file (add to index). Handles deleted files too (`git add` records
+/// the deletion).
 #[tauri::command]
-pub fn git_stage_file(repo_path: String, file_path: String) -> Result<(), StudioError> {
-    let expanded = expand_tilde(&repo_path);
-    let repo = Repository::open(&expanded)
-        .map_err(|e| StudioError::Other(format!("Cannot open repo: {e}")))?;
-    let mut index = repo
-        .index()
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-
-    let full_path = Path::new(&expanded).join(&file_path);
-    if full_path.exists() {
-        index
-            .add_path(Path::new(&file_path))
-            .map_err(|e| StudioError::Other(e.to_string()))?;
-    } else {
-        index
-            .remove_path(Path::new(&file_path))
-            .map_err(|e| StudioError::Other(e.to_string()))?;
-    }
-    index
-        .write()
-        .map_err(|e| StudioError::Other(e.to_string()))
+pub async fn git_stage_file(repo_path: String, file_path: String) -> Result<(), StudioError> {
+    let v = harness::repo_rpc(
+        "git.stageFile",
+        &repo_path,
+        json!({ "filePath": file_path }),
+    )
+    .await
+    .map_err(StudioError::Other)?;
+    require_success(&v)
 }
 
-/// Unstage a file (reset HEAD → index). For new repos with no HEAD, removes from index.
+/// Unstage a file (restore the index entry from HEAD).
 #[tauri::command]
-pub fn git_unstage_file(repo_path: String, file_path: String) -> Result<(), StudioError> {
-    let repo = open_repo(&repo_path)?;
-
-    // Resolve HEAD into an owned OID to avoid lifetime entanglement with the
-    // temporary Reference returned by repo.head().
-    let head_oid = repo.head().ok().and_then(|h| h.target());
-
-    if let Some(oid) = head_oid {
-        let obj = repo
-            .find_object(oid, None)
-            .map_err(|e| StudioError::Other(e.to_string()))?;
-        repo.reset_default(Some(&obj), [&file_path])
-            .map_err(|e| StudioError::Other(e.to_string()))
-    } else {
-        // Initial commit — no HEAD to reset to; just remove from index
-        let mut index = repo
-            .index()
-            .map_err(|e| StudioError::Other(e.to_string()))?;
-        index
-            .remove_path(Path::new(&file_path))
-            .map_err(|e| StudioError::Other(e.to_string()))?;
-        index
-            .write()
-            .map_err(|e| StudioError::Other(e.to_string()))
-    }
+pub async fn git_unstage_file(repo_path: String, file_path: String) -> Result<(), StudioError> {
+    let v = harness::repo_rpc(
+        "git.unstageFile",
+        &repo_path,
+        json!({ "filePath": file_path }),
+    )
+    .await
+    .map_err(StudioError::Other)?;
+    require_success(&v)
 }
 
-/// Discard working-tree changes to a file by checking it out from the index.
+/// Discard working-tree changes to a file by restoring it from the index.
 #[tauri::command]
-pub fn git_discard_file(repo_path: String, file_path: String) -> Result<(), StudioError> {
-    let repo = open_repo(&repo_path)?;
-    let mut checkout_opts = git2::build::CheckoutBuilder::new();
-    checkout_opts.path(&file_path).force();
-    repo.checkout_index(None, Some(&mut checkout_opts))
-        .map_err(|e| StudioError::Other(e.to_string()))
+pub async fn git_discard_file(repo_path: String, file_path: String) -> Result<(), StudioError> {
+    let v = harness::repo_rpc(
+        "git.discardFile",
+        &repo_path,
+        json!({ "filePath": file_path }),
+    )
+    .await
+    .map_err(StudioError::Other)?;
+    require_success(&v)
 }
 
 /// List all local branches. The currently checked-out branch has `is_current = true`.
 #[tauri::command]
-pub fn git_list_branches(repo_path: String) -> Result<Vec<GitBranch>, StudioError> {
-    let repo = open_repo(&repo_path)?;
-
-    let head_name = repo
-        .head()
-        .ok()
-        .and_then(|h| h.shorthand().map(str::to_string));
-
-    let branches = repo
-        .branches(Some(git2::BranchType::Local))
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-
-    let result: Vec<GitBranch> = branches
-        .filter_map(|b| b.ok())
-        .filter_map(|(branch, _)| {
-            let name = branch.name().ok()??.to_string();
-            let is_current = head_name.as_deref() == Some(name.as_str());
-            Some(GitBranch { name, is_current })
+pub async fn git_list_branches(repo_path: String) -> Result<Vec<GitBranch>, StudioError> {
+    let v = harness::repo_rpc("git.listBranches", &repo_path, json!({}))
+        .await
+        .map_err(StudioError::Other)?;
+    require_success(&v)?;
+    let current = v.get("current").and_then(Value::as_str);
+    let branches = v
+        .get("branches")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_str)
+                .map(|name| GitBranch {
+                    name: name.to_string(),
+                    is_current: Some(name) == current,
+                })
+                .collect()
         })
-        .collect();
-
-    Ok(result)
+        .unwrap_or_default();
+    Ok(branches)
 }
 
 /// Create a new local branch from the current HEAD (does not switch to it).
 #[tauri::command]
-pub fn git_create_branch(repo_path: String, name: String) -> Result<(), StudioError> {
-    let repo = open_repo(&repo_path)?;
-    let head = repo
-        .head()
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-    let commit = head
-        .peel_to_commit()
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-    repo.branch(&name, &commit, false)
-        .map_err(|e| StudioError::Other(format!("Cannot create branch '{name}': {e}")))?;
-    Ok(())
+pub async fn git_create_branch(repo_path: String, name: String) -> Result<(), StudioError> {
+    let v = harness::repo_rpc("git.createBranch", &repo_path, json!({ "name": name }))
+        .await
+        .map_err(StudioError::Other)?;
+    require_success(&v)
 }
 
-/// Switch the working tree to an existing local branch (checkout + set HEAD).
+/// Switch the working tree to an existing local branch.
 #[tauri::command]
-pub fn git_switch_branch(repo_path: String, name: String) -> Result<(), StudioError> {
-    let repo = open_repo(&repo_path)?;
-    let refname = format!("refs/heads/{name}");
-    let obj = repo
-        .revparse_single(&refname)
-        .map_err(|e| StudioError::Other(format!("Branch not found '{name}': {e}")))?;
-    let mut checkout_opts = git2::build::CheckoutBuilder::new();
-    checkout_opts.safe();
-    repo.checkout_tree(&obj, Some(&mut checkout_opts))
-        .map_err(|e| StudioError::Other(format!("Checkout failed: {e}")))?;
-    repo.set_head(&refname)
-        .map_err(|e| StudioError::Other(e.to_string()))
+pub async fn git_switch_branch(repo_path: String, name: String) -> Result<(), StudioError> {
+    let v = harness::repo_rpc("git.switchBranch", &repo_path, json!({ "name": name }))
+        .await
+        .map_err(StudioError::Other)?;
+    require_success(&v)
 }
 
-/// Delete a local branch (must not be the current branch).
+/// Delete a local branch. Force-deletes to preserve the prior git2 behavior
+/// (which removed the ref regardless of merge state).
 #[tauri::command]
-pub fn git_delete_branch(repo_path: String, name: String) -> Result<(), StudioError> {
-    let repo = open_repo(&repo_path)?;
-    let mut branch = repo
-        .find_branch(&name, git2::BranchType::Local)
-        .map_err(|e| StudioError::Other(format!("Branch not found '{name}': {e}")))?;
-    branch
-        .delete()
-        .map_err(|e| StudioError::Other(e.to_string()))
+pub async fn git_delete_branch(repo_path: String, name: String) -> Result<(), StudioError> {
+    let v = harness::repo_rpc(
+        "git.deleteBranch",
+        &repo_path,
+        json!({ "name": name, "force": true }),
+    )
+    .await
+    .map_err(StudioError::Other)?;
+    require_success(&v)
 }
 
-/// Push a branch to a remote using the system `git` binary (inherits SSH agent / credential store).
+/// Push a branch to a remote (the daemon shells the system `git`, inheriting
+/// the WSL-side SSH agent / credential store).
 #[tauri::command]
-pub fn git_push(
+pub async fn git_push(
     repo_path: String,
     remote: String,
     branch: String,
 ) -> Result<GitPushResult, StudioError> {
-    let expanded = expand_tilde(&repo_path);
-    let output = std::process::Command::new("git")
-        .args(["-C", &expanded, "push", &remote, &branch])
-        .output()
-        .map_err(|e| StudioError::Other(format!("Failed to run git: {e}")))?;
-
-    let success = output.status.success();
-    let raw = if success {
-        String::from_utf8_lossy(&output.stdout)
+    let v = harness::repo_rpc(
+        "git.push",
+        &repo_path,
+        json!({ "remote": remote, "branch": branch }),
+    )
+    .await
+    .map_err(StudioError::Other)?;
+    let success = v.get("success").and_then(Value::as_bool).unwrap_or(false);
+    let message = if success {
+        v.get("stdout").and_then(Value::as_str).unwrap_or("")
     } else {
-        String::from_utf8_lossy(&output.stderr)
-    };
-    let message = raw.trim().to_string();
+        v.get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("git push failed")
+    }
+    .trim()
+    .to_string();
     Ok(GitPushResult { success, message })
 }
 
-/// Pull from a remote using the system `git` binary (inherits SSH agent / credential store).
+/// Pull from a remote (daemon shells the system `git`).
 #[tauri::command]
-pub fn git_pull(
+pub async fn git_pull(
     repo_path: String,
     remote: String,
     branch: String,
 ) -> Result<GitPullResult, StudioError> {
-    let expanded = expand_tilde(&repo_path);
-    let output = std::process::Command::new("git")
-        .args(["-C", &expanded, "pull", &remote, &branch])
-        .output()
-        .map_err(|e| StudioError::Other(format!("Failed to run git: {e}")))?;
-
-    let success = output.status.success();
-    let raw = if success {
-        String::from_utf8_lossy(&output.stdout)
+    let v = harness::repo_rpc(
+        "git.pull",
+        &repo_path,
+        json!({ "remote": remote, "branch": branch }),
+    )
+    .await
+    .map_err(StudioError::Other)?;
+    let success = v.get("success").and_then(Value::as_bool).unwrap_or(false);
+    let message = if success {
+        v.get("stdout").and_then(Value::as_str).unwrap_or("")
     } else {
-        String::from_utf8_lossy(&output.stderr)
-    };
-    let message = raw.trim().to_string();
+        v.get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("git pull failed")
+    }
+    .trim()
+    .to_string();
     Ok(GitPullResult { success, message })
 }
 
 /// Return the last `limit` commits on the current branch (default 50).
 #[tauri::command]
-pub fn git_log(repo_path: String, limit: Option<u32>) -> Result<Vec<GitCommitInfo>, StudioError> {
-    let repo = open_repo(&repo_path)?;
-    let mut revwalk = repo
-        .revwalk()
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-    revwalk
-        .push_head()
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-    revwalk
-        .set_sorting(git2::Sort::TIME)
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-
-    let max = limit.unwrap_or(50) as usize;
-    let commits = revwalk
-        .take(max)
-        .filter_map(|oid| oid.ok())
-        .filter_map(|oid| repo.find_commit(oid).ok())
-        .map(|commit| {
-            let sha = commit.id().to_string();
-            let short_sha = sha[..7].to_string();
-            let message = commit.summary().unwrap_or("").to_string();
-            let author = commit.author().name().unwrap_or("").to_string();
-            let timestamp = commit.time().seconds();
-            GitCommitInfo { sha, short_sha, message, author, timestamp }
+pub async fn git_log(
+    repo_path: String,
+    limit: Option<u32>,
+) -> Result<Vec<GitCommitInfo>, StudioError> {
+    let mut params = json!({});
+    if let Some(l) = limit {
+        params["limit"] = json!(l);
+    }
+    let v = harness::repo_rpc("git.log", &repo_path, params)
+        .await
+        .map_err(StudioError::Other)?;
+    require_success(&v)?;
+    let commits = v
+        .get("commits")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|c| {
+                    let sha = c.get("hash").and_then(Value::as_str)?.to_string();
+                    let short_sha = sha.get(..7).unwrap_or(&sha).to_string();
+                    Some(GitCommitInfo {
+                        sha,
+                        short_sha,
+                        message: c
+                            .get("subject")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string(),
+                        author: c
+                            .get("author")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string(),
+                        timestamp: c.get("timestamp").and_then(Value::as_i64).unwrap_or(0),
+                    })
+                })
+                .collect()
         })
-        .collect();
-
+        .unwrap_or_default();
     Ok(commits)
 }
 
 /// Read a file from the working tree. Path is relative to `repo_path`.
 #[tauri::command]
-pub fn git_read_file(repo_path: String, file_path: String) -> Result<String, StudioError> {
-    let expanded = expand_tilde(&repo_path);
-    let full = Path::new(&expanded).join(&file_path);
-    std::fs::read_to_string(&full)
-        .map_err(|e| StudioError::Other(format!("Cannot read '{file_path}': {e}")))
+pub async fn git_read_file(repo_path: String, file_path: String) -> Result<String, StudioError> {
+    let v = harness::repo_rpc("file.read", &repo_path, json!({ "filePath": file_path }))
+        .await
+        .map_err(StudioError::Other)?;
+    if v.get("tooLarge").and_then(Value::as_bool) == Some(true) {
+        let bytes = v.get("bytes").and_then(Value::as_u64).unwrap_or(0);
+        return Err(StudioError::Other(format!(
+            "'{file_path}' is too large to open inline ({bytes} bytes)"
+        )));
+    }
+    v.get("content")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| StudioError::Other(format!("Cannot read '{file_path}'")))
 }
 
 // ── Diff content for MergeView ────────────────────────────────────────────────
@@ -449,97 +440,133 @@ pub struct GitDiffContent {
 /// - `staged = true`:  HEAD → index  (original = HEAD blob, modified = staged blob)
 /// - `staged = false`: index → worktree (original = staged or HEAD blob, modified = working tree)
 #[tauri::command]
-pub fn git_diff_content(
+pub async fn git_diff_content(
     repo_path: String,
     file_path: String,
     staged: bool,
 ) -> Result<GitDiffContent, StudioError> {
-    let repo = open_repo(&repo_path)?;
-
     if staged {
-        let original = read_blob_at_head(&repo, &file_path).unwrap_or_default();
-        let modified = read_blob_at_index(&repo, &file_path).unwrap_or_default();
-        Ok(GitDiffContent { original, modified })
-    } else {
-        let original = read_blob_at_index(&repo, &file_path)
-            .or_else(|_| read_blob_at_head(&repo, &file_path))
+        let original = read_blob(&repo_path, &file_path, "git.readBlobAtHead")
+            .await
             .unwrap_or_default();
-        let expanded = expand_tilde(&repo_path);
-        let full = std::path::Path::new(&expanded).join(&file_path);
-        let modified = std::fs::read_to_string(&full).unwrap_or_default();
-        Ok(GitDiffContent { original, modified })
+        let modified = read_blob(&repo_path, &file_path, "git.readBlobAtIndex")
+            .await
+            .unwrap_or_default();
+        return Ok(GitDiffContent { original, modified });
     }
-}
 
-fn read_blob_at_head(repo: &Repository, file_path: &str) -> Result<String, StudioError> {
-    let tree = repo
-        .head()
-        .map_err(|e| StudioError::Other(e.to_string()))?
-        .peel_to_tree()
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-    let entry = tree
-        .get_path(std::path::Path::new(file_path))
-        .map_err(|e| StudioError::Other(format!("'{file_path}' not in HEAD: {e}")))?;
-    let blob = repo
-        .find_blob(entry.id())
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-    String::from_utf8(blob.content().to_vec())
-        .map_err(|_| StudioError::Other(format!("'{file_path}' contains binary content")))
-}
-
-fn read_blob_at_index(repo: &Repository, file_path: &str) -> Result<String, StudioError> {
-    let index = repo
-        .index()
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-    let entry = index
-        .get_path(std::path::Path::new(file_path), 0)
-        .ok_or_else(|| StudioError::Other(format!("'{file_path}' not in index")))?;
-    let blob = repo
-        .find_blob(entry.id)
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-    String::from_utf8(blob.content().to_vec())
-        .map_err(|_| StudioError::Other(format!("'{file_path}' contains binary content")))
+    // Unstaged: original is the staged blob, falling back to HEAD; modified is
+    // the working-tree content.
+    let original = match read_blob(&repo_path, &file_path, "git.readBlobAtIndex").await {
+        Some(c) => c,
+        None => read_blob(&repo_path, &file_path, "git.readBlobAtHead")
+            .await
+            .unwrap_or_default(),
+    };
+    let modified = harness::repo_rpc(
+        "git.diffContent",
+        &repo_path,
+        json!({ "filePath": file_path }),
+    )
+    .await
+    .ok()
+    .filter(|v| v.get("tooLarge").and_then(Value::as_bool) != Some(true))
+    .and_then(|v| v.get("content").and_then(Value::as_str).map(str::to_string))
+    .unwrap_or_default();
+    Ok(GitDiffContent { original, modified })
 }
 
 /// Write content to a file in the working tree. Path is relative to `repo_path`.
 #[tauri::command]
-pub fn git_write_file(
+pub async fn git_write_file(
     repo_path: String,
     file_path: String,
     content: String,
 ) -> Result<(), StudioError> {
-    let expanded = expand_tilde(&repo_path);
-    let full = Path::new(&expanded).join(&file_path);
-    std::fs::write(&full, content)
-        .map_err(|e| StudioError::Other(format!("Cannot write '{file_path}': {e}")))
+    let v = harness::repo_rpc(
+        "file.write",
+        &repo_path,
+        json!({ "filePath": file_path, "content": content }),
+    )
+    .await
+    .map_err(StudioError::Other)?;
+    require_success(&v)
 }
 
-/// Commit the current index with the given message using the repo's git identity.
-/// Returns the short commit SHA.
+/// Commit the current index with the given message. Returns the commit SHA.
 #[tauri::command]
-pub fn git_commit(repo_path: String, message: String) -> Result<String, StudioError> {
-    let repo = open_repo(&repo_path)?;
+pub async fn git_commit(repo_path: String, message: String) -> Result<String, StudioError> {
+    let v = harness::repo_rpc("git.commit", &repo_path, json!({ "message": message }))
+        .await
+        .map_err(StudioError::Other)?;
+    require_success(&v)?;
+    Ok(v.get("sha")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string())
+}
 
-    let sig = repo
-        .signature()
-        .map_err(|e| StudioError::Other(format!("No git identity configured: {e}")))?;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let mut index = repo
-        .index()
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-    let tree_id = index
-        .write_tree()
-        .map_err(|e| StudioError::Other(e.to_string()))?;
-    let tree = repo
-        .find_tree(tree_id)
-        .map_err(|e| StudioError::Other(e.to_string()))?;
+    fn entry(path: &str, status: &str) -> Value {
+        json!({ "path": path, "status": status })
+    }
 
-    let parent_commit: Option<git2::Commit> = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
-    let parents: Vec<&git2::Commit> = parent_commit.iter().collect();
+    #[test]
+    fn buckets_porcelain_xy_codes() {
+        let files = vec![
+            entry("staged.txt", "M "), // staged modified
+            entry("both.txt", "MM"),   // staged + unstaged modified
+            entry("wt.txt", " M"),     // unstaged modified
+            entry("new.txt", "A "),    // staged new
+            entry("gone.txt", " D"),   // unstaged deleted
+            entry("untracked.txt", "??"),
+            entry("conflict.txt", "UU"),
+        ];
+        let (staged, unstaged, untracked) = bucket_porcelain(&files);
 
-    let oid = repo
-        .commit(Some("HEAD"), &sig, &sig, &message, &tree, &parents)
-        .map_err(|e| StudioError::Other(e.to_string()))?;
+        let staged: Vec<_> = staged
+            .iter()
+            .map(|e| (e.path.as_str(), e.status.as_str()))
+            .collect();
+        assert!(staged.contains(&("staged.txt", "modified")));
+        assert!(staged.contains(&("both.txt", "modified")));
+        assert!(staged.contains(&("new.txt", "new")));
 
-    Ok(oid.to_string())
+        let unstaged: Vec<_> = unstaged
+            .iter()
+            .map(|e| (e.path.as_str(), e.status.as_str()))
+            .collect();
+        assert!(unstaged.contains(&("both.txt", "modified")));
+        assert!(unstaged.contains(&("wt.txt", "modified")));
+        assert!(unstaged.contains(&("gone.txt", "deleted")));
+        assert!(unstaged.contains(&("conflict.txt", "conflicted")));
+
+        assert_eq!(untracked.len(), 1);
+        assert_eq!(untracked[0].path, "untracked.txt");
+        // A conflicted path is reported once, in the unstaged bucket.
+        assert_eq!(
+            staged.iter().filter(|(p, _)| *p == "conflict.txt").count(),
+            0
+        );
+    }
+
+    #[test]
+    fn maps_status_chars() {
+        assert_eq!(map_status_char(b'A'), "new");
+        assert_eq!(map_status_char(b'D'), "deleted");
+        assert_eq!(map_status_char(b'R'), "renamed");
+        assert_eq!(map_status_char(b'M'), "modified");
+        assert_eq!(map_status_char(b'T'), "modified");
+    }
+
+    #[test]
+    fn require_success_flags_failed_results() {
+        assert!(require_success(&json!({ "success": true })).is_ok());
+        assert!(require_success(&json!({ "branch": "main" })).is_ok()); // no field → ok
+        let err = require_success(&json!({ "success": false, "error": "boom" }));
+        assert!(err.is_err());
+    }
 }

--- a/apps/studio/src-tauri/src/harness.rs
+++ b/apps/studio/src-tauri/src/harness.rs
@@ -10,7 +10,9 @@
 
 use crate::signing;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{LazyLock, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(unix)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -163,6 +165,52 @@ pub async fn rpc_call(
         }
     }
     rpc_call_raw(method, params, signature).await
+}
+
+/// Project roots already registered with the daemon this session, so we skip a
+/// redundant `project.open` round-trip per call. Self-heals on daemon restart:
+/// a "not registered" error clears the entry and `repo_rpc` re-opens + retries.
+static OPENED_PROJECTS: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+/// Ensure `repo_path` is registered as a daemon project root (idempotent). The
+/// daemon's file.* / git.* handlers reject any repo that hasn't been opened —
+/// it is the allowlist that confines file access to known roots.
+async fn ensure_project_open(repo_path: &str) -> Result<(), String> {
+    if OPENED_PROJECTS.lock().unwrap().contains(repo_path) {
+        return Ok(());
+    }
+    rpc_call("project.open", serde_json::json!({ "repoPath": repo_path })).await?;
+    OPENED_PROJECTS
+        .lock()
+        .unwrap()
+        .insert(repo_path.to_string());
+    Ok(())
+}
+
+/// Call a repo-scoped file.* / git.* method: register the root (cached), inject
+/// `repoPath`, dispatch, and — if the daemon was restarted and forgot the root
+/// — re-open and retry once.
+pub async fn repo_rpc(
+    method: &str,
+    repo_path: &str,
+    mut params: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    if let Some(obj) = params.as_object_mut() {
+        obj.insert(
+            "repoPath".to_string(),
+            serde_json::Value::String(repo_path.to_string()),
+        );
+    }
+    ensure_project_open(repo_path).await?;
+    match rpc_call(method, params.clone()).await {
+        Err(e) if e.contains("not registered") => {
+            OPENED_PROJECTS.lock().unwrap().remove(repo_path);
+            ensure_project_open(repo_path).await?;
+            rpc_call(method, params).await
+        }
+        other => other,
+    }
 }
 
 #[cfg(unix)]

--- a/packages/daemon/src/__tests__/filegit-git.test.ts
+++ b/packages/daemon/src/__tests__/filegit-git.test.ts
@@ -1,0 +1,140 @@
+/**
+ * End-to-end test of the signed git.* surface against a real git repo over a
+ * daemon socket. Covers the stage→commit→log flow Studio drives in P2, and in
+ * particular the two fields P2's Tauri contracts depend on:
+ *   - git.commit returns the new commit's `sha` / `shortSha`.
+ *   - git.log returns a numeric unix `timestamp` per commit.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { formatDid } from '@revdev/protocol/did';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  generateNonce,
+  hashParams,
+  serializeEnvelope,
+  signEnvelope,
+} from '../agent-identity-crypto.js';
+import '../filegit.js';
+import { startDaemon } from '../server.js';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+interface RpcResult {
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+}
+
+function rpc(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown>,
+  signature?: string,
+): Promise<RpcResult> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req: Record<string, unknown> = { jsonrpc: '2.0', id: 1, method, params };
+    if (signature) req['x-revdev-signature'] = signature;
+    sock.on('connect', () => sock.write(`${JSON.stringify(req)}\n`));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      sock.end();
+      try {
+        resolve(JSON.parse(buf.slice(0, nl)) as RpcResult);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error(`rpc timeout: ${method}`));
+    });
+  });
+}
+
+describe('signed git.* flow (zero-9P P2)', () => {
+  let daemon: { close: () => Promise<void> };
+  let socketPath: string;
+  let dataDir: string;
+  let repo: string;
+  const agentId = 'studio-git-test';
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid(agentId, fingerprint);
+
+  const sign = (method: string, params: Record<string, unknown>) =>
+    serializeEnvelope(
+      signEnvelope(
+        {
+          did,
+          kid: fingerprint,
+          nonce: generateNonce(),
+          ts: Math.floor(Date.now() / 1000),
+          method,
+          paramsHash: hashParams(method, params),
+        },
+        kp.privateKeyPem,
+      ),
+    );
+
+  beforeAll(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-git-'));
+    repo = await mkdtemp(join(tmpdir(), 'revdev-git-repo-'));
+    execFileSync('git', ['init', '-q'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 'test@revealui.com'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+    socketPath = join(dataDir, 'harness.sock');
+    daemon = await startDaemon({ socketPath, dataDir });
+    await rpc(socketPath, 'session.register', {
+      agentId,
+      agentName: 'studio-ui',
+      backend: 'studio',
+      publicKeyPem: kp.publicKeyPem,
+    });
+    await rpc(socketPath, 'project.open', { repoPath: repo, actorAgentId: agentId });
+  });
+
+  afterAll(async () => {
+    await daemon.close();
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('stages + commits and returns the new commit SHA', async () => {
+    await writeFile(join(repo, 'a.txt'), 'hello\n');
+    const stage = { repoPath: repo, filePath: 'a.txt' };
+    const s = await rpc(socketPath, 'git.stageFile', stage, sign('git.stageFile', stage));
+    expect(s.result?.success).toBe(true);
+
+    const commitParams = { repoPath: repo, message: 'initial commit' };
+    const c = await rpc(socketPath, 'git.commit', commitParams, sign('git.commit', commitParams));
+    expect(c.result?.success).toBe(true);
+    expect(typeof c.result?.sha).toBe('string');
+    expect((c.result?.sha as string).length).toBe(40);
+    expect((c.result?.shortSha as string).length).toBe(7);
+  });
+
+  it('git.log returns a numeric unix timestamp per commit', async () => {
+    // git.log is signature-optional; identity rides actorAgentId.
+    const r = await rpc(socketPath, 'git.log', {
+      repoPath: repo,
+      actorAgentId: agentId,
+      limit: 10,
+    });
+    const commits = r.result?.commits as Array<Record<string, unknown>>;
+    expect(commits.length).toBe(1);
+    expect(typeof commits[0].timestamp).toBe('number');
+    expect(commits[0].timestamp as number).toBeGreaterThan(0);
+    expect(commits[0].subject).toBe('initial commit');
+  });
+});

--- a/packages/daemon/src/__tests__/filegit-git.test.ts
+++ b/packages/daemon/src/__tests__/filegit-git.test.ts
@@ -133,8 +133,9 @@ describe('signed git.* flow (zero-9P P2)', () => {
     });
     const commits = r.result?.commits as Array<Record<string, unknown>>;
     expect(commits.length).toBe(1);
-    expect(typeof commits[0].timestamp).toBe('number');
-    expect(commits[0].timestamp as number).toBeGreaterThan(0);
-    expect(commits[0].subject).toBe('initial commit');
+    const first = commits[0] as Record<string, unknown>;
+    expect(typeof first.timestamp).toBe('number');
+    expect(first.timestamp as number).toBeGreaterThan(0);
+    expect(first.subject).toBe('initial commit');
   });
 });

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -329,8 +329,10 @@ registerHandler('git.log', async (params) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const limit = typeof params.limit === 'number' ? Math.max(1, Math.floor(params.limit)) : 50;
   // %x1f = ASCII unit separator, unambiguous against any commit subject text.
+  // %aI = author date ISO-8601 (display); %at = author date as a unix timestamp
+  // (integer seconds, what UI clients sort/format with).
   const r = await runGit(
-    ['log', '--pretty=format:%H%x1f%an%x1f%aI%x1f%s', '-n', String(limit)],
+    ['log', '--pretty=format:%H%x1f%an%x1f%aI%x1f%at%x1f%s', '-n', String(limit)],
     repoReal,
   );
   if (!r.ok) {
@@ -340,8 +342,8 @@ registerHandler('git.log', async (params) => {
   }
   const commits = r.stdout
     ? r.stdout.split('\n').map((l) => {
-        const [hash, author, date, subject] = l.split('\x1f');
-        return { hash, author, date, subject };
+        const [hash, author, date, at, subject] = l.split('\x1f');
+        return { hash, author, date, timestamp: Number(at), subject };
       })
     : [];
   return { success: true, commits };
@@ -398,7 +400,13 @@ registerHandler('git.deleteBranch', async (params) => {
 registerHandler('git.commit', async (params) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const message = requireStr(params.message, 'message');
-  return gitOutcome(await runGit(['commit', '-m', message], repoReal), 'git commit');
+  const commit = await runGit(['commit', '-m', message], repoReal);
+  if (!commit.ok) return { success: false, error: commit.stderr || 'git commit failed' };
+  // Resolve the new HEAD so callers get the created commit's SHA (the editor
+  // surfaces the short SHA after a commit).
+  const head = await runGit(['rev-parse', 'HEAD'], repoReal);
+  const sha = head.ok ? head.stdout : '';
+  return { success: true, sha, shortSha: sha.slice(0, 7), stdout: commit.stdout };
 });
 
 registerHandler('git.push', async (params) => {


### PR DESCRIPTION
**Completes P2.** Stacked on #164 (P1) → retarget down the stack as P0/P1 merge. Deletes Studio's Windows ext4 path: the 9P boundary is now gone **by construction** — no Windows process performs file or git I/O on a project path.

## What changed
- **`harness.rs`**: adds `repo_rpc` on top of the P1 signed transport — registers the project root via `project.open` (cached client-side, self-healing if the daemon restarts and forgets a root), injects `repoPath`, dispatches.
- **`commands/git.rs`**: rewritten as a thin typed adapter. **Every struct + `#[tauri::command]` signature is unchanged** (the ts-rs bindings the frontend imports are byte-identical), only the bodies change — each maps a daemon RPC response onto the existing return type. Deletes `expand_tilde` / `open_repo` / `read_blob_at_*` and all `git2` imports.
  - `git_status` reconstructs staged/unstaged/untracked from porcelain XY codes (unit-tested).
  - `git_diff_content` composes `git.readBlobAtHead/Index` + `git.diffContent`.
  - `require_success` surfaces daemon `{ success:false }` results as errors.
- **`commands/agent.rs`**: `agent_read_workboard` reads via `file.read` (the file's dir registered as a root, basename read within it).
- **`Cargo.toml`**: `git2` removed (sole consumer) — drops 68 lines of transitive deps from the lock (libgit2-sys, vendored openssl, …).
- **Daemon support** (`filegit.ts`): `git.commit` now returns `{ sha, shortSha }`; `git.log` returns a numeric unix `timestamp`. Covered by a new signed `filegit-git.test.ts`.

## Verification
- Studio Rust unit tests: porcelain bucketing, status-char mapping, `require_success` ✅
- Full studio lib suite green (80 tests) ✅; clean build, `git2` fully gone ✅
- Daemon `git.*` stage→commit→log flow (`filegit-git.test.ts`) ✅
- The full Studio↔daemon round-trip over the Windows relay still needs the same Windows+WSL smoke test flagged in P1 (folds into P4 / QA).

## Behavior notes
- `git_delete_branch` force-deletes (`force: true`) to preserve the prior git2 `branch.delete()` semantics (removed the ref regardless of merge state).
- `git_diff_content` / `git_status` now make several daemon round-trips where git2 made in-process calls — correct, and a candidate for batching later if Windows relay spawn cost shows up in profiling.

## Remaining ADR phases
P3 (systemd-user lifecycle), P4 (install pipeline: build Linux daemon+relay, stage into WSL — Windows smoke test lands here), P5 (CI deny-list fence: fail the build if `commands/git.rs`/`agent.rs` reintroduce `std::fs`/`git2`/`Command("git")`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)