### PR TITLE
fix(daemon): block .git-internal writes + re-scan filter config on stage/checkout (close #172 residual)

### DIFF
--- a/packages/daemon/src/__tests__/filegit-config-exec.test.ts
+++ b/packages/daemon/src/__tests__/filegit-config-exec.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { execFile as execFileCb } from 'node:child_process';
-import { access, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -221,6 +221,77 @@ describe('git config-exec hardening (zero-9P security)', () => {
     const sw = await signedRpc('git.switchBranch', { repoPath: repo, name: 'feature' });
     expect((sw.result as { success: boolean }).success).toBe(true);
     expect(await exists(hookSentinel)).toBe(false);
+
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('blocks file.write / file.delete into <root>/.git/** (closes the config-plant route)', async () => {
+    const repo = await initRepo('revdev-cfgexec-gitwrite-');
+    const open = await signedRpc('project.open', { repoPath: repo });
+    expect((open.result as { success: boolean }).success).toBe(true);
+
+    // A signed agent tries to plant a filter driver in .git/config via file.write.
+    const w = await signedRpc('file.write', {
+      repoPath: repo,
+      filePath: '.git/config',
+      content: '[filter "evil"]\n\tprocess = touch /tmp/revdev-should-not-run\n',
+    });
+    expect(w.result).toBeUndefined();
+    expect(w.error?.message ?? '').toContain('.git/');
+    // The real .git/config was NOT overwritten — still a valid repo config.
+    expect(await readFile(join(repo, '.git', 'config'), 'utf8')).not.toContain('filter "evil"');
+
+    // A nested .git/hooks write and a .git internal delete are blocked too.
+    const wHook = await signedRpc('file.write', {
+      repoPath: repo,
+      filePath: '.git/hooks/pre-commit',
+      content: '#!/bin/sh\n: > /tmp/revdev-should-not-run\n',
+    });
+    expect(wHook.error?.message ?? '').toContain('.git/');
+    const del = await signedRpc('file.delete', { repoPath: repo, filePath: '.git/HEAD' });
+    expect(del.error?.message ?? '').toContain('.git/');
+    expect(await exists(join(repo, '.git', 'HEAD'))).toBe(true);
+
+    // A normal in-tree write still works (the block is scoped to .git/).
+    const ok = await signedRpc('file.write', {
+      repoPath: repo,
+      filePath: 'note.txt',
+      content: 'hi',
+    });
+    expect((ok.result as { success: boolean }).success).toBe(true);
+
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('refuses git.stageFile / git.switchBranch when a filter driver is planted post-open', async () => {
+    // The filter.* residual: a content filter cannot be -c-cleared per spawn, so
+    // the runtime backstop must REFUSE the op. Plant the filter via `git config`
+    // (a non-daemon route, since file.write into .git/ is now blocked above) and
+    // prove the clean/smudge driver never fires.
+    const repo = await initRepo('revdev-cfgexec-filter-');
+    await git(repo, ['branch', 'feature']);
+    const open = await signedRpc('project.open', { repoPath: repo });
+    expect((open.result as { success: boolean }).success).toBe(true);
+
+    const filterSentinel = join(repo, 'FILTER_SENTINEL');
+    const filterScript = join(repo, 'filter-payload.sh');
+    await writeFile(filterScript, `#!/bin/sh\n: > '${filterSentinel}'\ncat\n`, { mode: 0o755 });
+    await git(repo, ['config', 'filter.evil.clean', filterScript]);
+    await git(repo, ['config', 'filter.evil.smudge', filterScript]);
+    await writeFile(join(repo, '.gitattributes'), '* filter=evil\n');
+    await writeFile(join(repo, 'f.txt'), 'changed\n');
+
+    // git.stageFile (clean) must REFUSE and the filter must NOT fire.
+    const stage = await signedRpc('git.stageFile', { repoPath: repo, filePath: 'f.txt' });
+    expect(stage.result).toBeUndefined();
+    expect(stage.error?.message ?? '').toContain('filter');
+    expect(await exists(filterSentinel)).toBe(false);
+
+    // git.switchBranch (checkout → smudge) likewise refuses.
+    const sw = await signedRpc('git.switchBranch', { repoPath: repo, name: 'feature' });
+    expect(sw.result).toBeUndefined();
+    expect(sw.error?.message ?? '').toContain('filter');
+    expect(await exists(filterSentinel)).toBe(false);
 
     await rm(repo, { recursive: true, force: true });
   });

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -185,6 +185,27 @@ function gitRelPath(repoReal: string, filePathRaw: string): string {
 }
 
 /**
+ * Refuse a `file.*` mutation whose resolved target is the repo's `.git`
+ * directory or anything inside it. Git internals are reached through the
+ * `git.*` RPCs, never `file.*`; permitting a write here is the post-`project.open`
+ * config-exec vector: a signed agent could `file.write` `.git/config`
+ * `filter.<d>.process=<cmd>` + an in-tree `.gitattributes`, then `git.stageFile`
+ * (clean) or a checkout (smudge) fires the filter as the daemon UID. The
+ * `filter.*` namespace cannot be `-c`-cleared at runtime, and `assertNoExecConfig`
+ * only runs at `project.open`, so a post-open `.git/config` write would otherwise
+ * slip past every guard. `repoReal` and `target` are both realpath-resolved by
+ * the caller, so this lexical first-segment check is not symlink-foolable.
+ */
+function assertNotGitInternal(repoReal: string, target: string, filePathRaw: string): void {
+  const rel = relative(repoReal, target);
+  if (rel === '.git' || rel.split(sep)[0] === '.git') {
+    throw new Error(
+      `refusing to modify git internals via file.*: ${filePathRaw} resolves into .git/`,
+    );
+  }
+}
+
+/**
  * True when a git config key (already lower-cased by `git config --list`) names
  * an arbitrary-command vector that runs as the daemon UID on a routine read or
  * checkout. A command-line `-c` neutralizes some of these per-spawn, but
@@ -232,27 +253,64 @@ function isExecBearingConfigKey(key: string, value: string): boolean {
 }
 
 /**
- * Scan a repo's effective git config (local + any includes it pulls in) and
- * refuse to register a repo that carries an exec-bearing key. `git config
- * --list` itself never invokes a filter/diff/hook driver, so listing the
+ * List a repo's effective local git config as lower-cased `[key, value]` pairs.
+ * `git config --list` never invokes a filter/diff/hook driver, so listing the
  * config of an untrusted repo is safe; it runs under the hardened env from
  * vcs.ts. `-z` is NUL-delimited so a multi-line value can't be confused with an
- * entry boundary; within an entry the key and value are split on the first \n.
- * A config git itself cannot parse (r.ok === false) can't drive an exploit
- * either, so we treat that as "nothing to refuse".
+ * entry boundary; within an entry the key and value split on the first `\n`. A
+ * config git itself cannot parse (r.ok === false) yields `[]` — it can't drive
+ * an exploit either, so "unreadable" and "empty" are treated the same.
  */
-async function assertNoExecConfig(repoReal: string): Promise<void> {
+async function localConfigEntries(repoReal: string): Promise<Array<[string, string]>> {
   const r = await runGit(['config', '--list', '--local', '-z'], repoReal);
-  if (!r.ok) return;
+  if (!r.ok) return [];
+  const entries: Array<[string, string]> = [];
   for (const entry of r.stdout.split('\0')) {
     if (entry.length === 0) continue;
     const nl = entry.indexOf('\n');
     const key = (nl === -1 ? entry : entry.slice(0, nl)).toLowerCase();
     const value = nl === -1 ? '' : entry.slice(nl + 1);
+    entries.push([key, value]);
+  }
+  return entries;
+}
+
+/**
+ * Refuse to register a repo whose config carries any exec-bearing key. Runs once
+ * at `project.open` — the trust boundary for a third-party repo.
+ */
+async function assertNoExecConfig(repoReal: string): Promise<void> {
+  for (const [key, value] of await localConfigEntries(repoReal)) {
     if (isExecBearingConfigKey(key, value)) {
       throw new Error(
         `refusing to open repo: .git/config sets exec-bearing key "${key}" ` +
           '(arbitrary-command vector; remove it before opening this repo)',
+      );
+    }
+  }
+}
+
+/**
+ * Refuse a worktree-materializing op (`git add` → `clean`, checkout/restore →
+ * `smudge`/`process`) when the repo defines a `filter.<d>.process/.clean/.smudge`
+ * driver. This is the residual `project.open`'s open-time scan can't cover alone:
+ * unlike diff.external/textconv (runtime-neutralized by `--no-ext-diff`/
+ * `--no-textconv`) and hooks (`core.hooksPath=/dev/null`), a content filter
+ * CANNOT be `-c`-cleared per spawn, so the only safe response to a repo that
+ * carries one is to refuse the op. The `.git/`-write block keeps a filter out of
+ * a daemon-opened repo; this is the runtime backstop for a config planted by any
+ * other route. Narrower than `assertNoExecConfig` on purpose — `add`/checkout do
+ * not run diff.external/textconv, so those stay neutralize-and-proceed.
+ */
+async function assertNoFilterDriver(repoReal: string): Promise<void> {
+  for (const [key] of await localConfigEntries(repoReal)) {
+    if (
+      key.startsWith('filter.') &&
+      (key.endsWith('.process') || key.endsWith('.clean') || key.endsWith('.smudge'))
+    ) {
+      throw new Error(
+        `refusing op: .git/config sets a content filter driver "${key}" ` +
+          '(arbitrary-command vector that cannot be neutralized per-spawn; remove it)',
       );
     }
   }
@@ -327,7 +385,9 @@ registerHandler('file.read', async (params, _db, ctx) => {
 
 registerHandler('file.write', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
-  const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), false);
+  const filePathRaw = requireStr(params.filePath, 'filePath');
+  const target = await resolveInRoot(repoReal, filePathRaw, false);
+  assertNotGitInternal(repoReal, target, filePathRaw);
   const content = str(params.content) ?? '';
   // Open with O_NOFOLLOW so a symlink swapped in at the FINAL component between
   // resolveInRoot's parent-realpath check and the write (leaf TOCTOU) is
@@ -348,7 +408,9 @@ registerHandler('file.write', async (params, _db, ctx) => {
 
 registerHandler('file.delete', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
-  const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), true);
+  const filePathRaw = requireStr(params.filePath, 'filePath');
+  const target = await resolveInRoot(repoReal, filePathRaw, true);
+  assertNotGitInternal(repoReal, target, filePathRaw);
   await unlink(target);
   return { success: true };
 });
@@ -494,6 +556,11 @@ registerHandler('git.log', async (params, _db, ctx) => {
 
 registerHandler('git.stageFile', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
+  // Re-scan config right before the op: `git add` runs a `filter.<d>.clean`
+  // driver, which the per-spawn `-c` flags cannot neutralize. project.open's
+  // open-time scan + the .git/ write block already gate the daemon route, so
+  // this is defense in depth against a config planted by any other route.
+  await assertNoFilterDriver(repoReal);
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   return gitOutcome(await runGit(['add', '--', rel], repoReal), 'git add');
 });
@@ -509,6 +576,9 @@ registerHandler('git.unstageFile', async (params, _db, ctx) => {
 
 registerHandler('git.discardFile', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
+  // `git restore` re-materializes the working-tree copy → runs a `smudge`
+  // filter; re-scan config first (defense in depth, see git.stageFile).
+  await assertNoFilterDriver(repoReal);
   const rel = gitRelPath(repoReal, requireStr(params.filePath, 'filePath'));
   // Restore the working-tree copy from the index (discard unstaged edits).
   return gitOutcome(await runGit(['restore', '--', rel], repoReal), 'git restore');
@@ -527,6 +597,9 @@ registerHandler('git.createBranch', async (params, _db, ctx) => {
 
 registerHandler('git.switchBranch', async (params, _db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
+  // A checkout runs a `filter.<d>.smudge`/`process` driver on the new tree;
+  // re-scan config first (defense in depth, see git.stageFile).
+  await assertNoFilterDriver(repoReal);
   const name = requireStr(params.name, 'name');
   return gitOutcome(await runGit(['switch', '--', name], repoReal), 'git switch');
 });


### PR DESCRIPTION
## Security — closes the #172 residual (HIGH; HOLDS revdev test→main)

The review/coord peer verified post-merge that **#172 left one residual** (workboard coord note ~09:10Z): `assertNoExecConfig` runs **only at `project.open`**, but `filter.<d>.clean/.smudge/.process` **cannot be `-c`-cleared at runtime**, and `file.write` did **not** block writes into `<root>/.git/**`. So a **signed** agent could `file.write` `.git/config` `filter.*.process=<script>` + an in-tree `.gitattributes` + the script (all in-root, allowed), then `git.stageFile` (clean) / checkout (smudge) fires the filter **as the daemon UID** — defeating the realpath-confinement promise. #172's regression test covered post-open `diff.external` + hook (both runtime-neutralized); `filter.*` was the uncovered gap.

## Fix (defense in depth)

1. **`file.write` / `file.delete` refuse any target resolving into `<root>/.git/**`** (`assertNotGitInternal`). Git internals are reached through `git.*` RPCs, never `file.*` — this is the **primary fix**, closing the only daemon route to plant a filter driver. `repoReal` + `target` are both realpath'd, so the lexical first-segment check is not symlink-foolable.
2. **`git.stageFile` / `git.switchBranch` / `git.discardFile` re-scan local config for a `filter.*` driver and refuse** if present (`assertNoFilterDriver`) — the runtime backstop for a config planted by any other route. **Narrower than `assertNoExecConfig` on purpose**: `add`/checkout don't run `diff.external`/`textconv` (those stay neutralize-and-proceed per #172, so the existing "diff.external + hook ops still succeed" test is unaffected); only the un-`-c`-clearable `filter.*` warrants refusal. Factored `localConfigEntries` so both scanners share one NUL-safe lister.

## Tests (`filegit-config-exec.test.ts`, over the signed socket)

- `file.write`/`file.delete` into `.git/**` is **rejected** while a normal in-tree write still works.
- A filter driver planted **post-open via direct fs** makes `git.stageFile` + `git.switchBranch` **REFUSE**, and the clean/smudge driver **never fires** (sentinel absent).

Both **red against pre-fix code, green after**. Full daemon suite **431 green**; `tsc --noEmit` + Biome clean; no authored regex.

## Not self-merging — review/coord peer is the gate.

Composes with #173 (per-agent root scoping, merged): handlers carry `ctx`, `requireRoot` enforces per-agent ownership; this adds the `.git/`-write + filter-driver gates on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
