### PR TITLE
fix(studio,console): accessible status indicators (a11y pass)

### DIFF
--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -134,23 +134,46 @@ func (p *Proxy) spawnSession(name string) (string, error) {
 func (p *Proxy) pickSession(s ssh.Session, sessions []SessionInfo) (string, error) {
 	fmt.Fprintf(s, "\033[1;33mRevealUI Terminal — Agent Sessions\033[0m\r\n\r\n")
 
-	// Filter to PTY sessions only
+	// Partition PTY sessions: running ones are selectable; non-running ones are
+	// still listed (dimmed, with an explicit status word) instead of being
+	// hidden, so an operator can see that a crashed/exited session exists rather
+	// than wondering why it silently vanished. Status is shown as text, not by
+	// color alone.
 	ptySessions := make([]SessionInfo, 0)
+	otherSessions := make([]SessionInfo, 0)
 	for _, sess := range sessions {
-		if sess.IsPty && sess.Status == "running" {
+		if !sess.IsPty {
+			continue
+		}
+		if sess.Status == "running" {
 			ptySessions = append(ptySessions, sess)
+		} else {
+			otherSessions = append(otherSessions, sess)
 		}
 	}
 
 	if len(ptySessions) > 0 {
 		fmt.Fprintf(s, "  \033[1mActive sessions:\033[0m\r\n")
 		for i, sess := range ptySessions {
-			fmt.Fprintf(s, "    \033[36m%d)\033[0m %s \033[90m(%s)\033[0m\r\n",
+			fmt.Fprintf(s, "    \033[36m%d)\033[0m %s \033[90m(%s)\033[0m \033[32m[running]\033[0m\r\n",
 				i+1, sess.Name, short(sess.ID))
 		}
 		fmt.Fprintf(s, "\r\n")
 	} else {
 		fmt.Fprintf(s, "  \033[90mNo active sessions.\033[0m\r\n\r\n")
+	}
+
+	if len(otherSessions) > 0 {
+		fmt.Fprintf(s, "  \033[1mInactive sessions:\033[0m \033[90m(not attachable)\033[0m\r\n")
+		for _, sess := range otherSessions {
+			status := sess.Status
+			if status == "" {
+				status = "unknown"
+			}
+			fmt.Fprintf(s, "    \033[90m-) %s (%s) [%s]\033[0m\r\n",
+				sess.Name, short(sess.ID), status)
+		}
+		fmt.Fprintf(s, "\r\n")
 	}
 
 	fmt.Fprintf(s, "  \033[36mn)\033[0m New agent session\r\n")

--- a/apps/studio/src/__tests__/components/StatusDot.test.tsx
+++ b/apps/studio/src/__tests__/components/StatusDot.test.tsx
@@ -48,9 +48,30 @@ describe('StatusDot', () => {
     expect(container.querySelector('span')?.className).not.toContain('animate-pulse');
   });
 
-  it('has aria-hidden="true" for accessibility', () => {
-    const { container } = render(<StatusDot status="ok" />);
-    expect(container.querySelector('span')?.getAttribute('aria-hidden')).toBe('true');
+  it('exposes status to assistive tech via role="img" + aria-label by default', () => {
+    const { container } = render(<StatusDot status="error" />);
+    const span = container.querySelector('span');
+    expect(span?.getAttribute('role')).toBe('img');
+    expect(span?.getAttribute('aria-label')).toBe('Error');
+    expect(span?.getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('uses a per-status default label', () => {
+    const { container } = render(<StatusDot status="warn" />);
+    expect(container.querySelector('span')?.getAttribute('aria-label')).toBe('Warning');
+  });
+
+  it('honors a custom label override', () => {
+    const { container } = render(<StatusDot status="ok" label="Database: healthy" />);
+    expect(container.querySelector('span')?.getAttribute('aria-label')).toBe('Database: healthy');
+  });
+
+  it('is hidden from screen readers when decorative (adjacent text conveys status)', () => {
+    const { container } = render(<StatusDot status="ok" decorative />);
+    const span = container.querySelector('span');
+    expect(span?.getAttribute('aria-hidden')).toBe('true');
+    expect(span?.getAttribute('role')).toBeNull();
+    expect(span?.getAttribute('aria-label')).toBeNull();
   });
 
   it('applies custom className', () => {

--- a/apps/studio/src/components/agent/AgentTerminalPane.tsx
+++ b/apps/studio/src/components/agent/AgentTerminalPane.tsx
@@ -188,9 +188,9 @@ export default function AgentTerminalPane() {
                     stopSession(s.id);
                   }}
                   className="rounded px-1 text-xs text-neutral-500 hover:bg-red-900/30 hover:text-red-400"
-                  title="Stop"
+                  aria-label="Stop agent"
                 >
-                  ■
+                  <span aria-hidden="true">■</span>
                 </button>
               )}
             </button>

--- a/apps/studio/src/components/dashboard/DeployDashboard.tsx
+++ b/apps/studio/src/components/dashboard/DeployDashboard.tsx
@@ -4,6 +4,7 @@ import { healthCheck } from '../../lib/deploy';
 import type { StudioConfig } from '../../types';
 import Button from '../ui/Button';
 import PanelHeader from '../ui/PanelHeader';
+import StatusDot from '../ui/StatusDot';
 
 type ServiceStatus = 'healthy' | 'degraded' | 'down' | 'checking';
 
@@ -121,25 +122,30 @@ export default function DeployDashboard() {
   );
 }
 
+const domainStatusMap: Record<ServiceStatus, 'ok' | 'warn' | 'error' | 'off'> = {
+  healthy: 'ok',
+  degraded: 'warn',
+  down: 'error',
+  checking: 'off',
+};
+
+const statusLabels: Record<ServiceStatus, string> = {
+  healthy: 'Healthy',
+  degraded: 'Degraded',
+  down: 'Down',
+  checking: 'Checking...',
+};
+
 function HealthCard({ service }: { service: ServiceState }) {
-  const dotClasses: Record<ServiceStatus, string> = {
-    healthy: 'bg-green-500',
-    degraded: 'bg-yellow-500',
-    down: 'bg-red-500',
-    checking: 'bg-neutral-500 animate-pulse',
-  };
-
-  const statusLabels: Record<ServiceStatus, string> = {
-    healthy: 'Healthy',
-    degraded: 'Degraded',
-    down: 'Down',
-    checking: 'Checking...',
-  };
-
   return (
     <div className="rounded-lg border border-neutral-700 bg-neutral-900/50 p-4">
       <div className="flex items-center gap-2 mb-2">
-        <span className={`inline-block size-2.5 rounded-full ${dotClasses[service.status]}`} />
+        <StatusDot
+          status={domainStatusMap[service.status]}
+          size="md"
+          pulse={service.status === 'checking'}
+          decorative
+        />
         <span className="text-sm font-medium text-neutral-200">{service.label}</span>
       </div>
       <p className="text-xs text-neutral-500">{statusLabels[service.status]}</p>
@@ -156,7 +162,7 @@ function QuickLink({ label, url }: { label: string; url: string }) {
       rel="noopener noreferrer"
       className="flex items-center gap-2 text-sm text-orange-400 hover:text-orange-300 transition-colors"
     >
-      <span>{'\u2192'}</span>
+      <span>{'→'}</span>
       <span>{label}</span>
       <span className="font-mono text-xs text-neutral-500">{url}</span>
     </a>

--- a/apps/studio/src/components/dashboard/HealthCard.tsx
+++ b/apps/studio/src/components/dashboard/HealthCard.tsx
@@ -16,6 +16,18 @@ const STATUS_MAP = {
   unreachable: { dot: 'off', label: 'Unreachable', color: 'text-neutral-500' },
 } as const;
 
+const CHECK_DOT_MAP = {
+  healthy: 'ok',
+  degraded: 'warn',
+  unhealthy: 'error',
+} as const satisfies Record<HealthCheck['status'], 'ok' | 'warn' | 'error'>;
+
+const CHECK_COLOR_MAP = {
+  healthy: 'text-emerald-400',
+  degraded: 'text-amber-400',
+  unhealthy: 'text-red-400',
+} as const satisfies Record<HealthCheck['status'], string>;
+
 function formatUptime(seconds: number): string {
   const days = Math.floor(seconds / 86400);
   const hours = Math.floor((seconds % 86400) / 3600);
@@ -56,7 +68,7 @@ export default function HealthCard() {
   return (
     <div className="rounded-lg border border-neutral-800 bg-neutral-900 p-4">
       <div className="flex items-center gap-2">
-        <StatusDot status={info.dot as 'ok' | 'warn' | 'error' | 'off'} size="md" />
+        <StatusDot status={info.dot as 'ok' | 'warn' | 'error' | 'off'} size="md" decorative />
         <h3 className="text-sm font-medium text-neutral-200">API Health</h3>
       </div>
 
@@ -71,15 +83,8 @@ export default function HealthCard() {
           {checks.map((check) => (
             <div key={check.name} className="flex items-center justify-between text-xs">
               <span className="text-neutral-400">{check.name}</span>
-              <span
-                className={
-                  check.status === 'healthy'
-                    ? 'text-emerald-400'
-                    : check.status === 'degraded'
-                      ? 'text-amber-400'
-                      : 'text-red-400'
-                }
-              >
+              <span className={`flex items-center gap-1 ${CHECK_COLOR_MAP[check.status]}`}>
+                <StatusDot status={CHECK_DOT_MAP[check.status]} size="sm" decorative />
                 {check.status}
               </span>
             </div>

--- a/apps/studio/src/components/deploy/StepDeploy.tsx
+++ b/apps/studio/src/components/deploy/StepDeploy.tsx
@@ -174,7 +174,7 @@ const STATUS_LABELS: Record<AppStatus, string> = {
   idle: 'Waiting',
   'pushing-env': 'Pushing env vars...',
   deploying: 'Deploying...',
-  polling: 'Waiting for deployment...',
+  polling: 'Awaiting readiness...',
   ready: 'Ready',
   error: 'Error',
 };
@@ -293,15 +293,21 @@ function AppCard({ name, state }: { name: AppName; state: AppState }) {
   );
 }
 
-function StatusDot({ status }: { status: AppStatus }) {
+function StatusDot({ status }: { status: AppStatus }): React.ReactElement {
   const colors: Record<AppStatus, string> = {
     idle: 'bg-neutral-600',
     'pushing-env': 'bg-yellow-500 animate-pulse',
     deploying: 'bg-orange-500 animate-pulse',
-    polling: 'bg-orange-500 animate-pulse',
+    polling: 'bg-amber-300 animate-pulse',
     ready: 'bg-green-500',
     error: 'bg-red-500',
   };
 
-  return <span className={`inline-block size-2.5 rounded-full ${colors[status]}`} />;
+  return (
+    <span
+      className={`inline-block size-2.5 rounded-full ${colors[status]}`}
+      role="img"
+      aria-label={STATUS_LABELS[status]}
+    />
+  );
 }

--- a/apps/studio/src/components/ui/StatusDot.tsx
+++ b/apps/studio/src/components/ui/StatusDot.tsx
@@ -17,11 +17,11 @@
  * compliance ADR.
  */
 
-const colorMap = {
-  ok: 'bg-[var(--rvui-success)]',
-  warn: 'bg-[var(--rvui-warning)]',
-  error: 'bg-[var(--rvui-error)]',
-  off: 'bg-[var(--rvui-text-2)]',
+const statusMeta = {
+  ok: { color: 'bg-[var(--rvui-success)]', label: 'OK' },
+  warn: { color: 'bg-[var(--rvui-warning)]', label: 'Warning' },
+  error: { color: 'bg-[var(--rvui-error)]', label: 'Error' },
+  off: { color: 'bg-[var(--rvui-text-2)]', label: 'Off' },
 } as const;
 
 const sizeMap = {
@@ -30,10 +30,23 @@ const sizeMap = {
 } as const;
 
 interface StatusDotProps {
-  status: keyof typeof colorMap;
+  status: keyof typeof statusMeta;
   size?: keyof typeof sizeMap;
   pulse?: boolean;
   className?: string;
+  /**
+   * Accessible label for assistive tech. Defaults to a per-status word ("OK",
+   * "Warning", "Error", "Off"). Pass a richer context string at the call site
+   * (e.g. "Database: healthy") when the dot stands alone.
+   */
+  label?: string;
+  /**
+   * Set when an adjacent VISIBLE text label already conveys the status (e.g.
+   * HealthCard renders "Degraded" next to the dot). The dot is then hidden from
+   * screen readers to avoid a redundant double-announcement. Defaults to false,
+   * so a bare dot announces its status via `role="img"` + `aria-label`.
+   */
+  decorative?: boolean;
 }
 
 export default function StatusDot({
@@ -41,11 +54,21 @@ export default function StatusDot({
   size = 'sm',
   pulse = false,
   className = '',
+  label,
+  decorative = false,
 }: StatusDotProps) {
+  const meta = statusMeta[status];
+  // Color alone is not an accessible status cue (color-only fails WCAG 1.4.1 and
+  // is ambiguous for colorblind users). A bare dot therefore exposes its status
+  // as text to assistive tech; a dot paired with a visible label opts out.
+  const a11y = decorative
+    ? ({ 'aria-hidden': true } as const)
+    : ({ role: 'img', 'aria-label': label ?? meta.label } as const);
+
   return (
     <span
-      className={`inline-block shrink-0 rounded-full ${colorMap[status]} ${sizeMap[size]} ${pulse ? 'animate-pulse' : ''} ${className}`}
-      aria-hidden="true"
+      className={`inline-block shrink-0 rounded-full ${meta.color} ${sizeMap[size]} ${pulse ? 'animate-pulse' : ''} ${className}`}
+      {...a11y}
     />
   );
 }


### PR DESCRIPTION
Item **11** (Theme 8 — accessibility: color-only status & unlabeled controls) of the 2026-06-23 UX & durability audit. At-a-glance health was invisible to assistive tech and ambiguous to colorblind users.

## Shared primitive (every consumer inherits the fix)
- **`StatusDot`** — was `aria-hidden` with color as the only signal. Now exposes `role="img"` + a per-status `aria-label` (`OK`/`Warning`/`Error`/`Off`, overridable via `label`). New **`decorative`** prop hides the dot from screen readers when an adjacent visible text label already conveys the status (avoids double-announcement).

## Consumers
| File | Change |
|---|---|
| `DeployDashboard` | raw color-only service dot → `StatusDot` (decorative; "Healthy/Degraded/Down" text is the visible label) |
| `HealthCard` | aria-hidden dots + bare daemon span → `StatusDot` (decorative) |
| `StepDeploy` | `deploying` & `polling` both rendered **orange** — `polling` is now **amber** + relabeled "Awaiting readiness...", and the local dot gained `role="img"` + aria-label, so the two states differ by brightness **and** to screen readers |
| `AgentTerminalPane` | `■` stop button got `aria-label="Stop agent"`; glyph now `aria-hidden` |
| `apps/console/proxy.go` | non-running PTY sessions are no longer silently hidden — listed in a dimmed **"Inactive sessions (not attachable)"** section with an explicit status word; running sessions show a `[running]` text tag instead of color alone |

## Verification
- `pnpm typecheck:studio` clean · **553** studio tests green (StatusDot tests updated for the new role/aria-label/decorative contract) · console **gofmt/vet/build** clean.

Base `test`, manual merge (no `--auto`) per the audit's execution rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)