### PR TITLE
feat(studio): zero-9P P4 (partial) — WSL setup command + systemd gate + relay CI

### DIFF
--- a/.github/workflows/studio-rust-tests.yml
+++ b/.github/workflows/studio-rust-tests.yml
@@ -13,6 +13,7 @@ on:
     branches: [main, test]
     paths:
       - "apps/studio/src-tauri/**"
+      - "apps/studio/relay/**"
       - "packages/daemon/**"
       - "packages/protocol/**"
       - ".github/workflows/studio-rust-tests.yml"
@@ -20,6 +21,7 @@ on:
     branches: [main, test]
     paths:
       - "apps/studio/src-tauri/**"
+      - "apps/studio/relay/**"
       - "packages/daemon/**"
       - "packages/protocol/**"
       - ".github/workflows/studio-rust-tests.yml"
@@ -81,3 +83,23 @@ jobs:
             --test harness_integration \
             --test daemon_ctl_integration \
             -- --test-threads=1
+
+  relay:
+    name: Relay (AF_UNIX <-> stdio bridge)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: apps/studio/relay -> target
+
+      # The relay is a zero-dependency std-only binary (no tauri / system libs),
+      # so it builds + tests in isolation. Bidirectional-bridge integration
+      # tests drive the real built binary against a mock socket.
+      - name: Build + test the WSL relay
+        run: cargo test --manifest-path apps/studio/relay/Cargo.toml --release

--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -82,15 +82,62 @@ mod wsl {
         std::env::var("REVDEV_WSL_DISTRO").unwrap_or_else(|_| "Ubuntu".to_string())
     }
 
-    /// Run `systemctl --user <args>` inside WSL and capture its output.
-    pub async fn systemctl(args: &[&str]) -> Result<std::process::Output, String> {
+    /// Run an arbitrary command inside WSL (`wsl.exe -d <distro> -e <args>`).
+    pub async fn run(args: &[&str]) -> Result<std::process::Output, String> {
         let distro = distro();
         let mut cmd = Command::new("wsl.exe");
-        cmd.args(["-d", &distro, "-e", "systemctl", "--user"])
-            .args(args);
+        cmd.args(["-d", &distro, "-e"]).args(args);
         cmd.output()
             .await
-            .map_err(|e| format!("wsl.exe systemctl failed: {e}"))
+            .map_err(|e| format!("wsl.exe failed: {e}"))
+    }
+
+    /// Run `systemctl --user <args>` inside WSL and capture its output.
+    pub async fn systemctl(args: &[&str]) -> Result<std::process::Output, String> {
+        let mut full = vec!["systemctl", "--user"];
+        full.extend_from_slice(args);
+        run(&full).await
+    }
+
+    /// Whether the WSL distro's systemd manager is up (the first-run gate).
+    /// `systemctl is-system-running` reports `running`/`degraded` when systemd
+    /// is active; `offline` or an error means systemd isn't enabled yet.
+    pub async fn is_system_running() -> bool {
+        match run(&["systemctl", "is-system-running"]).await {
+            Ok(out) => {
+                let s = String::from_utf8_lossy(&out.stdout);
+                matches!(s.trim(), "running" | "degraded")
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Ensure WSL systemd is enabled. If not, write `systemd=true` to
+    /// /etc/wsl.conf and return an ACTIONABLE error — enabling systemd needs a
+    /// one-time `wsl --shutdown` from Windows, so setup must stop here loudly
+    /// rather than silently no-op (ADR P4 gate).
+    pub async fn ensure_systemd() -> Result<(), String> {
+        if is_system_running().await {
+            return Ok(());
+        }
+        // Best-effort: append the [boot] systemd=true stanza (idempotent) using
+        // the WSL user's sudo. Either way we return an error — systemd only
+        // takes effect after a shutdown.
+        let _ = run(&[
+            "bash",
+            "-lc",
+            "grep -qs '^systemd=true' /etc/wsl.conf || \
+             printf '[boot]\\nsystemd=true\\n' | sudo tee -a /etc/wsl.conf >/dev/null",
+        ])
+        .await;
+        Err(
+            "WSL systemd is not enabled. `systemd=true` has been written to \
+             /etc/wsl.conf (if sudo allowed it); run `wsl --shutdown` from a \
+             Windows terminal, reopen WSL, then re-run setup. If the write was \
+             refused, add this to /etc/wsl.conf inside WSL manually:\n\n  \
+             [boot]\n  systemd=true"
+                .to_string(),
+        )
     }
 
     /// True when the daemon unit reports `active`.
@@ -119,6 +166,13 @@ pub struct DaemonStatus {
     pub running: bool,
     pub pid: Option<u32>,
     pub reachable: bool,
+    /// Whether the systemd-user manager that owns the daemon is available.
+    /// On Windows this is `systemctl is-system-running` inside WSL — `false`
+    /// means systemd-user isn't enabled yet (first-run setup required), which
+    /// the UI must surface DISTINCTLY from a merely-stopped daemon. Always
+    /// `true` on native Unix (the daemon runs as a local process, not gated by
+    /// a WSL systemd manager).
+    pub systemd_available: bool,
 }
 
 /// Check if the daemon is running and reachable.
@@ -135,6 +189,7 @@ pub async fn daemon_status() -> Result<DaemonStatus, String> {
         running: process_alive,
         pid,
         reachable,
+        systemd_available: true, // not gated by a WSL systemd manager on native Unix
     })
 }
 
@@ -142,8 +197,10 @@ pub async fn daemon_status() -> Result<DaemonStatus, String> {
 #[tauri::command]
 pub async fn daemon_status() -> Result<DaemonStatus, String> {
     // Liveness from systemd (NOT the ext4 PID file); reachability from a ping
-    // over the relay.
-    let running = wsl::is_active().await;
+    // over the relay. systemd_available lets the UI distinguish "needs first-run
+    // setup" from "stopped".
+    let systemd_available = wsl::is_system_running().await;
+    let running = systemd_available && wsl::is_active().await;
     let pid = wsl::main_pid().await;
     let reachable = crate::harness::rpc_call("ping", serde_json::json!({}))
         .await
@@ -153,6 +210,7 @@ pub async fn daemon_status() -> Result<DaemonStatus, String> {
         running,
         pid,
         reachable,
+        systemd_available,
     })
 }
 
@@ -282,6 +340,74 @@ pub async fn daemon_stop() -> Result<(), String> {
 }
 
 // ── Restart ───────────────────────────────────────────────────────────────────
+
+// ── First-run setup ───────────────────────────────────────────────────────────
+
+/// Provision the WSL side on Windows: assert systemd is enabled (writing the
+/// gate + failing with an actionable error if not), stage the bundled relay
+/// into `~/.local/bin`, and enable the daemon's systemd-user unit. Returns a
+/// human-readable summary. Idempotent.
+///
+/// NOTE: the daemon itself (a Node tsup bundle) is expected to already be
+/// present in WSL via packages/daemon/systemd/install.sh; embedding + staging
+/// the full daemon payload into the Windows installer is the remaining
+/// release-engineering step (tracked in the P4 PR).
+#[cfg(not(unix))]
+#[tauri::command]
+pub async fn daemon_setup(app: tauri::AppHandle) -> Result<String, String> {
+    use tauri::Manager;
+
+    // Gate: stops here with actionable `wsl --shutdown` guidance if systemd-user
+    // isn't available yet.
+    wsl::ensure_systemd().await?;
+
+    // Resolve the payload dir holding the bundled Linux relay binary.
+    let payload = match std::env::var("REVDEV_SETUP_PAYLOAD") {
+        Ok(p) => std::path::PathBuf::from(p),
+        Err(_) => app
+            .path()
+            .resource_dir()
+            .map_err(|e| format!("cannot resolve resource dir: {e}"))?
+            .join("wsl"),
+    };
+    let payload_str = payload.to_string_lossy().to_string();
+
+    // Translate the Windows path to a WSL path so the relay can be copied in.
+    let wp = wsl::run(&["wslpath", "-a", &payload_str]).await?;
+    if !wp.status.success() {
+        return Err(format!(
+            "wslpath failed for {payload_str}: {}",
+            String::from_utf8_lossy(&wp.stderr).trim()
+        ));
+    }
+    let wsl_payload = String::from_utf8_lossy(&wp.stdout).trim().to_string();
+
+    let script = format!(
+        "set -e; \
+         mkdir -p \"$HOME/.local/bin\"; \
+         cp '{wsl_payload}/revdev-relay' \"$HOME/.local/bin/revdev-relay\"; \
+         chmod +x \"$HOME/.local/bin/revdev-relay\"; \
+         systemctl --user daemon-reload; \
+         systemctl --user enable --now {}",
+        wsl::DAEMON_UNIT
+    );
+    let out = wsl::run(&["bash", "-lc", &script]).await?;
+    if !out.status.success() {
+        return Err(format!(
+            "WSL setup failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok("RevDev relay installed and daemon enabled in WSL.".to_string())
+}
+
+/// Native Unix: the daemon runs as a local process; no WSL staging is needed.
+/// Register a systemd-user unit with packages/daemon/systemd/install.sh.
+#[cfg(unix)]
+#[tauri::command]
+pub async fn daemon_setup(_app: tauri::AppHandle) -> Result<String, String> {
+    Ok("No WSL setup required on this platform.".to_string())
+}
 
 /// Restart the daemon: stop then start. Both halves are platform-specific
 /// (direct process control on Unix; systemctl-in-WSL on Windows).

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -59,14 +59,9 @@ pub fn run() {
             // Register the tile-gallery hotkey dynamically so registration
             // failures (e.g. a stale WSLg compositor claim) degrade to a
             // warning instead of crashing the whole app.
-            let shortcut = Shortcut::new(
-                Some(Modifiers::CONTROL | Modifiers::SHIFT),
-                Code::KeyL,
-            );
+            let shortcut = Shortcut::new(Some(Modifiers::CONTROL | Modifiers::SHIFT), Code::KeyL);
             if let Err(err) = app.global_shortcut().register(shortcut) {
-                eprintln!(
-                    "warning: failed to register CmdOrCtrl+Shift+L global shortcut: {err}"
-                );
+                eprintln!("warning: failed to register CmdOrCtrl+Shift+L global shortcut: {err}");
             }
             Ok(())
         })
@@ -181,6 +176,7 @@ pub fn run() {
             daemon_ctl::daemon_start,
             daemon_ctl::daemon_stop,
             daemon_ctl::daemon_restart,
+            daemon_ctl::daemon_setup,
             updater::check_for_update,
             updater::install_update,
         ])


### PR DESCRIPTION
**Partial P4.** Stacked on #167 (P3). Delivers the **ownable, verifiable** half of the install pipeline; the installer-embedding + end-to-end first-run are explicitly release-engineering that needs a real Windows+WSL+CI environment (see "Remaining").

## Landed (verified where possible)
- **`daemon_setup` command** (Windows): `ensure_systemd()` gate → stage the bundled relay into WSL `~/.local/bin` → `systemctl --user enable --now revdev-daemon`. Idempotent. Native Unix variant is a no-op (local daemon).
- **systemd gate** (`wsl::ensure_systemd`): if `systemctl is-system-running` isn't active, write `systemd=true` to `/etc/wsl.conf` (best-effort sudo) and **fail loudly** with the one-time `wsl --shutdown` instruction — never a silent no-op (ADR P4 requirement).
- **`DaemonStatus.systemd_available`**: lets the UI distinguish "WSL systemd not enabled — run setup" from "daemon stopped". Windows reports it from `is-system-running`; native Unix is always `true`.
- **CI**: a new `relay` job builds + runs the relay's bridge integration tests in release mode (the relay had no CI coverage since P1), + the `apps/studio/relay/**` path filter.

### Verification
- Unix `daemon_ctl_integration` tests pass (new `systemd_available` field didn't regress the lifecycle) ✅
- Relay release tests pass (the exact CI command) ✅; clean studio build ✅
- Windows `systemctl` / `ensure_systemd` / `daemon_setup` logic type-checked out-of-tree (no Windows toolchain here)

## Remaining (release-eng — needs real Windows+WSL+CI, this is the smoke-test gate)
Deliberately **not** done blind, because a wrong `bundle.resources` entry breaks the Studio release build and none of it is verifiable here:
1. **Embed the Linux relay into the Tauri bundle** — a CI job builds the relay on `ubuntu`, the `windows` tauri job downloads it into the resource path, and `tauri.conf.json` `bundle.resources` ships it. `daemon_setup` already reads it from the resource dir (or `REVDEV_SETUP_PAYLOAD`).
2. **Package + stage the daemon payload** — the daemon is a multi-file tsup bundle (needs node in WSL); embed it + stage the full `dist/` (today `daemon_setup` assumes the unit is installed via `packages/daemon/systemd/install.sh`).
3. **End-to-end first-run smoke test** on real Windows+WSL — also covers the deferred relay round-trip (P1/P2) and systemctl lifecycle (P3).

## Phases
P0 #162 · P1 #164 · P2 #166 · P3 #167 · **P4 (partial) here** · P5 = CI deny-list fence + signed-RPC round-trip integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)