### PR TITLE
feat(studio): gate remaining destructive actions behind ConfirmDialog

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -61,6 +61,11 @@ function AuthGatedApp() {
 function MainApp() {
   const [page, setPage] = useState<Page>('dashboard');
   const [editorTarget, setEditorTarget] = useState<EditorTarget | null>(null);
+  // Session-level dismiss of the setup wizard. Distinct from `config.setupComplete`:
+  // dismissing only hides the wizard for this launch (it reappears next start),
+  // whereas completing setup persists. Conflating the two used to mark setup
+  // permanently complete on any close gesture (UX-durability audit, Theme 3).
+  const [wizardDismissed, setWizardDismissed] = useState(false);
   const { config, loading, setIntent, updateConfig } = useConfig();
 
   // Listen for tray-click navigation events from Rust
@@ -139,11 +144,14 @@ function MainApp() {
           {page === 'setup' ? <SetupPage /> : null}
           {page === 'settings' ? <SettingsPanel /> : null}
         </AppShell>
-        <SetupWizard
-          onClose={() => {
-            void updateConfig({ setupComplete: true });
-          }}
-        />
+        {!wizardDismissed && (
+          <SetupWizard
+            onComplete={() => {
+              void updateConfig({ setupComplete: true });
+            }}
+            onDismiss={() => setWizardDismissed(true)}
+          />
+        )}
       </>
     );
   }

--- a/apps/studio/src/__tests__/components/SetupWizard.test.tsx
+++ b/apps/studio/src/__tests__/components/SetupWizard.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// NOTE: vitest hoists vi.mock above all imports/consts, so the factory must not
+// reference outer variables — the status object is inlined here on purpose.
 vi.mock('../../hooks/use-setup', () => ({
   useSetup: vi.fn().mockReturnValue({
     status: {
@@ -47,25 +49,37 @@ vi.mock('../../lib/invoke', () => ({
 }));
 
 import SetupWizard from '../../components/setup/SetupWizard';
+import { markSetupComplete, useSetup } from '../../hooks/use-setup';
+
+function renderWizard(overrides?: { onComplete?: () => void; onDismiss?: () => void }) {
+  const onComplete = overrides?.onComplete ?? vi.fn();
+  const onDismiss = overrides?.onDismiss ?? vi.fn();
+  render(<SetupWizard onComplete={onComplete} onDismiss={onDismiss} />);
+  return { onComplete, onDismiss };
+}
 
 describe('SetupWizard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('renders "Setup RevealUI Studio" title', () => {
-    render(<SetupWizard onClose={vi.fn()} />);
+    renderWizard();
     expect(screen.getByText('Setup RevealUI Studio')).toBeInTheDocument();
   });
 
   it('renders Skip button', () => {
-    render(<SetupWizard onClose={vi.fn()} />);
+    renderWizard();
     expect(screen.getByText('Skip')).toBeInTheDocument();
   });
 
   it('renders Complete Setup button', () => {
-    render(<SetupWizard onClose={vi.fn()} />);
+    renderWizard();
     expect(screen.getByText('Complete Setup')).toBeInTheDocument();
   });
 
   it('renders all setup rows', () => {
-    render(<SetupWizard onClose={vi.fn()} />);
+    renderWizard();
     expect(screen.getByText('WSL')).toBeInTheDocument();
     expect(screen.getByText('Nix')).toBeInTheDocument();
     expect(screen.getByText('DevPod')).toBeInTheDocument();
@@ -76,8 +90,61 @@ describe('SetupWizard', () => {
   });
 
   it('enables Complete Setup when all checks pass', () => {
-    render(<SetupWizard onClose={vi.fn()} />);
+    renderWizard();
     const completeButton = screen.getByText('Complete Setup').closest('button');
     expect(completeButton).not.toBeDisabled();
+  });
+
+  it('completing setup calls onComplete and markSetupComplete, not onDismiss', () => {
+    const { onComplete, onDismiss } = renderWizard();
+    fireEvent.click(screen.getByText('Complete Setup'));
+    expect(markSetupComplete).toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('skipping with all checks passing dismisses directly without a confirm', () => {
+    const { onComplete, onDismiss } = renderWizard();
+    fireEvent.click(screen.getByText('Skip'));
+    // allDone === true → no confirmation gate, dismiss is immediate
+    expect(screen.queryByText('Dismiss setup?')).not.toBeInTheDocument();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('skipping an unfinished setup requires confirmation and never marks complete', () => {
+    // Override the mock for this render only: setup is NOT finished.
+    vi.mocked(useSetup).mockReturnValueOnce({
+      status: {
+        wsl_running: false,
+        nix_installed: true,
+        devbox_mounted: true,
+        git_name: 'RevealUI Studio',
+        git_email: 'founder@revealui.com',
+      },
+      loading: false,
+      error: null,
+      gitName: 'RevealUI Studio',
+      gitEmail: 'founder@revealui.com',
+      saving: false,
+      mounting: false,
+      refresh: vi.fn(),
+      saveGitIdentity: vi.fn(),
+      doMount: vi.fn(),
+      setGitName: vi.fn(),
+      setGitEmail: vi.fn(),
+    } as unknown as ReturnType<typeof useSetup>);
+
+    const { onComplete, onDismiss } = renderWizard();
+    fireEvent.click(screen.getByText('Skip'));
+
+    // The dismiss is gated behind the confirm dialog; onDismiss has not fired yet.
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(screen.getByText('Dismiss setup?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss setup' }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(markSetupComplete).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
   });
 });

--- a/apps/studio/src/__tests__/components/SshBookmarkSidebar.test.tsx
+++ b/apps/studio/src/__tests__/components/SshBookmarkSidebar.test.tsx
@@ -88,7 +88,12 @@ describe('SshBookmarkSidebar', () => {
       expect(screen.getAllByText('Delete')).toHaveLength(2);
     });
 
+    // The row trash button now opens a confirm dialog instead of deleting outright.
     fireEvent.click(screen.getAllByText('Delete')[0]);
+    expect(invoke.sshBookmarkDelete).not.toHaveBeenCalled();
+
+    // Confirming in the dialog performs the delete.
+    fireEvent.click(screen.getByRole('button', { name: 'Delete bookmark' }));
     await waitFor(() => {
       expect(invoke.sshBookmarkDelete).toHaveBeenCalledWith('1');
     });

--- a/apps/studio/src/components/deploy/StepDatabase.tsx
+++ b/apps/studio/src/components/deploy/StepDatabase.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { neonTestConnection, runDbMigrate, runDbSeed } from '../../lib/deploy';
 import type { StudioConfig, WizardData } from '../../types';
 import Button from '../ui/Button';
+import ConfirmDialog from '../ui/ConfirmDialog';
 import Input from '../ui/Input';
 import WizardStep from './WizardStep';
 
@@ -37,6 +38,7 @@ export default function StepDatabase({
   const [supabaseSecretKey, setSupabaseSecretKey] = useState(data.supabaseSecretKey || '');
   const [phase, setPhase] = useState<Phase>('input');
   const [error, setError] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<'migrate' | 'seed' | null>(null);
 
   const isRunning = phase !== 'input' && phase !== 'done';
 
@@ -48,10 +50,32 @@ export default function StepDatabase({
     try {
       setPhase('testing');
       await neonTestConnection(postgresUrl.trim());
+      setPendingAction('migrate');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Database setup failed');
+      setPhase('input');
+    }
+  }
 
+  async function handleConfirmMigrate() {
+    setPendingAction(null);
+    setError(null);
+
+    try {
       setPhase('migrating');
       await runDbMigrate('.');
+      setPendingAction('seed');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Migration failed');
+      setPhase('input');
+    }
+  }
 
+  async function handleConfirmSeed() {
+    setPendingAction(null);
+    setError(null);
+
+    try {
       setPhase('seeding');
       await runDbSeed('.');
 
@@ -67,9 +91,14 @@ export default function StepDatabase({
           : {}),
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Database setup failed');
+      setError(err instanceof Error ? err.message : 'Seeding failed');
       setPhase('input');
     }
+  }
+
+  function handleDialogClose() {
+    setPendingAction(null);
+    setPhase('input');
   }
 
   return (
@@ -163,6 +192,20 @@ export default function StepDatabase({
           Next
         </Button>
       </div>
+
+      <ConfirmDialog
+        open={pendingAction !== null}
+        title={pendingAction === 'seed' ? 'Seed database?' : 'Run schema migration?'}
+        body={
+          pendingAction === 'seed'
+            ? 'Seeding will insert or replace rows in the target database. Existing data in seeded tables may be overwritten and cannot be recovered.'
+            : 'This will apply pending schema migrations to the target database, altering its structure. Ensure you have a backup before proceeding.'
+        }
+        confirmLabel={pendingAction === 'seed' ? 'Seed database' : 'Run migration'}
+        typeToConfirm={pendingAction === 'seed' ? 'seed' : undefined}
+        onConfirm={pendingAction === 'seed' ? handleConfirmSeed : handleConfirmMigrate}
+        onClose={handleDialogClose}
+      />
     </WizardStep>
   );
 }

--- a/apps/studio/src/components/git/GitPanel.tsx
+++ b/apps/studio/src/components/git/GitPanel.tsx
@@ -25,6 +25,7 @@ import type {
   GitFileEntry,
   GitStatusResult,
 } from '../../types';
+import ConfirmDialog from '../ui/ConfirmDialog';
 import DiffView from './DiffView';
 
 // ── Status badge ─────────────────────────────────────────────────────────────
@@ -411,6 +412,9 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
   const [rightTab, setRightTab] = useState<'diff' | 'log'>('diff');
   const [log, setLog] = useState<GitCommitInfo[]>([]);
   const [logLoading, setLogLoading] = useState(false);
+
+  // Pending discard confirmation
+  const [pendingDiscard, setPendingDiscard] = useState<string | null>(null);
 
   const loadBranches = useCallback(async () => {
     try {
@@ -849,7 +853,7 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
                       void stageFile(entry.path);
                     }}
                     onDiscard={() => {
-                      void discardFile(entry.path);
+                      setPendingDiscard(entry.path);
                     }}
                     onOpenEditor={
                       onOpenEditor
@@ -958,6 +962,22 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
           {rightTab === 'log' && <CommitLog entries={log} loading={logLoading} />}
         </div>
       </div>
+
+      <ConfirmDialog
+        open={pendingDiscard !== null}
+        title="Discard changes"
+        body="This will permanently discard all uncommitted changes to this file. This cannot be undone."
+        affectedItems={pendingDiscard !== null ? [pendingDiscard] : undefined}
+        confirmLabel="Discard changes"
+        typeToConfirm="discard"
+        onConfirm={() => {
+          if (pendingDiscard !== null) {
+            void discardFile(pendingDiscard);
+          }
+          setPendingDiscard(null);
+        }}
+        onClose={() => setPendingDiscard(null)}
+      />
     </div>
   );
 }

--- a/apps/studio/src/components/inference/InferencePanel.tsx
+++ b/apps/studio/src/components/inference/InferencePanel.tsx
@@ -8,6 +8,12 @@
 import { useState } from 'react';
 
 import { useInference } from '../../hooks/use-inference';
+import ConfirmDialog from '../ui/ConfirmDialog';
+
+interface PendingDelete {
+  kind: 'model' | 'snapshot';
+  name: string;
+}
 
 export default function InferencePanel() {
   const {
@@ -28,6 +34,17 @@ export default function InferencePanel() {
   } = useInference();
 
   const [pullInput, setPullInput] = useState('');
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null);
+
+  function handleConfirmDelete(): void {
+    if (pendingDelete === null) return;
+    if (pendingDelete.kind === 'model') {
+      void deleteModel(pendingDelete.name);
+    } else {
+      void removeSnap(pendingDelete.name);
+    }
+    setPendingDelete(null);
+  }
 
   if (loading) {
     return (
@@ -170,7 +187,7 @@ export default function InferencePanel() {
                   </span>
                   <button
                     type="button"
-                    onClick={() => void removeSnap(snap.name)}
+                    onClick={() => setPendingDelete({ kind: 'snapshot', name: snap.name })}
                     className="rounded px-2 py-0.5 text-[10px] text-neutral-500 transition-colors hover:bg-red-900/30 hover:text-red-400"
                   >
                     Remove
@@ -241,7 +258,7 @@ export default function InferencePanel() {
                 </div>
                 <button
                   type="button"
-                  onClick={() => void deleteModel(m.name)}
+                  onClick={() => setPendingDelete({ kind: 'model', name: m.name })}
                   className="shrink-0 rounded px-2 py-0.5 text-[10px] text-neutral-500 transition-colors hover:bg-red-900/30 hover:text-red-400"
                 >
                   Delete
@@ -259,6 +276,27 @@ export default function InferencePanel() {
           </p>
         )}
       </div>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title={pendingDelete?.kind === 'model' ? 'Delete model' : 'Remove snap'}
+        body={
+          pendingDelete?.kind === 'model' ? (
+            <>
+              Delete <strong className="text-neutral-100">{pendingDelete.name}</strong>? The model
+              files will be removed from disk. Re-downloading it is a multi-GB operation.
+            </>
+          ) : (
+            <>
+              Remove the <strong className="text-neutral-100">{pendingDelete?.name}</strong> snap?
+              It can be reinstalled at any time with a single command.
+            </>
+          )
+        }
+        confirmLabel={pendingDelete?.kind === 'model' ? 'Delete model' : 'Delete snapshot'}
+        onConfirm={handleConfirmDelete}
+        onClose={() => setPendingDelete(null)}
+      />
     </div>
   );
 }

--- a/apps/studio/src/components/infrastructure/DaemonPanel.tsx
+++ b/apps/studio/src/components/infrastructure/DaemonPanel.tsx
@@ -7,6 +7,7 @@ import {
   daemonStatus,
   daemonStop,
 } from '../../lib/invoke';
+import ConfirmDialog from '../ui/ConfirmDialog';
 
 interface DaemonPanelProps {
   harnessStatus: HarnessStatus;
@@ -16,6 +17,7 @@ export default function DaemonPanel({ harnessStatus }: DaemonPanelProps) {
   const [status, setStatus] = useState<DaemonStatus | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<'stop' | 'restart' | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -46,24 +48,18 @@ export default function DaemonPanel({ harnessStatus }: DaemonPanelProps) {
     }
   }
 
-  async function handleStop() {
+  async function handleConfirm() {
+    if (pendingAction === null) return;
+    const action = pendingAction;
+    setPendingAction(null);
     setLoading(true);
     setError(null);
     try {
-      await daemonStop();
-      await refresh();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleRestart() {
-    setLoading(true);
-    setError(null);
-    try {
-      await daemonRestart();
+      if (action === 'stop') {
+        await daemonStop();
+      } else {
+        await daemonRestart();
+      }
       await refresh();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -85,6 +81,15 @@ export default function DaemonPanel({ harnessStatus }: DaemonPanelProps) {
       : harnessStatus === 'connecting'
         ? 'Connecting...'
         : 'Disconnected';
+
+  const dialogTitle = pendingAction === 'stop' ? 'Stop daemon?' : 'Restart daemon?';
+
+  const dialogBody =
+    pendingAction === 'stop'
+      ? 'Stopping the daemon disconnects all active agent sessions. Unsaved agent work may be lost.'
+      : 'Restarting the daemon briefly disconnects all active agent sessions. Unsaved agent work may be lost.';
+
+  const dialogConfirmLabel = pendingAction === 'stop' ? 'Stop daemon' : 'Restart daemon';
 
   return (
     <div className="space-y-4">
@@ -110,19 +115,19 @@ export default function DaemonPanel({ harnessStatus }: DaemonPanelProps) {
           <>
             <button
               type="button"
-              onClick={handleRestart}
+              onClick={() => setPendingAction('restart')}
               disabled={loading}
               className="rounded bg-yellow-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-yellow-600 disabled:opacity-50"
             >
-              {loading ? 'Restarting...' : 'Restart'}
+              {loading && pendingAction === null ? 'Restarting...' : 'Restart'}
             </button>
             <button
               type="button"
-              onClick={handleStop}
+              onClick={() => setPendingAction('stop')}
               disabled={loading}
               className="rounded bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-600 disabled:opacity-50"
             >
-              {loading ? 'Stopping...' : 'Stop'}
+              {loading && pendingAction === null ? 'Stopping...' : 'Stop'}
             </button>
           </>
         )}
@@ -139,6 +144,15 @@ export default function DaemonPanel({ harnessStatus }: DaemonPanelProps) {
           {status.pid && <div>PID: {status.pid}</div>}
         </div>
       )}
+
+      <ConfirmDialog
+        open={pendingAction !== null}
+        title={dialogTitle}
+        body={dialogBody}
+        confirmLabel={dialogConfirmLabel}
+        onConfirm={handleConfirm}
+        onClose={() => setPendingAction(null)}
+      />
     </div>
   );
 }

--- a/apps/studio/src/components/setup/SetupWizard.tsx
+++ b/apps/studio/src/components/setup/SetupWizard.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import { markSetupComplete, useSetup } from '../../hooks/use-setup';
 import Button from '../ui/Button';
+import ConfirmDialog from '../ui/ConfirmDialog';
 import ErrorAlert from '../ui/ErrorAlert';
 import Modal from '../ui/Modal';
 import {
@@ -15,16 +17,13 @@ import {
 } from './SetupRows';
 
 interface SetupWizardProps {
-  onClose: () => void;
+  onComplete: () => void;
+  onDismiss: () => void;
 }
 
-export default function SetupWizard({ onClose }: SetupWizardProps) {
+export default function SetupWizard({ onComplete, onDismiss }: SetupWizardProps) {
   const setup = useSetup();
-
-  const handleComplete = () => {
-    markSetupComplete();
-    onClose();
-  };
+  const [confirmingDismiss, setConfirmingDismiss] = useState(false);
 
   const allDone =
     setup.status?.wsl_running &&
@@ -33,40 +32,68 @@ export default function SetupWizard({ onClose }: SetupWizardProps) {
     !!setup.status?.git_name &&
     !!setup.status?.git_email;
 
+  const handleComplete = () => {
+    markSetupComplete();
+    onComplete();
+  };
+
+  const handleSkip = () => {
+    if (allDone) {
+      onDismiss();
+    } else {
+      setConfirmingDismiss(true);
+    }
+  };
+
   return (
-    <Modal
-      title="Setup RevealUI Studio"
-      open={true}
-      onClose={onClose}
-      maxWidth="lg"
-      footer={
-        <>
-          <Button variant="ghost" onClick={onClose}>
-            Skip
-          </Button>
-          <Button variant="primary" size="lg" onClick={handleComplete} disabled={!allDone}>
-            Complete Setup
-          </Button>
-        </>
-      }
-    >
-      <div className="space-y-4">
-        {setup.loading && !setup.status && (
-          <p className="text-sm text-neutral-400">Checking environment...</p>
-        )}
+    <>
+      <Modal
+        title="Setup RevealUI Studio"
+        open={true}
+        onClose={handleSkip}
+        maxWidth="lg"
+        footer={
+          <>
+            <Button variant="ghost" onClick={handleSkip}>
+              Skip
+            </Button>
+            <Button variant="primary" size="lg" onClick={handleComplete} disabled={!allDone}>
+              Complete Setup
+            </Button>
+          </>
+        }
+      >
+        <div className="space-y-4">
+          {setup.loading && !setup.status && (
+            <p className="text-sm text-neutral-400">Checking environment...</p>
+          )}
 
-        <ErrorAlert message={setup.error} />
+          <ErrorAlert message={setup.error} />
 
-        <WslRow setup={setup} />
-        <NixRow setup={setup} />
-        <DevPodRow setup={setup} />
-        <GitIdentityRow setup={setup} />
-        <VaultRow />
-        <TailscaleRow />
-        <InferenceSnapsRow />
-        <ProjectSetupRow />
-        <TerminalProfileRow />
-      </div>
-    </Modal>
+          <WslRow setup={setup} />
+          <NixRow setup={setup} />
+          <DevPodRow setup={setup} />
+          <GitIdentityRow setup={setup} />
+          <VaultRow />
+          <TailscaleRow />
+          <InferenceSnapsRow />
+          <ProjectSetupRow />
+          <TerminalProfileRow />
+        </div>
+      </Modal>
+
+      <ConfirmDialog
+        open={confirmingDismiss}
+        title="Dismiss setup?"
+        body="Setup isn't finished. Dismiss anyway? You can reopen setup later."
+        confirmLabel="Dismiss setup"
+        cancelLabel="Keep going"
+        onConfirm={() => {
+          setConfirmingDismiss(false);
+          onDismiss();
+        }}
+        onClose={() => setConfirmingDismiss(false)}
+      />
+    </>
   );
 }

--- a/apps/studio/src/components/terminal/SshBookmarkSidebar.tsx
+++ b/apps/studio/src/components/terminal/SshBookmarkSidebar.tsx
@@ -4,6 +4,7 @@ import type { SshBookmark, SshConnectParams } from '../../types';
 import Badge from '../ui/Badge';
 import Button from '../ui/Button';
 import Card from '../ui/Card';
+import ConfirmDialog from '../ui/ConfirmDialog';
 import Input from '../ui/Input';
 
 interface SshBookmarkSidebarProps {
@@ -14,6 +15,7 @@ export default function SshBookmarkSidebar({ onSelect }: SshBookmarkSidebarProps
   const [bookmarks, setBookmarks] = useState<SshBookmark[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<SshBookmark | null>(null);
 
   // Form state
   const [label, setLabel] = useState('');
@@ -50,8 +52,10 @@ export default function SshBookmarkSidebar({ onSelect }: SshBookmarkSidebarProps
     });
   };
 
-  const handleDelete = async (id: string) => {
-    await sshBookmarkDelete(id);
+  const handleDeleteConfirmed = async () => {
+    if (pendingDelete === null) return;
+    await sshBookmarkDelete(pendingDelete.id);
+    setPendingDelete(null);
     await loadBookmarks();
   };
 
@@ -190,7 +194,7 @@ export default function SshBookmarkSidebar({ onSelect }: SshBookmarkSidebarProps
                 >
                   Connect
                 </Button>
-                <Button variant="danger" size="sm" onClick={() => handleDelete(bookmark.id)}>
+                <Button variant="danger" size="sm" onClick={() => setPendingDelete(bookmark)}>
                   Delete
                 </Button>
               </div>
@@ -198,6 +202,20 @@ export default function SshBookmarkSidebar({ onSelect }: SshBookmarkSidebarProps
           ))}
         </div>
       </div>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete bookmark"
+        body={
+          <>
+            Delete <strong>{pendingDelete?.label}</strong> ({pendingDelete?.username}@
+            {pendingDelete?.host})?
+          </>
+        }
+        confirmLabel="Delete bookmark"
+        onConfirm={handleDeleteConfirmed}
+        onClose={() => setPendingDelete(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Finishes **item 5** (Theme 3 — destructive actions with no confirmation) of the 2026-06-23 UX & durability audit. The reusable `ConfirmDialog` primitive already existed and was wired to vault-delete; this wires it through the rest.

## Gated actions
| Surface | Action | Variant |
|---|---|---|
| `GitPanel` | per-file "Discard changes" | type-to-confirm (`discard`), shows affected path |
| `DaemonPanel` | daemon stop / restart | simple confirm (warns active agent sessions drop); Start ungated |
| `InferencePanel` | model + snapshot delete | simple confirm (warns multi-GB re-download) |
| `SshBookmarkSidebar` | bookmark delete | simple confirm |
| `StepDatabase` | migrate / seed | migrate = confirm; seed = type-to-confirm (`seed`). Now separate gated steps. |
| `SetupWizard` + `App` | dismiss vs complete | split `onClose` into `onComplete` (persists `setupComplete`) vs `onDismiss` (session-only hide); dismissing an unfinished setup confirms and never marks complete |

**Design rule:** type-to-confirm is reserved for the unrecoverable actions (git discard, DB seed); recoverable ones (daemon, model/snapshot, bookmark) use a simple confirm.

## Tests
- Updated `SshBookmarkSidebar.test.tsx` for the new confirm step.
- Updated `SetupWizard.test.tsx` for the `onComplete`/`onDismiss` contract; added coverage that dismissing an unfinished setup requires confirmation and never marks complete.
- `pnpm typecheck:studio` clean · affected test files green · Biome clean.

## Notes
- Base `test`, manual merge (no `--auto`) per the audit's execution rules.
- Supersedes the stale `feat/destructive-confirm` branch (162 commits behind `test`, 0 ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)