### PR TITLE
feat: zero-9P P5 — regression fence + traversal/tooLarge tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,20 @@ jobs:
       - name: Scan for private paths and credentials
         run: bash scripts/check-no-private-leaks.sh
 
+  zero-9p-fence:
+    name: Zero-9P Fence
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+      # Fails if Studio's file/git command modules reintroduce direct ext4 / git
+      # access — all I/O must route through the WSL daemon (ADR P5). No deps.
+      - name: Zero-9P regression fence
+        run: node scripts/check-zero-9p-fence.mjs
+
   docs-accuracy:
     name: Docs Accuracy
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,17 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Scan for private paths and credentials
         run: bash scripts/check-no-private-leaks.sh
+
+  zero-9p-fence:
+    name: Zero-9P Fence
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+      # Fails if Studio's file/git command modules reintroduce direct ext4 / git
+      # access — all I/O must route through the WSL daemon (ADR P5). No deps.
+      - name: Zero-9P regression fence
+        run: node scripts/check-zero-9p-fence.mjs

--- a/packages/daemon/src/__tests__/filegit-git.test.ts
+++ b/packages/daemon/src/__tests__/filegit-git.test.ts
@@ -133,8 +133,10 @@ describe('signed git.* flow (zero-9P P2)', () => {
     });
     const commits = r.result?.commits as Array<Record<string, unknown>>;
     expect(commits.length).toBe(1);
-    expect(typeof commits[0].timestamp).toBe('number');
-    expect(commits[0].timestamp as number).toBeGreaterThan(0);
-    expect(commits[0].subject).toBe('initial commit');
+    const head = commits[0];
+    expect(head).toBeDefined();
+    expect(typeof head?.timestamp).toBe('number');
+    expect(head?.timestamp as number).toBeGreaterThan(0);
+    expect(head?.subject).toBe('initial commit');
   });
 });

--- a/packages/daemon/src/__tests__/filegit-signed.test.ts
+++ b/packages/daemon/src/__tests__/filegit-signed.test.ts
@@ -13,7 +13,7 @@
  * side): produce envelopes byte-compatible with what this test sends.
  */
 
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -174,5 +174,54 @@ describe('Studio client-key signing (zero-9P P1)', () => {
       sign('file.read', params, did, otherFp, other.privateKeyPem),
     );
     expect(res.error?.code).toBe(-32003);
+  });
+
+  it('rejects a signed read of a literal ../ traversal (validation barrier)', async () => {
+    // The cheap first barrier: the safePath schema rejects `..` before dispatch.
+    const params = { repoPath: repo, filePath: '../../../../etc/passwd' };
+    const res = await rpcFrame(
+      socketPath,
+      'file.read',
+      params,
+      sign('file.read', params, did, fingerprint, kp.privateKeyPem),
+    );
+    expect(res.error?.code).toBe(-32602); // Invalid params
+    expect(res.result).toBeUndefined();
+  });
+
+  it('rejects a signed read through a symlink escaping the root (realpath barrier)', async () => {
+    // A symlink passes `..` validation, so this exercises the realpath
+    // descendant check in the handler — a key-holder still cannot read outside
+    // the registered root.
+    const secret = join(dataDir, 'outside-secret.txt');
+    await writeFile(secret, 'TOP SECRET');
+    await symlink(secret, join(repo, 'link.txt'));
+    const params = { repoPath: repo, filePath: 'link.txt' };
+    const res = await rpcFrame(
+      socketPath,
+      'file.read',
+      params,
+      sign('file.read', params, did, fingerprint, kp.privateKeyPem),
+    );
+    expect(res.error?.code).toBe(-32000);
+    expect(res.error?.message).toContain('escapes project root');
+  });
+
+  it('returns { tooLarge } instead of content above the inline read cap', async () => {
+    // Default maxInlineReadBytes is 768 KiB; write past it and confirm the
+    // daemon returns the size envelope rather than serializing the whole file.
+    const big = 'a'.repeat(800_000);
+    await writeFile(join(repo, 'big.txt'), big);
+    const params = { repoPath: repo, filePath: 'big.txt' };
+    const res = await rpcFrame(
+      socketPath,
+      'file.read',
+      params,
+      sign('file.read', params, did, fingerprint, kp.privateKeyPem),
+    );
+    const result = res.result as { tooLarge?: boolean; bytes?: number; content?: string };
+    expect(result.tooLarge).toBe(true);
+    expect(result.bytes).toBe(800_000);
+    expect(result.content).toBeUndefined();
   });
 });

--- a/scripts/check-zero-9p-fence.mjs
+++ b/scripts/check-zero-9p-fence.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Zero-9P regression fence (ADR 2026-06-23, P5).
+//
+// Fails the build if Studio's file/git command modules reintroduce direct ext4
+// or git access. Every file/git operation MUST route through the WSL daemon via
+// `harness::repo_rpc` — that is what makes the 9P boundary gone *by
+// construction* rather than guarded by review convention.
+//
+// Literal substring checks only (no regex). The needles are chosen to match
+// real code, not prose: `git2::` carries the path separator so a comment that
+// merely mentions "git2 behavior" does not trip it.
+
+import { readFileSync } from 'node:fs';
+
+const FILES = [
+  'apps/studio/src-tauri/src/commands/git.rs',
+  'apps/studio/src-tauri/src/commands/agent.rs',
+];
+
+const FORBIDDEN = [
+  ['std::fs::', 'direct filesystem access — route through harness::repo_rpc file.*'],
+  ['git2::', 'in-process libgit2 — route through harness::repo_rpc git.*'],
+  ['Command::new', 'spawning a subprocess (e.g. git) — route through harness::repo_rpc'],
+  ['process::Command', 'spawning a subprocess (e.g. git) — route through harness::repo_rpc'],
+];
+
+let violations = 0;
+
+for (const file of FILES) {
+  let text;
+  try {
+    text = readFileSync(file, 'utf8');
+  } catch (err) {
+    console.error(`fence: cannot read ${file}: ${err.message}`);
+    process.exitCode = 1;
+    continue;
+  }
+  const lines = text.split('\n');
+  for (const [needle, why] of FORBIDDEN) {
+    lines.forEach((line, i) => {
+      if (line.includes(needle)) {
+        console.error(`fence: ${file}:${i + 1}: forbidden "${needle}" — ${why}`);
+        console.error(`    ${line.trim()}`);
+        violations++;
+      }
+    });
+  }
+}
+
+if (violations > 0) {
+  console.error(
+    `\nzero-9P fence FAILED: ${violations} reintroduced ext4/git access in Studio command modules.`,
+  );
+  console.error(
+    'All file/git I/O must go through the WSL daemon (harness::repo_rpc). ' +
+      'See docs/decisions/2026-06-23-daemon-in-wsl-zero-9p.md.',
+  );
+  process.exit(1);
+}
+
+console.log('zero-9P fence OK: Studio command modules route all file/git I/O through the daemon.');


### PR DESCRIPTION
**Completes the verifiable scope of P5** (the final ADR phase). Stacked on #168 (P4).

## Regression fence (the centerpiece)
`scripts/check-zero-9p-fence.mjs` + a blocking `zero-9p-fence` job in `ci.yml` (runs on every push/PR, no path filter). Fails the build if `apps/studio/src-tauri/src/commands/{git,agent}.rs` reintroduce `std::fs::`, `git2::`, `Command::new`, or `process::Command`. After P2 all file/git I/O routes through the WSL daemon; this enforces it **by construction in CI** so the 9P boundary can't silently creep back via a future edit. Literal substring checks (no regex); verified it passes clean code and **fails closed on an injected violation**.

## Integration tests (the P5 list, Linux-runnable parts)
Extended `filegit-signed.test.ts`:
- `{ tooLarge }` response path — a file past `maxInlineReadBytes` returns the size envelope, not a multi-MB frame.
- literal `../` traversal rejected at the `safePath` **validation** barrier (`-32602`).
- symlink escaping the root rejected at the **realpath** barrier (`-32000`) — a key-holder still can't read outside the registered root.

Already covered in earlier phases: signed round-trip + no stale read, unsigned/wrong-key `-32003`, free-tier exemptions (guard test), client-key registration.

## Also
- Fixed a latent strict-mode (`noUncheckedIndexedAccess`) typecheck error in the P2 `filegit-git.test.ts` that vitest (esbuild) didn't catch but CI's `tsc --noEmit` does.
- The ADR itself was already committed in P0 (#159); "no host-absolute paths in committed artifacts" verified (`target/` is gitignored; tracked source clean).

## Verification
Daemon zero-9P tests (80 across filegit / filegit-signed / filegit-git / guard) ✅; relay tests ✅; fence passes clean + fails on violation ✅; daemon typecheck clean ✅.

## Not in P5 (needs real Windows+WSL — the QA gate)
The relay-respawn-after-kill and `systemctl`-in-WSL lifecycle integration tests from the ADR's P5 list require a Windows+WSL runtime; they fold into the same smoke test gating P4's installer-embedding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)