### PR TITLE
chore(release): promote test → main (ci path-filter for Rust daemon tests)

### DIFF
--- a/.github/workflows/studio-rust-tests.yml
+++ b/.github/workflows/studio-rust-tests.yml
@@ -17,6 +17,9 @@ on:
       - "packages/daemon/**"
       - "packages/protocol/**"
       - ".github/workflows/studio-rust-tests.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
   pull_request:
     branches: [main, test]
     paths:
@@ -25,6 +28,9 @@ on:
       - "packages/daemon/**"
       - "packages/protocol/**"
       - ".github/workflows/studio-rust-tests.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Promotes `test` → `main` carrying #196: adds `package.json`/`pnpm-lock.yaml`/`pnpm-workspace.yaml` to the `studio-rust-tests.yml` path filter
- "Rust Integration (bridge <-> daemon)" runs on this promotion, providing the on-main verification of the node-pty fix

## Changes included

- **#196** `ci(studio-rust-tests): run on dependency-manifest changes` — closes the gate hole that let the node-pty regression slip through undetected

## Test plan

- [ ] Rust Integration (bridge <-> daemon) green — `daemon_lifecycle_start_status_stop` passes on main
- [ ] All other CI jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)