### PR TITLE
feat(daemon): B6 items 0b/3/10 — forceRotate removal, nested-root containment, session eviction

### DIFF
--- a/docs/lanes/multi-agent-filesystem-isolation/plan.md
+++ b/docs/lanes/multi-agent-filesystem-isolation/plan.md
@@ -1,9 +1,9 @@
 ---
 lane: multi-agent-filesystem-isolation
 repo: revdev
-status: proposed
+status: active
 created: 2026-06-24
-last-updated: 2026-06-24
+last-updated: 2026-06-25
 revision: 2 (folded adversarial-critic findings, verified against code)
 security-class: data-segregation / least-privilege
 adr: revdev/docs/decisions/2026-06-24-zero-9p-agent-isolation.md

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -480,24 +480,24 @@ describe('agent identity bootstrap', () => {
     expect(r2.publicKeyPem).toBe(r1.publicKeyPem);
   });
 
-  it('forceRotate:true supersedes old key and issues a new one', async () => {
+  it('forceRotate param is silently ignored — re-register returns the same keypair', async () => {
+    // forceRotate was an unauthenticated key-rotation escape hatch removed in
+    // B6 item 0b. Passing it must not cause key supersession.
     const r1 = (await rpc(socketPath, 'session.register', {
-      agentId: 'identity-test-rotate',
+      agentId: 'identity-test-rotate-ignored',
       agentName: 'identity-tester',
       backend: 'test',
     })) as { did: string; publicKeyPem: string };
 
     const r2 = (await rpc(socketPath, 'session.register', {
-      agentId: 'identity-test-rotate',
+      agentId: 'identity-test-rotate-ignored',
       agentName: 'identity-tester',
       backend: 'test',
       forceRotate: true,
     })) as { did: string; publicKeyPem: string };
 
-    expect(r2.did).not.toBe(r1.did);
-    expect(r2.publicKeyPem).not.toBe(r1.publicKeyPem);
-    expect(r2.did.startsWith('did:revfleet:identity-test-rotate:')).toBe(true);
-    expect(r2.publicKeyPem).toContain('BEGIN PUBLIC KEY');
+    expect(r2.did).toBe(r1.did);
+    expect(r2.publicKeyPem).toBe(r1.publicKeyPem);
   });
 
   it('register succeeds when revvault CLI is absent', async () => {

--- a/packages/daemon/src/eviction.ts
+++ b/packages/daemon/src/eviction.ts
@@ -1,0 +1,22 @@
+/**
+ * Eviction pub/sub hub — lets handler modules (filegit.ts, etc.) register
+ * cleanup callbacks that server.ts fires when an agent session ends.
+ *
+ * This module exists to avoid a circular import: filegit.ts already imports
+ * `registerHandler` from server.ts. If server.ts imported filegit.ts to call
+ * `evictRootsForAgent` directly the two modules would form a cycle. The hub
+ * sits at zero dependencies so both sides can import it safely.
+ */
+
+type AgentEndedHook = (agentId: string) => void;
+const hooks: AgentEndedHook[] = [];
+
+/** Register a cleanup hook to be called whenever an agent session ends. */
+export function onAgentEnded(hook: AgentEndedHook): void {
+  hooks.push(hook);
+}
+
+/** Fire all registered cleanup hooks for the given agentId. */
+export function notifyAgentEnded(agentId: string): void {
+  for (const hook of hooks) hook(agentId);
+}

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -383,6 +383,19 @@ registerHandler('project.open', async (params, _db, ctx) => {
   // the daemon UID (e.g. exfil ~/.age-identity/keys.txt). Done BEFORE adding to
   // registeredRoots so a refused repo is never usable by file.*/git.*.
   if (isRepo) await assertNoExecConfig(real);
+  // Nested-root containment (B6 item 3): reject a root that is an ancestor or
+  // descendant of a different agent's owned root. A parent-root owner reaches
+  // a child root's files via within(); a child-root opener would inherit access
+  // to the parent agent's tree via requireRoot + within(). Both directions are
+  // rejected here before any registration occurs.
+  for (const [existingRoot, ownerId] of registeredRoots) {
+    if (ownerId === ctx.agentId) continue;
+    if (within(existingRoot, real) || within(real, existingRoot)) {
+      throw new Error(
+        `project root conflict: ${repoPathRaw} overlaps with a root owned by another agent`,
+      );
+    }
+  }
   registeredRoots.set(real, ctx.agentId);
   return { success: true, root: real, isGitRepo: isRepo };
 });

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -28,6 +28,7 @@ import { constants as fsConstants } from 'node:fs';
 import { open, readFile, realpath, stat, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { onAgentEnded } from './eviction.js';
 import { getDaemonConfig, registerHandler } from './server.js';
 import { runGit, type ShellResult } from './vcs.js';
 

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -46,6 +46,20 @@ import { runGit, type ShellResult } from './vcs.js';
  */
 const registeredRoots = new Map<string, string>();
 
+/**
+ * Remove all roots owned by `agentId`. Called when the agent's session ends so
+ * terminated agents cannot inherit ownership of paths they opened.
+ */
+function evictRootsForAgent(agentId: string): void {
+  for (const [root, ownerId] of registeredRoots) {
+    if (ownerId === agentId) registeredRoots.delete(root);
+  }
+}
+
+// Register the eviction callback so server.ts can fire it on session.end and
+// harness.prune without a circular import (see eviction.ts).
+onAgentEnded(evictRootsForAgent);
+
 /** @internal — test seam: clear the allowlist between test cases. */
 export function _clearRegisteredRootsForTest(): void {
   registeredRoots.clear();

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -614,10 +614,7 @@ interface IdentityResult {
   publicKeyPem: string;
 }
 
-async function bootstrapAgentIdentity(
-  db: PGlite,
-  agentId: string,
-): Promise<IdentityResult> {
+async function bootstrapAgentIdentity(db: PGlite, agentId: string): Promise<IdentityResult> {
   const existing = await db.query<{ did: string; fingerprint: string; public_key_pem: string }>(
     `SELECT did, fingerprint, public_key_pem FROM agent_identity WHERE agent_id = $1`,
     [agentId],

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -548,8 +548,6 @@ registerHandler('session.register', async (params, db, ctx) => {
   const backend = str(params.backend, str(params.env, 'unknown'));
   const env = `${backend}:${agentName}`;
   const pid = num(params.pid, 0) || null;
-  const forceRotate = params.forceRotate === true;
-
   if (supplied) {
     // UPSERT: insert or re-open existing row.
     await db.query(
@@ -594,7 +592,7 @@ registerHandler('session.register', async (params, db, ctx) => {
   const clientPublicKeyPem = strOrNull(params.publicKeyPem);
   const { did, publicKeyPem } = clientPublicKeyPem
     ? await registerClientIdentity(db, id, clientPublicKeyPem)
-    : await bootstrapAgentIdentity(db, id, forceRotate);
+    : await bootstrapAgentIdentity(db, id);
 
   // Include `session: {id}` for back-compat with hook clients that read
   // `result.session.id`. New clients should use `sessionId`/`agentId`.

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -247,6 +247,8 @@ async function runPrune(
       RETURNING id`,
     [stale],
   );
+  // Evict filesystem roots for every stale-terminated agent (B6 item 10).
+  for (const { id } of aged.rows) notifyAgentEnded(id);
   const deleted = await db.query<{ id: string }>(
     `DELETE FROM agent_sessions
       WHERE ended_at IS NOT NULL

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -896,6 +896,8 @@ registerHandler('session.end', async (params, db, ctx) => {
     ctx.agentId = null;
     ctx.agentName = null;
   }
+  // Evict all filesystem roots owned by this agent (B6 item 10).
+  notifyAgentEnded(target);
   // Best-effort dual-write — see GAP-154 §E.
   await syncSessionEnd({ sessionId: target, summary: exitSummary });
   return { ended: target };

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -615,52 +615,32 @@ interface IdentityResult {
 async function bootstrapAgentIdentity(
   db: PGlite,
   agentId: string,
-  forceRotate: boolean,
 ): Promise<IdentityResult> {
   const existing = await db.query<{ did: string; fingerprint: string; public_key_pem: string }>(
     `SELECT did, fingerprint, public_key_pem FROM agent_identity WHERE agent_id = $1`,
     [agentId],
   );
 
-  if (existing.rows.length > 0 && !forceRotate) {
+  if (existing.rows.length > 0) {
     const row = existing.rows[0] as { did: string; fingerprint: string; public_key_pem: string };
     return { did: row.did, publicKeyPem: row.public_key_pem };
   }
 
+  // First registration — generate a new keypair.
   const kp = generateAgentKeypair();
   const fingerprint = computeFingerprint(kp.publicKeyRaw);
   const did = formatDid(agentId, fingerprint);
 
-  if (existing.rows.length === 0) {
-    await db.query(
-      `INSERT INTO agent_identity (agent_id, did, fingerprint, public_key_pem)
-       VALUES ($1, $2, $3, $4)`,
-      [agentId, did, fingerprint, kp.publicKeyPem],
-    );
-    await db.query(
-      `INSERT INTO agent_identity_keys (fingerprint, agent_id, public_key_pem)
-       VALUES ($1, $2, $3)`,
-      [fingerprint, agentId, kp.publicKeyPem],
-    );
-  } else {
-    await db.query(
-      `UPDATE agent_identity_keys
-       SET superseded_at = NOW()
-       WHERE agent_id = $1 AND superseded_at IS NULL`,
-      [agentId],
-    );
-    await db.query(
-      `INSERT INTO agent_identity_keys (fingerprint, agent_id, public_key_pem)
-       VALUES ($1, $2, $3)`,
-      [fingerprint, agentId, kp.publicKeyPem],
-    );
-    await db.query(
-      `UPDATE agent_identity
-       SET did = $1, fingerprint = $2, public_key_pem = $3, last_seen_at = NOW()
-       WHERE agent_id = $4`,
-      [did, fingerprint, kp.publicKeyPem, agentId],
-    );
-  }
+  await db.query(
+    `INSERT INTO agent_identity (agent_id, did, fingerprint, public_key_pem)
+     VALUES ($1, $2, $3, $4)`,
+    [agentId, did, fingerprint, kp.publicKeyPem],
+  );
+  await db.query(
+    `INSERT INTO agent_identity_keys (fingerprint, agent_id, public_key_pem)
+     VALUES ($1, $2, $3)`,
+    [fingerprint, agentId, kp.publicKeyPem],
+  );
 
   void persistIdentityToRevvault(agentId, kp.privateKeyPem, kp.publicKeyPem);
 

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -31,6 +31,7 @@ import {
   verifyEnvelope,
 } from './agent-identity-crypto.js';
 import { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
+import { notifyAgentEnded } from './eviction.js';
 import {
   guardRpcMethod,
   initLicenseGuard,

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -101,7 +101,6 @@ export const schemas: Record<string, z.ZodType> = {
       task: z.string().max(MAX_PATH_LENGTH).optional(),
       env: z.string().max(64).optional(),
       pid: z.number().int().nonnegative().optional(),
-      forceRotate: z.boolean().optional(),
       // Client-owned identity (Studio zero-9P): an SPKI PEM Ed25519 public
       // key. When present the daemon registers only this public half and
       // never mints a keypair. Bounded generously — a PEM is ~120 bytes.


### PR DESCRIPTION
## Summary

Three load-bearing B6 isolation items — all MUST per `docs/lanes/multi-agent-filesystem-isolation/plan.md`.

- **Item 0b — authenticated registration**: Remove unauthenticated `forceRotate` escape hatch from `session.register`. Previously any client could supersede a daemon-minted identity's keypair without holding the current key. Now `bootstrapAgentIdentity` is idempotent: re-register always returns the existing keypair; the rotation code path is deleted. `forceRotate` removed from the Zod schema; param discarded via passthrough.

- **Item 3 — nested-root containment**: `project.open` now rejects a root path that is an ancestor or descendant of any other agent's registered root. Prevents two cross-agent vectors: parent-root owner reaching child-root files via `within()`, and child-root opener naming parent tree paths in subsequent `file.*`/`git.*` calls.

- **Item 10 — eviction on session end/prune**: New `eviction.ts` pub/sub hub breaks the would-be circular import between `server.ts` and `filegit.ts`. `filegit.ts` registers an `evictRootsForAgent` hook at module init; `server.ts` calls `notifyAgentEnded` in `session.end` and `harness.prune` so terminated agents' root registrations are cleaned up immediately.

## Test plan

- [ ] `coordination.test.ts > agent identity bootstrap > forceRotate param is silently ignored` passes (replaces the old supersession test)
- [ ] All coordination, identity, filegit-signed, filegit-enrollment tests pass locally
- [ ] Biome lint clean on all changed files
- [ ] TypeScript typecheck clean (`pnpm typecheck`)
- [ ] CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
