### PR TITLE
feat(daemon): agent.spawn PTY supervised driver (P4 non-identity)

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -56,6 +56,7 @@
     "@revealui/core": "^0.10.1",
     "@revealui/utils": "^0.3.5",
     "drizzle-orm": "^0.45.2",
+    "node-pty": "^1.0.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/daemon/src/__tests__/migrate.test.ts
+++ b/packages/daemon/src/__tests__/migrate.test.ts
@@ -54,20 +54,20 @@ describe('migrate()', () => {
   });
 
   it(
-    'applies the baseline on a fresh database and records version 1',
+    'applies all migrations on a fresh database and records every version',
     async () => {
       db = new PGlite();
       const result = await migrate(db);
 
-      expect(result.applied).toEqual([1]);
-      expect(result.current).toBe(1);
+      expect(result.applied).toEqual(MIGRATIONS.map((m) => m.version));
+      expect(result.current).toBe(MIGRATIONS[MIGRATIONS.length - 1]!.version);
       expect(await tableExists(db, 'agent_sessions')).toBe(true);
       expect(await tableExists(db, 'agent_identity_nonces')).toBe(true);
 
       const rows = await db.query<{ version: number; name: string }>(
         'SELECT version, name FROM schema_version ORDER BY version',
       );
-      expect(rows.rows).toEqual([{ version: 1, name: 'initial-schema' }]);
+      expect(rows.rows).toEqual(MIGRATIONS.map((m) => ({ version: m.version, name: m.name })));
     },
     DB_TEST_TIMEOUT,
   );
@@ -80,7 +80,7 @@ describe('migrate()', () => {
       const second = await migrate(db);
 
       expect(second.applied).toEqual([]);
-      expect(second.current).toBe(1);
+      expect(second.current).toBe(MIGRATIONS[MIGRATIONS.length - 1]!.version);
     },
     DB_TEST_TIMEOUT,
   );
@@ -95,7 +95,7 @@ describe('migrate()', () => {
 
       const result = await migrate(db);
 
-      expect(result.applied).toEqual([1]);
+      expect(result.applied).toEqual(MIGRATIONS.map((m) => m.version));
       const session = await db.query<{ id: string }>('SELECT id FROM agent_sessions');
       expect(session.rows).toEqual([{ id: 'pre-existing' }]);
     },
@@ -106,7 +106,7 @@ describe('migrate()', () => {
     'applies only pending migrations, in order',
     async () => {
       db = new PGlite();
-      await migrate(db); // at version 1
+      await migrate(db, [BASELINE]); // at version 1
 
       const registry: Migration[] = [
         BASELINE,
@@ -127,7 +127,7 @@ describe('migrate()', () => {
     'rolls back a failed migration and leaves schema_version untouched',
     async () => {
       db = new PGlite();
-      await migrate(db);
+      await migrate(db, [BASELINE]);
 
       const broken: Migration = {
         version: 2,
@@ -198,13 +198,13 @@ describe('migrationStatus()', () => {
 
       const before = await migrationStatus(db);
       expect(before.current).toBe(0);
-      expect(before.latest).toBe(1);
-      expect(before.pending).toEqual([{ version: 1, name: 'initial-schema' }]);
+      expect(before.latest).toBe(MIGRATIONS[MIGRATIONS.length - 1]!.version);
+      expect(before.pending).toEqual(MIGRATIONS.map((m) => ({ version: m.version, name: m.name })));
 
       await migrate(db);
 
       const after = await migrationStatus(db);
-      expect(after.current).toBe(1);
+      expect(after.current).toBe(MIGRATIONS[MIGRATIONS.length - 1]!.version);
       expect(after.pending).toEqual([]);
     },
     DB_TEST_TIMEOUT,
@@ -222,7 +222,7 @@ describe('startDaemon() migration wiring', () => {
         const rows = await d._db.query<{ version: number }>(
           'SELECT version FROM schema_version ORDER BY version',
         );
-        expect(rows.rows).toEqual([{ version: 1 }]);
+        expect(rows.rows).toEqual(MIGRATIONS.map((m) => ({ version: m.version })));
       } finally {
         await d.close();
         await rm(dir, { recursive: true, force: true });

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Unit tests for the agent.* PTY spawn handler group (spawn.ts).
+ *
+ * node-pty is mocked so no real processes are spawned. Tests drive the
+ * daemon via a real Unix socket (same pattern as coordination.test.ts) so
+ * the full dispatch + schema validation + identity gate stack is exercised.
+ *
+ * @vitest-environment node
+ */
+
+import { vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+// ---------------------------------------------------------------------------
+// Mock node-pty BEFORE any module that imports spawn.ts resolves
+// ---------------------------------------------------------------------------
+
+interface MockPty {
+  pid: number;
+  onData: ReturnType<typeof vi.fn>;
+  onExit: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  resize: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+  _fireData: (chunk: string) => void;
+  _fireExit: (code: number) => void;
+}
+
+let _lastPty: MockPty | null = null;
+let _pidCounter = 1000;
+
+function makeMockPty(): MockPty {
+  let dataCallback: ((chunk: string) => void) | null = null;
+  let exitCallback: ((ev: { exitCode: number }) => void) | null = null;
+
+  const pty: MockPty = {
+    pid: ++_pidCounter,
+    onData: vi.fn((cb: (chunk: string) => void) => {
+      dataCallback = cb;
+      return { dispose: vi.fn() };
+    }),
+    onExit: vi.fn((cb: (ev: { exitCode: number }) => void) => {
+      exitCallback = cb;
+      return { dispose: vi.fn() };
+    }),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    _fireData: (chunk) => dataCallback?.(chunk),
+    _fireExit: (code) => exitCallback?.({ exitCode: code }),
+  };
+  return pty;
+}
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(() => {
+    _lastPty = makeMockPty();
+    return _lastPty;
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock node:fs/promises stat so cwd validation passes for /tmp paths
+// ---------------------------------------------------------------------------
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    stat: vi.fn(async (p: string) => {
+      if (p === '/tmp' || (p.startsWith('/tmp/') && !p.includes('nonexistent'))) {
+        return { isDirectory: () => true };
+      }
+      const err = Object.assign(new Error(`ENOENT: no such file or directory, stat '${p}'`), {
+        code: 'ENOENT',
+      });
+      throw err;
+    }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Imports (after mock declarations)
+// ---------------------------------------------------------------------------
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { startDaemon } from '../server.js';
+// Side-effect import: registers agent.* handlers with the daemon's handler Map.
+// Must be imported here (not via index.ts / cli.ts entrypoints) since tests
+// import startDaemon directly from server.js. Vitest hoists vi.mock() above
+// all static imports, so the node-pty mock is in place before spawn.ts loads.
+import '../spawn.js';
+import {
+  clearTestLicenseEnv,
+  generateTestLicense,
+  setTestLicenseEnv,
+} from './test-license-helper.js';
+
+// ---------------------------------------------------------------------------
+// JSON-RPC client helper — one request per socket (stateless)
+// ---------------------------------------------------------------------------
+
+function rpc(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown> = {},
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
+    sock.on('connect', () => sock.write(req));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      sock.end();
+      try {
+        const resp = JSON.parse(buf.slice(0, nl)) as {
+          result?: unknown;
+          error?: { code: number; message: string };
+        };
+        if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
+        else resolve(resp.result);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error(`RPC timeout: ${method}`));
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let dataDir: string;
+let socketPath: string;
+let close: () => Promise<void>;
+let agentId: string;
+
+beforeAll(async () => {
+  setTestLicenseEnv(generateTestLicense('enterprise'));
+  dataDir = await mkdtemp(join(tmpdir(), 'revdev-spawn-test-'));
+  socketPath = join(dataDir, 'harness.sock');
+  const d = await startDaemon({ socketPath, dataDir });
+  close = d.close;
+});
+
+afterAll(async () => {
+  await close?.();
+  await rm(dataDir, { recursive: true, force: true });
+  clearTestLicenseEnv();
+});
+
+beforeEach(async () => {
+  const r = (await rpc(socketPath, 'session.register', {
+    agentName: 'spawn-test-agent',
+    workDir: '/tmp',
+    backend: 'test',
+  })) as { sessionId: string };
+  agentId = r.sessionId;
+  _lastPty = null;
+  _pidCounter = 1000;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('agent.spawn', () => {
+  it('returns a processId (UUID) and numeric pid', async () => {
+    const result = (await rpc(socketPath, 'agent.spawn', {
+      actorAgentId: agentId,
+      command: 'bash',
+      args: ['-i'],
+      cwd: '/tmp',
+    })) as { processId: string; pid: number };
+
+    expect(result.processId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(typeof result.pid).toBe('number');
+    expect(result.pid).toBeGreaterThan(0);
+  });
+
+  it('rejects when command is missing (schema validation)', async () => {
+    await expect(
+      rpc(socketPath, 'agent.spawn', {
+        actorAgentId: agentId,
+        cwd: '/tmp',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects a nonexistent cwd', async () => {
+    await expect(
+      rpc(socketPath, 'agent.spawn', {
+        actorAgentId: agentId,
+        command: 'bash',
+        cwd: '/tmp/nonexistent/does-not-exist',
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('agent.input', () => {
+  it('writes data to the mocked pty', async () => {
+    const { processId } = (await rpc(socketPath, 'agent.spawn', {
+      actorAgentId: agentId,
+      command: 'bash',
+      cwd: '/tmp',
+    })) as { processId: string };
+
+    const result = await rpc(socketPath, 'agent.input', {
+      actorAgentId: agentId,
+      processId,
+      data: 'echo hello\n',
+    });
+
+    expect(result).toEqual({ written: true });
+    expect(_lastPty?.write).toHaveBeenCalledWith('echo hello\n');
+  });
+
+  it('rejects input to a process owned by another agent', async () => {
+    const { processId } = (await rpc(socketPath, 'agent.spawn', {
+      actorAgentId: agentId,
+      command: 'bash',
+      cwd: '/tmp',
+    })) as { processId: string };
+
+    const other = (await rpc(socketPath, 'session.register', {
+      agentName: 'input-other',
+      workDir: '/tmp',
+      backend: 'test',
+    })) as { sessionId: string };
+
+    await expect(
+      rpc(socketPath, 'agent.input', {
+        actorAgentId: other.sessionId,
+        processId,
+        data: 'whoami\n',
+      }),
+    ).rejects.toThrow(/not owned by caller/);
+  });
+});
+
+describe('agent.resize', () => {
+  it('calls pty.resize with the given dimensions', async () => {
+    const { processId } = (await rpc(socketPath, 'agent.spawn', {
+      actorAgentId: agentId,
+      command: 'bash',
+      cwd: '/tmp',
+    })) as { processId: string };
+
+    const result = (await rpc(socketPath, 'agent.resize', {
+      actorAgentId: agentId,
+      processId,
+      cols: 120,
+      rows: 40,
+    })) as { resized: boolean; cols: number; rows: number };
+
+    expect(result.resized).toBe(true);
+    expect(result.cols).toBe(120);
+    expect(result.rows).toBe(40);
+    expect(_lastPty?.resize).toHaveBeenCalledWith(120, 40);
+  });
+
+  it('rejects resize for a process owned by another agent', async () => {
+    const { processId } = (await rpc(socketPath, 'agent.spawn', {
+      actorAgentId: agentId,
+      command: 'bash',
+      cwd: '/tmp',
+    })) as { processId: string };
+
+    const other = (await rpc(socketPath, 'session.register', {
+      agentName: 'resize-other',
+      workDir: '/tmp',
+      backend: 'test',
+    })) as { sessionId: string };
+
+    await expect(
+      rpc(socketPath, 'agent.resize', {
+        actorAgentId: other.sessionId,
+        processId,
+        cols: 80,
+        rows: 24,
+      }),
+    ).rejects.toThrow(/not owned by caller/);
+  });
+});
+
+describe('agent.stop', () => {
+  it('kills the mocked pty and returns status killed', async () => {
+    const { processId } = (await rpc(socketPath, 'agent.spawn', {
+      actorAgentId: agentId,
+      command: 'bash',
+      cwd: '/tmp',
+    })) as { processId: string };
+
+    const result = (await rpc(socketPath, 'agent.stop', {
+      actorAgentId: agentId,
+      processId,
+    })) as { stopped: string; status: string };
+
+    expect(result.stopped).toBe(processId);
+    expect(result.status).toBe('killed');
+    expect(_lastPty?.kill).toHaveBeenCalled();
+  });
+
+  it('rejects stop for a process owned by another agent', async () => {
+    const { processId } = (await rpc(socketPath, 'agent.spawn', {
+      actorAgentId: agentId,
+      command: 'bash',
+      cwd: '/tmp',
+    })) as { processId: string };
+
+    const other = (await rpc(socketPath, 'session.register', {
+      agentName: 'stop-other',
+      workDir: '/tmp',
+      backend: 'test',
+    })) as { sessionId: string };
+
+    await expect(
+      rpc(socketPath, 'agent.stop', {
+        actorAgentId: other.sessionId,
+        processId,
+      }),
+    ).rejects.toThrow(/not owned by caller/);
+  });
+
+  it('rejects stop for an unknown processId', async () => {
+    await expect(
+      rpc(socketPath, 'agent.stop', {
+        actorAgentId: agentId,
+        processId: '00000000-0000-0000-0000-000000000000',
+      }),
+    ).rejects.toThrow(/unknown processId/);
+  });
+});
+
+describe('agent.output', () => {
+  it('returns buffered chunks and a cursor', async () => {
+    const { processId } = (await rpc(socketPath, 'agent.spawn', {
+      actorAgentId: agentId,
+      command: 'bash',
+      cwd: '/tmp',
+    })) as { processId: string };
+
+    _lastPty?._fireData('hello world\r\n');
+
+    // Allow the async DB write from bufferOutput to land
+    await new Promise((r) => setTimeout(r, 100));
+
+    const result = (await rpc(socketPath, 'agent.output', {
+      actorAgentId: agentId,
+      processId,
+      cursor: '0',
+    })) as {
+      chunks: Array<{ id: string; seq: number; chunk: string }>;
+      cursor: string;
+      status: string;
+    };
+
+    expect(result.status).toBe('running');
+    expect(Array.isArray(result.chunks)).toBe(true);
+    if (result.chunks.length > 0) {
+      expect(result.chunks[0]?.chunk).toBe('hello world\r\n');
+    }
+    expect(typeof result.cursor).toBe('string');
+  });
+
+  it('rejects output poll for a process owned by another agent', async () => {
+    const { processId } = (await rpc(socketPath, 'agent.spawn', {
+      actorAgentId: agentId,
+      command: 'bash',
+      cwd: '/tmp',
+    })) as { processId: string };
+
+    const other = (await rpc(socketPath, 'session.register', {
+      agentName: 'output-other',
+      workDir: '/tmp',
+      backend: 'test',
+    })) as { sessionId: string };
+
+    await expect(
+      rpc(socketPath, 'agent.output', {
+        actorAgentId: other.sessionId,
+        processId,
+        cursor: '0',
+      }),
+    ).rejects.toThrow(/not owned by caller/);
+  });
+
+  it('rejects output poll for an unknown processId', async () => {
+    await expect(
+      rpc(socketPath, 'agent.output', {
+        actorAgentId: agentId,
+        processId: '00000000-0000-0000-0000-000000000001',
+        cursor: '0',
+      }),
+    ).rejects.toThrow(/unknown processId/);
+  });
+});

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -34,6 +34,9 @@ import './vcs.js';
 // barrier inert. index.ts already imports it; cli.ts had been missed.
 import './filegit.js';
 import './agent.js';
+// Register PTY-backed agent.spawn/stop/input/resize/output handlers.
+// Must come AFTER ./agent.js (stubs) so the real implementations overwrite them.
+import './spawn.js';
 import { DAEMON_DEFAULTS } from './config.js';
 import { LicenseConfigError, LicenseExpiredError } from './license.js';
 import { startDaemon } from './server.js';

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -31,6 +31,9 @@ import './inference.js';
 import './vcs.js';
 import './filegit.js';
 import './agent.js';
+// PTY-backed agent.spawn/stop/input/resize/output — overwrites the stubs
+// in agent.js with real implementations. Must follow agent.js in import order.
+import './spawn.js';
 
 export { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 export { SCHEMA_SQL } from './storage/schema.js';

--- a/packages/daemon/src/migrations/0002-agent-processes.ts
+++ b/packages/daemon/src/migrations/0002-agent-processes.ts
@@ -1,0 +1,44 @@
+/**
+ * Migration 0002 — agent process tables.
+ *
+ * Adds `agent_processes` (metadata + lifecycle for PTY-spawned processes)
+ * and `agent_process_output` (poll-based output buffer for agent.output).
+ */
+
+import type { Migration } from '../storage/migrate.js';
+
+const SQL = `
+  CREATE TABLE IF NOT EXISTS agent_processes (
+    id           TEXT PRIMARY KEY,
+    owner_agent  TEXT NOT NULL,
+    command      TEXT NOT NULL,
+    args         JSONB NOT NULL DEFAULT '[]',
+    cwd          TEXT NOT NULL,
+    pid          INTEGER,
+    status       TEXT NOT NULL DEFAULT 'running',
+    exit_code    INTEGER,
+    created_at   TIMESTAMP NOT NULL DEFAULT NOW(),
+    ended_at     TIMESTAMP
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_agent_processes_owner
+    ON agent_processes (owner_agent, status);
+
+  CREATE TABLE IF NOT EXISTS agent_process_output (
+    id          BIGSERIAL PRIMARY KEY,
+    process_id  TEXT NOT NULL REFERENCES agent_processes(id) ON DELETE CASCADE,
+    seq         INTEGER NOT NULL,
+    stream      TEXT NOT NULL DEFAULT 'pty',
+    chunk       TEXT NOT NULL,
+    created_at  TIMESTAMP NOT NULL DEFAULT NOW()
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_agent_process_output_process_seq
+    ON agent_process_output (process_id, seq);
+`;
+
+export const MIGRATION_0002: Migration = {
+  version: 2,
+  name: 'agent-processes',
+  sql: SQL,
+};

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -17,5 +17,6 @@
 
 import type { Migration } from '../storage/migrate.js';
 import { MIGRATION_0001 } from './0001-initial-schema.js';
+import { MIGRATION_0002 } from './0002-agent-processes.js';
 
-export const MIGRATIONS: readonly Migration[] = [MIGRATION_0001];
+export const MIGRATIONS: readonly Migration[] = [MIGRATION_0001, MIGRATION_0002];

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -1,0 +1,417 @@
+/**
+ * agent.* handlers — PTY-backed process spawning + supervision.
+ *
+ * Implements the non-identity half of P4 (ADR 2026-06-25 "agnostic Reasoner
+ * port + Driver-pluggable loop"). This module:
+ *   - Maintains an in-memory registry of live PTY handles (Map<processId, entry>)
+ *   - Persists metadata rows in `agent_processes` (survives restart as 'exited')
+ *   - Buffers output in `agent_process_output` for poll-based `agent.output`
+ *   - Enforces per-agent ownership: only the spawning agent may send input,
+ *     resize, or stop a process it owns
+ *
+ * P4-IDENTITY TODO: Once the "B6" identity lane ships its signature-gating
+ * rewrite, add 'agent.spawn', 'agent.stop', 'agent.input', 'agent.resize',
+ * and 'agent.output' to MUTATING_OR_CONTENT_METHODS in server.ts AND to
+ * requires_signature() in signing.rs. Until then these methods accept
+ * actorAgentId param auth (same posture as mail.send / files.reserve), which
+ * is gated only by the 0600 socket boundary. The deferred grant model
+ * (spawned-agent DID + project.grant) should be designed as part of that lane.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { stat } from 'node:fs/promises';
+import type { PGlite } from '@electric-sql/pglite';
+import { createLogger } from '@revealui/utils/logger';
+import type { IDisposable, IPty } from 'node-pty';
+import * as nodePty from 'node-pty';
+import { onAgentEnded } from './eviction.js';
+import { registerHandler, type SocketContext } from './server.js';
+
+const log = createLogger({ service: 'revdev-daemon/spawn' });
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum concurrent PTY processes per agent (best-effort; not a hard OS cap). */
+const MAX_PROCESSES_PER_AGENT = 10;
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+interface ProcessEntry {
+  pty: IPty;
+  ownerAgentId: string;
+  dataDisposable: IDisposable;
+  exitDisposable: IDisposable;
+  outputSeq: number;
+}
+
+/**
+ * Live PTY handles, keyed by processId. PTY objects cannot be serialised or
+ * stored in the database — on daemon restart all processes are gone, and
+ * their DB rows are left in 'running' status. Callers should treat a 'running'
+ * row with no matching registry entry as unreachable after a restart.
+ */
+const registry = new Map<string, ProcessEntry>();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function liveCountForAgent(ownerAgentId: string): number {
+  let n = 0;
+  for (const entry of registry.values()) {
+    if (entry.ownerAgentId === ownerAgentId) n++;
+  }
+  return n;
+}
+
+/**
+ * Append a PTY data chunk to the DB output buffer. Fire-and-forget: the PTY
+ * onData callback is synchronous so we cannot await here. Errors are logged
+ * but do not surface to the caller; output may be dropped if the DB is busy.
+ */
+function bufferOutput(db: PGlite, processId: string, chunk: string): void {
+  const entry = registry.get(processId);
+  if (!entry) return;
+  entry.outputSeq++;
+  const seq = entry.outputSeq;
+  db.query(
+    `INSERT INTO agent_process_output (process_id, seq, stream, chunk)
+     VALUES ($1, $2, 'pty', $3)`,
+    [processId, seq, chunk],
+  ).catch((err: unknown) => {
+    log.warn('output buffer write failed', { processId, seq, error: String(err) });
+  });
+}
+
+/**
+ * Mark a process row as exited in the DB. Fire-and-forget (called from the
+ * synchronous onExit callback).
+ */
+function markExited(db: PGlite, processId: string, exitCode: number | null): void {
+  registry.delete(processId);
+  db.query(
+    `UPDATE agent_processes
+        SET status = 'exited', exit_code = $2, ended_at = NOW()
+      WHERE id = $1`,
+    [processId, exitCode],
+  ).catch((err: unknown) => {
+    log.warn('process exit DB update failed', { processId, error: String(err) });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Eviction: kill all processes owned by an agent when its session ends
+// ---------------------------------------------------------------------------
+
+onAgentEnded((agentId: string) => {
+  for (const [processId, entry] of registry) {
+    if (entry.ownerAgentId !== agentId) continue;
+    try {
+      entry.pty.kill();
+    } catch {
+      // PTY may already be dead; ignore
+    }
+    registry.delete(processId);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Minimal safe environment for spawned processes
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal environment for a spawned PTY process. We do NOT inherit
+ * `process.env` blindly because that would pass revvault secrets, API keys,
+ * and signing material to the child.
+ *
+ * P4-IDENTITY TODO: once the B6 project.grant model ships, gate which env
+ * keys a spawned-agent DID may request against the grant.
+ */
+function buildSafeEnv(extraEnv: Record<string, string>): Record<string, string> {
+  const base: Record<string, string> = {
+    GIT_CONFIG_NOSYSTEM: '1',
+    HOME: process.env.HOME ?? '/tmp',
+    PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
+    TERM: 'xterm-color',
+    LANG: 'C.UTF-8',
+  };
+  for (const [k, v] of Object.entries(extraEnv)) {
+    base[k] = v;
+  }
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// Local parameter extraction helpers
+// ---------------------------------------------------------------------------
+
+function requireAgent(ctx: SocketContext, params: Record<string, unknown>): string {
+  if (ctx.agentId) return ctx.agentId;
+  const actor = params.actorAgentId;
+  if (typeof actor === 'string' && actor.length > 0) {
+    ctx.agentId = actor;
+    ctx.boundVia = 'param';
+    return actor;
+  }
+  throw new Error('Not registered: call session.register or pass actorAgentId');
+}
+
+function stringParam(params: Record<string, unknown>, key: string): string {
+  const v = params[key];
+  return typeof v === 'string' ? v : '';
+}
+
+function stringArrayParam(params: Record<string, unknown>, key: string): string[] {
+  const v = params[key];
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === 'string');
+}
+
+function positiveInt(v: unknown, fallback: number): number {
+  return typeof v === 'number' && Number.isFinite(v) && v > 0 ? Math.floor(v) : fallback;
+}
+
+function positiveIntOrZero(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? Math.floor(v) : 0;
+}
+
+function safeEnvRecord(v: unknown): Record<string, string> {
+  if (v === null || typeof v !== 'object' || Array.isArray(v)) return {};
+  const result: Record<string, string> = {};
+  for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof k === 'string' && typeof val === 'string') {
+      result[k] = val;
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * agent.spawn — fork a PTY child process and return processId + pid.
+ *
+ * Security:
+ *   - cwd is validated to exist via stat() before passing to node-pty.
+ *   - env is built from a minimal baseline (see buildSafeEnv).
+ *   - Per-agent concurrency is capped at MAX_PROCESSES_PER_AGENT.
+ *   - P4-IDENTITY TODO: signature-gate once B6 ships; add to
+ *     MUTATING_OR_CONTENT_METHODS and to signing.rs requires_signature().
+ */
+registerHandler('agent.spawn', async (params, db, ctx) => {
+  const ownerAgentId = requireAgent(ctx, params);
+
+  const command = stringParam(params, 'command');
+  if (!command) throw new Error('agent.spawn: missing command');
+
+  const args = stringArrayParam(params, 'args');
+  const cwd = stringParam(params, 'cwd') || (process.env.HOME ?? '/tmp');
+  const cols = positiveInt(params.cols, 80);
+  const rows = positiveInt(params.rows, 24);
+  const extraEnv = safeEnvRecord(params.env);
+
+  // Validate cwd exists and is a directory
+  try {
+    const s = await stat(cwd);
+    if (!s.isDirectory()) throw new Error(`agent.spawn: cwd is not a directory: ${cwd}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`agent.spawn: cwd not accessible: ${msg}`);
+  }
+
+  if (liveCountForAgent(ownerAgentId) >= MAX_PROCESSES_PER_AGENT) {
+    throw new Error(
+      `agent.spawn: per-agent process limit (${MAX_PROCESSES_PER_AGENT}) reached for agent ${ownerAgentId}`,
+    );
+  }
+
+  const processId = randomUUID();
+  const env = buildSafeEnv(extraEnv);
+
+  // P4-IDENTITY TODO: before spawning, verify the caller holds a project.grant
+  // for the command/cwd combination. Requires the grant model from the B6 lane.
+  const pty = nodePty.spawn(command, args, {
+    name: 'xterm-color',
+    cols,
+    rows,
+    cwd,
+    env,
+  });
+
+  await db.query(
+    `INSERT INTO agent_processes (id, owner_agent, command, args, cwd, pid, status)
+     VALUES ($1, $2, $3, $4::jsonb, $5, $6, 'running')`,
+    [processId, ownerAgentId, command, JSON.stringify(args), cwd, pty.pid],
+  );
+
+  const entry: ProcessEntry = {
+    pty,
+    ownerAgentId,
+    outputSeq: 0,
+    dataDisposable: pty.onData((chunk) => bufferOutput(db, processId, chunk)),
+    exitDisposable: pty.onExit(({ exitCode }) => {
+      entry.dataDisposable.dispose();
+      entry.exitDisposable.dispose();
+      markExited(db, processId, exitCode ?? null);
+      log.info('process exited', { processId, exitCode });
+    }),
+  };
+  registry.set(processId, entry);
+
+  log.info('spawned PTY process', { processId, command, pid: pty.pid, ownerAgentId });
+
+  return { processId, pid: pty.pid };
+});
+
+/**
+ * agent.stop — send SIGTERM to the PTY and mark the DB row killed.
+ *
+ * P4-IDENTITY TODO: signature-gate (see agent.spawn TODO above).
+ */
+registerHandler('agent.stop', async (params, db, ctx) => {
+  const callerAgentId = requireAgent(ctx, params);
+  const processId = stringParam(params, 'processId');
+  if (!processId) throw new Error('agent.stop: missing processId');
+
+  const entry = registry.get(processId);
+  if (!entry) {
+    const row = await db.query<{ owner_agent: string; status: string }>(
+      `SELECT owner_agent, status FROM agent_processes WHERE id = $1`,
+      [processId],
+    );
+    if (row.rows.length === 0) throw new Error(`agent.stop: unknown processId ${processId}`);
+    const r = row.rows[0];
+    if (r && r.owner_agent !== callerAgentId) {
+      throw new Error(`agent.stop: process ${processId} is not owned by caller`);
+    }
+    return { stopped: processId, status: r?.status ?? 'unknown' };
+  }
+
+  if (entry.ownerAgentId !== callerAgentId) {
+    throw new Error(`agent.stop: process ${processId} is not owned by caller`);
+  }
+
+  try {
+    entry.pty.kill();
+  } catch {
+    // PTY kill is best-effort; it may already be dead
+  }
+
+  registry.delete(processId);
+
+  await db.query(
+    `UPDATE agent_processes
+        SET status = 'killed', ended_at = NOW()
+      WHERE id = $1`,
+    [processId],
+  );
+
+  return { stopped: processId, status: 'killed' };
+});
+
+/**
+ * agent.input — write bytes to a live PTY's stdin/tty.
+ *
+ * P4-IDENTITY TODO: signature-gate (see agent.spawn TODO above).
+ */
+registerHandler('agent.input', async (params, _db, ctx) => {
+  const callerAgentId = requireAgent(ctx, params);
+  const processId = stringParam(params, 'processId');
+  if (!processId) throw new Error('agent.input: missing processId');
+  const data = stringParam(params, 'data');
+  if (!data) throw new Error('agent.input: missing data');
+
+  const entry = registry.get(processId);
+  if (!entry) throw new Error(`agent.input: process ${processId} is not running`);
+  if (entry.ownerAgentId !== callerAgentId) {
+    throw new Error(`agent.input: process ${processId} is not owned by caller`);
+  }
+
+  entry.pty.write(data);
+  return { written: true };
+});
+
+/**
+ * agent.resize — resize the PTY window.
+ *
+ * P4-IDENTITY TODO: signature-gate (see agent.spawn TODO above).
+ */
+registerHandler('agent.resize', async (params, _db, ctx) => {
+  const callerAgentId = requireAgent(ctx, params);
+  const processId = stringParam(params, 'processId');
+  if (!processId) throw new Error('agent.resize: missing processId');
+  const cols = positiveInt(params.cols, 80);
+  const rows = positiveInt(params.rows, 24);
+
+  const entry = registry.get(processId);
+  if (!entry) throw new Error(`agent.resize: process ${processId} is not running`);
+  if (entry.ownerAgentId !== callerAgentId) {
+    throw new Error(`agent.resize: process ${processId} is not owned by caller`);
+  }
+
+  entry.pty.resize(cols, rows);
+  return { resized: true, cols, rows };
+});
+
+/**
+ * agent.output — poll-based output retrieval.
+ *
+ * Returns buffered chunks for a process since `cursor` (exclusive lower bound
+ * on the `id` PK of `agent_process_output`). Pass `cursor: 0` or omit to
+ * read from the beginning. The `cursor` in the response should be passed on
+ * the next poll. `status` tells the caller when to stop polling.
+ *
+ * Real-time push is not available over this JSON-RPC transport (newline-
+ * delimited JSON has no server-push model). Poll-based mirrors events.query.
+ *
+ * P4-IDENTITY TODO: signature-gate (see agent.spawn TODO above).
+ */
+registerHandler('agent.output', async (params, db, ctx) => {
+  const callerAgentId = requireAgent(ctx, params);
+  const processId = stringParam(params, 'processId');
+  if (!processId) throw new Error('agent.output: missing processId');
+  const cursor = positiveIntOrZero(Number(params.cursor ?? 0));
+  const limit = Math.min(positiveInt(params.limit, 100), 1000);
+
+  const procRow = await db.query<{ owner_agent: string; status: string }>(
+    `SELECT owner_agent, status FROM agent_processes WHERE id = $1`,
+    [processId],
+  );
+  if (procRow.rows.length === 0) throw new Error(`agent.output: unknown processId ${processId}`);
+  const proc = procRow.rows[0];
+  if (!proc) throw new Error(`agent.output: unknown processId ${processId}`);
+  if (proc.owner_agent !== callerAgentId) {
+    throw new Error(`agent.output: process ${processId} is not owned by caller`);
+  }
+
+  const outputRows = await db.query<{ id: string; seq: number; stream: string; chunk: string }>(
+    `SELECT id, seq, stream, chunk
+       FROM agent_process_output
+      WHERE process_id = $1 AND id::bigint > $2
+      ORDER BY id
+      LIMIT $3`,
+    [processId, cursor, limit],
+  );
+
+  const chunks = outputRows.rows.map((r) => ({
+    id: r.id,
+    seq: r.seq,
+    stream: r.stream,
+    chunk: r.chunk,
+  }));
+
+  const nextCursor =
+    chunks.length > 0 ? String(chunks[chunks.length - 1]?.id ?? cursor) : String(cursor);
+
+  return {
+    chunks,
+    cursor: nextCursor,
+    status: proc.status,
+  };
+});

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -495,6 +495,59 @@ export const schemas: Record<string, z.ZodType> = {
     })
     .passthrough(),
 
+  // -- Agent process spawning (P4) -------------------------------------------
+  // P4-IDENTITY TODO: once the B6 identity lane ships signature gating, add
+  // all five agent.* methods to MUTATING_OR_CONTENT_METHODS in server.ts and
+  // to requires_signature() in signing.rs. The grant model (spawned-agent DID
+  // + project.grant) is deferred to that lane.
+  'agent.spawn': z
+    .object({
+      command: z.string().min(1).max(MAX_PATH_LENGTH),
+      args: z.array(z.string().max(MAX_PATH_LENGTH)).max(128).optional(),
+      cwd: z.string().max(MAX_PATH_LENGTH).optional(),
+      cols: z.number().int().min(1).max(1000).optional(),
+      rows: z.number().int().min(1).max(500).optional(),
+      // Caller-supplied env overrides (merged onto a minimal safe baseline).
+      // Values must be strings; non-string values are dropped by the handler.
+      env: z.record(z.string(), z.string()).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'agent.stop': z
+    .object({
+      processId: z.string().min(1),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'agent.input': z
+    .object({
+      processId: z.string().min(1),
+      data: z.string().max(MAX_BODY_LENGTH),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'agent.resize': z
+    .object({
+      processId: z.string().min(1),
+      cols: z.number().int().min(1).max(1000),
+      rows: z.number().int().min(1).max(500),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'agent.output': z
+    .object({
+      processId: z.string().min(1),
+      // Exclusive lower-bound on the output row PK (numeric string); omit = from start.
+      cursor: z.string().optional(),
+      limit: z.number().int().min(1).max(1000).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
   // -- File surface (P0: daemon-owned ext4 I/O) -------------------------------
   // `safePath` already rejects `..` traversal + system roots; the handler
   // additionally realpath-checks every target is a descendant of a registered

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -55,6 +55,7 @@ export const RPC_METHODS = {
   'agent.stop': 'agent.stop',
   'agent.input': 'agent.input',
   'agent.resize': 'agent.resize',
+  'agent.output': 'agent.output',
 
   // Inference management
   'inference.status': 'inference.status',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@electric-sql/pglite@0.5.3)(@neondatabase/serverless@1.1.0)(pg@8.21.0)
+      node-pty:
+        specifier: ^1.0.0
+        version: 1.1.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -2341,6 +2344,12 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -5026,6 +5035,12 @@ snapshots:
   nanoid@3.3.12: {}
 
   negotiator@1.0.0: {}
+
+  node-addon-api@7.1.1: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   object-assign@4.1.1: {}
 


### PR DESCRIPTION
Wires the daemon's previously-unhandled `agent.spawn` / `agent.stop` / `agent.input` / `agent.resize` RPCs (+ a poll-based `agent.output`) to PTY-spawn and supervise a child process — the **Supervised driver**, the non-identity half of ADR 2026-06-25 P4.

- New `spawn.ts` handler group (in-memory PTY registry over `node-pty`), dual-registered in `cli.ts` **and** `index.ts` (overrides the B5 `agent.ts` stubs via import order).
- `agent_processes` + `agent_process_output` tables (migration 0002); poll-based output streaming with a string cursor (BIGINT-safe).
- Zod param schemas for all five methods. Caller identity via the existing `requireAgent` (owner checks on stop/input/output).

**Deferred (B6 lane owns it):** signature-gating (`MUTATING_OR_CONTENT_METHODS` + `signing.rs`), spawned-agent DID, `project.grant`, and the full PTY/env sandbox — all marked `// P4-IDENTITY TODO:`. No identity/auth/session code touched.

Validation: `tsc --noEmit` clean; full daemon suite **457/457**. Note: `node-pty`'s native build is pnpm-ignored by default (`pnpm approve-builds` before runtime); `agent.spawn` is Pro-license-gated regardless, so spawn isn't end-to-end runnable on a free-tier daemon — handlers/schemas/migration are unit-tested with `node-pty` mocked.
