### PR TITLE
fix(daemon): SECURITY follow-up to #173 — B-1/B-2/B-3 + Windows ACL (merged too early)

### DIFF
--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -343,6 +343,42 @@ pub async fn daemon_stop() -> Result<(), String> {
 
 // ── First-run setup ───────────────────────────────────────────────────────────
 
+/// Root-owned trust anchor path the daemon reads at client-key enrollment time.
+/// MUST match `DaemonConfig.trustedClientFingerprintPath` in
+/// packages/daemon/src/config.ts.
+#[cfg(any(not(unix), test))]
+const TRUST_ANCHOR_PATH: &str = "/etc/revdev/trusted-client-fingerprint";
+
+/// Validate a client signing fingerprint before it is shell-interpolated into
+/// the provisioning script. base58 (bs58) fingerprints are ASCII-alphanumeric;
+/// refuse anything else so a malformed identity file can never inject shell.
+/// Platform-independent + unit-tested on Linux even though the only caller is
+/// the not(unix) WSL `daemon_setup`.
+#[cfg(any(not(unix), test))]
+fn validate_client_fingerprint(fp: &str) -> Result<(), String> {
+    if fp.is_empty() || !fp.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return Err(format!(
+            "refusing to provision a malformed client fingerprint: {fp:?}"
+        ));
+    }
+    Ok(())
+}
+
+/// Build the sudo script that writes `fp` to the root-owned trust anchor. It
+/// OVERWRITES (not appends), so re-running setup after an identity rotation
+/// replaces the value rather than accumulating stale keys. Callers MUST
+/// `validate_client_fingerprint(fp)` first.
+#[cfg(any(not(unix), test))]
+fn build_trust_anchor_provision_script(fp: &str) -> String {
+    let path = TRUST_ANCHOR_PATH;
+    format!(
+        "set -e; \
+         sudo mkdir -p /etc/revdev; \
+         printf '%s\\n' '{fp}' | sudo tee {path} >/dev/null; \
+         sudo chmod 0644 {path}"
+    )
+}
+
 /// Provision the WSL side on Windows: assert systemd is enabled (writing the
 /// gate + failing with an actionable error if not), stage the bundled relay
 /// into `~/.local/bin`, and enable the daemon's systemd-user unit. Returns a

--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -499,29 +499,34 @@ pub async fn daemon_restart() -> Result<u32, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        build_trust_anchor_provision_script, validate_client_fingerprint, TRUST_ANCHOR_PATH,
-    };
+    use super::{build_trust_anchor_provision_script, validate_anchor_components, TRUST_ANCHOR_PATH};
 
     #[test]
-    fn validate_accepts_a_base58_fingerprint() {
-        // Representative bs58 string — alphanumeric, no 0/O/I/l.
-        assert!(validate_client_fingerprint("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy").is_ok());
+    fn validate_accepts_a_studio_agent_and_base58_fingerprint() {
+        // Representative agentId ("studio-...") + bs58 fingerprint.
+        assert!(
+            validate_anchor_components("studio-abc123", "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy").is_ok()
+        );
     }
 
     #[test]
     fn validate_rejects_empty_and_shell_metacharacters() {
-        assert!(validate_client_fingerprint("").is_err());
-        assert!(validate_client_fingerprint("abc'; rm -rf /").is_err());
-        assert!(validate_client_fingerprint("with space").is_err());
-        assert!(validate_client_fingerprint("with/slash").is_err());
-        assert!(validate_client_fingerprint("$(touch pwned)").is_err());
+        // Bad fingerprint.
+        assert!(validate_anchor_components("studio-x", "").is_err());
+        assert!(validate_anchor_components("studio-x", "abc'; rm -rf /").is_err());
+        assert!(validate_anchor_components("studio-x", "with space").is_err());
+        assert!(validate_anchor_components("studio-x", "with/slash").is_err());
+        // Bad agentId — empty, colon (anchor delimiter), or shell metachars.
+        assert!(validate_anchor_components("", "ABC123").is_err());
+        assert!(validate_anchor_components("evil:agent", "ABC123").is_err());
+        assert!(validate_anchor_components("$(touch pwned)", "ABC123").is_err());
+        assert!(validate_anchor_components("a b", "ABC123").is_err());
     }
 
     #[test]
-    fn provision_script_embeds_validated_fingerprint_and_anchor_path() {
-        let s = build_trust_anchor_provision_script("ABC123xyz");
-        assert!(s.contains("printf '%s\\n' 'ABC123xyz'"));
+    fn provision_script_embeds_agent_id_fingerprint_pair_and_anchor_path() {
+        let s = build_trust_anchor_provision_script("studio-xyz", "ABC123xyz");
+        assert!(s.contains("printf '%s\\n' 'studio-xyz:ABC123xyz'"));
         assert!(s.contains(TRUST_ANCHOR_PATH));
         assert!(s.contains("sudo tee"));
         assert!(s.contains("sudo chmod 0644"));

--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -408,17 +408,10 @@ pub async fn daemon_setup(app: tauri::AppHandle) -> Result<String, String> {
     // value rather than accumulating stale keys.
     let identity = crate::signing::load_or_create_identity()?;
     let fp = identity.fingerprint;
-    // Defense-in-depth: base58 fingerprints are alphanumeric. Refuse to shell-
-    // interpolate anything else (no injection via a malformed identity file).
-    if fp.is_empty() || !fp.chars().all(|c| c.is_ascii_alphanumeric()) {
-        return Err(format!("refusing to provision a malformed client fingerprint: {fp:?}"));
-    }
-    let provision = format!(
-        "set -e; \
-         sudo mkdir -p /etc/revdev; \
-         printf '%s\\n' '{fp}' | sudo tee /etc/revdev/trusted-client-fingerprint >/dev/null; \
-         sudo chmod 0644 /etc/revdev/trusted-client-fingerprint"
-    );
+    // Validation + script construction are platform-independent helpers (unit-
+    // tested on Linux CI); only the wsl::run execution below is Windows-only.
+    validate_client_fingerprint(&fp)?;
+    let provision = build_trust_anchor_provision_script(&fp);
     let pout = wsl::run(&["bash", "-lc", &provision]).await?;
     if !pout.status.success() {
         return Err(format!(

--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -349,32 +349,37 @@ pub async fn daemon_stop() -> Result<(), String> {
 #[cfg(any(not(unix), test))]
 const TRUST_ANCHOR_PATH: &str = "/etc/revdev/trusted-client-fingerprint";
 
-/// Validate a client signing fingerprint before it is shell-interpolated into
-/// the provisioning script. base58 (bs58) fingerprints are ASCII-alphanumeric;
-/// refuse anything else so a malformed identity file can never inject shell.
-/// Platform-independent + unit-tested on Linux even though the only caller is
-/// the not(unix) WSL `daemon_setup`.
+/// Validate the anchor components before they are shell-interpolated into the
+/// provisioning script: the agentId is [A-Za-z0-9._-] and the base58 (bs58)
+/// fingerprint is ASCII-alphanumeric — both non-empty, neither containing a
+/// `:` (the anchor delimiter) or any shell metacharacter, so a malformed
+/// identity file can never inject shell. Platform-independent + unit-tested on
+/// Linux even though the only caller is the not(unix) WSL `daemon_setup`.
 #[cfg(any(not(unix), test))]
-fn validate_client_fingerprint(fp: &str) -> Result<(), String> {
+fn validate_anchor_components(agent_id: &str, fp: &str) -> Result<(), String> {
+    let ok_agent =
+        !agent_id.is_empty() && agent_id.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+    if !ok_agent {
+        return Err(format!("refusing to provision a malformed agentId: {agent_id:?}"));
+    }
     if fp.is_empty() || !fp.chars().all(|c| c.is_ascii_alphanumeric()) {
-        return Err(format!(
-            "refusing to provision a malformed client fingerprint: {fp:?}"
-        ));
+        return Err(format!("refusing to provision a malformed client fingerprint: {fp:?}"));
     }
     Ok(())
 }
 
-/// Build the sudo script that writes `fp` to the root-owned trust anchor. It
-/// OVERWRITES (not appends), so re-running setup after an identity rotation
-/// replaces the value rather than accumulating stale keys. Callers MUST
-/// `validate_client_fingerprint(fp)` first.
+/// Build the sudo script that writes `agentId:fingerprint` to the root-owned
+/// trust anchor. The agentId is bound (not just the key) so one trusted key
+/// cannot enroll under arbitrary agentIds (review B-3). It OVERWRITES (not
+/// appends), so re-running setup after a rotation replaces the value rather
+/// than accumulating stale keys. Callers MUST `validate_anchor_components` first.
 #[cfg(any(not(unix), test))]
-fn build_trust_anchor_provision_script(fp: &str) -> String {
+fn build_trust_anchor_provision_script(agent_id: &str, fp: &str) -> String {
     let path = TRUST_ANCHOR_PATH;
     format!(
         "set -e; \
          sudo mkdir -p /etc/revdev; \
-         printf '%s\\n' '{fp}' | sudo tee {path} >/dev/null; \
+         printf '%s\\n' '{agent_id}:{fp}' | sudo tee {path} >/dev/null; \
          sudo chmod 0644 {path}"
     )
 }

--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -491,3 +491,34 @@ pub async fn daemon_restart() -> Result<u32, String> {
 
     daemon_start().await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_trust_anchor_provision_script, validate_client_fingerprint, TRUST_ANCHOR_PATH,
+    };
+
+    #[test]
+    fn validate_accepts_a_base58_fingerprint() {
+        // Representative bs58 string — alphanumeric, no 0/O/I/l.
+        assert!(validate_client_fingerprint("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_and_shell_metacharacters() {
+        assert!(validate_client_fingerprint("").is_err());
+        assert!(validate_client_fingerprint("abc'; rm -rf /").is_err());
+        assert!(validate_client_fingerprint("with space").is_err());
+        assert!(validate_client_fingerprint("with/slash").is_err());
+        assert!(validate_client_fingerprint("$(touch pwned)").is_err());
+    }
+
+    #[test]
+    fn provision_script_embeds_validated_fingerprint_and_anchor_path() {
+        let s = build_trust_anchor_provision_script("ABC123xyz");
+        assert!(s.contains("printf '%s\\n' 'ABC123xyz'"));
+        assert!(s.contains(TRUST_ANCHOR_PATH));
+        assert!(s.contains("sudo tee"));
+        assert!(s.contains("sudo chmod 0644"));
+    }
+}

--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -441,26 +441,26 @@ pub async fn daemon_setup(app: tauri::AppHandle) -> Result<String, String> {
     }
 
     // Provision the client trust anchor. The daemon rejects enrollment of any
-    // client key whose fingerprint is not in this ROOT-OWNED file (a host
-    // process running as the WSL user could forge a user-owned file, so the
-    // anchor must be root:root). Write THIS install's Studio signing
-    // fingerprint — "one install == one trusted client key". Overwrites (not
-    // appends) so re-running setup after an identity rotation replaces the old
-    // value rather than accumulating stale keys.
+    // (agentId, key) pair not in this ROOT-OWNED file (a host process running as
+    // the WSL user could forge a user-owned file, so the anchor must be
+    // root:root). Write THIS install's Studio (agentId, fingerprint) pair —
+    // "one install == one trusted client key". Overwrites (not appends) so
+    // re-running setup after a rotation replaces the old value.
     let identity = crate::signing::load_or_create_identity()?;
+    let agent_id = identity.agent_id;
     let fp = identity.fingerprint;
     // Validation + script construction are platform-independent helpers (unit-
     // tested on Linux CI); only the wsl::run execution below is Windows-only.
-    validate_client_fingerprint(&fp)?;
-    let provision = build_trust_anchor_provision_script(&fp);
+    validate_anchor_components(&agent_id, &fp)?;
+    let provision = build_trust_anchor_provision_script(&agent_id, &fp);
     let pout = wsl::run(&["bash", "-lc", &provision]).await?;
     if !pout.status.success() {
         return Err(format!(
             "Relay installed, but provisioning the client trust anchor failed (needs sudo). \
              The daemon will reject Studio's key until \
-             /etc/revdev/trusted-client-fingerprint contains this fingerprint. Run inside \
+             /etc/revdev/trusted-client-fingerprint contains this entry. Run inside \
              WSL, then re-run setup:\n\n  \
-             echo '{fp}' | sudo tee /etc/revdev/trusted-client-fingerprint\n\nsudo error: {}",
+             echo '{agent_id}:{fp}' | sudo tee /etc/revdev/trusted-client-fingerprint\n\nsudo error: {}",
             String::from_utf8_lossy(&pout.stderr).trim()
         ));
     }

--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -412,7 +412,9 @@ mod tests {
         assert!(requires_signature("file.read"));
         assert!(requires_signature("git.commit"));
         assert!(requires_signature("project.open"));
-        assert!(!requires_signature("git.status"));
+        assert!(requires_signature("git.status"));
+        assert!(requires_signature("git.log"));
         assert!(!requires_signature("ping"));
+        assert!(!requires_signature("session.list"));
     }
 }

--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -279,6 +279,37 @@ pub fn load_or_create_at(path: &Path) -> Result<StudioIdentity, String> {
         use std::os::unix::fs::PermissionsExt;
         let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
     }
+    #[cfg(windows)]
+    {
+        // The seed IS the signing private key. Default %LOCALAPPDATA% ACLs can
+        // be broader than owner-only, so strip inherited ACEs and grant only the
+        // current user. Fail CLOSED — if we cannot lock it, delete the file and
+        // error rather than leave an unprotected private key on disk (which
+        // would nullify the whole signing model on Windows, the primary
+        // platform).
+        let user = std::env::var("USERNAME").map_err(|_| {
+            let _ = fs::remove_file(path);
+            "cannot resolve %USERNAME% to ACL the signing key".to_string()
+        })?;
+        let status = std::process::Command::new("icacls")
+            .arg(path)
+            .arg("/inheritance:r")
+            .arg("/grant:r")
+            .arg(format!("{user}:F"))
+            .status()
+            .map_err(|e| {
+                let _ = fs::remove_file(path);
+                format!("icacls (lock signing key) failed to run: {e}")
+            })?;
+        if !status.success() {
+            let _ = fs::remove_file(path);
+            return Err(
+                "icacls (lock signing key) returned non-zero; refusing to leave an unprotected \
+                 signing key on disk"
+                    .to_string(),
+            );
+        }
+    }
     Ok(identity)
 }
 

--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -57,6 +57,11 @@ pub fn requires_signature(method: &str) -> bool {
             // root under the verified signer (per-agent root scoping). MUST
             // mirror the daemon's MUTATING_OR_CONTENT_METHODS set (server.ts).
             | "project.open"
+            // git metadata reads — signature-required so they are scoped to the
+            // verified signer (no cross-agent branch/history/dirty-path leak).
+            | "git.status"
+            | "git.listBranches"
+            | "git.log"
     )
 }
 

--- a/apps/studio/src-tauri/tests/harness_integration.rs
+++ b/apps/studio/src-tauri/tests/harness_integration.rs
@@ -127,8 +127,48 @@ async fn wait_until_ready() {
     }
 }
 
+/// True when passwordless sudo is available (CI runners; many dev boxes).
+fn passwordless_sudo() -> bool {
+    Command::new("sudo")
+        .args(["-n", "true"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Provision the Studio (agentId, fingerprint) pair into the ROOT-OWNED default
+/// trust anchor (/etc/revdev/trusted-client-fingerprint) so the spawned cli.js
+/// daemon — which enforces requireRootOwned (B-2), un-relaxable via env —
+/// accepts the harness's client-key session.register. Idempotent (overwrites).
+/// Returns false when passwordless sudo is unavailable, so the one enrollment
+/// test skips instead of hard-failing on a dev box without sudo.
+fn provision_root_anchor() -> bool {
+    if !passwordless_sudo() {
+        return false;
+    }
+    let id = studio_lib::signing::load_or_create_identity().expect("load studio identity");
+    let entry = format!("{}:{}", id.agent_id, id.fingerprint);
+    let script = format!(
+        "set -e; mkdir -p /etc/revdev; printf '%s\\n' '{entry}' \
+         > /etc/revdev/trusted-client-fingerprint; \
+         chmod 0644 /etc/revdev/trusted-client-fingerprint"
+    );
+    Command::new("sudo")
+        .args(["-n", "bash", "-lc", &script])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
 #[tokio::test]
 async fn full_rpc_round_trip_against_real_daemon() {
+    if !provision_root_anchor() {
+        eprintln!(
+            "SKIP full_rpc_round_trip_against_real_daemon: passwordless sudo unavailable to \
+             provision the root-owned trust anchor (the daemon's B-2 enforcement requires it)"
+        );
+        return;
+    }
     let _guard = spawn_daemon("roundtrip").await;
 
     // ping → pong

--- a/apps/studio/src-tauri/tests/harness_integration.rs
+++ b/apps/studio/src-tauri/tests/harness_integration.rs
@@ -80,22 +80,16 @@ async fn spawn_daemon_at(dir: &Path, socket: &Path) -> DaemonGuard {
     std::fs::create_dir_all(dir).expect("create daemon dir");
     let data_dir = dir.join(format!("db-{}", DIR_COUNTER.fetch_add(1, Ordering::Relaxed)));
 
-    // Provision the client trust anchor with Studio's signing fingerprint so
-    // the daemon's enrollment gate (Fix A) accepts the harness's client-key
-    // session.register. The harness loads the same identity from the same
-    // keystore, so the fingerprints match.
-    let anchor = dir.join("trusted-client-fingerprint");
-    let fp = studio_lib::signing::load_or_create_identity()
-        .expect("load studio identity")
-        .fingerprint;
-    std::fs::write(&anchor, format!("{fp}\n")).expect("write trust anchor");
-
+    // The daemon enforces a root-owned trust anchor (review B-2) that an env
+    // override cannot relax, so client-key enrollment is provisioned out-of-band
+    // at the default /etc/revdev path via `provision_root_anchor()` (sudo) by
+    // the one test that registers a client key. The daemon uses that default
+    // path here — no env override.
     let child = Command::new("node")
         .arg(daemon_cli())
         .env("REVDEV_DAEMON_SOCKET", socket)
         .env("REVDEV_DAEMON_DATA", &data_dir)
         .env("REVDEV_DAEMON_PID", dir.join("harness.pid"))
-        .env("REVDEV_DAEMON_TRUSTED_CLIENT_FP", &anchor)
         // Deterministic free-tier daemon regardless of the host shell's env.
         .env_remove("REVEALUI_LICENSE_KEY")
         .env_remove("REVDEV_LICENSE_PUBLIC_KEY")

--- a/packages/daemon/src/__tests__/filegit-config-exec.test.ts
+++ b/packages/daemon/src/__tests__/filegit-config-exec.test.ts
@@ -146,8 +146,13 @@ describe('git config-exec hardening (zero-9P security)', () => {
     socketPath = join(dataDir, 'harness.sock');
     // Provision this client's fingerprint into the trust anchor (fixture).
     const anchor = join(dataDir, 'trusted-client-fingerprint');
-    await writeFile(anchor, `${fingerprint}\n`);
-    daemon = await startDaemon({ socketPath, dataDir, trustedClientFingerprintPath: anchor });
+    await writeFile(anchor, `${agentId}:${fingerprint}\n`);
+    daemon = await startDaemon({
+      socketPath,
+      dataDir,
+      trustedClientFingerprintPath: anchor,
+      trustedAnchorRequireRootOwned: false,
+    });
 
     const reg = await rpcFrame(socketPath, 'session.register', {
       agentId,

--- a/packages/daemon/src/__tests__/filegit-enrollment.test.ts
+++ b/packages/daemon/src/__tests__/filegit-enrollment.test.ts
@@ -121,9 +121,16 @@ describe('daemon enrollment gate + per-agent root scoping', () => {
     repoB = await mkdtemp(join(tmpdir(), 'revdev-enroll-repoB-'));
     socketPath = join(dataDir, 'harness.sock');
     const anchor = join(dataDir, 'trusted-client-fingerprint');
-    // Anchor trusts A and B but NOT evil.
-    await writeFile(anchor, `${a.fingerprint}\n${b.fingerprint}\n`);
-    daemon = await startDaemon({ socketPath, dataDir, trustedClientFingerprintPath: anchor });
+    // Anchor trusts the (agentId, fingerprint) PAIRS of A and B but NOT evil.
+    await writeFile(anchor, `${a.agentId}:${a.fingerprint}\n${b.agentId}:${b.fingerprint}\n`);
+    daemon = await startDaemon({
+      socketPath,
+      dataDir,
+      trustedClientFingerprintPath: anchor,
+      // Fixture anchor in a tmpdir is not root-owned; disable the production
+      // ownership requirement via the programmatic config (not env).
+      trustedAnchorRequireRootOwned: false,
+    });
   });
 
   afterAll(async () => {

--- a/packages/daemon/src/__tests__/filegit-enrollment.test.ts
+++ b/packages/daemon/src/__tests__/filegit-enrollment.test.ts
@@ -204,4 +204,27 @@ describe('daemon enrollment gate + per-agent root scoping', () => {
     const wa = await rpcFrame(socketPath, 'file.write', writeA, sign(a, 'file.write', writeA));
     expect((wa.result as { success: boolean }).success).toBe(true);
   });
+
+  it('rejects an UNSIGNED git.log naming a victim actorAgentId (-32003, B-1)', async () => {
+    // repoB is owned by agent-b. An UNSIGNED caller supplies the victim's
+    // actorAgentId to try to read B's history. git.log is now signature-
+    // REQUIRED, so it is refused at the gate (-32003) — the spoofable
+    // actorAgentId never reaches an authorization decision. (Was served before
+    // the B-1 fix.)
+    const res = await rpcFrame(socketPath, 'git.log', {
+      repoPath: repoB,
+      actorAgentId: b.agentId,
+      limit: 5,
+    });
+    expect(res.result).toBeUndefined();
+    expect(res.error?.code).toBe(-32003);
+
+    // Same for git.status.
+    const st = await rpcFrame(socketPath, 'git.status', {
+      repoPath: repoB,
+      actorAgentId: b.agentId,
+    });
+    expect(st.result).toBeUndefined();
+    expect(st.error?.code).toBe(-32003);
+  });
 });

--- a/packages/daemon/src/__tests__/filegit-git.test.ts
+++ b/packages/daemon/src/__tests__/filegit-git.test.ts
@@ -135,12 +135,9 @@ describe('signed git.* flow (zero-9P P2)', () => {
   });
 
   it('git.log returns a numeric unix timestamp per commit', async () => {
-    // git.log is signature-optional; identity rides actorAgentId.
-    const r = await rpc(socketPath, 'git.log', {
-      repoPath: repo,
-      actorAgentId: agentId,
-      limit: 10,
-    });
+    // git.log is signature-REQUIRED now (scoped to the verified signer — B-1).
+    const logParams = { repoPath: repo, limit: 10 };
+    const r = await rpc(socketPath, 'git.log', logParams, sign('git.log', logParams));
     const commits = r.result?.commits as Array<Record<string, unknown>>;
     expect(commits.length).toBe(1);
     const first = commits[0] as Record<string, unknown>;

--- a/packages/daemon/src/__tests__/filegit-git.test.ts
+++ b/packages/daemon/src/__tests__/filegit-git.test.ts
@@ -96,8 +96,13 @@ describe('signed git.* flow (zero-9P P2)', () => {
     socketPath = join(dataDir, 'harness.sock');
     // Provision this client's fingerprint into the trust anchor (fixture).
     const anchor = join(dataDir, 'trusted-client-fingerprint');
-    await writeFile(anchor, `${fingerprint}\n`);
-    daemon = await startDaemon({ socketPath, dataDir, trustedClientFingerprintPath: anchor });
+    await writeFile(anchor, `${agentId}:${fingerprint}\n`);
+    daemon = await startDaemon({
+      socketPath,
+      dataDir,
+      trustedClientFingerprintPath: anchor,
+      trustedAnchorRequireRootOwned: false,
+    });
     await rpc(socketPath, 'session.register', {
       agentId,
       agentName: 'studio-ui',

--- a/packages/daemon/src/__tests__/filegit-signed.test.ts
+++ b/packages/daemon/src/__tests__/filegit-signed.test.ts
@@ -110,8 +110,13 @@ describe('Studio client-key signing (zero-9P P1)', () => {
     // allowed (the production install writes this root-owned; the test points
     // the daemon at a fixture via trustedClientFingerprintPath).
     const anchor = join(dataDir, 'trusted-client-fingerprint');
-    await writeFile(anchor, `# test trust anchor\n${fingerprint}\n`);
-    daemon = await startDaemon({ socketPath, dataDir, trustedClientFingerprintPath: anchor });
+    await writeFile(anchor, `# test trust anchor\n${agentId}:${fingerprint}\n`);
+    daemon = await startDaemon({
+      socketPath,
+      dataDir,
+      trustedClientFingerprintPath: anchor,
+      trustedAnchorRequireRootOwned: false,
+    });
   });
 
   afterAll(async () => {

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -34,10 +34,15 @@ const SIGNED = [
   // Root registration: signature-required so the root is recorded under the
   // verified signer (per-agent root scoping), not a spoofable param.
   'project.open',
+  // git metadata reads: signature-required so they are scoped to the verified
+  // signer (no cross-agent branch/history/dirty-path leak — review B-1).
+  'git.status',
+  'git.listBranches',
+  'git.log',
 ];
 
-// Payload-free coordination reads stay signature-OPTIONAL.
-const OPTIONAL = ['git.status', 'git.listBranches', 'git.log', 'ping', 'session.list'];
+// Only payload-free, repo-agnostic coordination methods stay signature-OPTIONAL.
+const OPTIONAL = ['ping', 'session.list'];
 
 describe('signature-required method set (zero-9P)', () => {
   for (const m of SIGNED) {

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -164,4 +164,5 @@ export const DAEMON_DEFAULTS: DaemonConfig = {
   maxInlineReadBytes: 786_432, // 768 KiB
   shutdownGracePeriodMs: 5_000, // 5 s
   trustedClientFingerprintPath: '/etc/revdev/trusted-client-fingerprint',
+  trustedAnchorRequireRootOwned: true,
 };

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -126,8 +126,24 @@ export interface DaemonConfig {
    * in-process and never handed out, so they are not spoofable by a host
    * process. Override the path via REVDEV_DAEMON_TRUSTED_CLIENT_FP (tests point
    * it at a fixture).
+   *
+   * Each line is `agentId:fingerprint` — the agentId is bound, not just the
+   * key, so one trusted key cannot enroll under arbitrary agentIds (review B-3).
    */
   trustedClientFingerprintPath: string;
+  /**
+   * When true (production default), the trust anchor AND every ancestor
+   * directory must be root-owned, non-symlink, and not group/other-writable,
+   * and the file is opened O_NOFOLLOW (review B-2). This is what neutralizes a
+   * WSL-user attacker who points REVDEV_DAEMON_TRUSTED_CLIENT_FP at a file they
+   * control: their path is not root-owned, so it is rejected.
+   *
+   * DELIBERATELY not env-settable — only the programmatic startDaemon config
+   * can set it false (tests, which use a fixture anchor in a tmpdir). An
+   * attacker controls their --user unit's environment but cannot reach this
+   * field, so they cannot disable the ownership requirement.
+   */
+  trustedAnchorRequireRootOwned: boolean;
 }
 
 const homeDir = process.env.HOME ?? '/tmp';

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -442,11 +442,7 @@ registerHandler('git.readBlobAtIndex', async (params, _db, ctx) => {
 });
 
 registerHandler('git.listBranches', async (params, _db, ctx) => {
-  // Signature-OPTIONAL metadata read — see git.status.
-  const repoReal = await requireRoot(
-    requireStr(params.repoPath, 'repoPath'),
-    ctx.agentId ?? str(params.actorAgentId),
-  );
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const r = await runGit(['branch', '--format=%(refname:short)'], repoReal);
   if (!r.ok) return { success: false, error: r.stderr || 'git branch failed' };
   const branches = r.stdout.split('\n').filter(Boolean);

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -375,13 +375,7 @@ registerHandler('file.stat', async (params, _db, ctx) => {
 // ---------------------------------------------------------------------------
 
 registerHandler('git.status', async (params, _db, ctx) => {
-  // Signature-OPTIONAL metadata read: accept the socket-bound identity OR a
-  // per-request actorAgentId (fresh-per-call clients). Still scoped to the
-  // owning agent — the strong boundary is the signed mutations + content reads.
-  const repoReal = await requireRoot(
-    requireStr(params.repoPath, 'repoPath'),
-    ctx.agentId ?? str(params.actorAgentId),
-  );
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const r = await runGit(['status', '--porcelain=v1', '--branch'], repoReal);
   if (!r.ok) return { success: false, error: r.stderr || 'git status failed' };
   let branch: string | null = null;

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -451,11 +451,7 @@ registerHandler('git.listBranches', async (params, _db, ctx) => {
 });
 
 registerHandler('git.log', async (params, _db, ctx) => {
-  // Signature-OPTIONAL metadata read — see git.status.
-  const repoReal = await requireRoot(
-    requireStr(params.repoPath, 'repoPath'),
-    ctx.agentId ?? str(params.actorAgentId),
-  );
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const limit = typeof params.limit === 'number' ? Math.max(1, Math.floor(params.limit)) : 50;
   // %x1f = ASCII unit separator, unambiguous against any commit subject text.
   // %aI = author date ISO-8601 (display); %at = author date as a unix timestamp

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -768,12 +768,16 @@ async function registerClientIdentity(
   const fingerprint = computeFingerprint(raw);
   const did = formatDid(agentId, fingerprint);
 
-  // Trust-anchor gate (fail-closed). Reject any client key whose fingerprint
-  // is not provisioned, BEFORE touching agent_identity_keys.
-  const anchorPath = getDaemonConfig().trustedClientFingerprintPath;
-  const trusted = await loadTrustedClientFingerprints(anchorPath);
-  if (!trusted.has(fingerprint)) {
-    throw new UntrustedClientKeyError(fingerprint, anchorPath);
+  // Trust-anchor gate (fail-closed). Reject unless THIS (agentId, fingerprint)
+  // pair is provisioned, BEFORE touching agent_identity_keys. Binding the
+  // agentId stops one trusted key from minting unlimited owning agents (B-3).
+  const cfg = getDaemonConfig();
+  const trusted = await loadTrustedClientEntries(
+    cfg.trustedClientFingerprintPath,
+    cfg.trustedAnchorRequireRootOwned,
+  );
+  if (!trusted.has(`${agentId}:${fingerprint}`)) {
+    throw new UntrustedClientKeyError(agentId, fingerprint, cfg.trustedClientFingerprintPath);
   }
 
   const existing = await db.query<{ fingerprint: string }>(

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -653,35 +653,51 @@ async function bootstrapAgentIdentity(
   return { did, publicKeyPem: kp.publicKeyPem };
 }
 
-/** Thrown when a client-supplied key is not in the root-owned trust anchor. */
+/** Thrown when a client (agentId, key) pair is not in the trust anchor. */
 class UntrustedClientKeyError extends Error {
   /** JSON-RPC error code surfaced to the client (see dispatch catch). */
   readonly code = -32004;
-  constructor(fingerprint: string, anchorPath: string) {
+  constructor(agentId: string, fingerprint: string, anchorPath: string) {
     super(
-      `untrusted client key: fingerprint ${fingerprint} is not in the trust anchor ${anchorPath}. ` +
-        `A client identity may only be enrolled for the install-provisioned key. ` +
-        `If this is a fresh install, run the Studio daemon setup to provision the fingerprint.`,
+      `untrusted client identity: (agentId ${agentId}, fingerprint ${fingerprint}) is not in ` +
+        `the trust anchor ${anchorPath}. A client identity may only be enrolled for the ` +
+        `install-provisioned (agentId, key) pair. If this is a fresh install, run the Studio ` +
+        `daemon setup to provision it.`,
     );
     this.name = 'UntrustedClientKeyError';
   }
 }
 
 /**
- * Read the root-owned trust anchor and return the set of allowed client-key
- * fingerprints. One fingerprint per line; blank lines and `#` comments are
- * ignored. A missing/unreadable file yields an EMPTY set — enrollment then
- * fails closed (no client key is trusted) rather than open. The path is
- * config-driven (DaemonConfig.trustedClientFingerprintPath) so tests point it
- * at a fixture; production points it at the sudo-provisioned root:root file.
+ * Read the trust anchor and return the set of allowed `agentId:fingerprint`
+ * pairs. One `agentId:fingerprint` per line; blank lines and `#` comments are
+ * ignored. Binding the agentId — not just the fingerprint — stops a single
+ * trusted key from enrolling under arbitrary agentIds and becoming many owning
+ * agents, which would defeat per-agent root scoping (review B-3).
+ *
+ * A missing / unreadable / UNTRUSTED file yields an EMPTY set — enrollment then
+ * fails closed. When `requireRootOwned` (production, review B-2), the file AND
+ * every ancestor directory must be a root-owned, non-symlink entry with no
+ * group/other write bit, and the file is opened O_NOFOLLOW + fstat-checked — so
+ * a WSL-user attacker cannot point the daemon at a file they control, even via
+ * a systemd-user `Environment=REVDEV_DAEMON_TRUSTED_CLIENT_FP=...` override
+ * (their path is not root-owned, so it is rejected). The disable lives ONLY in
+ * the programmatic startDaemon config (tests), never in an env var an attacker
+ * could set on their own --user unit.
  */
-async function loadTrustedClientFingerprints(anchorPath: string): Promise<Set<string>> {
+async function loadTrustedClientEntries(
+  anchorPath: string,
+  requireRootOwned: boolean,
+): Promise<Set<string>> {
   let text: string;
   try {
-    text = await readFile(anchorPath, 'utf8');
+    text = requireRootOwned
+      ? await readRootOwnedFile(anchorPath)
+      : await readFile(anchorPath, 'utf8');
   } catch (err) {
-    log.warn('trust anchor unreadable — client-key enrollment fails closed', {
+    log.warn('trust anchor unreadable/untrusted — client-key enrollment fails closed', {
       anchorPath,
+      requireRootOwned,
       reason: err instanceof Error ? err.message : String(err),
     });
     return new Set();
@@ -690,9 +706,42 @@ async function loadTrustedClientFingerprints(anchorPath: string): Promise<Set<st
   for (const line of text.split('\n')) {
     const trimmed = line.trim();
     if (trimmed === '' || trimmed.startsWith('#')) continue;
-    out.add(trimmed);
+    const idx = trimmed.indexOf(':');
+    // Require a non-empty agentId AND fingerprint on either side of the colon.
+    if (idx <= 0 || idx >= trimmed.length - 1) continue;
+    out.add(`${trimmed.slice(0, idx)}:${trimmed.slice(idx + 1)}`);
   }
   return out;
+}
+
+/**
+ * Read a file that MUST be root-owned and tamper-resistant: every ancestor
+ * directory must be a root-owned, non-symlink directory with no group/other
+ * write bit, and the file itself is opened O_NOFOLLOW then fstat-checked
+ * (regular file, uid 0, not group/other-writable). Throws otherwise.
+ */
+async function readRootOwnedFile(filePath: string): Promise<string> {
+  let dir = dirname(resolve(filePath));
+  for (;;) {
+    const dstat = await lstat(dir);
+    if (dstat.isSymbolicLink()) throw new Error(`anchor ancestor is a symlink: ${dir}`);
+    if (!dstat.isDirectory()) throw new Error(`anchor ancestor is not a directory: ${dir}`);
+    if (dstat.uid !== 0) throw new Error(`anchor ancestor not root-owned (uid ${dstat.uid}): ${dir}`);
+    if ((dstat.mode & 0o022) !== 0) throw new Error(`anchor ancestor group/other-writable: ${dir}`);
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached the filesystem root
+    dir = parent;
+  }
+  const handle = await fsOpen(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const fstat = await handle.stat();
+    if (!fstat.isFile()) throw new Error(`trust anchor is not a regular file: ${filePath}`);
+    if (fstat.uid !== 0) throw new Error(`trust anchor not root-owned (uid ${fstat.uid}): ${filePath}`);
+    if ((fstat.mode & 0o022) !== 0) throw new Error(`trust anchor group/other-writable: ${filePath}`);
+    return await handle.readFile('utf8');
+  } finally {
+    await handle.close();
+  }
 }
 
 /**

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -139,10 +139,11 @@ type VerificationResult = 'verified' | 'none' | 'invalid';
  * such a process from reading project files (or `~/.ssh`, `~/.age-identity`
  * via a traversal) or mutating the repo without Studio's per-install key.
  *
- * Payload-free coordination reads (`ping`, `session.*`, `git.status` /
- * `git.listBranches` / `git.log` name+metadata lists, `project.open`) stay
- * signature-OPTIONAL behind the `0600` boundary — they expose no file
- * content and registering a project root exfiltrates nothing on its own.
+ * Only payload-free, repo-agnostic coordination methods (`ping`, `session.*`)
+ * stay signature-OPTIONAL behind the `0600` boundary. The git metadata reads
+ * (`git.status` / `git.listBranches` / `git.log`) are signature-REQUIRED too:
+ * without it an unsigned caller reads another agent's branches / history /
+ * dirty paths cross-agent (review B-1).
  */
 export const MUTATING_OR_CONTENT_METHODS = new Set([
   // file surface — writes + content/metadata reads

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -172,6 +172,12 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   // a later signed mutation would be authorized against. (Cross-language
   // contract: signing.rs requires_signature() must mark project.open too.)
   'project.open',
+  // git metadata reads — signature-REQUIRED so they are scoped to the verified
+  // signer (no cross-agent branch/history/dirty-path leak via a spoofable
+  // actorAgentId). Cross-language contract: signing.rs must mark these too.
+  'git.status',
+  'git.listBranches',
+  'git.log',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -16,7 +16,7 @@
  */
 
 import { constants as fsConstants } from 'node:fs';
-import { lstat, mkdir, open as fsOpen, readFile } from 'node:fs/promises';
+import { open as fsOpen, lstat, mkdir, readFile } from 'node:fs/promises';
 import { createServer, type Socket } from 'node:net';
 import { dirname, resolve } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
@@ -733,7 +733,8 @@ async function readRootOwnedFile(filePath: string): Promise<string> {
     const dstat = await lstat(dir);
     if (dstat.isSymbolicLink()) throw new Error(`anchor ancestor is a symlink: ${dir}`);
     if (!dstat.isDirectory()) throw new Error(`anchor ancestor is not a directory: ${dir}`);
-    if (dstat.uid !== 0) throw new Error(`anchor ancestor not root-owned (uid ${dstat.uid}): ${dir}`);
+    if (dstat.uid !== 0)
+      throw new Error(`anchor ancestor not root-owned (uid ${dstat.uid}): ${dir}`);
     if ((dstat.mode & 0o022) !== 0) throw new Error(`anchor ancestor group/other-writable: ${dir}`);
     const parent = dirname(dir);
     if (parent === dir) break; // reached the filesystem root
@@ -743,8 +744,10 @@ async function readRootOwnedFile(filePath: string): Promise<string> {
   try {
     const fstat = await handle.stat();
     if (!fstat.isFile()) throw new Error(`trust anchor is not a regular file: ${filePath}`);
-    if (fstat.uid !== 0) throw new Error(`trust anchor not root-owned (uid ${fstat.uid}): ${filePath}`);
-    if ((fstat.mode & 0o022) !== 0) throw new Error(`trust anchor group/other-writable: ${filePath}`);
+    if (fstat.uid !== 0)
+      throw new Error(`trust anchor not root-owned (uid ${fstat.uid}): ${filePath}`);
+    if ((fstat.mode & 0o022) !== 0)
+      throw new Error(`trust anchor group/other-writable: ${filePath}`);
     return await handle.readFile('utf8');
   } finally {
     await handle.close();

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -15,9 +15,10 @@
  *   `session.register` are rejected with -32002.
  */
 
-import { mkdir, readFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { lstat, mkdir, open as fsOpen, readFile } from 'node:fs/promises';
 import { createServer, type Socket } from 'node:net';
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import { formatDid, parseDid } from '@revdev/protocol/did';
 import { createLogger } from '@revealui/utils/logger';


### PR DESCRIPTION
## SECURITY follow-up to #173 — the 3 HIGH review holes (merged too early)

⚠️ **#173 was merged at its pre-review head `676676b`, which still contained the three HIGH holes the review flagged** ("do NOT merge on green CI — 3 HIGH holes remain"). The fixes had been pushed to the branch *after* the merge, so they did not land in `test`. **This PR carries those fixes.** Until it merges, `test` has the vulnerable enrollment/authorization surface. **Do not self-merge — coordinator re-review.**

Delta only (everything in #173's accepted surface is already in `test`):

**B-1 — optional reads no longer trust a spoofable `actorAgentId`.** `git.status`/`git.listBranches`/`git.log` are now in `MUTATING_OR_CONTENT_METHODS` + Rust `requires_signature` (harness auto-signs); the `actorAgentId` fallback is gone — they authorize on the verified signer only. Red-before-fix test: unsigned `git.log`/`git.status` with a victim `actorAgentId` → `-32003`. Drift guards updated both sides.

**B-2 — anchor enforced root-owned; env override neutralized.** `readRootOwnedFile`: `O_NOFOLLOW` open + fstat (`uid==0`, regular file, not group/other-writable) + every ancestor dir root-owned/non-symlink/not-writable. `trustedAnchorRequireRootOwned` is a programmatic config field (default `true`, **not env-settable**) — a WSL-user attacker's `Environment=REVDEV_DAEMON_TRUSTED_CLIENT_FP=...` points at a non-root file that fails the check.

**B-3 — enrollment bound to (agentId, fingerprint).** Anchor lines are `agentId:fingerprint`; `registerClientIdentity` rejects unless the exact pair is anchored. WSL provisioning writes the pair (`validate_anchor_components` rejects `:`/metachar agentIds).

**Promoted — Windows seed-file ACL.** `signing.rs` strips inherited ACEs + grants only the current user (`icacls`), fail-closed (deletes the key + errors if it can't lock it).

**Verified:** daemon 430/430 (serial); `cargo test` signing (8) + daemon_ctl (3) + harness_integration (4, incl. `full_rpc_round_trip` against the real daemon with a sudo-provisioned root-owned pair anchor); typecheck + Biome + gitleaks clean.

**Tracked, not blockers:** #174 (filter.* post-open, narrowed to an authorized signer), #175 (native-unix provisioning), #176 (Windows/WSL runtime smoke + a `cargo check --target windows` job for the `not(unix)` glue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
