### PR TITLE
fix(daemon): sign-gate + confine worktree.create/remove (B-WT)

### DIFF
--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -62,6 +62,11 @@ pub fn requires_signature(method: &str) -> bool {
             | "git.status"
             | "git.listBranches"
             | "git.log"
+            // worktree mutations — `git worktree add/remove` shell out as the
+            // daemon UID, so they are signature-required (the B-WT fix). MUST
+            // mirror the daemon's MUTATING_OR_CONTENT_METHODS set (server.ts).
+            | "worktree.create"
+            | "worktree.remove"
     )
 }
 
@@ -487,6 +492,8 @@ mod tests {
         assert!(requires_signature("project.open"));
         assert!(requires_signature("git.status"));
         assert!(requires_signature("git.log"));
+        assert!(requires_signature("worktree.create"));
+        assert!(requires_signature("worktree.remove"));
         assert!(!requires_signature("ping"));
         assert!(!requires_signature("session.list"));
     }

--- a/packages/daemon/src/__tests__/filegit-worktree.test.ts
+++ b/packages/daemon/src/__tests__/filegit-worktree.test.ts
@@ -1,0 +1,283 @@
+/**
+ * worktree.* signature-gate + confinement regression test (B-WT, HIGH).
+ *
+ * Before this fix `worktree.create` / `worktree.remove` lived in vcs.ts, absent
+ * from the dispatch signature gate (MUTATING_OR_CONTENT_METHODS) AND with no
+ * requireRoot / assertNoFilterDriver. An UNSIGNED host process could
+ * session.register a bare identity and drive `git worktree add` as the daemon
+ * UID against an attacker-controlled base repo — a filter.* driver on that base
+ * then ran arbitrary code as the daemon UID on the checkout (unsigned daemon-UID
+ * RCE). The fix moves both handlers into filegit.ts behind the same barriers as
+ * file.* / git.*, and adds them to the signature gate.
+ *
+ * worktree.* is Pro-gated (multi-agent coordination), so the test runs the
+ * daemon under a Pro license — the license guard is NOT a security barrier
+ * against this threat (a host process can set REVEALUI_LICENSE_KEY); the
+ * signature gate is. With the license satisfied, the signature gate is the
+ * barrier actually exercised below.
+ *
+ * Everything here is proven over a real signed socket round-trip (mirrors
+ * filegit-config-exec.test.ts / filegit-enrollment.test.ts):
+ *   (a) an UNSIGNED worktree.create / worktree.remove is rejected with -32003.
+ *   (b) a signed worktree.create against a base repo carrying a filter.* driver
+ *       is REFUSED and the driver never fires.
+ *   (c) a signed worktree.create on a project.open'd base SUCCEEDS, materializes
+ *       the worktree at the deterministic sibling path, ignores a malicious
+ *       params.path, and worktree.remove cleans it up.
+ *   (d) a signed worktree.create on a root the caller never project.open'd is
+ *       refused (per-agent ownership), and an option-injecting branch is rejected.
+ */
+
+import { execFile as execFileCb } from 'node:child_process';
+import { access, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+import { formatDid } from '@revdev/protocol/did';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  generateNonce,
+  hashParams,
+  serializeEnvelope,
+  signEnvelope,
+} from '../agent-identity-crypto.js';
+import { startDaemon } from '../server.js';
+import {
+  clearTestLicenseEnv,
+  generateTestLicense,
+  setTestLicenseEnv,
+} from './test-license-helper.js';
+// Side-effect import: registers project.open / file.* / git.* / worktree.* handlers.
+import '../filegit.js';
+
+const execFile = promisify(execFileCb);
+
+// PGlite cold-init can exceed the 10s default hook budget under load.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+interface RpcResult {
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+function rpcFrame(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown>,
+  signature?: string,
+): Promise<RpcResult> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req: Record<string, unknown> = { jsonrpc: '2.0', id: 1, method, params };
+    if (signature) req['x-revdev-signature'] = signature;
+    sock.on('connect', () => sock.write(`${JSON.stringify(req)}\n`));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      sock.end();
+      try {
+        resolve(JSON.parse(buf.slice(0, nl)) as RpcResult);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error(`rpc timeout: ${method}`));
+    });
+  });
+}
+
+/** True if a path exists on disk. */
+async function exists(p: string): Promise<boolean> {
+  return access(p).then(
+    () => true,
+    () => false,
+  );
+}
+
+describe('worktree.* signature gate + confinement (B-WT)', () => {
+  let daemon: { close: () => Promise<void> };
+  let socketPath: string;
+  let dataDir: string;
+  const agentId = 'worktree-test';
+
+  // Client-held keypair — simulates the key Studio keeps in its Windows vault.
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid(agentId, fingerprint);
+
+  // (c) sanity: the test depends on signEnvelope being a real export of
+  // agent-identity-crypto.ts (the prior draft guessed and silently no-op'd).
+  it('signEnvelope is a real export used for the signed round-trip', () => {
+    expect(typeof signEnvelope).toBe('function');
+  });
+
+  /** Sign a request exactly as the Studio client must. */
+  function sign(method: string, params: Record<string, unknown>): string {
+    const payload = {
+      did,
+      kid: fingerprint,
+      nonce: generateNonce(),
+      ts: Math.floor(Date.now() / 1000),
+      method,
+      paramsHash: hashParams(method, params),
+    };
+    return serializeEnvelope(signEnvelope(payload, kp.privateKeyPem));
+  }
+
+  /** Signed RPC convenience wrapper for MUTATING_OR_CONTENT_METHODS. */
+  function signedRpc(method: string, params: Record<string, unknown>): Promise<RpcResult> {
+    return rpcFrame(socketPath, method, params, sign(method, params));
+  }
+
+  const git = (repo: string, args: string[]) => execFile('git', args, { cwd: repo });
+
+  /** Initialize a real git repo with one commit on `main`. */
+  async function initRepo(prefix: string): Promise<string> {
+    const repo = await mkdtemp(join(tmpdir(), prefix));
+    await git(repo, ['init', '-q', '-b', 'main']);
+    await git(repo, ['config', 'user.email', 'test@revdev.local']);
+    await git(repo, ['config', 'user.name', 'RevDev Test']);
+    await git(repo, ['config', 'commit.gpgsign', 'false']);
+    await writeFile(join(repo, 'f.txt'), 'original\n');
+    await git(repo, ['add', 'f.txt']);
+    await git(repo, ['commit', '-qm', 'init']);
+    return repo;
+  }
+
+  beforeAll(async () => {
+    // worktree.* is Pro-gated; provision a Pro license BEFORE startDaemon so the
+    // license guard passes and the SIGNATURE gate is the barrier under test.
+    setTestLicenseEnv(generateTestLicense('pro'));
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-worktree-'));
+    socketPath = join(dataDir, 'harness.sock');
+    // Provision this client's fingerprint into the trust anchor (fixture).
+    const anchor = join(dataDir, 'trusted-client-fingerprint');
+    await writeFile(anchor, `${agentId}:${fingerprint}\n`);
+    daemon = await startDaemon({
+      socketPath,
+      dataDir,
+      trustedClientFingerprintPath: anchor,
+      trustedAnchorRequireRootOwned: false,
+    });
+
+    const reg = await rpcFrame(socketPath, 'session.register', {
+      agentId,
+      agentName: 'studio-ui',
+      backend: 'studio',
+      publicKeyPem: kp.publicKeyPem,
+    });
+    expect((reg.result as { did: string }).did).toBe(did);
+  });
+
+  afterAll(async () => {
+    await daemon.close();
+    await rm(dataDir, { recursive: true, force: true });
+    clearTestLicenseEnv();
+  });
+
+  // (a) The core of B-WT: the dispatch sig-gate now covers worktree.*.
+  it('rejects an UNSIGNED worktree.create / worktree.remove with -32003', async () => {
+    const repo = await initRepo('revdev-wt-unsigned-');
+    const create = await rpcFrame(socketPath, 'worktree.create', {
+      repoPath: repo,
+      branch: 'feature/x',
+    });
+    expect(create.error?.code).toBe(-32003);
+    const remove = await rpcFrame(socketPath, 'worktree.remove', {
+      repoPath: repo,
+      branch: 'feature/x',
+    });
+    expect(remove.error?.code).toBe(-32003);
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  // (b) Real assertNoFilterDriver refusal over a signed socket — NOT the
+  // _isExecBearingConfigKeyForTest classifier the prior draft asserted.
+  it('refuses a signed worktree.create whose base repo carries a filter driver', async () => {
+    const repo = await initRepo('revdev-wt-filter-');
+    // Open while clean (passes the exec-key scan at project.open).
+    const open = await signedRpc('project.open', { repoPath: repo });
+    expect((open.result as { success: boolean }).success).toBe(true);
+
+    // Plant a content filter via `git config` (a non-daemon route, since
+    // file.write into .git/ is blocked) + a .gitattributes that routes the
+    // tree through it. The checkout `git worktree add` performs would fire it.
+    const sentinel = join(repo, 'WT_FILTER_SENTINEL');
+    const script = join(repo, 'filter-payload.sh');
+    await writeFile(script, `#!/bin/sh\n: > '${sentinel}'\ncat\n`, { mode: 0o755 });
+    await git(repo, ['config', 'filter.evil.process', script]);
+    await git(repo, ['config', 'filter.evil.clean', script]);
+    await git(repo, ['config', 'filter.evil.smudge', script]);
+    await writeFile(join(repo, '.gitattributes'), '* filter=evil\n');
+
+    const wt = await signedRpc('worktree.create', { repoPath: repo, branch: 'feature/x' });
+    expect(wt.result).toBeUndefined();
+    expect(wt.error?.message ?? '').toContain('filter');
+    // The driver never ran, and no worktree was materialized.
+    expect(await exists(sentinel)).toBe(false);
+
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  // (c) Signed round-trip: success at the deterministic path, attacker path
+  // ignored, then remove cleans up.
+  it('signed worktree.create materializes the deterministic sibling path and remove cleans up', async () => {
+    const repo = await initRepo('revdev-wt-ok-');
+    const open = await signedRpc('project.open', { repoPath: repo });
+    const root = (open.result as { success: boolean; root: string }).root;
+    expect((open.result as { success: boolean }).success).toBe(true);
+
+    // A malicious params.path must be IGNORED — the path is daemon-derived.
+    const attackerPath = join(tmpdir(), `revdev-wt-attacker-${process.pid}`);
+    const wt = await signedRpc('worktree.create', {
+      repoPath: repo,
+      branch: 'feature/x',
+      path: attackerPath,
+    });
+    const expectedPath = join(dirname(root), `${basename(root)}-feature-x`);
+    expect((wt.result as { success: boolean }).success).toBe(true);
+    expect((wt.result as { worktreePath: string }).worktreePath).toBe(expectedPath);
+    expect(await exists(expectedPath)).toBe(true);
+    expect(await exists(join(expectedPath, '.git'))).toBe(true);
+    // The attacker-supplied path was not used.
+    expect(await exists(attackerPath)).toBe(false);
+
+    const rmw = await signedRpc('worktree.remove', { repoPath: repo, branch: 'feature/x' });
+    expect((rmw.result as { success: boolean }).success).toBe(true);
+    expect(await exists(expectedPath)).toBe(false);
+
+    await rm(repo, { recursive: true, force: true });
+    await rm(expectedPath, { recursive: true, force: true });
+    await rm(attackerPath, { recursive: true, force: true });
+  });
+
+  // (d) requireRoot per-agent ownership + option-injection guard.
+  it('refuses worktree.create on a root the caller never opened, and an option-injecting branch', async () => {
+    const repo = await initRepo('revdev-wt-guard-');
+
+    // No project.open → not registered under this agent.
+    const unowned = await signedRpc('worktree.create', { repoPath: repo, branch: 'feature/x' });
+    expect(unowned.result).toBeUndefined();
+    expect(unowned.error?.message ?? '').toContain('not registered');
+
+    // Open it, then try a branch name that would be read as a git option.
+    const open = await signedRpc('project.open', { repoPath: repo });
+    expect((open.result as { success: boolean }).success).toBe(true);
+    const inj = await signedRpc('worktree.create', {
+      repoPath: repo,
+      branch: '--upload-pack=touch /tmp/revdev-should-not-run',
+    });
+    expect(inj.result).toBeUndefined();
+    expect(inj.error?.message ?? '').toContain('option injection');
+
+    await rm(repo, { recursive: true, force: true });
+  });
+});

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -39,6 +39,10 @@ const SIGNED = [
   'git.status',
   'git.listBranches',
   'git.log',
+  // worktree mutations: shell `git worktree add/remove` as the daemon UID, so
+  // signature-required (B-WT). Handlers live in filegit.ts behind requireRoot.
+  'worktree.create',
+  'worktree.remove',
 ];
 
 // Only payload-free, repo-agnostic coordination methods stay signature-OPTIONAL.

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -26,6 +26,13 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import './inference.js';
 import './vcs.js';
+// Register the file.* / git.* / project.open / worktree.* handler group. cli.js
+// is the PRODUCTION daemon entrypoint (systemd ExecStart → dist/cli.js); without
+// this side-effect import the entire zero-9P filegit surface — including the now
+// sign-gated worktree.create / worktree.remove (moved here from vcs.ts for the
+// B-WT fix) — is never registered on the shipped daemon, leaving the signature
+// barrier inert. index.ts already imports it; cli.ts had been missed.
+import './filegit.js';
 import { DAEMON_DEFAULTS } from './config.js';
 import { LicenseConfigError, LicenseExpiredError } from './license.js';
 import { startDaemon } from './server.js';

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -628,3 +628,108 @@ registerHandler('git.pull', async (params, _db, ctx) => {
   if (branch) args.push(branch);
   return gitOutcome(await runGit(args, repoReal), 'git pull');
 });
+
+// ---------------------------------------------------------------------------
+// worktree.* — mutations (moved here from vcs.ts for the B-WT fix)
+//
+// `git worktree add/remove` shells out as the daemon UID, so — exactly like the
+// git.* mutations above — these MUST sit behind the two barriers vcs.ts could
+// not provide:
+//   1. The dispatch signature gate (MUTATING_OR_CONTENT_METHODS / signing.rs::
+//      requires_signature) — binds ctx.agentId to the VERIFIED signer. In vcs.ts
+//      these were absent from the gate, so an UNSIGNED host process could
+//      session.register a bare identity and drive `git worktree add` as the
+//      daemon UID — the B-WT unsigned-RCE blocker.
+//   2. requireRoot(repoPath, ctx.agentId) — the base repo must have been
+//      project.open'd by THIS agent (project.open already ran assertNoExecConfig
+//      on it). The worktree path is daemon-derived (a deterministic sibling of
+//      the realpath'd root), NEVER the caller's free-form params.path, so it is
+//      attacker-uncontrollable. The legacy handler shelled into a DB-`task` cwd
+//      with a caller-supplied path — both dropped here.
+// worktree.list (read-only registry view) stays in vcs.ts.
+// ---------------------------------------------------------------------------
+
+/**
+ * Reject an argument git would read as an option (leading '-'). `branch` and
+ * `baseBranch` reach `git worktree add` in option position (a `--` separator is
+ * not accepted before the new-branch/commit-ish there), so the value itself
+ * must be guarded — mirrors the leading-'-' intent of git.createBranch's `--`.
+ */
+function assertNotGitOption(value: string, name: string): void {
+  if (value.startsWith('-')) {
+    throw new Error(`invalid ${name}: must not start with '-' (option injection)`);
+  }
+}
+
+/**
+ * Deterministic, attacker-uncontrollable worktree path: a sibling of the
+ * realpath'd registered root named `<repo>-<branch>`, with branch slashes folded
+ * to dashes (no regex). Used by BOTH create and remove so the git target is
+ * identical and is never derived from caller input.
+ */
+function worktreePathFor(repoReal: string, branch: string): string {
+  return join(dirname(repoReal), `${basename(repoReal)}-${branch.split('/').join('-')}`);
+}
+
+registerHandler('worktree.create', async (params, db, ctx) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
+  // requireRoot guarantees a non-null owner === ctx.agentId; re-assert for the
+  // type narrowing + belt-and-suspenders (mirrors project.open).
+  const agentId = ctx.agentId;
+  if (agentId === null) throw new Error('worktree.create requires a verified signer identity');
+  const branch = requireStr(params.branch, 'branch');
+  assertNotGitOption(branch, 'branch');
+  const baseBranch = str(params.baseBranch) ?? 'main';
+  assertNotGitOption(baseBranch, 'baseBranch');
+  // `git worktree add` checks out the new tree → runs a filter.<d>.smudge/process
+  // driver, which cannot be -c-cleared per spawn. Refuse a base repo carrying one
+  // (same backstop as git.switchBranch/git.stageFile).
+  await assertNoFilterDriver(repoReal);
+  const worktreePath = worktreePathFor(repoReal, branch);
+  const result = await runGit(
+    ['worktree', 'add', '-b', branch, worktreePath, baseBranch],
+    repoReal,
+  );
+  if (!result.ok) {
+    return { success: false, error: result.stderr || 'git worktree add failed' };
+  }
+  await db.query(
+    `INSERT INTO worktrees (agent_id, branch, worktree_path, base_branch, status)
+     VALUES ($1, $2, $3, $4, 'active')
+     ON CONFLICT (agent_id) DO UPDATE SET
+       branch = EXCLUDED.branch,
+       worktree_path = EXCLUDED.worktree_path,
+       base_branch = EXCLUDED.base_branch,
+       status = 'active'`,
+    [agentId, branch, worktreePath, baseBranch],
+  );
+  return { success: true, branch, worktreePath, baseBranch };
+});
+
+registerHandler('worktree.remove', async (params, db, ctx) => {
+  const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
+  const agentId = ctx.agentId;
+  if (agentId === null) throw new Error('worktree.remove requires a verified signer identity');
+  const branch = requireStr(params.branch, 'branch');
+  assertNotGitOption(branch, 'branch');
+  const row = await db.query<{ worktree_path: string }>(
+    `SELECT worktree_path FROM worktrees
+     WHERE agent_id = $1 AND branch = $2 AND status = 'active'`,
+    [agentId, branch],
+  );
+  if (!row.rows[0]?.worktree_path) {
+    return { success: false, error: `No active worktree for branch ${branch}` };
+  }
+  // Recompute the path from (realpath'd root, branch) rather than trust the
+  // stored string, so the git target stays attacker-uncontrollable.
+  const worktreePath = worktreePathFor(repoReal, branch);
+  const result = await runGit(['worktree', 'remove', worktreePath], repoReal);
+  if (!result.ok) {
+    return { success: false, error: result.stderr || 'git worktree remove failed' };
+  }
+  await db.query(`UPDATE worktrees SET status = 'removed' WHERE agent_id = $1 AND branch = $2`, [
+    agentId,
+    branch,
+  ]);
+  return { success: true, branch, worktreePath };
+});

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -161,6 +161,14 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   'git.commit',
   'git.push',
   'git.pull',
+  // worktree mutations — `git worktree add/remove` shells out as the daemon UID,
+  // so they MUST be signed (binds ctx.agentId to the verified signer) and gated
+  // by requireRoot in filegit.ts. Their absence from this set was the B-WT
+  // blocker: an unsigned host process could session.register a bare identity and
+  // drive `git worktree add` as the daemon UID (filter.* base → RCE on checkout).
+  // Cross-language contract: signing.rs requires_signature() must mark these too.
+  'worktree.create',
+  'worktree.remove',
   // git content-returning reads (diffFile/diffContent embed source lines)
   'git.diffFile',
   'git.diffContent',

--- a/packages/daemon/src/vcs.ts
+++ b/packages/daemon/src/vcs.ts
@@ -1,10 +1,15 @@
 /**
- * VCS handlers — git worktree management and merge-request tracking.
+ * VCS handlers — read-only worktree registry view + merge-request tracking,
+ * plus the shared `runGit` / `runChild` git-spawn helpers used across the daemon.
  *
- * Worktrees are real: we shell out to `git worktree add/remove` in the
- * agent's working directory. Merge requests are tracked in the
- * `merge_requests` table; actual PR creation is left to the client
- * (agents call `gh pr create` themselves and then update status here).
+ * The MUTATING worktree ops (`worktree.create` / `worktree.remove`) moved to
+ * filegit.ts so they sit behind the same `requireRoot` per-agent project-ownership
+ * check and Ed25519 signature barrier as `file.*` / `git.*` — they shell
+ * `git worktree add` as the daemon UID, a shared-UID RCE vector if left unsigned
+ * and unconfined (the B-WT fix). Only the read-only `worktree.list` registry view
+ * stays here. Merge requests are tracked in the `merge_requests` table; actual PR
+ * creation is left to the client (agents call `gh pr create` themselves and then
+ * update status here).
  *
  * Reliability: every git spawn is bounded by `DAEMON_DEFAULTS.gitTimeoutMs`
  * (default 60 s, env-overridable via REVDEV_DAEMON_GIT_TIMEOUT_MS) AND
@@ -227,46 +232,14 @@ function strOrNull(v: unknown): string | null {
   return typeof v === 'string' ? v : null;
 }
 
-async function agentWorkDir(
-  db: import('@electric-sql/pglite').PGlite,
-  agentId: string,
-): Promise<string> {
-  const r = await db.query<{ task: string }>(`SELECT task FROM agent_sessions WHERE id = $1`, [
-    agentId,
-  ]);
-  return r.rows[0]?.task || process.cwd();
-}
-
 // ---------------------------------------------------------------------------
-// worktree.*
+// worktree.* — read-only registry view
+//
+// The mutating worktree ops (`worktree.create` / `worktree.remove`) live in
+// filegit.ts behind requireRoot + the signature barrier (B-WT). This list view
+// only reads the daemon's own `worktrees` table, so it carries no exec or
+// path-traversal surface and stays here.
 // ---------------------------------------------------------------------------
-
-registerHandler('worktree.create', async (params, db, ctx) => {
-  if (!ctx.agentId) throw new Error('worktree.create: no registered session');
-  const branch = strOrNull(params.branch);
-  if (!branch) throw new Error('worktree.create: missing branch');
-  const baseBranch = str(params.baseBranch, 'main');
-  const cwd = await agentWorkDir(db, ctx.agentId);
-  // Derive worktree path as ../<repo>-<branch>
-  const worktreePath =
-    strOrNull(params.path) ?? `${cwd.replace(/\/+$/, '')}-${branch.replace(/\//g, '-')}`;
-
-  const result = await runGit(['worktree', 'add', '-b', branch, worktreePath, baseBranch], cwd);
-  if (!result.ok) {
-    return { success: false, error: result.stderr || 'git worktree add failed' };
-  }
-  await db.query(
-    `INSERT INTO worktrees (agent_id, branch, worktree_path, base_branch, status)
-     VALUES ($1, $2, $3, $4, 'active')
-     ON CONFLICT (agent_id) DO UPDATE SET
-       branch = EXCLUDED.branch,
-       worktree_path = EXCLUDED.worktree_path,
-       base_branch = EXCLUDED.base_branch,
-       status = 'active'`,
-    [ctx.agentId, branch, worktreePath, baseBranch],
-  );
-  return { success: true, branch, worktreePath, baseBranch };
-});
 
 registerHandler('worktree.list', async (params, db) => {
   const agentId = strOrNull(params.agentId);
@@ -275,33 +248,6 @@ registerHandler('worktree.list', async (params, db) => {
     : `SELECT * FROM worktrees WHERE status = 'active' ORDER BY created_at DESC`;
   const result = await db.query<Record<string, unknown>>(sql, agentId ? [agentId] : []);
   return { worktrees: result.rows };
-});
-
-registerHandler('worktree.remove', async (params, db, ctx) => {
-  if (!ctx.agentId) throw new Error('worktree.remove: no registered session');
-  const branch = strOrNull(params.branch);
-  if (!branch) throw new Error('worktree.remove: missing branch');
-
-  const row = await db.query<{ worktree_path: string }>(
-    `SELECT worktree_path FROM worktrees
-     WHERE agent_id = $1 AND branch = $2 AND status = 'active'`,
-    [ctx.agentId, branch],
-  );
-  const worktreePath = row.rows[0]?.worktree_path;
-  if (!worktreePath) {
-    return { success: false, error: `No active worktree for branch ${branch}` };
-  }
-  const cwd = await agentWorkDir(db, ctx.agentId);
-  const result = await runGit(['worktree', 'remove', worktreePath], cwd);
-  if (!result.ok) {
-    return { success: false, error: result.stderr || 'git worktree remove failed' };
-  }
-  await db.query(
-    `UPDATE worktrees SET status = 'removed'
-     WHERE agent_id = $1 AND branch = $2`,
-    [ctx.agentId, branch],
-  );
-  return { success: true, branch, worktreePath };
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## B-WT — sign-gate + confine `worktree.create` / `worktree.remove` (promotion blocker)

The consolidated promotion gate (`wbafajy2s`) returned **NO-GO** on one HIGH blocker the six per-PR zero-9P reviews structurally could not catch: a **composition gap** at the `vcs.ts` worktree seam.

### The bug (unsigned daemon-UID RCE)
`worktree.create` / `worktree.remove` lived in `vcs.ts` and were **absent from the signature barrier** — not in `MUTATING_OR_CONTENT_METHODS` (server.ts) nor `signing.rs::requires_signature`. So:
- the dispatch signature gate never fired for them;
- `ctx.agentId` was satisfiable by an **UNSIGNED** `session.register`;
- the handler shelled `git worktree add` as the **daemon UID** with an attacker-controlled `params.path` / DB-`task` cwd and **no `requireRoot` / `assertNoFilterDriver`**.

A base repo carrying a `filter.<d>.process` driver + `.gitattributes` therefore ran **arbitrary code as the daemon UID on checkout** — an unsigned daemon-UID RCE.

### The fix (the move is all-or-nothing)
- **Move** both handlers `vcs.ts → filegit.ts` so they reuse the module-private `requireRoot` + `assertNoFilterDriver` (filegit already imports `runGit` from vcs; moving avoids a circular dep). `vcs.ts` keeps `str`/`strOrNull` (merge.* use them) and the read-only `worktree.list`; `agentWorkDir` is removed.
- `worktree.create`: `requireRoot(repoPath, ctx.agentId)` (a `project.open`'d, **per-agent-owned** base) → `assertNoFilterDriver(repoReal)` before the checkout → reject leading-`-` `branch`/`baseBranch` (option injection) → **deterministic, regex-free** `worktreePath = <repo>-<branch>` sibling of the realpath'd root; the caller's `params.path` is **dropped**. `worktree.remove` recomputes the same deterministic path rather than trusting the stored string.
- Add both to `MUTATING_OR_CONTENT_METHODS` (server.ts) and `signing.rs::requires_signature` (+ parity test). `merge.*` stay pure-DB, untouched.

### Additional composition gap found + fixed: `cli.ts` never imported `filegit.js`
The production daemon is `dist/cli.js` (systemd `ExecStart`). `cli.ts` imported `./inference.js` + `./vcs.js` but **not `./filegit.js`** — only `index.ts` did. So today the **entire filegit surface** (`file.*` / `git.*` / `project.open`) is unregistered on the shipped daemon, and post-move `worktree.*` would de-register there too, leaving this signature barrier **inert in production**. Added the missing `import './filegit.js'` to `cli.ts`. This is required for the move to be non-regressive and closes the latent gap.

### Tests + verification
New `packages/daemon/src/__tests__/filegit-worktree.test.ts` proves over a **real signed socket** (worktree.* is Pro-gated, so it runs under a test Pro license — the license guard is not a security barrier against a host process; the signature gate is):
- **(a)** unsigned `worktree.create` / `worktree.remove` → `-32003`;
- **(b)** signed `worktree.create` against a `filter.*`-bearing base is **refused** and the driver never fires;
- **(c)** signed `worktree.create` lands at the deterministic sibling path, **ignores a malicious `params.path`**, `worktree.remove` cleans up;
- **(d)** create on an unopened root is refused (per-agent ownership) and an option-injecting branch is rejected.

`signature-gate.test.ts` exact-set fence updated; cross-language parity test in `signing.rs` extended.

Local results:
- `pnpm --filter @revdev/daemon typecheck` — clean
- `pnpm --filter @revdev/daemon exec vitest run --no-file-parallelism` — **444 passed (23 files)**
- `cargo test --lib` (apps/studio/src-tauri) — **85 passed** (incl. `requires_signature_matches_daemon_set`)
- Biome + rustfmt clean on changed files

### ⚠️ Merge gating
Authored by the same session that wrote the fix, so it **must not self-gate**. An **independent re-gate** (separate fresh session, `wbafajy2s` composition lens on the `worktree.*` path) is required before merge. **Do not self-merge** — owner merges after GO, then re-confirms and promotes `test → main`. **Merge-commit only** (no squash).

Refs: B-WT (gate `wbafajy2s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
