### PR TITLE
refactor(studio): error-contract sweep — surface swallowed async failures

### DIFF
--- a/apps/studio/src/__tests__/lib/http.test.ts
+++ b/apps/studio/src/__tests__/lib/http.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HttpError, httpRequest } from '../../lib/http';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+function malformedResponse(status: number): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => {
+      throw new SyntaxError('Unexpected token < in JSON');
+    },
+  } as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('httpRequest', () => {
+  it('returns the parsed body of a 2xx response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(200, { ok: true, value: 42 })));
+    await expect(httpRequest<{ value: number }>('https://x/ok')).resolves.toEqual({
+      ok: true,
+      value: 42,
+    });
+  });
+
+  it('throws a client HttpError carrying the server message on 4xx', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse(429, { error: 'Too many requests' })),
+    );
+    const err = await httpRequest('https://x/rate').catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(err.kind).toBe('client');
+    expect(err.status).toBe(429);
+    expect(err.message).toBe('Too many requests');
+    expect(err.body).toEqual({ error: 'Too many requests' });
+  });
+
+  it('throws a server HttpError with a fallback message on 5xx', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(500, {})));
+    const err = await httpRequest('https://x/boom').catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(err.kind).toBe('server');
+    expect(err.status).toBe(500);
+    expect(err.message).toMatch(/server encountered an error/i);
+  });
+
+  it('throws a network HttpError when fetch rejects', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    const err = await httpRequest('https://x/down').catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(err.kind).toBe('network');
+    expect(err.message).toMatch(/unable to reach/i);
+  });
+
+  it('classifies an aborted fetch as a network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new DOMException('aborted', 'AbortError')));
+    const err = await httpRequest('https://x/slow').catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(err.kind).toBe('network');
+    expect(err.message).toMatch(/timed out or was canceled/i);
+  });
+
+  it('throws a parse HttpError when a 2xx body is malformed', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(malformedResponse(200)));
+    const err = await httpRequest('https://x/garbage').catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(err.kind).toBe('parse');
+  });
+});

--- a/apps/studio/src/__tests__/lib/http.test.ts
+++ b/apps/studio/src/__tests__/lib/http.test.ts
@@ -6,7 +6,7 @@ function jsonResponse(status: number, body: unknown): Response {
     ok: status >= 200 && status < 300,
     status,
     json: async () => body,
-  } as Response;
+  } as unknown as Response;
 }
 
 function malformedResponse(status: number): Response {
@@ -16,7 +16,17 @@ function malformedResponse(status: number): Response {
     json: async () => {
       throw new SyntaxError('Unexpected token < in JSON');
     },
-  } as Response;
+  } as unknown as Response;
+}
+
+/** Await a request expected to reject, returning the thrown HttpError (typed). */
+async function expectHttpError(promise: Promise<unknown>): Promise<HttpError> {
+  try {
+    await promise;
+  } catch (e) {
+    return e as HttpError;
+  }
+  throw new Error('expected httpRequest to throw, but it resolved');
 }
 
 afterEach(() => {
@@ -37,7 +47,7 @@ describe('httpRequest', () => {
       'fetch',
       vi.fn().mockResolvedValue(jsonResponse(429, { error: 'Too many requests' })),
     );
-    const err = await httpRequest('https://x/rate').catch((e) => e);
+    const err = await expectHttpError(httpRequest('https://x/rate'));
     expect(err).toBeInstanceOf(HttpError);
     expect(err.kind).toBe('client');
     expect(err.status).toBe(429);
@@ -47,7 +57,7 @@ describe('httpRequest', () => {
 
   it('throws a server HttpError with a fallback message on 5xx', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(500, {})));
-    const err = await httpRequest('https://x/boom').catch((e) => e);
+    const err = await expectHttpError(httpRequest('https://x/boom'));
     expect(err).toBeInstanceOf(HttpError);
     expect(err.kind).toBe('server');
     expect(err.status).toBe(500);
@@ -56,7 +66,7 @@ describe('httpRequest', () => {
 
   it('throws a network HttpError when fetch rejects', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
-    const err = await httpRequest('https://x/down').catch((e) => e);
+    const err = await expectHttpError(httpRequest('https://x/down'));
     expect(err).toBeInstanceOf(HttpError);
     expect(err.kind).toBe('network');
     expect(err.message).toMatch(/unable to reach/i);
@@ -64,7 +74,7 @@ describe('httpRequest', () => {
 
   it('classifies an aborted fetch as a network error', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new DOMException('aborted', 'AbortError')));
-    const err = await httpRequest('https://x/slow').catch((e) => e);
+    const err = await expectHttpError(httpRequest('https://x/slow'));
     expect(err).toBeInstanceOf(HttpError);
     expect(err.kind).toBe('network');
     expect(err.message).toMatch(/timed out or was canceled/i);
@@ -72,7 +82,7 @@ describe('httpRequest', () => {
 
   it('throws a parse HttpError when a 2xx body is malformed', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(malformedResponse(200)));
-    const err = await httpRequest('https://x/garbage').catch((e) => e);
+    const err = await expectHttpError(httpRequest('https://x/garbage'));
     expect(err).toBeInstanceOf(HttpError);
     expect(err.kind).toBe('parse');
   });

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -391,11 +391,32 @@ export default function AgentPanel() {
     setEditingRepo(false);
   };
 
-  const stageFile = (path: string) => gitStageFile(repoPath, path).then(() => loadChanges());
+  const stageFile = async (path: string): Promise<void> => {
+    try {
+      await gitStageFile(repoPath, path);
+      await loadChanges();
+    } catch (e) {
+      setGitError(e instanceof Error ? e.message : String(e));
+    }
+  };
 
-  const unstageFile = (path: string) => gitUnstageFile(repoPath, path).then(() => loadChanges());
+  const unstageFile = async (path: string): Promise<void> => {
+    try {
+      await gitUnstageFile(repoPath, path);
+      await loadChanges();
+    } catch (e) {
+      setGitError(e instanceof Error ? e.message : String(e));
+    }
+  };
 
-  const discardFile = (path: string) => gitDiscardFile(repoPath, path).then(() => loadChanges());
+  const discardFile = async (path: string): Promise<void> => {
+    try {
+      await gitDiscardFile(repoPath, path);
+      await loadChanges();
+    } catch (e) {
+      setGitError(e instanceof Error ? e.message : String(e));
+    }
+  };
 
   const stageAll = async () => {
     if (!gitState || stagingAll) return;
@@ -405,6 +426,8 @@ export default function AgentPanel() {
         [...gitState.unstaged, ...gitState.untracked].map((f) => gitStageFile(repoPath, f.path)),
       );
       await loadChanges();
+    } catch (e) {
+      setGitError(e instanceof Error ? e.message : String(e));
     } finally {
       setStagingAll(false);
     }
@@ -416,6 +439,8 @@ export default function AgentPanel() {
     try {
       await Promise.all(gitState.unstaged.map((f) => gitDiscardFile(repoPath, f.path)));
       await loadChanges();
+    } catch (e) {
+      setGitError(e instanceof Error ? e.message : String(e));
     } finally {
       setDiscardingAll(false);
     }

--- a/apps/studio/src/components/intent/IntentScreen.tsx
+++ b/apps/studio/src/components/intent/IntentScreen.tsx
@@ -1,12 +1,29 @@
 import { useState } from 'react';
 import Button from '../ui/Button';
+import ErrorAlert from '../ui/ErrorAlert';
 
 interface IntentScreenProps {
-  onSelect: (intent: 'deploy' | 'develop') => void;
+  onSelect: (intent: 'deploy' | 'develop') => Promise<void> | void;
 }
 
 export default function IntentScreen({ onSelect }: IntentScreenProps) {
   const [selected, setSelected] = useState<'deploy' | 'develop' | null>(null);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleContinue(): Promise<void> {
+    if (!selected) return;
+    setError(null);
+    setPending(true);
+    try {
+      await onSelect(selected);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to save your selection. Please try again.',
+      );
+      setPending(false);
+    }
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-950">
@@ -53,14 +70,17 @@ export default function IntentScreen({ onSelect }: IntentScreenProps) {
           </button>
         </div>
 
-        <div className="mt-8 flex justify-center">
+        <div className="mt-8 flex flex-col items-center gap-4">
+          <ErrorAlert message={error} className="w-full" />
           <Button
             variant="primary"
             size="lg"
-            disabled={!selected}
-            onClick={() => selected && onSelect(selected)}
+            disabled={!selected || pending}
+            onClick={() => {
+              void handleContinue();
+            }}
           >
-            Continue
+            {pending ? 'Saving…' : 'Continue'}
           </Button>
         </div>
       </div>

--- a/apps/studio/src/hooks/use-harness.ts
+++ b/apps/studio/src/hooks/use-harness.ts
@@ -176,10 +176,14 @@ export function useHarness(agentId?: string): UseHarnessReturn {
       }
     }
 
-    setupListeners();
+    setupListeners().catch((e: unknown) => {
+      setError(e instanceof Error ? e.message : String(e));
+    });
 
     // Do one initial fetch so we don't wait for the first watcher tick
-    void loadAllRef.current();
+    loadAllRef.current().catch((e: unknown) => {
+      setError(e instanceof Error ? e.message : String(e));
+    });
 
     return () => {
       cancelled = true;
@@ -212,39 +216,68 @@ export function useHarness(agentId?: string): UseHarnessReturn {
     subject: string,
     body: string,
   ): Promise<HarnessMessage> {
-    const msg = await harnessSendMessage(fromAgent, toAgent, subject, body);
-    // In browser mode, refresh immediately. In Tauri mode, the watcher will push.
-    if (!isTauri()) await loadAll();
-    return msg;
+    try {
+      const msg = await harnessSendMessage(fromAgent, toAgent, subject, body);
+      if (!isTauri()) await loadAll();
+      return msg;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      throw e;
+    }
   }
 
   async function markRead(messageIds: number[]): Promise<void> {
-    await harnessMarkRead(messageIds);
-    if (!isTauri()) await loadAll();
+    try {
+      await harnessMarkRead(messageIds);
+      if (!isTauri()) await loadAll();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      throw e;
+    }
   }
 
   async function createTask(taskId: string, description: string): Promise<HarnessTask> {
-    const task = await harnessCreateTask(taskId, description);
-    if (!isTauri()) await loadAll();
-    return task;
+    try {
+      const task = await harnessCreateTask(taskId, description);
+      if (!isTauri()) await loadAll();
+      return task;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      throw e;
+    }
   }
 
   async function claimTask(taskId: string, aid: string): Promise<HarnessClaimResult> {
-    const result = await harnessClaimTask(taskId, aid);
-    if (!isTauri()) await loadAll();
-    return result;
+    try {
+      const result = await harnessClaimTask(taskId, aid);
+      if (!isTauri()) await loadAll();
+      return result;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      throw e;
+    }
   }
 
   async function completeTask(taskId: string, aid: string): Promise<boolean> {
-    const ok = await harnessCompleteTask(taskId, aid);
-    if (!isTauri()) await loadAll();
-    return ok;
+    try {
+      const ok = await harnessCompleteTask(taskId, aid);
+      if (!isTauri()) await loadAll();
+      return ok;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      throw e;
+    }
   }
 
   async function releaseTask(taskId: string, aid: string): Promise<boolean> {
-    const ok = await harnessReleaseTask(taskId, aid);
-    if (!isTauri()) await loadAll();
-    return ok;
+    try {
+      const ok = await harnessReleaseTask(taskId, aid);
+      if (!isTauri()) await loadAll();
+      return ok;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      throw e;
+    }
   }
 
   async function reserveFile(
@@ -253,9 +286,14 @@ export function useHarness(agentId?: string): UseHarnessReturn {
     ttlSeconds: number,
     reason: string,
   ): Promise<HarnessReserveResult> {
-    const result = await harnessReserveFile(filePath, aid, ttlSeconds, reason);
-    if (!isTauri()) await loadAll();
-    return result;
+    try {
+      const result = await harnessReserveFile(filePath, aid, ttlSeconds, reason);
+      if (!isTauri()) await loadAll();
+      return result;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      throw e;
+    }
   }
 
   return {

--- a/apps/studio/src/hooks/use-local-shell.ts
+++ b/apps/studio/src/hooks/use-local-shell.ts
@@ -104,17 +104,45 @@ export function useLocalShell(options: UseLocalShellOptions = {}) {
     setState({ sessionId: null, isOpen: false, opening: false, error: null });
   }, [clearListeners]);
 
-  const send = useCallback(async (data: string) => {
-    const id = sessionIdRef.current;
-    if (!id) return;
-    await shellSend(id, btoa(data));
-  }, []);
+  const send = useCallback(
+    async (data: string) => {
+      const id = sessionIdRef.current;
+      if (!id) return;
+      try {
+        await shellSend(id, btoa(data));
+      } catch (err) {
+        sessionIdRef.current = null;
+        clearListeners();
+        setState({
+          sessionId: null,
+          isOpen: false,
+          opening: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [clearListeners],
+  );
 
-  const resize = useCallback(async (cols: number, rows: number) => {
-    const id = sessionIdRef.current;
-    if (!id) return;
-    await shellResize(id, cols, rows);
-  }, []);
+  const resize = useCallback(
+    async (cols: number, rows: number) => {
+      const id = sessionIdRef.current;
+      if (!id) return;
+      try {
+        await shellResize(id, cols, rows);
+      } catch (err) {
+        sessionIdRef.current = null;
+        clearListeners();
+        setState({
+          sessionId: null,
+          isOpen: false,
+          opening: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [clearListeners],
+  );
 
   useEffect(() => {
     return () => {

--- a/apps/studio/src/hooks/use-spawner.ts
+++ b/apps/studio/src/hooks/use-spawner.ts
@@ -46,8 +46,8 @@ export function useSpawner() {
         // Refresh sessions to get updated status
         agentList()
           .then(setSessions)
-          .catch(() => {
-            /* refresh failure is non-critical */
+          .catch((err) => {
+            setError(err instanceof Error ? err.message : String(err));
           });
         // Append exit message to output
         setOutput((prev) => ({

--- a/apps/studio/src/hooks/use-ssh.ts
+++ b/apps/studio/src/hooks/use-ssh.ts
@@ -42,61 +42,68 @@ export function useSsh(options: UseSshOptions = {}) {
   onDisconnectRef.current = options.onDisconnect;
   onHostKeyRef.current = options.onHostKey;
 
-  const connect = useCallback(async (params: SshConnectParams) => {
-    setState((prev) => ({ ...prev, connecting: true, error: null }));
-    try {
-      // Listen for host key verification events (fires during handshake)
-      const unlistenHk = await listen<SshHostKeyEvent>('ssh_host_key', (event) => {
-        onHostKeyRef.current?.(event.payload);
-      });
-      unlistenHostKeyRef.current = unlistenHk;
+  const handleSessionLost = useCallback((reason: string) => {
+    sessionIdRef.current = null;
+    unlistenOutputRef.current?.();
+    unlistenDisconnectRef.current?.();
+    unlistenHostKeyRef.current?.();
+    unlistenOutputRef.current = null;
+    unlistenDisconnectRef.current = null;
+    unlistenHostKeyRef.current = null;
+    setState({
+      sessionId: null,
+      connected: false,
+      connecting: false,
+      error: reason,
+    });
+    onDisconnectRef.current?.(reason);
+  }, []);
 
-      const id = await sshConnect(params);
-      sessionIdRef.current = id;
+  const connect = useCallback(
+    async (params: SshConnectParams) => {
+      setState((prev) => ({ ...prev, connecting: true, error: null }));
+      try {
+        // Listen for host key verification events (fires during handshake)
+        const unlistenHk = await listen<SshHostKeyEvent>('ssh_host_key', (event) => {
+          onHostKeyRef.current?.(event.payload);
+        });
+        unlistenHostKeyRef.current = unlistenHk;
 
-      // Listen for output events
-      const unlistenOut = await listen<SshOutputEvent>('ssh_output', (event) => {
-        if (event.payload.session_id !== sessionIdRef.current) return;
-        const bytes = Uint8Array.from(atob(event.payload.data), (c) => c.charCodeAt(0));
-        onDataRef.current?.(bytes);
-      });
-      unlistenOutputRef.current = unlistenOut;
+        const id = await sshConnect(params);
+        sessionIdRef.current = id;
 
-      // Listen for disconnect events
-      const unlistenDc = await listen<SshDisconnectEvent>('ssh_disconnect', (event) => {
-        if (event.payload.session_id !== sessionIdRef.current) return;
-        sessionIdRef.current = null;
-        unlistenOutputRef.current?.();
-        unlistenDisconnectRef.current?.();
-        unlistenHostKeyRef.current?.();
-        unlistenOutputRef.current = null;
-        unlistenDisconnectRef.current = null;
-        unlistenHostKeyRef.current = null;
+        // Listen for output events
+        const unlistenOut = await listen<SshOutputEvent>('ssh_output', (event) => {
+          if (event.payload.session_id !== sessionIdRef.current) return;
+          const bytes = Uint8Array.from(atob(event.payload.data), (c) => c.charCodeAt(0));
+          onDataRef.current?.(bytes);
+        });
+        unlistenOutputRef.current = unlistenOut;
+
+        // Listen for disconnect events
+        const unlistenDc = await listen<SshDisconnectEvent>('ssh_disconnect', (event) => {
+          if (event.payload.session_id !== sessionIdRef.current) return;
+          handleSessionLost(event.payload.reason);
+        });
+        unlistenDisconnectRef.current = unlistenDc;
+
+        setState({
+          sessionId: id,
+          connected: true,
+          connecting: false,
+          error: null,
+        });
+      } catch (err) {
         setState({
           sessionId: null,
           connected: false,
           connecting: false,
-          error: null,
+          error: err instanceof Error ? err.message : String(err),
         });
-        onDisconnectRef.current?.(event.payload.reason);
-      });
-      unlistenDisconnectRef.current = unlistenDc;
-
-      setState({
-        sessionId: id,
-        connected: true,
-        connecting: false,
-        error: null,
-      });
-    } catch (err) {
-      setState({
-        sessionId: null,
-        connected: false,
-        connecting: false,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }, []);
+      }
+    },
+    [handleSessionLost],
+  );
 
   const disconnect = useCallback(async () => {
     const id = sessionIdRef.current;
@@ -121,19 +128,32 @@ export function useSsh(options: UseSshOptions = {}) {
     });
   }, []);
 
-  const send = useCallback(async (data: string) => {
-    const id = sessionIdRef.current;
-    if (!id) return;
-    // base64 encode
-    const encoded = btoa(data);
-    await sshSend(id, encoded);
-  }, []);
+  const send = useCallback(
+    async (data: string) => {
+      const id = sessionIdRef.current;
+      if (!id) return;
+      const encoded = btoa(data);
+      try {
+        await sshSend(id, encoded);
+      } catch (err) {
+        handleSessionLost(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [handleSessionLost],
+  );
 
-  const resize = useCallback(async (cols: number, rows: number) => {
-    const id = sessionIdRef.current;
-    if (!id) return;
-    await sshResize(id, cols, rows);
-  }, []);
+  const resize = useCallback(
+    async (cols: number, rows: number) => {
+      const id = sessionIdRef.current;
+      if (!id) return;
+      try {
+        await sshResize(id, cols, rows);
+      } catch (err) {
+        handleSessionLost(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [handleSessionLost],
+  );
 
   // Cleanup on unmount
   useEffect(() => {

--- a/apps/studio/src/hooks/use-vault.ts
+++ b/apps/studio/src/hooks/use-vault.ts
@@ -104,21 +104,37 @@ export function useVault() {
 
   const createSecret = useCallback(
     async (path: string, value: string) => {
-      await vaultSet(path, value, false);
-      await refresh();
+      setState((prev) => ({ ...prev, error: null }));
+      try {
+        await vaultSet(path, value, false);
+        await refresh();
+      } catch (err) {
+        setState((prev) => ({
+          ...prev,
+          error: err instanceof Error ? err.message : String(err),
+        }));
+      }
     },
     [refresh],
   );
 
   const deleteSecret = useCallback(
     async (path: string) => {
-      await vaultDelete(path);
-      setState((prev) => ({
-        ...prev,
-        selectedPath: prev.selectedPath === path ? null : prev.selectedPath,
-        selectedValue: prev.selectedPath === path ? null : prev.selectedValue,
-      }));
-      await refresh();
+      setState((prev) => ({ ...prev, error: null }));
+      try {
+        await vaultDelete(path);
+        setState((prev) => ({
+          ...prev,
+          selectedPath: prev.selectedPath === path ? null : prev.selectedPath,
+          selectedValue: prev.selectedPath === path ? null : prev.selectedValue,
+        }));
+        await refresh();
+      } catch (err) {
+        setState((prev) => ({
+          ...prev,
+          error: err instanceof Error ? err.message : String(err),
+        }));
+      }
     },
     [refresh],
   );

--- a/apps/studio/src/lib/auth-api.ts
+++ b/apps/studio/src/lib/auth-api.ts
@@ -5,6 +5,8 @@
  * for device-based OTP authentication.
  */
 
+import { HttpError, httpRequest } from './http';
+
 // ── Response types ──────────────────────────────────────────────────────────
 
 export interface LinkResponse {
@@ -65,22 +67,47 @@ function getDeviceName(): string {
   return `RevealUI Studio (${platform})`;
 }
 
-async function request<T>(apiUrl: string, path: string, init: RequestInit): Promise<T> {
-  const res = await fetch(`${apiUrl}/api/studio-auth${path}`, {
+function endpoint(apiUrl: string, path: string): string {
+  return `${apiUrl}/api/studio-auth${path}`;
+}
+
+function jsonInit(init: RequestInit): RequestInit {
+  return {
     ...init,
     headers: {
       'Content-Type': 'application/json',
       ...init.headers,
     },
-  });
-  return (await res.json()) as T;
+  };
+}
+
+/**
+ * Request helper for the `{ success, error }`-shaped endpoints. A categorized
+ * {@link HttpError} (4xx/5xx/network/parse) is mapped back into the response's
+ * own contract as `{ success: false, error }` with an actionable message — so
+ * callers keep their existing `if (res.success)` branch but now see a useful
+ * message instead of a generic "Unable to reach the API" for every failure.
+ */
+async function requestResult<T extends { success: boolean; error?: string }>(
+  apiUrl: string,
+  path: string,
+  init: RequestInit,
+): Promise<T> {
+  try {
+    return await httpRequest<T>(endpoint(apiUrl, path), jsonInit(init));
+  } catch (err) {
+    if (err instanceof HttpError) {
+      return { success: false, error: err.message } as T;
+    }
+    throw err;
+  }
 }
 
 /**
  * Request an OTP code to be sent to the given email.
  */
 export async function linkDevice(apiUrl: string, email: string): Promise<LinkResponse> {
-  return request<LinkResponse>(apiUrl, '/link', {
+  return requestResult<LinkResponse>(apiUrl, '/link', {
     method: 'POST',
     body: JSON.stringify({
       email,
@@ -99,7 +126,7 @@ export async function verifyDevice(
   email: string,
   code: string,
 ): Promise<VerifyResponse> {
-  return request<VerifyResponse>(apiUrl, '/verify', {
+  return requestResult<VerifyResponse>(apiUrl, '/verify', {
     method: 'POST',
     body: JSON.stringify({
       email,
@@ -113,28 +140,38 @@ export async function verifyDevice(
  * Rotate the bearer token. Returns a new token.
  */
 export async function refreshToken(apiUrl: string, token: string): Promise<RefreshResponse> {
-  return request<RefreshResponse>(apiUrl, '/refresh', {
+  return requestResult<RefreshResponse>(apiUrl, '/refresh', {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` },
   });
 }
 
 /**
- * Revoke the bearer token (sign out).
+ * Revoke the bearer token (sign out). Best-effort: a failed revoke must never
+ * block the local sign-out, so categorized HTTP failures are swallowed.
  */
 export async function revokeToken(apiUrl: string, token: string): Promise<void> {
-  await request(apiUrl, '/revoke', {
-    method: 'DELETE',
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  try {
+    await httpRequest(
+      endpoint(apiUrl, '/revoke'),
+      jsonInit({ method: 'DELETE', headers: { Authorization: `Bearer ${token}` } }),
+    );
+  } catch (err) {
+    if (err instanceof HttpError) return;
+    throw err;
+  }
 }
 
 /**
  * Check auth status and get user info.
+ *
+ * Intentionally throws {@link HttpError} on any failure: `use-auth` treats a
+ * throw here as "API unreachable" and preserves the existing session (offline
+ * access) rather than signing the user out on a transient server/network error.
  */
 export async function checkStatus(apiUrl: string, token: string): Promise<StatusResponse> {
-  return request<StatusResponse>(apiUrl, '/status', {
-    method: 'GET',
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  return httpRequest<StatusResponse>(
+    endpoint(apiUrl, '/status'),
+    jsonInit({ method: 'GET', headers: { Authorization: `Bearer ${token}` } }),
+  );
 }

--- a/apps/studio/src/lib/billing-api.ts
+++ b/apps/studio/src/lib/billing-api.ts
@@ -5,6 +5,8 @@
  * using the device bearer token for authentication.
  */
 
+import { httpRequest } from './http';
+
 // ── Response types ──────────────────────────────────────────────────────────
 
 export type BillingTier = 'free' | 'pro' | 'max' | 'enterprise';
@@ -27,13 +29,19 @@ export interface UsageResponse {
 
 // ── Client ──────────────────────────────────────────────────────────────────
 
+/**
+ * Authenticated GET against the billing API. Routes through httpRequest so a
+ * non-2xx response throws a categorized {@link HttpError} with an actionable,
+ * server-provided message (instead of the old bare `returned 500`), and a
+ * malformed body is reported as a parse error rather than leaking a SyntaxError.
+ */
 async function authedGet<T>(
   apiUrl: string,
   path: string,
   token: string,
   signal?: AbortSignal,
 ): Promise<T> {
-  const res = await fetch(`${apiUrl}/api/billing${path}`, {
+  return httpRequest<T>(`${apiUrl}/api/billing${path}`, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -41,12 +49,6 @@ async function authedGet<T>(
     },
     signal,
   });
-
-  if (!res.ok) {
-    throw new Error(`Billing API ${path} returned ${res.status}`);
-  }
-
-  return (await res.json()) as T;
 }
 
 /**

--- a/apps/studio/src/lib/health-api.ts
+++ b/apps/studio/src/lib/health-api.ts
@@ -5,6 +5,8 @@
  * /health/ready endpoint (public, no auth required).
  */
 
+import { HttpError, httpRequest } from './http';
+
 // ── Response types ──────────────────────────────────────────────────────────
 
 export interface HealthCheck {
@@ -26,7 +28,10 @@ export interface HealthResponse {
 
 /**
  * Fetch the readiness probe from the API. Public endpoint — no auth needed.
- * Returns null if the API is unreachable (network error or timeout).
+ * Returns null if the API is unreachable, times out, or returns a non-2xx /
+ * malformed response (all surfaced as {@link HttpError} by httpRequest). The
+ * `res.ok` check now lives in httpRequest, so a 5xx HTML error page is no
+ * longer parsed as a HealthResponse.
  *
  * Accepts an optional caller-supplied AbortSignal that's combined with
  * an internal 5 s timeout via `AbortSignal.any` — either source aborting
@@ -44,12 +49,12 @@ export async function fetchHealth(
   const combined = sources.length > 1 ? AbortSignal.any(sources) : sources[0];
 
   try {
-    const res = await fetch(`${apiUrl}/health/ready`, {
+    return await httpRequest<HealthResponse>(`${apiUrl}/health/ready`, {
       method: 'GET',
       signal: combined,
     });
-    return (await res.json()) as HealthResponse;
-  } catch {
-    return null;
+  } catch (err) {
+    if (err instanceof HttpError) return null;
+    throw err;
   }
 }

--- a/apps/studio/src/lib/http.ts
+++ b/apps/studio/src/lib/http.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared HTTP request contract for Studio's API clients.
+ *
+ * Every fetch against the RevealUI API or daemon should go through
+ * {@link httpRequest} so failures are categorized in one place instead of each
+ * client guessing: `client` (4xx — usually actionable by the user), `server`
+ * (5xx), `network` (unreachable, timeout, or aborted), or `parse` (a 2xx with a
+ * malformed body). Callers can surface `error.message` directly — it is already
+ * written for a human — and branch on `error.kind` when they need to.
+ *
+ * Closes the Theme 4 finding that `res.ok` was unchecked and raw `TypeError` /
+ * `SyntaxError` leaked out as "Unable to reach the API" for every failure mode.
+ */
+
+export type HttpErrorKind = 'client' | 'server' | 'network' | 'parse';
+
+export class HttpError extends Error {
+  readonly kind: HttpErrorKind;
+  readonly status?: number;
+  /** Parsed response body, when present — a non-2xx response may carry a server message. */
+  readonly body?: unknown;
+
+  constructor(message: string, kind: HttpErrorKind, status?: number, body?: unknown) {
+    super(message);
+    this.name = 'HttpError';
+    this.kind = kind;
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/** Pull a human-readable message out of a JSON error body, if one is present. */
+function messageFromBody(body: unknown): string | undefined {
+  if (body && typeof body === 'object') {
+    const record = body as Record<string, unknown>;
+    if (typeof record.error === 'string' && record.error.trim()) return record.error;
+    if (typeof record.message === 'string' && record.message.trim()) return record.message;
+  }
+  return undefined;
+}
+
+/** Read and parse a JSON body without throwing — returns undefined on any failure. */
+async function readJson(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Fetch `url` and return the parsed JSON body of a 2xx response.
+ *
+ * Throws {@link HttpError} (never a raw `TypeError` or `SyntaxError`) for every
+ * failure mode, with `kind` set so callers can branch and `message` set to the
+ * server-provided error when the body carried one.
+ */
+export async function httpRequest<T>(url: string, init?: RequestInit): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(url, init);
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new HttpError('The request timed out or was canceled.', 'network');
+    }
+    throw new HttpError(
+      'Unable to reach the server. Check your connection and try again.',
+      'network',
+    );
+  }
+
+  if (!res.ok) {
+    const body = await readJson(res);
+    const kind: HttpErrorKind = res.status >= 500 ? 'server' : 'client';
+    const fallback =
+      kind === 'server'
+        ? `The server encountered an error (${res.status}). Please try again later.`
+        : `Request failed (${res.status}).`;
+    throw new HttpError(messageFromBody(body) ?? fallback, kind, res.status, body);
+  }
+
+  try {
+    return (await res.json()) as T;
+  } catch {
+    throw new HttpError('The server returned a malformed response.', 'parse', res.status);
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -54,5 +54,20 @@
         "noUnusedVariables": "warn"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["apps/studio/src/hooks/**", "apps/studio/src/lib/**"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noVoid": "error"
+          },
+          "suspicious": {
+            "noEmptyBlockStatements": "error"
+          }
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Item **8** (Theme 4 — silent async failures & swallowed errors) of the 2026-06-23 UX & durability audit. Rejections were dropped via `void`/empty-catch, so operators acted on a broken surface with no feedback.

## Shared HTTP contract
- **New `lib/http.ts`** — `httpRequest<T>` checks `res.ok`, splits failures into **client** (4xx) / **server** (5xx) / **network** (unreachable/abort) / **parse** (malformed body), surfaces the server-provided message, and always throws a typed `HttpError` (never a raw `TypeError`/`SyntaxError`). Unit-tested in `__tests__/lib/http.test.ts` (6 cases).
- Routed `auth-api`, `health-api`, `billing-api` through it:
  - auth `link/verify/refresh` map the typed error back into their `{success,error}` contract (callers keep `if (res.success)` but get an actionable message); **`checkStatus` intentionally throws** so `use-auth`'s offline path is preserved.
  - health returns `null` on any failure (a 5xx HTML page is no longer parsed as a HealthResponse).
  - billing surfaces an actionable message instead of `returned 500`.

## Hook error contract (mutations write the hook's existing `error` state)
| Hook | Change |
|---|---|
| `use-vault` | `createSecret`/`deleteSecret` try/catch → `error` |
| `use-harness` | 7 mutations wrapped; 2 floating promises (`setupListeners`, `loadAll`) now `.catch`-routed |
| `use-spawner` | `agent_exit` refresh failure surfaced |
| `use-ssh` / `use-local-shell` | `send`/`resize` on a dead session route to the existing disconnect/error path instead of silently eating input |
| `use-apps` | already fully guarded via `usePollingFetch` — **no change** |

## Components
- `AgentPanel`: git stage/unstage/discard/stageAll/discardAll → existing `gitError` banner.
- `IntentScreen`: config-write failure now shows `ErrorAlert` and re-enables retry (onboarding no longer dead-ends silently).

## Durable enforcement
- `biome.json` override bans `noVoid` + `noEmptyBlockStatements` in `hooks/` and `lib/` (zero existing violations).

## Verification
- `pnpm typecheck:studio` clean · full suite **553 passed** (547 + 6 new) · Biome clean.

## ⚠️ Owner decision (not changed here)
The `use-auth` finding "offline access keeps a **locally-expired token** authenticated" (`use-auth.ts:151-157`) is a security-posture call — tightening it risks locking users out offline. Left for owner sign-off as a follow-up.

Base `test`, manual merge (no `--auto`) per the audit's execution rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)