### PR TITLE
fix(daemon): build node-pty native addon so the daemon boots (clears Studio Rust Tests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
       "postcss": ">=8.5.10",
       "qs": ">=6.15.2",
       "ws@8": ">=8.20.1"
-    }
+    },
+    "onlyBuiltDependencies": ["node-pty"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
       "qs": ">=6.15.2",
       "ws@8": ">=8.20.1"
     },
-    "onlyBuiltDependencies": ["node-pty"]
+    "onlyBuiltDependencies": [
+      "node-pty"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `"onlyBuiltDependencies": ["node-pty"]` to the root `pnpm` block in `package.json`
- This allowlists node-pty's native build script in pnpm v10, which otherwise silently skips it
- Without the compiled `pty.node` addon, the daemon throws at import time and exits immediately

## Root cause

pnpm v10 ignores all dependency build scripts unless explicitly allowlisted via `onlyBuiltDependencies`. CI install logs showed `"Ignored build scripts: esbuild, node-pty"`. esbuild's skip was benign; node-pty's skip meant the native addon (`pty.node`) was never compiled, and `packages/daemon/src/spawn.ts` eagerly imports `node-pty` on the daemon boot path (registered in both `cli.ts` and `index.ts`).

Regression from #190 (P4 — added node-pty / PTY support), carried to main by #191.

## Verification

- `pnpm install` now compiles node-pty via node-gyp (`gyp info ok`) — confirmed locally
- Native addon confirmed at `node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty/build/Release/pty.node`
- "Ignored build scripts" warning now lists only `esbuild` (not node-pty)
- Lockfile unchanged (`pnpm-lock.yaml` not dirtied — `onlyBuiltDependencies` doesn't affect the dep graph)
- CI "Studio Rust Tests" job (daemon_lifecycle_start_status_stop) should go GREEN on this PR

## Test plan

- [ ] Studio Rust Tests CI job passes (daemon_lifecycle_start_status_stop green)
- [ ] No lockfile churn in the diff
- [ ] Only esbuild remains in "Ignored build scripts" on a clean install

🤖 Generated with [Claude Code](https://claude.com/claude-code)
