### PR TITLE
chore(release): promote test → main (fix daemon node-pty boot)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
       "postcss": ">=8.5.10",
       "qs": ">=6.15.2",
       "ws@8": ">=8.20.1"
-    }
+    },
+    "onlyBuiltDependencies": ["node-pty"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
       "qs": ">=6.15.2",
       "ws@8": ">=8.20.1"
     },
-    "onlyBuiltDependencies": ["node-pty"]
+    "onlyBuiltDependencies": [
+      "node-pty"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Promotes `test` → `main`, carrying the node-pty native addon fix (#193)
- Clears the RED on `main`'s Studio Rust Tests (`daemon_lifecycle_start_status_stop`)

## Changes included

- **#193** `fix(daemon): build node-pty native addon via pnpm onlyBuiltDependencies` — adds `onlyBuiltDependencies: [node-pty]` to root `package.json` so pnpm v10 compiles the native addon during install. Without it the daemon exits at boot.

## Test plan

- [ ] Studio Rust Tests passes (daemon boots and reaches reachable state within 5s)
- [ ] All other CI jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)