### PR TITLE
feat(studio+daemon): B5 AgentPanel Discard All confirm gate + B2 agent.* daemon stubs

### DIFF
--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -617,7 +617,7 @@ export default function AgentPanel() {
               {(gitState?.unstaged.length ?? 0) > 0 ? (
                 <button
                   type="button"
-                  onClick={() => void discardAll()}
+                  onClick={() => setConfirmDiscardAll(true)}
                   disabled={discardingAll}
                   className="rounded px-2 py-1 text-[10px] text-neutral-500 transition-colors hover:bg-red-900/30 hover:text-red-400 disabled:opacity-40"
                 >

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -789,7 +789,7 @@ export default function AgentPanel() {
         open={confirmDiscardAll}
         title="Discard all changes?"
         body="This will permanently discard all unstaged changes in the working tree. Staged files are not affected."
-        affectedItems={gitState?.unstaged.map((f) => f.path)}
+        affectedItems={gitState?.unstaged.map((f: GitFileEntry) => f.path)}
         confirmLabel="Discard All"
         typeToConfirm="discard"
         onConfirm={() => {

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -7,13 +7,12 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+import ConfirmDialog from '../ui/ConfirmDialog';
 import AgentChat from './AgentChat';
 import FileReservations from './FileReservations';
 import MessageInbox from './MessageInbox';
 import SpawnerPanel from './SpawnerPanel';
 import TaskBoard from './TaskBoard';
-
-import ConfirmDialog from '../ui/ConfirmDialog';
 
 const AGENT_POLL_INTERVAL_MS = 30_000;
 

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -308,6 +308,7 @@ export default function AgentPanel() {
 
   const [stagingAll, setStagingAll] = useState(false);
   const [discardingAll, setDiscardingAll] = useState(false);
+  const [confirmDiscardAll, setConfirmDiscardAll] = useState(false);
 
   // Tab state for right pane
   const [rightTab, setRightTab] = useState<RightTab>('changes');

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -13,6 +13,8 @@ import MessageInbox from './MessageInbox';
 import SpawnerPanel from './SpawnerPanel';
 import TaskBoard from './TaskBoard';
 
+import ConfirmDialog from '../ui/ConfirmDialog';
+
 const AGENT_POLL_INTERVAL_MS = 30_000;
 
 type RightTab = 'changes' | 'chat' | 'messages' | 'tasks' | 'reservations';

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -785,6 +785,19 @@ export default function AgentPanel() {
           <FileReservations reservations={harness.reservations} agentId="studio" />
         ) : null}
       </div>
+      <ConfirmDialog
+        open={confirmDiscardAll}
+        title="Discard all changes?"
+        body="This will permanently discard all unstaged changes in the working tree. Staged files are not affected."
+        affectedItems={gitState?.unstaged.map((f) => f.path)}
+        confirmLabel="Discard All"
+        typeToConfirm="discard"
+        onConfirm={() => {
+          setConfirmDiscardAll(false);
+          void discardAll();
+        }}
+        onClose={() => setConfirmDiscardAll(false)}
+      />
     </div>
   );
 }

--- a/packages/daemon/src/agent.ts
+++ b/packages/daemon/src/agent.ts
@@ -1,0 +1,39 @@
+/**
+ * agent.* stub handlers — register the agent spawning surface in the daemon
+ * so browser+daemon mode receives a descriptive -32005 error instead of the
+ * silent -32601 "Method not found" returned when no handler exists.
+ *
+ * Full agent spawning runs through spawner.rs in Tauri desktop mode; the
+ * daemon does not own the PTY lifecycle. These stubs exist purely to surface
+ * an actionable error in browser+daemon mode.
+ */
+
+import { registerHandler } from './server.js';
+
+class DesktopOnlyError extends Error {
+  readonly code = -32005;
+  constructor(method: string) {
+    super(
+      `${method} requires the RevDev desktop app (Tauri). Agent spawning is handled by the ` +
+        `native Rust backend (spawner.rs) and is not available via the JSON-RPC daemon socket. ` +
+        `Launch RevDev Studio to use agent operations.`,
+    );
+    this.name = 'DesktopOnlyError';
+  }
+}
+
+registerHandler('agent.spawn', async () => {
+  throw new DesktopOnlyError('agent.spawn');
+});
+
+registerHandler('agent.stop', async () => {
+  throw new DesktopOnlyError('agent.stop');
+});
+
+registerHandler('agent.input', async () => {
+  throw new DesktopOnlyError('agent.input');
+});
+
+registerHandler('agent.resize', async () => {
+  throw new DesktopOnlyError('agent.resize');
+});

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -33,6 +33,7 @@ import './vcs.js';
 // B-WT fix) — is never registered on the shipped daemon, leaving the signature
 // barrier inert. index.ts already imports it; cli.ts had been missed.
 import './filegit.js';
+import './agent.js';
 import { DAEMON_DEFAULTS } from './config.js';
 import { LicenseConfigError, LicenseExpiredError } from './license.js';
 import { startDaemon } from './server.js';

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -30,6 +30,7 @@ export { registerHandler, startDaemon } from './server.js';
 import './inference.js';
 import './vcs.js';
 import './filegit.js';
+import './agent.js';
 
 export { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 export { SCHEMA_SQL } from './storage/schema.js';


### PR DESCRIPTION
## Summary

- **B5 critical**: Wire `ConfirmDialog` to the Discard All button in `AgentPanel.tsx` — replaces direct `discardAll()` call with a type-to-confirm gate (`typeToConfirm="discard"`) that shows affected files before destroying all unstaged working-tree changes
- **B2**: Add `agent.spawn/stop/input/resize` stub handlers to the daemon — browser+daemon mode now receives a descriptive `-32005` error ("requires RevDev desktop app") instead of the silent `-32601` "Method not found"

## B5 detail

`AgentPanel.tsx` now:
1. Imports `ConfirmDialog` (already exists via PR #165)
2. Gates the "Discard All" button behind `setConfirmDiscardAll(true)`
3. Renders `<ConfirmDialog typeToConfirm="discard">` with the affected file list before calling `discardAll()`

Per-file discard is not gated — only the bulk destructive action is (consistent with the ConfirmDialog docstring: "git discard-all" is the truly irreversible case).

## B2 detail

`packages/daemon/src/agent.ts` — new side-effect module:
- Defines `DesktopOnlyError` (code `-32005`) with an actionable message
- Registers all 4 `agent.*` methods via `registerHandler()`
- Imported in **both** `cli.ts` (production entrypoint) and `index.ts` (library entrypoint) following the B-WT pattern from PR #181

Full agent spawning continues to run through `spawner.rs` in Tauri mode; the daemon does not own PTY lifecycle.

## Test plan

- [ ] Typecheck: no new errors in `AgentPanel.tsx` (pre-existing TS7006 on generated types are unaffected)
- [ ] Tests: 346 passed, 1 pre-existing `shutdown-drain` timeout (not related to handler registration)
- [ ] Manual: click "Discard All" in Studio → ConfirmDialog opens with file list, requires typing "discard"
- [ ] Manual: in browser+daemon mode, `agent.spawn` call → `-32005` with actionable message (not `-32601`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
