### PR TITLE
fix(daemon): close git config-exec RCE holes + land #171 regression test (security)

### DIFF
--- a/packages/daemon/src/__tests__/filegit-config-exec.test.ts
+++ b/packages/daemon/src/__tests__/filegit-config-exec.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Git config-exec hardening regression test (HIGH security fix, the test #171
+ * promised but never landed).
+ *
+ * The WSL daemon shells out to git as its own UID for RPC-driven ops on
+ * caller-supplied repos. git turns several config keys + an env var into an
+ * arbitrary-command vector (diff.external, filter.<d>.clean/.smudge/.process,
+ * textconv, hooks, GIT_EXTERNAL_DIFF). A third-party repo opened in Studio is
+ * the payload: a routine "view diff" / "stage file" / branch switch would run
+ * attacker code as the daemon UID and could exfil ~/.age-identity/keys.txt.
+ *
+ * Two layers, both proven here over a real signed socket round-trip:
+ *   1. project.open refuses to register a repo whose .git/config carries an
+ *      exec-bearing key (diff.external + filter.*.process here).
+ *   2. For a repo that passed open, the hardened spawn (env + --no-ext-diff +
+ *      core.hooksPath=/dev/null) neutralizes a config/hook exec vector planted
+ *      AFTER open — git.diffFile / git.stageFile / git.switchBranch all run the
+ *      op successfully while the planted command never fires (sentinel absent).
+ */
+
+import { execFile as execFileCb } from 'node:child_process';
+import { access, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { formatDid } from '@revdev/protocol/did';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  generateNonce,
+  hashParams,
+  serializeEnvelope,
+  signEnvelope,
+} from '../agent-identity-crypto.js';
+import { _isExecBearingConfigKeyForTest as isExec } from '../filegit.js';
+import { startDaemon } from '../server.js';
+// Side-effect import: registers project.open / file.* / git.* handlers.
+import '../filegit.js';
+
+const execFile = promisify(execFileCb);
+
+// PGlite cold-init can exceed the 10s default hook budget under load.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+interface RpcResult {
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+function rpcFrame(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown>,
+  signature?: string,
+): Promise<RpcResult> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req: Record<string, unknown> = { jsonrpc: '2.0', id: 1, method, params };
+    if (signature) req['x-revdev-signature'] = signature;
+    sock.on('connect', () => sock.write(`${JSON.stringify(req)}\n`));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      sock.end();
+      try {
+        resolve(JSON.parse(buf.slice(0, nl)) as RpcResult);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error(`rpc timeout: ${method}`));
+    });
+  });
+}
+
+/** True if a path exists on disk. */
+async function exists(p: string): Promise<boolean> {
+  return access(p).then(
+    () => true,
+    () => false,
+  );
+}
+
+describe('git config-exec hardening (zero-9P security)', () => {
+  let daemon: { close: () => Promise<void> };
+  let socketPath: string;
+  let dataDir: string;
+  const agentId = 'config-exec-test';
+
+  // Client-held keypair — simulates the key Studio keeps in its Windows vault.
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid(agentId, fingerprint);
+
+  /** Sign a request exactly as the Studio client must. */
+  function sign(method: string, params: Record<string, unknown>): string {
+    const payload = {
+      did,
+      kid: fingerprint,
+      nonce: generateNonce(),
+      ts: Math.floor(Date.now() / 1000),
+      method,
+      paramsHash: hashParams(method, params),
+    };
+    return serializeEnvelope(signEnvelope(payload, kp.privateKeyPem));
+  }
+
+  /** Signed RPC convenience wrapper for MUTATING_OR_CONTENT_METHODS. */
+  function signedRpc(method: string, params: Record<string, unknown>): Promise<RpcResult> {
+    return rpcFrame(socketPath, method, params, sign(method, params));
+  }
+
+  const git = (repo: string, args: string[]) => execFile('git', args, { cwd: repo });
+
+  /**
+   * Initialize a real git repo with one commit. Returns the repo path. Local
+   * identity is set so the daemon's git ops (which run with a pinned, possibly
+   * empty GIT_CONFIG_GLOBAL) don't need a global identity.
+   */
+  async function initRepo(prefix: string): Promise<string> {
+    const repo = await mkdtemp(join(tmpdir(), prefix));
+    await git(repo, ['init', '-q', '-b', 'main']);
+    await git(repo, ['config', 'user.email', 'test@revdev.local']);
+    await git(repo, ['config', 'user.name', 'RevDev Test']);
+    await git(repo, ['config', 'commit.gpgsign', 'false']);
+    await writeFile(join(repo, 'f.txt'), 'original\n');
+    await git(repo, ['add', 'f.txt']);
+    await git(repo, ['commit', '-qm', 'init']);
+    return repo;
+  }
+
+  /** Write an executable shell script that touches `sentinel` then exits 0. */
+  async function writeTouchScript(scriptPath: string, sentinel: string): Promise<void> {
+    await writeFile(scriptPath, `#!/bin/sh\n: > '${sentinel}'\nexit 0\n`, { mode: 0o755 });
+  }
+
+  beforeAll(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-cfgexec-'));
+    socketPath = join(dataDir, 'harness.sock');
+    daemon = await startDaemon({ socketPath, dataDir });
+
+    const reg = await rpcFrame(socketPath, 'session.register', {
+      agentId,
+      agentName: 'studio-ui',
+      backend: 'studio',
+      publicKeyPem: kp.publicKeyPem,
+    });
+    expect((reg.result as { did: string }).did).toBe(did);
+  });
+
+  afterAll(async () => {
+    await daemon.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it('refuses project.open on a repo whose .git/config sets exec-bearing keys', async () => {
+    const repo = await initRepo('revdev-cfgexec-evilrepo-');
+    const sentinel = join(repo, 'OPEN_SENTINEL');
+    const script = join(repo, 'payload.sh');
+    await writeTouchScript(script, sentinel);
+    // Exactly the third-party-repo payload from the bug report.
+    await git(repo, ['config', 'diff.external', script]);
+    await git(repo, ['config', 'filter.evil.process', script]);
+
+    const open = await rpcFrame(socketPath, 'project.open', {
+      repoPath: repo,
+      actorAgentId: agentId,
+    });
+    expect(open.error).toBeDefined();
+    expect(open.error?.message).toContain('exec-bearing');
+
+    // And the repo is NOT registered: a follow-up content read is rejected for
+    // an unregistered root (not silently served).
+    const read = await signedRpc('file.read', { repoPath: repo, filePath: 'f.txt' });
+    expect(read.error?.message ?? '').toContain('not registered');
+
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('neutralizes a post-open diff.external + hook while ops still succeed', async () => {
+    const repo = await initRepo('revdev-cfgexec-toctou-');
+    await git(repo, ['branch', 'feature']);
+
+    // Open while the repo is clean (passes the exec-key scan).
+    const open = await rpcFrame(socketPath, 'project.open', {
+      repoPath: repo,
+      actorAgentId: agentId,
+    });
+    expect((open.result as { success: boolean }).success).toBe(true);
+
+    // Now poison: a diff.external command + a post-checkout hook. These are the
+    // vectors the hardened spawn must defeat at RUN time (env + --no-ext-diff +
+    // core.hooksPath=/dev/null) even though the repo was already registered.
+    const diffSentinel = join(repo, 'DIFF_SENTINEL');
+    const hookSentinel = join(repo, 'HOOK_SENTINEL');
+    const diffScript = join(repo, 'diff-payload.sh');
+    await writeTouchScript(diffScript, diffSentinel);
+    await git(repo, ['config', 'diff.external', diffScript]);
+    await writeTouchScript(join(repo, '.git', 'hooks', 'post-checkout'), hookSentinel);
+    // A working-tree change so git.diffFile actually has a diff to render.
+    await writeFile(join(repo, 'f.txt'), 'original\nmodified\n');
+
+    // git.diffFile — must return the builtin diff, must NOT run diff.external.
+    const diff = await signedRpc('git.diffFile', { repoPath: repo, filePath: 'f.txt' });
+    expect((diff.result as { success: boolean }).success).toBe(true);
+    expect((diff.result as { diff: string }).diff).toContain('+modified');
+    expect(await exists(diffSentinel)).toBe(false);
+
+    // git.stageFile — must succeed; diff.external never fires on add.
+    const stage = await signedRpc('git.stageFile', { repoPath: repo, filePath: 'f.txt' });
+    expect((stage.result as { success: boolean }).success).toBe(true);
+    expect(await exists(diffSentinel)).toBe(false);
+
+    // git.switchBranch — must succeed; the post-checkout hook must NOT run.
+    const sw = await signedRpc('git.switchBranch', { repoPath: repo, name: 'feature' });
+    expect((sw.result as { success: boolean }).success).toBe(true);
+    expect(await exists(hookSentinel)).toBe(false);
+
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  // Direct unit coverage of the exec-key classifier across the full key matrix
+  // the socket tests can't each exercise. Keys arrive lower-cased from
+  // `git config --list`; subsection names keep their case but the tail variable
+  // is lower-cased (e.g. `url.<U>.insteadof`).
+  describe('isExecBearingConfigKey classifier', () => {
+    it.each([
+      ['diff.external', ''],
+      ['core.fsmonitor', ''],
+      ['core.sshcommand', ''],
+      ['core.pager', ''],
+      ['filter.lfs.process', ''],
+      ['filter.secret.clean', ''],
+      ['filter.secret.smudge', ''],
+      ['diff.gpg.textconv', ''],
+      ['remote.origin.uploadpack', ''],
+      ['remote.origin.receivepack', ''],
+      ['url.https://evil/.insteadof', ''],
+      ['url.x.pushinsteadof', ''],
+      ['alias.danger', '!sh -c "id"'],
+    ])('flags %s as exec-bearing', (key, value) => {
+      expect(isExec(key, value)).toBe(true);
+    });
+
+    it.each([
+      ['user.name', 'RevDev'],
+      ['user.email', 'x@y.z'],
+      ['core.repositoryformatversion', '0'],
+      ['core.bare', 'false'],
+      ['remote.origin.url', 'https://example/x.git'],
+      ['branch.main.remote', 'origin'],
+      // A non-shell alias (no leading '!') is an ordinary git alias, not RCE.
+      ['alias.co', 'checkout'],
+      // A key that merely contains a substring must not match.
+      ['diff.externalfoo', ''],
+    ])('does not flag %s', (key, value) => {
+      expect(isExec(key, value)).toBe(false);
+    });
+  });
+});

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -66,6 +66,11 @@ export function _gitRelPathForTest(repoReal: string, filePathRaw: string): strin
   return gitRelPath(repoReal, filePathRaw);
 }
 
+/** @internal — test seam: classify a git config key as exec-bearing or not. */
+export function _isExecBearingConfigKeyForTest(key: string, value: string): boolean {
+  return isExecBearingConfigKey(key, value);
+}
+
 // ---------------------------------------------------------------------------
 // Param + path helpers
 // ---------------------------------------------------------------------------
@@ -166,6 +171,80 @@ function gitRelPath(repoReal: string, filePathRaw: string): string {
 }
 
 /**
+ * True when a git config key (already lower-cased by `git config --list`) names
+ * an arbitrary-command vector that runs as the daemon UID on a routine read or
+ * checkout. A command-line `-c` neutralizes some of these per-spawn, but
+ * `filter.*` is a wildcard namespace that `-c` cannot blanket-clear and a hook
+ * driver fires regardless — so a repo carrying any of them is refused outright
+ * at `project.open` rather than trusted to a per-command flag.
+ *
+ *   - diff.external                       — external diff program
+ *   - filter.<d>.process/.clean/.smudge   — content filter driver (clean on add,
+ *                                            smudge/process on checkout)
+ *   - <section>.textconv                  — diff textconv driver
+ *   - core.fsmonitor / core.sshCommand    — fsmonitor + ssh command
+ *   - core.pager                          — pager command
+ *   - remote.<r>.uploadpack/.receivepack  — remote-side program override
+ *   - url.<u>.insteadOf/.pushInsteadOf    — URL rewrite (pairs with ext::/ssh)
+ *   - alias.<a> whose value starts with ! — shell alias
+ *
+ * Value is consulted only for aliases (the `!` shell-escape marker); for every
+ * other key the presence of the key is itself the finding.
+ */
+function isExecBearingConfigKey(key: string, value: string): boolean {
+  if (
+    key === 'diff.external' ||
+    key === 'core.fsmonitor' ||
+    key === 'core.sshcommand' ||
+    key === 'core.pager'
+  ) {
+    return true;
+  }
+  if (
+    key.startsWith('filter.') &&
+    (key.endsWith('.process') || key.endsWith('.clean') || key.endsWith('.smudge'))
+  ) {
+    return true;
+  }
+  if (key.endsWith('.textconv')) return true;
+  if (key.startsWith('remote.') && (key.endsWith('.uploadpack') || key.endsWith('.receivepack'))) {
+    return true;
+  }
+  if (key.startsWith('url.') && (key.endsWith('.insteadof') || key.endsWith('.pushinsteadof'))) {
+    return true;
+  }
+  if (key.startsWith('alias.') && value.startsWith('!')) return true;
+  return false;
+}
+
+/**
+ * Scan a repo's effective git config (local + any includes it pulls in) and
+ * refuse to register a repo that carries an exec-bearing key. `git config
+ * --list` itself never invokes a filter/diff/hook driver, so listing the
+ * config of an untrusted repo is safe; it runs under the hardened env from
+ * vcs.ts. `-z` is NUL-delimited so a multi-line value can't be confused with an
+ * entry boundary; within an entry the key and value are split on the first \n.
+ * A config git itself cannot parse (r.ok === false) can't drive an exploit
+ * either, so we treat that as "nothing to refuse".
+ */
+async function assertNoExecConfig(repoReal: string): Promise<void> {
+  const r = await runGit(['config', '--list', '--local', '-z'], repoReal);
+  if (!r.ok) return;
+  for (const entry of r.stdout.split('\0')) {
+    if (entry.length === 0) continue;
+    const nl = entry.indexOf('\n');
+    const key = (nl === -1 ? entry : entry.slice(0, nl)).toLowerCase();
+    const value = nl === -1 ? '' : entry.slice(nl + 1);
+    if (isExecBearingConfigKey(key, value)) {
+      throw new Error(
+        `refusing to open repo: .git/config sets exec-bearing key "${key}" ` +
+          '(arbitrary-command vector; remove it before opening this repo)',
+      );
+    }
+  }
+}
+
+/**
  * Wrap content in an inline-or-tooLarge envelope. The inbound maxLineBytes
  * cap guards request frames only; a content-returning READ would otherwise
  * serialize an unbounded file into a single response frame. Above the cap the
@@ -204,6 +283,12 @@ registerHandler('project.open', async (params) => {
     () => true,
     () => false,
   );
+  // Refuse to register a git repo whose config carries an exec-bearing key.
+  // project.open is the trust boundary for a third-party repo: without this a
+  // routine `git.diffFile`/`git.stageFile`/checkout would run attacker code as
+  // the daemon UID (e.g. exfil ~/.age-identity/keys.txt). Done BEFORE adding to
+  // registeredRoots so a refused repo is never usable by file.*/git.*.
+  if (isRepo) await assertNoExecConfig(real);
   registeredRoots.add(real);
   return { success: true, root: real, isGitRepo: isRepo };
 });
@@ -293,7 +378,12 @@ registerHandler('git.status', async (params) => {
 registerHandler('git.diffFile', async (params) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
-  const args = ['diff'];
+  // --no-ext-diff / --no-textconv neutralize a diff.external command or a
+  // textconv driver (both arbitrary-command vectors) for THIS spawn without
+  // breaking the diff — unlike `-c diff.external=`, which makes git try to exec
+  // the empty string and abort the diff. The config-set forms are also refused
+  // at project.open (assertNoExecConfig); this is the run-time backstop.
+  const args = ['diff', '--no-ext-diff', '--no-textconv'];
   if (params.staged === true) args.push('--cached');
   args.push('--', rel);
   const r = await runGit(args, repoReal);

--- a/packages/daemon/src/vcs.ts
+++ b/packages/daemon/src/vcs.ts
@@ -18,6 +18,8 @@
  */
 
 import { spawn } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { DAEMON_DEFAULTS } from './config.js';
 import { getShutdownSignal, registerHandler } from './server.js';
 
@@ -46,6 +48,12 @@ export interface RunChildOptions {
    * SIGTERM if any source aborts.
    */
   externalSignal?: AbortSignal;
+  /**
+   * Environment for the child. When omitted the child inherits the parent
+   * process environment (Node's default). `runGit` always supplies a hardened
+   * env (see `gitHardenedEnv`); only the generic test seam leaves it unset.
+   */
+  env?: NodeJS.ProcessEnv;
 }
 
 /**
@@ -90,6 +98,10 @@ export function runChild(
       cwd: opts.cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       signal,
+      // Only override the environment when a caller supplies one (runGit does;
+      // the generic runChild test seam does not). Passing `undefined` here would
+      // make spawn use an EMPTY env on some Node versions, so branch on it.
+      ...(opts.env ? { env: opts.env } : {}),
     });
 
     let stdout = '';
@@ -154,6 +166,14 @@ export function runChild(
  *   - protocol.ext.allow=never — block the `ext::` transport (arbitrary cmd).
  *   - core.fsmonitor= — disable the fsmonitor hook (runs a command).
  *   - core.sshCommand=false — neutralize an attacker-set ssh command.
+ *
+ * NOT here: `diff.external`. Forcing `-c diff.external=` (empty) does NOT make
+ * git fall back to the builtin diff — git tries to exec the empty string and
+ * fails the whole diff ("external diff died", exit 128). The non-breaking
+ * neutralizer is the per-command `--no-ext-diff`/`--no-textconv` flag, applied
+ * at the `git.diffFile` call site (filegit.ts). The config-set form of
+ * `diff.external`/`filter.*`/`*.textconv` is refused up front by the
+ * exec-key scan in `project.open`. See `gitHardenedEnv` for the env vectors.
  */
 const GIT_HARDENING = [
   '-c',
@@ -166,12 +186,37 @@ const GIT_HARDENING = [
   'core.sshCommand=false',
 ];
 
+/**
+ * Hardened environment for every daemon-spawned git. Closes the env-and-system
+ * config vectors a command-line `-c` cannot reach:
+ *   - GIT_CONFIG_NOSYSTEM=1 — ignore /etc/gitconfig (a system-level
+ *     diff.external/core.sshCommand would otherwise apply to every spawn).
+ *   - GIT_CONFIG_GLOBAL pinned to the DAEMON's own ~/.gitconfig — the only
+ *     trusted global, and immune to a $HOME-redirected global config. Pinning
+ *     (rather than nulling) preserves the daemon's commit identity.
+ *   - GIT_ATTR_NOSYSTEM=1 — ignore /etc/gitattributes, which can route a path
+ *     through a filter/textconv driver (arbitrary command) on diff/checkout.
+ *   - GIT_EXTERNAL_DIFF deleted — an inherited value would run on every diff.
+ */
+function gitHardenedEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  env.GIT_CONFIG_NOSYSTEM = '1';
+  env.GIT_CONFIG_GLOBAL = join(homedir(), '.gitconfig');
+  env.GIT_ATTR_NOSYSTEM = '1';
+  delete env.GIT_EXTERNAL_DIFF;
+  return env;
+}
+
 export function runGit(
   args: string[],
   cwd: string,
   opts?: Partial<RunChildOptions>,
 ): Promise<ShellResult> {
-  return runChild('git', [...GIT_HARDENING, ...args], { cwd, ...opts });
+  return runChild('git', [...GIT_HARDENING, ...args], {
+    cwd,
+    env: gitHardenedEnv(),
+    ...opts,
+  });
 }
 
 function str(v: unknown, fallback = ''): string {


### PR DESCRIPTION
## Security (HIGH) — blocks the zero-9P test→main promotion

The WSL daemon shells out to git as its own UID for RPC-driven ops on caller-supplied repos, so any command git executes on its behalf is a shared-UID RCE past the traversal confinement. #171 (1a3d6ac) added `GIT_HARDENING` but neutralized only `core.hooksPath` / `protocol.ext` / `core.fsmonitor` / `core.sshCommand`, spawned git with **no controlled env**, and never landed the promised regression test.

**Still open before this PR:**
- `diff.external` (+ `GIT_EXTERNAL_DIFF`) → arbitrary command on `git.diffFile`
- `filter.<d>.process/.clean/.smudge` (+ `.gitattributes`) → arbitrary command on `git.stageFile` and checkout
- `project.open` registered any `.git` dir **without inspecting config**, so a third-party repo runs attacker code as the daemon UID on a routine "view diff" / "stage file" → exfil `~/.age-identity/keys.txt`. Studio's signature is satisfied by the legit user; the repo is the payload.

## Fix — defense in depth at the two git chokepoints

Every git spawn funnels through `runGit`; `project.open` is the registration trust boundary.

1. **Hardened env on every git child** (`vcs.ts` `gitHardenedEnv`, applied in `runGit`): `GIT_CONFIG_NOSYSTEM=1`, `GIT_CONFIG_GLOBAL` pinned to the daemon's own `~/.gitconfig` (preserves commit identity, immune to `$HOME` redirection), `GIT_ATTR_NOSYSTEM=1`, and `GIT_EXTERNAL_DIFF` deleted.
2. **`git.diffFile` passes `--no-ext-diff --no-textconv`.** Deliberately **did not** add `-c diff.external=` as originally specified: an empty external diff makes git try to exec `""` and abort the diff (`external diff died`, exit 128), breaking the op (verified). `--no-ext-diff` neutralizes *and* keeps the op working.
3. **`project.open` exec-key scan** (`assertNoExecConfig`): refuses to register a repo whose config carries `diff.external`, `filter.*.process/.clean/.smudge`, `*.textconv`, `core.fsmonitor/sshCommand/pager`, `remote.*.uploadpack/receivepack`, `url.*.insteadOf`, or a shelling `alias.*`. This is the **only** defense for `filter.*`, which a per-spawn `-c` cannot wildcard-clear (verified: a filter driver is config-gated — `.gitattributes` alone is a no-op).

All git spawn sites covered: `runGit` is the single git chokepoint (`grep` confirms `vcs.ts` + `filegit.ts` are the only `runGit` callers; `cli.ts`/`revvault-client.ts` spawn the daemon/revvault, not git).

## Regression test (the one #171 promised)

`packages/daemon/src/__tests__/filegit-config-exec.test.ts`:
- Drives `project.open` / `git.diffFile` / `git.stageFile` / `git.switchBranch` over a **real signed Unix-socket** round-trip against a planted malicious repo (diff.external + filter.process + post-checkout hook). Asserts the planted command **never runs** (sentinel absent) and **each op still succeeds**.
- `project.open` refusal proven for a repo whose `.git/config` ships exec-bearing keys (and the repo is left unregistered).
- Unit matrix over the exec-key classifier (url/remote/alias/textconv/filter + negatives).

**Verified:** new test red against current `test` code, green after. Full daemon suite green (401 passed, bounded concurrency). `tsc --noEmit` clean. Biome clean. No authored regex.

## Not self-merging — owner is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)