### PR TITLE
fix(daemon): bound signature payload + add missing signed-RPC attack tests (#164 fast-follow)

### DIFF
--- a/packages/daemon/src/__tests__/filegit-signed.test.ts
+++ b/packages/daemon/src/__tests__/filegit-signed.test.ts
@@ -216,6 +216,83 @@ describe('Studio client-key signing (zero-9P P1)', () => {
     expect(res.error?.message).toContain('escapes project root');
   });
 
+  // ---- Signed-RPC attack matrix (the protections #164 added, now witnessed) ----
+  // Each forged/abused envelope must be rejected -32003 by verifyOrWarn before
+  // the handler runs. note.txt exists from the round-trip test above.
+
+  it('rejects a REPLAYED envelope (nonce reuse) with -32003', async () => {
+    const params = { repoPath: repo, filePath: 'note.txt' };
+    // One envelope, fixed nonce. First use must verify; the replay must fail.
+    const envelope = sign('file.read', params, did, fingerprint, kp.privateKeyPem);
+    const first = await rpcFrame(socketPath, 'file.read', params, envelope);
+    expect((first.result as { content: string }).content).toBe('zero-9P round trip');
+    const replay = await rpcFrame(socketPath, 'file.read', params, envelope);
+    expect(replay.error?.code).toBe(-32003);
+    expect(replay.result).toBeUndefined();
+  });
+
+  it('rejects a STALE-ts envelope (outside the ±60s window) with -32003', async () => {
+    const params = { repoPath: repo, filePath: 'note.txt' };
+    // Sign with a timestamp 120s in the past — correctly signed, just expired.
+    const stale = serializeEnvelope(
+      signEnvelope(
+        {
+          did,
+          kid: fingerprint,
+          nonce: generateNonce(),
+          ts: Math.floor(Date.now() / 1000) - 120,
+          method: 'file.read',
+          paramsHash: hashParams('file.read', params),
+        },
+        kp.privateKeyPem,
+      ),
+    );
+    const res = await rpcFrame(socketPath, 'file.read', params, stale);
+    expect(res.error?.code).toBe(-32003);
+  });
+
+  it('rejects a paramsHash-MISMATCH envelope (signed for other params) with -32003', async () => {
+    // Sign for one filePath, send the envelope on a request for another. The
+    // method matches, so this isolates the paramsHash binding.
+    const signedFor = { repoPath: repo, filePath: 'note.txt' };
+    const sentParams = { repoPath: repo, filePath: 'big.txt' };
+    const envelope = sign('file.read', signedFor, did, fingerprint, kp.privateKeyPem);
+    const res = await rpcFrame(socketPath, 'file.read', sentParams, envelope);
+    expect(res.error?.code).toBe(-32003);
+  });
+
+  it('rejects a method-SUBSTITUTION envelope (signed for a different method) with -32003', async () => {
+    // A valid envelope minted for file.read, replayed onto a file.delete frame.
+    // The signature binds the method, so the substitution is refused (and the
+    // file is NOT deleted).
+    const params = { repoPath: repo, filePath: 'note.txt' };
+    const readEnvelope = sign('file.read', params, did, fingerprint, kp.privateKeyPem);
+    const res = await rpcFrame(socketPath, 'file.delete', params, readEnvelope);
+    expect(res.error?.code).toBe(-32003);
+    expect(await readFile(join(repo, 'note.txt'), 'utf8')).toBe('zero-9P round trip');
+  });
+
+  it('rejects an over-long nonce (payload-field bound) with -32003', async () => {
+    // A correctly-signed envelope whose nonce breaks the .length(32) bound:
+    // SignaturePayloadSchema.safeParse fails in parseEnvelope → unverifiable.
+    const params = { repoPath: repo, filePath: 'note.txt' };
+    const fat = serializeEnvelope(
+      signEnvelope(
+        {
+          did,
+          kid: fingerprint,
+          nonce: 'a'.repeat(2048),
+          ts: Math.floor(Date.now() / 1000),
+          method: 'file.read',
+          paramsHash: hashParams('file.read', params),
+        },
+        kp.privateKeyPem,
+      ),
+    );
+    const res = await rpcFrame(socketPath, 'file.read', params, fat);
+    expect(res.error?.code).toBe(-32003);
+  });
+
   it('returns { tooLarge } instead of content above the inline read cap', async () => {
     // Default maxInlineReadBytes is 768 KiB; write past it and confirm the
     // daemon returns the size envelope rather than serializing the whole file.

--- a/packages/daemon/src/agent-identity-crypto.ts
+++ b/packages/daemon/src/agent-identity-crypto.ts
@@ -118,8 +118,19 @@ export function serializeEnvelope(envelope: SignatureEnvelope): EnvelopeString {
   return `${envelope.rawHeaderB64}.${envelope.rawPayloadB64}.${envelope.signature}`;
 }
 
+// DoS guard: the largest envelope SignatureEnvelopeSchema admits is its field
+// maxima base64url-expanded (header + payload + signature) plus the two `.`
+// separators — comfortably under 16 KiB. Reject anything larger BEFORE any
+// base64/JSON decode, so a multi-megabyte segment can't be expanded and parsed
+// just to be thrown out by the payload schema afterward. The envelope is
+// attacker-supplied and reaches this before the signature is ever checked.
+const MAX_ENVELOPE_CHARS = 16_384;
+
 export function parseEnvelope(envelopeString: EnvelopeString): SignatureEnvelope | null {
   try {
+    if (envelopeString.length > MAX_ENVELOPE_CHARS) {
+      return null;
+    }
     const parts = envelopeString.split('.');
     if (parts.length !== 3) {
       return null;

--- a/packages/protocol/src/signature-schemas.ts
+++ b/packages/protocol/src/signature-schemas.ts
@@ -1,13 +1,19 @@
 import { z } from 'zod';
 
+// Field bounds are DoS guards: every string is attacker-supplied and parsed
+// before the signature is verified, so an unbounded field lets a single frame
+// pin memory/CPU. The caps are generous relative to the real shapes (Ed25519 +
+// did:revdev + sha256) so a legitimate envelope always fits. `nonce` is the
+// tightest: `generateNonce()` is exactly `randomBytes(16).toString('hex')` →
+// 32 hex chars, so it is length-pinned rather than capped.
 export const SignaturePayloadSchema = z
   .object({
-    did: z.string(),
-    kid: z.string(),
-    nonce: z.string(),
-    ts: z.number().int(),
-    method: z.string(),
-    paramsHash: z.string(),
+    did: z.string().min(1).max(512),
+    kid: z.string().min(1).max(128),
+    nonce: z.string().length(32),
+    ts: z.number().int().nonnegative(),
+    method: z.string().min(1).max(128),
+    paramsHash: z.string().min(1).max(64),
   })
   .strict();
 
@@ -22,8 +28,10 @@ export const SignatureEnvelopeSchema = z
   .object({
     header: SignatureHeaderSchema,
     payload: SignaturePayloadSchema,
-    signature: z.string(),
-    rawHeaderB64: z.string(),
-    rawPayloadB64: z.string(),
+    // Ed25519 signature is 64 bytes → 86 base64url chars; the raw segments are
+    // the base64url of the (bounded) header + payload JSON. Cap all three.
+    signature: z.string().min(1).max(128),
+    rawHeaderB64: z.string().min(1).max(256),
+    rawPayloadB64: z.string().min(1).max(8192),
   })
   .strict();


### PR DESCRIPTION
## #164 fast-follow — signature payload bounds + the missing signed-RPC attack tests

Closes **two of the three** #164 security-review follow-ups. The third — the Windows seed-file ACL in `signing.rs` (`chmod 0600` is `cfg(unix)`-only) — is Rust/Windows-only and **cannot be verified from WSL**, so it's deliberately left for a Windows-runtime session rather than shipped blind.

### Hardening
- **`SignaturePayloadSchema` fields are now bounded.** Every string is attacker-supplied and parsed by `parseEnvelope` **before** the signature is verified, so an unbounded field lets one frame pin memory/CPU. `nonce` is length-pinned to **32** (`generateNonce` = `randomBytes(16).toString('hex')`); `did`/`kid`/`method`/`paramsHash` get generous `max()` caps. Enforced **live** via the existing `SignaturePayloadSchema.safeParse` in `parseEnvelope` (verified: the bound is what rejects an over-long nonce).
- **`parseEnvelope` rejects an envelope > 16 KiB before any base64/JSON decode** — a multi-MB segment can't be expanded just to be thrown out by the payload schema afterward.

### Tests (`filegit-signed.test.ts`, over the signed socket)
The signed-RPC attack matrix the #164 review flagged as missing, all asserting `-32003`:
- **REPLAY** — a reused-nonce envelope verifies once; the replay is rejected.
- **STALE-ts** — `ts` 120 s old (outside ±60 s) rejected.
- **paramsHash-MISMATCH** — an envelope signed for other params rejected.
- **method-SUBSTITUTION** — a `file.read` envelope replayed onto `file.delete` rejected (and the file is **not** deleted).
- **over-long nonce** — rejected (**witnesses the new bound; red against the unbounded schema, green after**).

The 4 attack tests characterize protections **#164 already had but never exercised** (green against current code — that was the gap). Full daemon suite **434 green**; protocol builds; `tsc` + Biome clean; no authored regex.

File-disjoint from #177 (that one touches `filegit.ts`); both PR to `test` independently.

### Not self-merging — review/coord peer is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
