### PR TITLE
fix(daemon): make the Ed25519 signature gate a real barrier (enrollment + per-agent root scoping)

### DIFF
--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -436,6 +436,14 @@ pub async fn daemon_setup(app: tauri::AppHandle) -> Result<String, String> {
 
 /// Native Unix: the daemon runs as a local process; no WSL staging is needed.
 /// Register a systemd-user unit with packages/daemon/systemd/install.sh.
+///
+/// NOTE: the client-key enrollment gate still applies on native Unix — a
+/// native-Unix Studio install must provision its signing fingerprint into the
+/// root-owned trust anchor (default `/etc/revdev/trusted-client-fingerprint`,
+/// or REVDEV_DAEMON_TRUSTED_CLIENT_FP) or the daemon rejects its key. This is
+/// left to install.sh / a manual step here because native Unix is the dev/test
+/// surface (tests point the daemon at a fixture anchor); production ships
+/// Windows Studio + WSL daemon, handled by the not(unix) daemon_setup above.
 #[cfg(unix)]
 #[tauri::command]
 pub async fn daemon_setup(_app: tauri::AppHandle) -> Result<String, String> {

--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -398,7 +398,40 @@ pub async fn daemon_setup(app: tauri::AppHandle) -> Result<String, String> {
             String::from_utf8_lossy(&out.stderr).trim()
         ));
     }
-    Ok("RevDev relay installed and daemon enabled in WSL.".to_string())
+
+    // Provision the client trust anchor. The daemon rejects enrollment of any
+    // client key whose fingerprint is not in this ROOT-OWNED file (a host
+    // process running as the WSL user could forge a user-owned file, so the
+    // anchor must be root:root). Write THIS install's Studio signing
+    // fingerprint — "one install == one trusted client key". Overwrites (not
+    // appends) so re-running setup after an identity rotation replaces the old
+    // value rather than accumulating stale keys.
+    let identity = crate::signing::load_or_create_identity()?;
+    let fp = identity.fingerprint;
+    // Defense-in-depth: base58 fingerprints are alphanumeric. Refuse to shell-
+    // interpolate anything else (no injection via a malformed identity file).
+    if fp.is_empty() || !fp.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return Err(format!("refusing to provision a malformed client fingerprint: {fp:?}"));
+    }
+    let provision = format!(
+        "set -e; \
+         sudo mkdir -p /etc/revdev; \
+         printf '%s\\n' '{fp}' | sudo tee /etc/revdev/trusted-client-fingerprint >/dev/null; \
+         sudo chmod 0644 /etc/revdev/trusted-client-fingerprint"
+    );
+    let pout = wsl::run(&["bash", "-lc", &provision]).await?;
+    if !pout.status.success() {
+        return Err(format!(
+            "Relay installed, but provisioning the client trust anchor failed (needs sudo). \
+             The daemon will reject Studio's key until \
+             /etc/revdev/trusted-client-fingerprint contains this fingerprint. Run inside \
+             WSL, then re-run setup:\n\n  \
+             echo '{fp}' | sudo tee /etc/revdev/trusted-client-fingerprint\n\nsudo error: {}",
+            String::from_utf8_lossy(&pout.stderr).trim()
+        ));
+    }
+
+    Ok("RevDev relay installed, client trust anchor provisioned, daemon enabled in WSL.".to_string())
 }
 
 /// Native Unix: the daemon runs as a local process; no WSL staging is needed.

--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -406,8 +406,8 @@ mod tests {
     fn requires_signature_matches_daemon_set() {
         assert!(requires_signature("file.read"));
         assert!(requires_signature("git.commit"));
+        assert!(requires_signature("project.open"));
         assert!(!requires_signature("git.status"));
-        assert!(!requires_signature("project.open"));
         assert!(!requires_signature("ping"));
     }
 }

--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -53,6 +53,10 @@ pub fn requires_signature(method: &str) -> bool {
             | "git.diffContent"
             | "git.readBlobAtHead"
             | "git.readBlobAtIndex"
+            // Root registration is signature-required so the daemon records the
+            // root under the verified signer (per-agent root scoping). MUST
+            // mirror the daemon's MUTATING_OR_CONTENT_METHODS set (server.ts).
+            | "project.open"
     )
 }
 

--- a/apps/studio/src-tauri/tests/harness_integration.rs
+++ b/apps/studio/src-tauri/tests/harness_integration.rs
@@ -80,11 +80,22 @@ async fn spawn_daemon_at(dir: &Path, socket: &Path) -> DaemonGuard {
     std::fs::create_dir_all(dir).expect("create daemon dir");
     let data_dir = dir.join(format!("db-{}", DIR_COUNTER.fetch_add(1, Ordering::Relaxed)));
 
+    // Provision the client trust anchor with Studio's signing fingerprint so
+    // the daemon's enrollment gate (Fix A) accepts the harness's client-key
+    // session.register. The harness loads the same identity from the same
+    // keystore, so the fingerprints match.
+    let anchor = dir.join("trusted-client-fingerprint");
+    let fp = studio_lib::signing::load_or_create_identity()
+        .expect("load studio identity")
+        .fingerprint;
+    std::fs::write(&anchor, format!("{fp}\n")).expect("write trust anchor");
+
     let child = Command::new("node")
         .arg(daemon_cli())
         .env("REVDEV_DAEMON_SOCKET", socket)
         .env("REVDEV_DAEMON_DATA", &data_dir)
         .env("REVDEV_DAEMON_PID", dir.join("harness.pid"))
+        .env("REVDEV_DAEMON_TRUSTED_CLIENT_FP", &anchor)
         // Deterministic free-tier daemon regardless of the host shell's env.
         .env_remove("REVEALUI_LICENSE_KEY")
         .env_remove("REVDEV_LICENSE_PUBLIC_KEY")

--- a/packages/daemon/src/__tests__/filegit-config-exec.test.ts
+++ b/packages/daemon/src/__tests__/filegit-config-exec.test.ts
@@ -144,7 +144,10 @@ describe('git config-exec hardening (zero-9P security)', () => {
   beforeAll(async () => {
     dataDir = await mkdtemp(join(tmpdir(), 'revdev-cfgexec-'));
     socketPath = join(dataDir, 'harness.sock');
-    daemon = await startDaemon({ socketPath, dataDir });
+    // Provision this client's fingerprint into the trust anchor (fixture).
+    const anchor = join(dataDir, 'trusted-client-fingerprint');
+    await writeFile(anchor, `${fingerprint}\n`);
+    daemon = await startDaemon({ socketPath, dataDir, trustedClientFingerprintPath: anchor });
 
     const reg = await rpcFrame(socketPath, 'session.register', {
       agentId,

--- a/packages/daemon/src/__tests__/filegit-config-exec.test.ts
+++ b/packages/daemon/src/__tests__/filegit-config-exec.test.ts
@@ -172,10 +172,8 @@ describe('git config-exec hardening (zero-9P security)', () => {
     await git(repo, ['config', 'diff.external', script]);
     await git(repo, ['config', 'filter.evil.process', script]);
 
-    const open = await rpcFrame(socketPath, 'project.open', {
-      repoPath: repo,
-      actorAgentId: agentId,
-    });
+    // project.open is signature-REQUIRED now (records the root under the signer).
+    const open = await signedRpc('project.open', { repoPath: repo });
     expect(open.error).toBeDefined();
     expect(open.error?.message).toContain('exec-bearing');
 
@@ -192,10 +190,8 @@ describe('git config-exec hardening (zero-9P security)', () => {
     await git(repo, ['branch', 'feature']);
 
     // Open while the repo is clean (passes the exec-key scan).
-    const open = await rpcFrame(socketPath, 'project.open', {
-      repoPath: repo,
-      actorAgentId: agentId,
-    });
+    // project.open is signature-REQUIRED now (records the root under the signer).
+    const open = await signedRpc('project.open', { repoPath: repo });
     expect((open.result as { success: boolean }).success).toBe(true);
 
     // Now poison: a diff.external command + a post-checkout hook. These are the

--- a/packages/daemon/src/__tests__/filegit-enrollment.test.ts
+++ b/packages/daemon/src/__tests__/filegit-enrollment.test.ts
@@ -169,11 +169,16 @@ describe('daemon enrollment gate + per-agent root scoping', () => {
 
     // A's original key still works end-to-end (the takeover did not supersede).
     const openParams = { repoPath: repoA };
-    const open = await rpcFrame(socketPath, 'project.open', openParams, sign(a, 'project.open', openParams));
+    const open = await rpcFrame(
+      socketPath,
+      'project.open',
+      openParams,
+      sign(a, 'project.open', openParams),
+    );
     expect((open.result as { success: boolean }).success).toBe(true);
   });
 
-  it("blocks agent A from mutating a root agent B registered", async () => {
+  it('blocks agent A from mutating a root agent B registered', async () => {
     // B opens repoB (signed → recorded under agent-b).
     const openB = { repoPath: repoB };
     const ob = await rpcFrame(socketPath, 'project.open', openB, sign(b, 'project.open', openB));

--- a/packages/daemon/src/__tests__/filegit-enrollment.test.ts
+++ b/packages/daemon/src/__tests__/filegit-enrollment.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Security tests for the daemon's signature-enrollment gate + per-agent root
+ * scoping (the "make the Ed25519 gate a real barrier" fix). Proves:
+ *
+ *   1. A client key whose fingerprint is NOT in the root-owned trust anchor is
+ *      rejected at session.register (-32004) — both as a fresh self-enrollment
+ *      under a new agentId AND as an attempted key-takeover (rotation) of an
+ *      already-enrolled agent.
+ *   2. A verified signer (agent A) cannot read/mutate a project root that a
+ *      different verified signer (agent B) registered via project.open —
+ *      registeredRoots is keyed by the opening agentId.
+ *
+ * Both run against a real daemon over a Unix socket, with the trust anchor
+ * pointed at a fixture (production writes it root-owned at install).
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { formatDid } from '@revdev/protocol/did';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  generateNonce,
+  hashParams,
+  serializeEnvelope,
+  signEnvelope,
+} from '../agent-identity-crypto.js';
+import { startDaemon } from '../server.js';
+// Side-effect import: registers project.open / file.* / git.* handlers.
+import '../filegit.js';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+interface RpcResult {
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+function rpcFrame(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown>,
+  signature?: string,
+): Promise<RpcResult> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req: Record<string, unknown> = { jsonrpc: '2.0', id: 1, method, params };
+    if (signature) req['x-revdev-signature'] = signature;
+    sock.on('connect', () => sock.write(`${JSON.stringify(req)}\n`));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      sock.end();
+      try {
+        resolve(JSON.parse(buf.slice(0, nl)) as RpcResult);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error(`rpc timeout: ${method}`));
+    });
+  });
+}
+
+interface Client {
+  agentId: string;
+  fingerprint: string;
+  did: string;
+  publicKeyPem: string;
+  privateKeyPem: string;
+}
+
+function makeClient(agentId: string): Client {
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  return {
+    agentId,
+    fingerprint,
+    did: formatDid(agentId, fingerprint),
+    publicKeyPem: kp.publicKeyPem,
+    privateKeyPem: kp.privateKeyPem,
+  };
+}
+
+function sign(c: Client, method: string, params: Record<string, unknown>): string {
+  const payload = {
+    did: c.did,
+    kid: c.fingerprint,
+    nonce: generateNonce(),
+    ts: Math.floor(Date.now() / 1000),
+    method,
+    paramsHash: hashParams(method, params),
+  };
+  return serializeEnvelope(signEnvelope(payload, c.privateKeyPem));
+}
+
+describe('daemon enrollment gate + per-agent root scoping', () => {
+  let daemon: { close: () => Promise<void> };
+  let socketPath: string;
+  let dataDir: string;
+  let repoA: string;
+  let repoB: string;
+
+  // Two PROVISIONED clients (fingerprints written to the anchor) and one
+  // UNPROVISIONED attacker key (absent from the anchor).
+  const a = makeClient('agent-a');
+  const b = makeClient('agent-b');
+  const evil = makeClient('agent-evil');
+
+  beforeAll(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-enroll-'));
+    repoA = await mkdtemp(join(tmpdir(), 'revdev-enroll-repoA-'));
+    repoB = await mkdtemp(join(tmpdir(), 'revdev-enroll-repoB-'));
+    socketPath = join(dataDir, 'harness.sock');
+    const anchor = join(dataDir, 'trusted-client-fingerprint');
+    // Anchor trusts A and B but NOT evil.
+    await writeFile(anchor, `${a.fingerprint}\n${b.fingerprint}\n`);
+    daemon = await startDaemon({ socketPath, dataDir, trustedClientFingerprintPath: anchor });
+  });
+
+  afterAll(async () => {
+    await daemon.close();
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(repoA, { recursive: true, force: true });
+    await rm(repoB, { recursive: true, force: true });
+  });
+
+  it('enrolls a provisioned client key', async () => {
+    const res = await rpcFrame(socketPath, 'session.register', {
+      agentId: a.agentId,
+      publicKeyPem: a.publicKeyPem,
+    });
+    expect((res.result as { did: string }).did).toBe(a.did);
+    // Register B too (needed for the root-scoping test below).
+    const resB = await rpcFrame(socketPath, 'session.register', {
+      agentId: b.agentId,
+      publicKeyPem: b.publicKeyPem,
+    });
+    expect((resB.result as { did: string }).did).toBe(b.did);
+  });
+
+  it('rejects an UNPROVISIONED client key at register (-32004)', async () => {
+    const res = await rpcFrame(socketPath, 'session.register', {
+      agentId: evil.agentId,
+      publicKeyPem: evil.publicKeyPem,
+    });
+    expect(res.result).toBeUndefined();
+    expect(res.error?.code).toBe(-32004);
+  });
+
+  it('rejects a key-TAKEOVER: enrolling a different key for an existing agent (-32004)', async () => {
+    // Attacker tries to supersede agent A's legit key by registering its own
+    // (unprovisioned) key under agentId 'agent-a'. Must be refused before the
+    // rotation/supersede path runs.
+    const res = await rpcFrame(socketPath, 'session.register', {
+      agentId: a.agentId,
+      publicKeyPem: evil.publicKeyPem,
+    });
+    expect(res.result).toBeUndefined();
+    expect(res.error?.code).toBe(-32004);
+
+    // A's original key still works end-to-end (the takeover did not supersede).
+    const openParams = { repoPath: repoA };
+    const open = await rpcFrame(socketPath, 'project.open', openParams, sign(a, 'project.open', openParams));
+    expect((open.result as { success: boolean }).success).toBe(true);
+  });
+
+  it("blocks agent A from mutating a root agent B registered", async () => {
+    // B opens repoB (signed → recorded under agent-b).
+    const openB = { repoPath: repoB };
+    const ob = await rpcFrame(socketPath, 'project.open', openB, sign(b, 'project.open', openB));
+    expect((ob.result as { success: boolean }).success).toBe(true);
+
+    // A (a valid signer, owns repoA from the previous test) tries to write into
+    // repoB. The signature is VALID — the barrier is root ownership, not the
+    // signature gate — so it must be refused as not-registered-for-A.
+    const writeB = { repoPath: repoB, filePath: 'pwn.txt', content: 'A should not write here' };
+    const w = await rpcFrame(socketPath, 'file.write', writeB, sign(a, 'file.write', writeB));
+    expect(w.result).toBeUndefined();
+    expect(w.error?.message).toContain('not registered');
+
+    // Control: A CAN write into its own repoA.
+    const writeA = { repoPath: repoA, filePath: 'ok.txt', content: 'A owns this root' };
+    const wa = await rpcFrame(socketPath, 'file.write', writeA, sign(a, 'file.write', writeA));
+    expect((wa.result as { success: boolean }).success).toBe(true);
+  });
+});

--- a/packages/daemon/src/__tests__/filegit-git.test.ts
+++ b/packages/daemon/src/__tests__/filegit-git.test.ts
@@ -94,14 +94,19 @@ describe('signed git.* flow (zero-9P P2)', () => {
     execFileSync('git', ['config', 'user.email', 'test@revealui.com'], { cwd: repo });
     execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
     socketPath = join(dataDir, 'harness.sock');
-    daemon = await startDaemon({ socketPath, dataDir });
+    // Provision this client's fingerprint into the trust anchor (fixture).
+    const anchor = join(dataDir, 'trusted-client-fingerprint');
+    await writeFile(anchor, `${fingerprint}\n`);
+    daemon = await startDaemon({ socketPath, dataDir, trustedClientFingerprintPath: anchor });
     await rpc(socketPath, 'session.register', {
       agentId,
       agentName: 'studio-ui',
       backend: 'studio',
       publicKeyPem: kp.publicKeyPem,
     });
-    await rpc(socketPath, 'project.open', { repoPath: repo, actorAgentId: agentId });
+    // project.open is signature-REQUIRED now (records the root under the signer).
+    const openParams = { repoPath: repo };
+    await rpc(socketPath, 'project.open', openParams, sign('project.open', openParams));
   });
 
   afterAll(async () => {

--- a/packages/daemon/src/__tests__/filegit-signed.test.ts
+++ b/packages/daemon/src/__tests__/filegit-signed.test.ts
@@ -106,7 +106,12 @@ describe('Studio client-key signing (zero-9P P1)', () => {
     dataDir = await mkdtemp(join(tmpdir(), 'revdev-signed-'));
     repo = await mkdtemp(join(tmpdir(), 'revdev-signed-repo-'));
     socketPath = join(dataDir, 'harness.sock');
-    daemon = await startDaemon({ socketPath, dataDir });
+    // Trust anchor: provision THIS client's fingerprint so enrollment is
+    // allowed (the production install writes this root-owned; the test points
+    // the daemon at a fixture via trustedClientFingerprintPath).
+    const anchor = join(dataDir, 'trusted-client-fingerprint');
+    await writeFile(anchor, `# test trust anchor\n${fingerprint}\n`);
+    daemon = await startDaemon({ socketPath, dataDir, trustedClientFingerprintPath: anchor });
   });
 
   afterAll(async () => {

--- a/packages/daemon/src/__tests__/filegit-signed.test.ts
+++ b/packages/daemon/src/__tests__/filegit-signed.test.ts
@@ -134,11 +134,15 @@ describe('Studio client-key signing (zero-9P P1)', () => {
   });
 
   it('accepts a signed file.write + file.read round-trip with no stale read', async () => {
-    // project.open is signature-optional but needs an identity → actorAgentId.
-    const open = await rpcFrame(socketPath, 'project.open', {
-      repoPath: repo,
-      actorAgentId: agentId,
-    });
+    // project.open is now signature-REQUIRED — the root is recorded under the
+    // verified signer (per-agent root scoping), so it must be signed too.
+    const openParams = { repoPath: repo };
+    const open = await rpcFrame(
+      socketPath,
+      'project.open',
+      openParams,
+      sign('project.open', openParams, did, fingerprint, kp.privateKeyPem),
+    );
     expect((open.result as { success: boolean }).success).toBe(true);
 
     const writeParams = { repoPath: repo, filePath: 'note.txt', content: 'zero-9P round trip' };

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -31,17 +31,13 @@ const SIGNED = [
   'git.diffContent',
   'git.readBlobAtHead',
   'git.readBlobAtIndex',
+  // Root registration: signature-required so the root is recorded under the
+  // verified signer (per-agent root scoping), not a spoofable param.
+  'project.open',
 ];
 
-// Payload-free coordination reads (and setup) stay signature-OPTIONAL.
-const OPTIONAL = [
-  'project.open',
-  'git.status',
-  'git.listBranches',
-  'git.log',
-  'ping',
-  'session.list',
-];
+// Payload-free coordination reads stay signature-OPTIONAL.
+const OPTIONAL = ['git.status', 'git.listBranches', 'git.log', 'ping', 'session.list'];
 
 describe('signature-required method set (zero-9P)', () => {
   for (const m of SIGNED) {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -179,6 +179,8 @@ const config = {
     'REVDEV_DAEMON_SHUTDOWN_GRACE_MS',
     DAEMON_DEFAULTS.shutdownGracePeriodMs,
   ),
+  trustedClientFingerprintPath:
+    process.env.REVDEV_DAEMON_TRUSTED_CLIENT_FP ?? DAEMON_DEFAULTS.trustedClientFingerprintPath,
 };
 
 const pidFile = process.env.REVDEV_DAEMON_PID ?? DAEMON_DEFAULTS.pidFile;

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -107,6 +107,27 @@ export interface DaemonConfig {
    * tune via REVDEV_DAEMON_SHUTDOWN_GRACE_MS for slower environments.
    */
   shutdownGracePeriodMs: number;
+  /**
+   * Path to the ROOT-OWNED trust anchor: a file listing the SHA-256
+   * fingerprint(s) of client public keys allowed to enroll a CLIENT-supplied
+   * identity (the Studio zero-9P model). One fingerprint per line; blank lines
+   * and `#` comments ignored.
+   *
+   * Why root-owned: the daemon runs as the WSL user, and the threat is a host
+   * process that `wsl.exe`-es in AS THAT SAME USER. Such a process could write
+   * any user-owned file, so a user-writable anchor is forgeable — it would let
+   * the attacker enroll its own key. Only a file the attacker cannot write
+   * (root:root, e.g. 0644) is a real anchor. The install-time setup writes it
+   * with sudo (see Studio daemon_ctl provisioning).
+   *
+   * Enrollment of a client-supplied key whose fingerprint is NOT listed here is
+   * rejected fail-closed (-32004). DAEMON-MINTED identities (headless hooks,
+   * no client key) never consult this file — their private key is generated
+   * in-process and never handed out, so they are not spoofable by a host
+   * process. Override the path via REVDEV_DAEMON_TRUSTED_CLIENT_FP (tests point
+   * it at a fixture).
+   */
+  trustedClientFingerprintPath: string;
 }
 
 const homeDir = process.env.HOME ?? '/tmp';

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -147,4 +147,5 @@ export const DAEMON_DEFAULTS: DaemonConfig = {
   gitTimeoutMs: 60_000, // 60 s
   maxInlineReadBytes: 786_432, // 768 KiB
   shutdownGracePeriodMs: 5_000, // 5 s
+  trustedClientFingerprintPath: '/etc/revdev/trusted-client-fingerprint',
 };

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -100,10 +100,16 @@ function within(root: string, target: string): boolean {
 }
 
 /**
- * Resolve a raw repoPath to its realpath and assert it is a registered root.
- * Throws if the path does not exist or was never registered via project.open.
+ * Resolve a raw repoPath to its realpath and assert it is a root registered by
+ * THIS caller (`callerAgentId`). Throws if the path does not exist, was never
+ * registered via project.open, OR was registered by a different agent.
+ *
+ * The "not registered" and "owned by another agent" cases throw the SAME
+ * message on purpose — a caller must not be able to probe which roots another
+ * agent has opened (no cross-agent existence oracle). The ownership mismatch
+ * is logged server-side for debugging.
  */
-async function requireRoot(repoPathRaw: string): Promise<string> {
+async function requireRoot(repoPathRaw: string, callerAgentId: string | null): Promise<string> {
   const expanded = expandTilde(repoPathRaw);
   let real: string;
   try {
@@ -111,7 +117,8 @@ async function requireRoot(repoPathRaw: string): Promise<string> {
   } catch {
     throw new Error(`project root does not exist: ${repoPathRaw}`);
   }
-  if (!registeredRoots.has(real)) {
+  const owner = registeredRoots.get(real);
+  if (owner === undefined || callerAgentId === null || owner !== callerAgentId) {
     throw new Error(`project root not registered: ${repoPathRaw} (call project.open first)`);
   }
   return real;

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -227,14 +227,14 @@ registerHandler('project.open', async (params, _db, ctx) => {
 // ---------------------------------------------------------------------------
 
 registerHandler('file.read', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), true);
   const buf = await readFile(target);
   return inlineContent(buf);
 });
 
 registerHandler('file.write', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), false);
   const content = str(params.content) ?? '';
   // Open with O_NOFOLLOW so a symlink swapped in at the FINAL component between
@@ -255,14 +255,14 @@ registerHandler('file.write', async (params, _db, ctx) => {
 });
 
 registerHandler('file.delete', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), true);
   await unlink(target);
   return { success: true };
 });
 
 registerHandler('file.stat', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), false);
   try {
     const s = await stat(target);
@@ -283,7 +283,7 @@ registerHandler('file.stat', async (params, _db, ctx) => {
 // ---------------------------------------------------------------------------
 
 registerHandler('git.status', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const r = await runGit(['status', '--porcelain=v1', '--branch'], repoReal);
   if (!r.ok) return { success: false, error: r.stderr || 'git status failed' };
   let branch: string | null = null;
@@ -305,7 +305,7 @@ registerHandler('git.status', async (params, _db, ctx) => {
 });
 
 registerHandler('git.diffFile', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   const args = ['diff'];
   if (params.staged === true) args.push('--cached');
@@ -318,14 +318,14 @@ registerHandler('git.diffFile', async (params, _db, ctx) => {
 registerHandler('git.diffContent', async (params, _db, ctx) => {
   // The working-tree ("after") content for a diff view. Read directly off
   // ext4 (untrimmed, full fidelity) rather than via `git show`.
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), true);
   const buf = await readFile(target);
   return inlineContent(buf);
 });
 
 registerHandler('git.readBlobAtHead', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   // NOTE: runGit trims trailing whitespace on stdout, so a blob's final
   // newline is not preserved here. Acceptable for the read-only "committed
@@ -337,7 +337,7 @@ registerHandler('git.readBlobAtHead', async (params, _db, ctx) => {
 });
 
 registerHandler('git.readBlobAtIndex', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   const r = await runGit(['show', `:${rel}`], repoReal);
   if (!r.ok) return { success: false, error: r.stderr || 'git show :index failed' };
@@ -345,7 +345,7 @@ registerHandler('git.readBlobAtIndex', async (params, _db, ctx) => {
 });
 
 registerHandler('git.listBranches', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const r = await runGit(['branch', '--format=%(refname:short)'], repoReal);
   if (!r.ok) return { success: false, error: r.stderr || 'git branch failed' };
   const branches = r.stdout.split('\n').filter(Boolean);
@@ -354,7 +354,7 @@ registerHandler('git.listBranches', async (params, _db, ctx) => {
 });
 
 registerHandler('git.log', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const limit = typeof params.limit === 'number' ? Math.max(1, Math.floor(params.limit)) : 50;
   // %x1f = ASCII unit separator, unambiguous against any commit subject text.
   // %aI = author date ISO-8601 (display); %at = author date as a unix timestamp
@@ -382,13 +382,13 @@ registerHandler('git.log', async (params, _db, ctx) => {
 // ---------------------------------------------------------------------------
 
 registerHandler('git.stageFile', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   return gitOutcome(await runGit(['add', '--', rel], repoReal), 'git add');
 });
 
 registerHandler('git.unstageFile', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   return gitOutcome(
     await runGit(['restore', '--staged', '--', rel], repoReal),
@@ -397,14 +397,14 @@ registerHandler('git.unstageFile', async (params, _db, ctx) => {
 });
 
 registerHandler('git.discardFile', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   // Restore the working-tree copy from the index (discard unstaged edits).
   return gitOutcome(await runGit(['restore', '--', rel], repoReal), 'git restore');
 });
 
 registerHandler('git.createBranch', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const name = requireStr(params.name, 'name');
   // `--` so a name/base that slipped past validation can't be read as a flag
   // (defense in depth; schema's gitRefArg already rejects a leading '-').
@@ -415,20 +415,20 @@ registerHandler('git.createBranch', async (params, _db, ctx) => {
 });
 
 registerHandler('git.switchBranch', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const name = requireStr(params.name, 'name');
   return gitOutcome(await runGit(['switch', '--', name], repoReal), 'git switch');
 });
 
 registerHandler('git.deleteBranch', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const name = requireStr(params.name, 'name');
   const flag = params.force === true ? '-D' : '-d';
   return gitOutcome(await runGit(['branch', flag, '--', name], repoReal), 'git branch -d');
 });
 
 registerHandler('git.commit', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const message = requireStr(params.message, 'message');
   const commit = await runGit(['commit', '-m', message], repoReal);
   if (!commit.ok) return { success: false, error: commit.stderr || 'git commit failed' };
@@ -440,7 +440,7 @@ registerHandler('git.commit', async (params, _db, ctx) => {
 });
 
 registerHandler('git.push', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const args = ['push'];
   const remote = str(params.remote);
   const branch = str(params.branch);
@@ -450,7 +450,7 @@ registerHandler('git.push', async (params, _db, ctx) => {
 });
 
 registerHandler('git.pull', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const args = ['pull'];
   const remote = str(params.remote);
   const branch = str(params.branch);

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -358,7 +358,11 @@ registerHandler('git.readBlobAtIndex', async (params, _db, ctx) => {
 });
 
 registerHandler('git.listBranches', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
+  // Signature-OPTIONAL metadata read — see git.status.
+  const repoReal = await requireRoot(
+    requireStr(params.repoPath, 'repoPath'),
+    ctx.agentId ?? str(params.actorAgentId),
+  );
   const r = await runGit(['branch', '--format=%(refname:short)'], repoReal);
   if (!r.ok) return { success: false, error: r.stderr || 'git branch failed' };
   const branches = r.stdout.split('\n').filter(Boolean);

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -218,7 +218,14 @@ registerHandler('project.open', async (params, _db, ctx) => {
     () => true,
     () => false,
   );
-  registeredRoots.add(real);
+  if (ctx.agentId === null) {
+    // Unreachable in practice: project.open is in MUTATING_OR_CONTENT_METHODS,
+    // so the dispatch signature gate binds ctx.agentId to the verified signer
+    // before this handler runs. Belt-and-suspenders so a future exemption
+    // change can never register an unowned (globally-usable) root.
+    throw new Error('project.open requires a verified signer identity');
+  }
+  registeredRoots.set(real, ctx.agentId);
   return { success: true, root: real, isGitRepo: isRepo };
 });
 

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -203,7 +203,7 @@ function gitOutcome(r: ShellResult, what: string): Record<string, unknown> {
 // project.*
 // ---------------------------------------------------------------------------
 
-registerHandler('project.open', async (params) => {
+registerHandler('project.open', async (params, _db, ctx) => {
   const repoPathRaw = requireStr(params.repoPath, 'repoPath');
   const expanded = expandTilde(repoPathRaw);
   let real: string;
@@ -226,14 +226,14 @@ registerHandler('project.open', async (params) => {
 // file.*
 // ---------------------------------------------------------------------------
 
-registerHandler('file.read', async (params) => {
+registerHandler('file.read', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), true);
   const buf = await readFile(target);
   return inlineContent(buf);
 });
 
-registerHandler('file.write', async (params) => {
+registerHandler('file.write', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), false);
   const content = str(params.content) ?? '';
@@ -254,14 +254,14 @@ registerHandler('file.write', async (params) => {
   return { success: true, bytes: Buffer.byteLength(content, 'utf8') };
 });
 
-registerHandler('file.delete', async (params) => {
+registerHandler('file.delete', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), true);
   await unlink(target);
   return { success: true };
 });
 
-registerHandler('file.stat', async (params) => {
+registerHandler('file.stat', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), false);
   try {
@@ -282,7 +282,7 @@ registerHandler('file.stat', async (params) => {
 // git.* — reads
 // ---------------------------------------------------------------------------
 
-registerHandler('git.status', async (params) => {
+registerHandler('git.status', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const r = await runGit(['status', '--porcelain=v1', '--branch'], repoReal);
   if (!r.ok) return { success: false, error: r.stderr || 'git status failed' };
@@ -304,7 +304,7 @@ registerHandler('git.status', async (params) => {
   return { success: true, branch, files, clean: files.length === 0 };
 });
 
-registerHandler('git.diffFile', async (params) => {
+registerHandler('git.diffFile', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   const args = ['diff'];
@@ -315,7 +315,7 @@ registerHandler('git.diffFile', async (params) => {
   return { success: true, diff: r.stdout };
 });
 
-registerHandler('git.diffContent', async (params) => {
+registerHandler('git.diffContent', async (params, _db, ctx) => {
   // The working-tree ("after") content for a diff view. Read directly off
   // ext4 (untrimmed, full fidelity) rather than via `git show`.
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
@@ -324,7 +324,7 @@ registerHandler('git.diffContent', async (params) => {
   return inlineContent(buf);
 });
 
-registerHandler('git.readBlobAtHead', async (params) => {
+registerHandler('git.readBlobAtHead', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   // NOTE: runGit trims trailing whitespace on stdout, so a blob's final
@@ -336,7 +336,7 @@ registerHandler('git.readBlobAtHead', async (params) => {
   return { success: true, ...inlineContent(Buffer.from(r.stdout, 'utf8')) };
 });
 
-registerHandler('git.readBlobAtIndex', async (params) => {
+registerHandler('git.readBlobAtIndex', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   const r = await runGit(['show', `:${rel}`], repoReal);
@@ -344,7 +344,7 @@ registerHandler('git.readBlobAtIndex', async (params) => {
   return { success: true, ...inlineContent(Buffer.from(r.stdout, 'utf8')) };
 });
 
-registerHandler('git.listBranches', async (params) => {
+registerHandler('git.listBranches', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const r = await runGit(['branch', '--format=%(refname:short)'], repoReal);
   if (!r.ok) return { success: false, error: r.stderr || 'git branch failed' };
@@ -353,7 +353,7 @@ registerHandler('git.listBranches', async (params) => {
   return { success: true, branches, current: cur.ok ? cur.stdout : null };
 });
 
-registerHandler('git.log', async (params) => {
+registerHandler('git.log', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const limit = typeof params.limit === 'number' ? Math.max(1, Math.floor(params.limit)) : 50;
   // %x1f = ASCII unit separator, unambiguous against any commit subject text.
@@ -381,13 +381,13 @@ registerHandler('git.log', async (params) => {
 // git.* — mutations
 // ---------------------------------------------------------------------------
 
-registerHandler('git.stageFile', async (params) => {
+registerHandler('git.stageFile', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   return gitOutcome(await runGit(['add', '--', rel], repoReal), 'git add');
 });
 
-registerHandler('git.unstageFile', async (params) => {
+registerHandler('git.unstageFile', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   return gitOutcome(
@@ -396,14 +396,14 @@ registerHandler('git.unstageFile', async (params) => {
   );
 });
 
-registerHandler('git.discardFile', async (params) => {
+registerHandler('git.discardFile', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   // Restore the working-tree copy from the index (discard unstaged edits).
   return gitOutcome(await runGit(['restore', '--', rel], repoReal), 'git restore');
 });
 
-registerHandler('git.createBranch', async (params) => {
+registerHandler('git.createBranch', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const name = requireStr(params.name, 'name');
   // `--` so a name/base that slipped past validation can't be read as a flag
@@ -414,20 +414,20 @@ registerHandler('git.createBranch', async (params) => {
   return gitOutcome(await runGit(args, repoReal), 'git branch');
 });
 
-registerHandler('git.switchBranch', async (params) => {
+registerHandler('git.switchBranch', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const name = requireStr(params.name, 'name');
   return gitOutcome(await runGit(['switch', '--', name], repoReal), 'git switch');
 });
 
-registerHandler('git.deleteBranch', async (params) => {
+registerHandler('git.deleteBranch', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const name = requireStr(params.name, 'name');
   const flag = params.force === true ? '-D' : '-d';
   return gitOutcome(await runGit(['branch', flag, '--', name], repoReal), 'git branch -d');
 });
 
-registerHandler('git.commit', async (params) => {
+registerHandler('git.commit', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const message = requireStr(params.message, 'message');
   const commit = await runGit(['commit', '-m', message], repoReal);
@@ -439,7 +439,7 @@ registerHandler('git.commit', async (params) => {
   return { success: true, sha, shortSha: sha.slice(0, 7), stdout: commit.stdout };
 });
 
-registerHandler('git.push', async (params) => {
+registerHandler('git.push', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const args = ['push'];
   const remote = str(params.remote);
@@ -449,7 +449,7 @@ registerHandler('git.push', async (params) => {
   return gitOutcome(await runGit(args, repoReal), 'git push');
 });
 
-registerHandler('git.pull', async (params) => {
+registerHandler('git.pull', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'));
   const args = ['pull'];
   const remote = str(params.remote);

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -36,20 +36,27 @@ import { runGit, type ShellResult } from './vcs.js';
 // ---------------------------------------------------------------------------
 
 /**
- * realpath-resolved absolute paths registered via `project.open`. Module-level
- * by design — the daemon is a singleton (mirrors pruneState in server.ts).
- * A handler rejects any repoPath whose realpath is not in this set.
+ * realpath-resolved absolute root → owning agentId. Module-level by design —
+ * the daemon is a singleton (mirrors pruneState in server.ts). A root is
+ * recorded under the VERIFIED signer that opened it (project.open is
+ * signature-required); a handler rejects any repoPath whose realpath is not
+ * registered OR is owned by a different agent (per-agent root scoping —
+ * agent A cannot read/mutate a root agent B opened).
  */
-const registeredRoots = new Set<string>();
+const registeredRoots = new Map<string, string>();
 
 /** @internal — test seam: clear the allowlist between test cases. */
 export function _clearRegisteredRootsForTest(): void {
   registeredRoots.clear();
 }
 
-/** @internal — test seam: register an already-realpath'd root directly. */
-export function _addRootForTest(realRoot: string): void {
-  registeredRoots.add(realRoot);
+/**
+ * @internal — test seam: register an already-realpath'd root directly under
+ * `agentId` (defaults to a sentinel for legacy path-resolution tests that do
+ * not exercise ownership).
+ */
+export function _addRootForTest(realRoot: string, agentId = '_test'): void {
+  registeredRoots.set(realRoot, agentId);
 }
 
 /** @internal — test seam: exercise the realpath descendant resolver. */

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -371,7 +371,11 @@ registerHandler('git.listBranches', async (params, _db, ctx) => {
 });
 
 registerHandler('git.log', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
+  // Signature-OPTIONAL metadata read — see git.status.
+  const repoReal = await requireRoot(
+    requireStr(params.repoPath, 'repoPath'),
+    ctx.agentId ?? str(params.actorAgentId),
+  );
   const limit = typeof params.limit === 'number' ? Math.max(1, Math.floor(params.limit)) : 50;
   // %x1f = ASCII unit separator, unambiguous against any commit subject text.
   // %aI = author date ISO-8601 (display); %at = author date as a unix timestamp

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -290,7 +290,13 @@ registerHandler('file.stat', async (params, _db, ctx) => {
 // ---------------------------------------------------------------------------
 
 registerHandler('git.status', async (params, _db, ctx) => {
-  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
+  // Signature-OPTIONAL metadata read: accept the socket-bound identity OR a
+  // per-request actorAgentId (fresh-per-call clients). Still scoped to the
+  // owning agent — the strong boundary is the signed mutations + content reads.
+  const repoReal = await requireRoot(
+    requireStr(params.repoPath, 'repoPath'),
+    ctx.agentId ?? str(params.actorAgentId),
+  );
   const r = await runGit(['status', '--porcelain=v1', '--branch'], repoReal);
   if (!r.ok) return { success: false, error: r.stderr || 'git status failed' };
   let branch: string | null = null;

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -15,7 +15,7 @@
  *   `session.register` are rejected with -32002.
  */
 
-import { mkdir } from 'node:fs/promises';
+import { mkdir, readFile } from 'node:fs/promises';
 import { createServer, type Socket } from 'node:net';
 import { dirname } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -164,6 +164,12 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   'git.diffContent',
   'git.readBlobAtHead',
   'git.readBlobAtIndex',
+  // Root registration. Signature-REQUIRED so the root is recorded under the
+  // VERIFIED signer's agentId (filegit per-agent root scoping) rather than a
+  // spoofable param — otherwise any unsigned caller could register a root that
+  // a later signed mutation would be authorized against. (Cross-language
+  // contract: signing.rs requires_signature() must mark project.open too.)
+  'project.open',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1578,12 +1578,18 @@ export async function startDaemon(
           socket.write(`${JSON.stringify({ jsonrpc: '2.0', id: req.id, result })}\n`);
         } catch (err) {
           trackRpcCall(req.method, 'error', Date.now() - startMs);
+          // A handler may carry an explicit numeric JSON-RPC code (e.g.
+          // UntrustedClientKeyError → -32004). Guard on `typeof === 'number'`
+          // so Node's string error codes (ENOENT, EACCES, …) don't leak into
+          // the JSON-RPC `code` field — those fall back to the generic -32000.
+          const rawCode = (err as { code?: unknown }).code;
+          const code = typeof rawCode === 'number' ? rawCode : -32000;
           socket.write(
             `${JSON.stringify({
               jsonrpc: '2.0',
               id: req.id,
               error: {
-                code: -32000,
+                code,
                 message: err instanceof Error ? err.message : 'Internal error',
               },
             })}\n`,

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -652,12 +652,62 @@ async function bootstrapAgentIdentity(
   return { did, publicKeyPem: kp.publicKeyPem };
 }
 
+/** Thrown when a client-supplied key is not in the root-owned trust anchor. */
+class UntrustedClientKeyError extends Error {
+  /** JSON-RPC error code surfaced to the client (see dispatch catch). */
+  readonly code = -32004;
+  constructor(fingerprint: string, anchorPath: string) {
+    super(
+      `untrusted client key: fingerprint ${fingerprint} is not in the trust anchor ${anchorPath}. ` +
+        `A client identity may only be enrolled for the install-provisioned key. ` +
+        `If this is a fresh install, run the Studio daemon setup to provision the fingerprint.`,
+    );
+    this.name = 'UntrustedClientKeyError';
+  }
+}
+
+/**
+ * Read the root-owned trust anchor and return the set of allowed client-key
+ * fingerprints. One fingerprint per line; blank lines and `#` comments are
+ * ignored. A missing/unreadable file yields an EMPTY set — enrollment then
+ * fails closed (no client key is trusted) rather than open. The path is
+ * config-driven (DaemonConfig.trustedClientFingerprintPath) so tests point it
+ * at a fixture; production points it at the sudo-provisioned root:root file.
+ */
+async function loadTrustedClientFingerprints(anchorPath: string): Promise<Set<string>> {
+  let text: string;
+  try {
+    text = await readFile(anchorPath, 'utf8');
+  } catch (err) {
+    log.warn('trust anchor unreadable — client-key enrollment fails closed', {
+      anchorPath,
+      reason: err instanceof Error ? err.message : String(err),
+    });
+    return new Set();
+  }
+  const out = new Set<string>();
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed.startsWith('#')) continue;
+    out.add(trimmed);
+  }
+  return out;
+}
+
 /**
  * Register a CLIENT-supplied Ed25519 public key for an agent (Studio zero-9P
  * model). The daemon derives the fingerprint + DID from the SPKI PEM and
  * stores ONLY the public half in agent_identity / agent_identity_keys — no
  * private key is generated or written to revvault. Idempotent: re-registering
  * the same key is a no-op; a different key rotates (supersedes the prior one).
+ *
+ * SECURITY: the supplied key's fingerprint MUST appear in the root-owned trust
+ * anchor or enrollment is rejected (-32004). This closes the self-enrollment
+ * hole (any process reaching the 0600 socket could previously enroll its own
+ * key) AND the key-takeover hole (supplying a different key for an existing
+ * agentId previously SUPERSEDED the legitimate key). The check runs on every
+ * path — fresh insert, rotation, and the idempotent re-register — so an
+ * untrusted key can never enter agent_identity_keys.
  */
 async function registerClientIdentity(
   db: PGlite,
@@ -667,6 +717,14 @@ async function registerClientIdentity(
   const raw = spkiPemToRaw(publicKeyPem);
   const fingerprint = computeFingerprint(raw);
   const did = formatDid(agentId, fingerprint);
+
+  // Trust-anchor gate (fail-closed). Reject any client key whose fingerprint
+  // is not provisioned, BEFORE touching agent_identity_keys.
+  const anchorPath = getDaemonConfig().trustedClientFingerprintPath;
+  const trusted = await loadTrustedClientFingerprints(anchorPath);
+  if (!trusted.has(fingerprint)) {
+    throw new UntrustedClientKeyError(fingerprint, anchorPath);
+  }
 
   const existing = await db.query<{ fingerprint: string }>(
     `SELECT fingerprint FROM agent_identity WHERE agent_id = $1`,


### PR DESCRIPTION
## Make the Ed25519 signature gate a real barrier (daemon enrollment + per-agent root scoping)

**Security: HIGH.** Closes the self-enrollment / key-takeover hole and the flat-global-roots authorization gap that let any process reaching the `0600` socket sign mutations against any project root. This is the owner's trust-domain decision deferred in commit `24cb306`. **Coordinator review requested — do not self-merge.**

### The vulnerability (audited on `origin/test`)
1. `registerClientIdentity` (server.ts) enrolled **any** client-supplied PEM under **any** agentId with zero proof-of-trust. Worse: supplying a *different* key for an *existing* agentId hit the rotation branch and **superseded the legitimate key** (key-takeover, not just self-enroll).
2. `registeredRoots` (filegit.ts) was a **flat module-level `Set`**, not keyed by agent; the file/git handlers didn't even receive `ctx`. Any registered root was usable by any connection.
3. `project.open` was signature-OPTIONAL and registered the root regardless.

Attack chain: a host process `wsl.exe`-es in as the WSL user → `session.register` self-enrolls its key (exempt) → `project.open` (exempt) registers a root → signs `file.write`/`git.commit` against it. The signature gate passed because the attacker's own key was "registered."

### The fix (A + B + minimum, per the directive)
- **Fix A — provisioned-fingerprint enrollment.** `registerClientIdentity` now rejects (`-32004`) any client key whose fingerprint isn't in a **root-owned** trust anchor (`/etc/revdev/trusted-client-fingerprint`, env-overridable via `REVDEV_DAEMON_TRUSTED_CLIENT_FP`). Root-owned because the threat runs *as the WSL user* and could forge a user-owned file. Fail-closed on a missing/unreadable anchor. Runs on every path — insert, rotation, idempotent re-register — so the key-takeover is closed too. Daemon-MINTED identities (headless hooks) never consult the anchor: their private key is generated in-process and never handed out, so they aren't spoofable by a host process.
- **Fix B — per-agent root scoping.** `registeredRoots` is now `Map<root, agentId>`; `ctx` is threaded into the filegit handlers; `requireRoot` enforces caller ownership. "Not registered" and "owned by another agent" throw the **same** error (no cross-agent existence oracle). Signed mutations + content reads authorize on the **verified signer** (`ctx.agentId`); the signature-optional metadata reads (`git.status`/`listBranches`/`log`) accept an `actorAgentId` fallback (still owner-scoped; they were already optional/metadata-only).
- **Minimum — `project.open` is now signature-REQUIRED** (added to `MUTATING_OR_CONTENT_METHODS`), so the root is recorded under the verified signer rather than a spoofable param. The Rust client mirror `requires_signature()` is flipped in lockstep (cross-language contract test updated).
- **Provisioning bundled (per owner decision):** Studio's WSL `daemon_setup` now writes this install's signing fingerprint to the root-owned anchor via sudo, so enforcement + provisioning land atomically and the legit client keeps working ("one install == one trusted client key").

### Tests (the 3 required + guards)
- **(1)** Unprovisioned key rejected at register (`-32004`) — fresh self-enroll AND key-takeover of an existing agent. (`filegit-enrollment.test.ts`)
- **(2)** Agent A's valid signature cannot mutate a root agent B opened; control proves A can write its own root. (`filegit-enrollment.test.ts`)
- **(3)** Legit Studio client still works end-to-end — `filegit-signed.test.ts` / `filegit-git.test.ts` updated to the new model (trust-anchor fixture + signed `project.open`).
- `signature-gate.test.ts` drift guard updated; `signing.rs` `requires_signature_matches_daemon_set` updated.

### Verification (local)
- Daemon: **406/406** tests pass (run serially — parallel runs hit PGlite cold-init contention, not failures), `pnpm typecheck` clean, gitleaks clean.
- Rust: `cargo test signing::` green (incl. the cross-language contract test); crate compiles on Linux.
- **CI gap:** the `daemon_setup` provisioning write is `#[cfg(not(unix))]`, so Linux CI does not compile it — reviewed against the existing `wsl::run` pattern; needs a Windows/WSL runtime smoke (folds into the P4 install pipeline, same as the #164 follow-up note). Native-unix installs must provision the anchor separately (documented in the unix `daemon_setup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
