### PR TITLE
ci(studio-rust-tests): run on dependency-manifest changes (closes daemon-test gate hole)

### DIFF
--- a/.github/workflows/studio-rust-tests.yml
+++ b/.github/workflows/studio-rust-tests.yml
@@ -17,6 +17,9 @@ on:
       - "packages/daemon/**"
       - "packages/protocol/**"
       - ".github/workflows/studio-rust-tests.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
   pull_request:
     branches: [main, test]
     paths:
@@ -25,6 +28,9 @@ on:
       - "packages/daemon/**"
       - "packages/protocol/**"
       - ".github/workflows/studio-rust-tests.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds `package.json`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml` to the path filters for both `push` and `pull_request` triggers
- Closes the gate hole that let the original node-pty regression (#190) slip through: a deps-only change broke the daemon, but the daemon Rust test never ran because manifests weren't in the filter

## Why this PR verifies the node-pty fix

The workflow file itself is already in the filter. Changing it triggers \"Rust Integration (bridge <-> daemon)\" — so this PR's CI run is the first time `daemon_lifecycle_start_status_stop` actually runs against the fix from #193. That's the verification we need.

## Test plan

- [ ] **Rust Integration (bridge <-> daemon)** goes GREEN on this PR — specifically `daemon_lifecycle_start_status_stop` — confirming the daemon boots with the compiled `pty.node` addon
- [ ] All other CI jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)