### PR TITLE
fix(daemon): neutralize git hooks/config-exec on every daemon git spawn (security)

### DIFF
--- a/packages/daemon/src/vcs.ts
+++ b/packages/daemon/src/vcs.ts
@@ -144,12 +144,34 @@ export function runChild(
   });
 }
 
+/**
+ * Hardening flags prepended to EVERY git spawn. The daemon runs git against
+ * project repos as its own UID, so any command git would execute on its
+ * behalf is a shared-UID RCE past the traversal confinement. A command-line
+ * `-c` overrides repo/global config, so these are authoritative:
+ *   - core.hooksPath=/dev/null — don't run a repo's hooks (a hook an agent
+ *     writes into its own root would otherwise execute as the daemon).
+ *   - protocol.ext.allow=never — block the `ext::` transport (arbitrary cmd).
+ *   - core.fsmonitor= — disable the fsmonitor hook (runs a command).
+ *   - core.sshCommand=false — neutralize an attacker-set ssh command.
+ */
+const GIT_HARDENING = [
+  '-c',
+  'core.hooksPath=/dev/null',
+  '-c',
+  'protocol.ext.allow=never',
+  '-c',
+  'core.fsmonitor=',
+  '-c',
+  'core.sshCommand=false',
+];
+
 export function runGit(
   args: string[],
   cwd: string,
   opts?: Partial<RunChildOptions>,
 ): Promise<ShellResult> {
-  return runChild('git', args, { cwd, ...opts });
+  return runChild('git', [...GIT_HARDENING, ...args], { cwd, ...opts });
 }
 
 function str(v: unknown, fallback = ''): string {


### PR DESCRIPTION
**Security fix that missed the #162 merge.** #162 was merged at `24cb306`, before this commit (`1e2ca2d`) landed on the branch, so the RCE fix isn't in `test`. This re-lands it.

The daemon runs git against project repos as its own UID, so anything git executes on its behalf is a shared-UID RCE past the traversal confinement — and it bites even a **single** agent (a hook written into your own root runs as the daemon). `runGit` now prepends authoritative `-c` flags to every spawn:
- `core.hooksPath=/dev/null` — don't run repo hooks
- `protocol.ext.allow=never` — block the `ext::` transport
- `core.fsmonitor=` — disable the fsmonitor command hook
- `core.sshCommand=false` — neutralize an attacker-set ssh command

Flagged by the zero-9P security review (lane item HG, ADR `2026-06-24-zero-9p-agent-isolation.md`). Verified: flags accepted by git; worktree/merge git ops pass (vcs.test 8/8). Fast-follow (tracked in the lane §5.8): a regression test that a repo hook does NOT fire through `runGit`, plus `include.path=`/submodule-config hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)