### PR TITLE
chore(studio): UX polish tail (item 12)

### DIFF
--- a/apps/studio/src/__tests__/components/RepoCard.test.tsx
+++ b/apps/studio/src/__tests__/components/RepoCard.test.tsx
@@ -26,52 +26,64 @@ const ERROR_RESULT: SyncResult = {
 
 describe('RepoCard', () => {
   it('renders repo name', () => {
-    render(<RepoCard result={OK_RESULT} onSync={vi.fn()} syncing={false} />);
+    render(<RepoCard result={OK_RESULT} onSync={vi.fn()} syncing={false} error={null} />);
     expect(screen.getByText('RevealUI')).toBeInTheDocument();
   });
 
   it('renders drive letter', () => {
-    render(<RepoCard result={OK_RESULT} onSync={vi.fn()} syncing={false} />);
+    render(<RepoCard result={OK_RESULT} onSync={vi.fn()} syncing={false} error={null} />);
     expect(screen.getByText('C')).toBeInTheDocument();
   });
 
   it('renders branch name', () => {
-    render(<RepoCard result={OK_RESULT} onSync={vi.fn()} syncing={false} />);
+    render(<RepoCard result={OK_RESULT} onSync={vi.fn()} syncing={false} error={null} />);
     expect(screen.getByText('main')).toBeInTheDocument();
   });
 
   it('renders status in uppercase', () => {
-    render(<RepoCard result={OK_RESULT} onSync={vi.fn()} syncing={false} />);
+    render(<RepoCard result={OK_RESULT} onSync={vi.fn()} syncing={false} error={null} />);
     expect(screen.getByText('OK')).toBeInTheDocument();
   });
 
   it('applies green style for ok status', () => {
-    render(<RepoCard result={OK_RESULT} onSync={vi.fn()} syncing={false} />);
+    render(<RepoCard result={OK_RESULT} onSync={vi.fn()} syncing={false} error={null} />);
     const statusEl = screen.getByText('OK');
     expect(statusEl.className).toContain('text-green-400');
   });
 
   it('applies yellow style for dirty status', () => {
-    render(<RepoCard result={DIRTY_RESULT} onSync={vi.fn()} syncing={false} />);
+    render(<RepoCard result={DIRTY_RESULT} onSync={vi.fn()} syncing={false} error={null} />);
     const statusEl = screen.getByText('DIRTY');
     expect(statusEl.className).toContain('text-yellow-400');
   });
 
   it('applies red style for error status', () => {
-    render(<RepoCard result={ERROR_RESULT} onSync={vi.fn()} syncing={false} />);
+    render(<RepoCard result={ERROR_RESULT} onSync={vi.fn()} syncing={false} error={null} />);
     const statusEl = screen.getByText('ERROR');
     expect(statusEl.className).toContain('text-red-400');
   });
 
+  it('renders a per-repo error message when one is set', () => {
+    render(
+      <RepoCard
+        result={ERROR_RESULT}
+        onSync={vi.fn()}
+        syncing={false}
+        error="Dirty working tree"
+      />,
+    );
+    expect(screen.getByText('Dirty working tree')).toBeInTheDocument();
+  });
+
   it('calls onSync when Sync button is clicked', () => {
     const onSync = vi.fn();
-    render(<RepoCard result={OK_RESULT} onSync={onSync} syncing={false} />);
+    render(<RepoCard result={OK_RESULT} onSync={onSync} syncing={false} error={null} />);
     fireEvent.click(screen.getByText('Sync'));
     expect(onSync).toHaveBeenCalledOnce();
   });
 
   it('disables Sync button when syncing', () => {
-    render(<RepoCard result={OK_RESULT} onSync={vi.fn()} syncing={true} />);
+    render(<RepoCard result={OK_RESULT} onSync={vi.fn()} syncing={true} error={null} />);
     expect(screen.getByText('Sync').closest('button')).toBeDisabled();
   });
 });

--- a/apps/studio/src/__tests__/components/SyncPanel.test.tsx
+++ b/apps/studio/src/__tests__/components/SyncPanel.test.tsx
@@ -3,10 +3,12 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../hooks/use-sync', () => ({
   useSync: vi.fn().mockReturnValue({
-    syncing: false,
+    syncingRepos: new Set<string>(),
+    anySyncing: false,
     results: [],
     log: [],
-    error: null,
+    globalError: null,
+    errors: {},
     syncAll: vi.fn(),
     syncOne: vi.fn(),
   }),
@@ -35,13 +37,15 @@ describe('SyncPanel', () => {
 
   it('shows repo cards when results exist', () => {
     vi.mocked(useSync).mockReturnValue({
-      syncing: false,
+      syncingRepos: new Set<string>(),
+      anySyncing: false,
       results: [
         { drive: 'C', repo: 'RevealUI', status: 'ok', branch: 'main' },
         { drive: 'E', repo: 'my-private-repo', status: 'dirty', branch: 'main' },
       ],
       log: [],
-      error: null,
+      globalError: null,
+      errors: {},
       syncAll: vi.fn(),
       syncOne: vi.fn(),
     });
@@ -52,10 +56,12 @@ describe('SyncPanel', () => {
 
   it('shows sync log when entries exist', () => {
     vi.mocked(useSync).mockReturnValue({
-      syncing: false,
+      syncingRepos: new Set<string>(),
+      anySyncing: false,
       results: [],
       log: ['Syncing...', 'Done'],
-      error: null,
+      globalError: null,
+      errors: {},
       syncAll: vi.fn(),
       syncOne: vi.fn(),
     });
@@ -64,12 +70,14 @@ describe('SyncPanel', () => {
     expect(screen.getByText('Done')).toBeInTheDocument();
   });
 
-  it('shows error when error is set', () => {
+  it('shows a global error when the Sync All path fails', () => {
     vi.mocked(useSync).mockReturnValue({
-      syncing: false,
+      syncingRepos: new Set<string>(),
+      anySyncing: false,
       results: [],
       log: [],
-      error: 'Sync failed',
+      globalError: 'Sync failed',
+      errors: {},
       syncAll: vi.fn(),
       syncOne: vi.fn(),
     });

--- a/apps/studio/src/__tests__/hooks/use-sync.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-sync.test.ts
@@ -27,10 +27,11 @@ describe('useSync', () => {
   it('initializes with default state', () => {
     const { result } = renderHook(() => useSync());
 
-    expect(result.current.syncing).toBe(false);
+    expect(result.current.anySyncing).toBe(false);
     expect(result.current.results).toEqual([]);
     expect(result.current.log).toEqual([]);
-    expect(result.current.error).toBeNull();
+    expect(result.current.globalError).toBeNull();
+    expect(result.current.errors).toEqual({});
   });
 
   it('syncs all repos successfully', async () => {
@@ -43,11 +44,11 @@ describe('useSync', () => {
     });
 
     expect(syncAllRepos).toHaveBeenCalledOnce();
-    expect(result.current.syncing).toBe(false);
+    expect(result.current.anySyncing).toBe(false);
     expect(result.current.results).toEqual(MOCK_RESULTS);
     expect(result.current.log).toContain('Starting full repo sync...');
     expect(result.current.log).toContain('Sync complete: 2/2 OK');
-    expect(result.current.error).toBeNull();
+    expect(result.current.globalError).toBeNull();
   });
 
   it('handles syncAll error', async () => {
@@ -59,8 +60,8 @@ describe('useSync', () => {
       await result.current.syncAll();
     });
 
-    expect(result.current.syncing).toBe(false);
-    expect(result.current.error).toBe('Network error');
+    expect(result.current.anySyncing).toBe(false);
+    expect(result.current.globalError).toBe('Network error');
     expect(result.current.log).toContain('Error: Network error');
   });
 
@@ -81,12 +82,12 @@ describe('useSync', () => {
     });
 
     expect(syncRepo).toHaveBeenCalledWith('RevealUI');
-    expect(result.current.syncing).toBe(false);
+    expect(result.current.anySyncing).toBe(false);
     expect(result.current.log).toContain('Syncing RevealUI...');
     expect(result.current.log).toContain('RevealUI: ok');
   });
 
-  it('handles syncOne error', async () => {
+  it('handles syncOne error (keyed to that repo, not global)', async () => {
     vi.mocked(syncRepo).mockRejectedValueOnce(new Error('Dirty working tree'));
 
     const { result } = renderHook(() => useSync());
@@ -95,8 +96,9 @@ describe('useSync', () => {
       await result.current.syncOne('RevealUI');
     });
 
-    expect(result.current.syncing).toBe(false);
-    expect(result.current.error).toBe('Dirty working tree');
+    expect(result.current.anySyncing).toBe(false);
+    expect(result.current.errors.RevealUI).toBe('Dirty working tree');
+    expect(result.current.globalError).toBeNull();
   });
 
   it('counts only ok results in sync summary', async () => {

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -290,9 +290,7 @@ export default function AgentPanel() {
   const workboardInputRef = useRef<HTMLInputElement>(null);
 
   const [repoPath, setRepoPath] = useState(
-    () =>
-      (typeof localStorage !== 'undefined' && localStorage.getItem('git-repo-path')) ||
-      '~/projects/RevealUI',
+    () => (typeof localStorage !== 'undefined' && localStorage.getItem('git-repo-path')) || '',
   );
   const [editingRepo, setEditingRepo] = useState(false);
   const [draftRepo, setDraftRepo] = useState(repoPath);

--- a/apps/studio/src/components/apps/AppsPanel.tsx
+++ b/apps/studio/src/components/apps/AppsPanel.tsx
@@ -28,6 +28,15 @@ export default function AppsPanel() {
         </div>
       )}
 
+      {apps.length === 0 && !loading && !error && (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <p className="text-sm text-neutral-600">No apps yet</p>
+          <p className="mt-1 text-xs text-neutral-700">
+            Apps configured in your harness will appear here.
+          </p>
+        </div>
+      )}
+
       {apps.length > 0 && (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {apps.map((status) => (

--- a/apps/studio/src/components/auth/LoginScreen.tsx
+++ b/apps/studio/src/components/auth/LoginScreen.tsx
@@ -8,11 +8,13 @@
  * Matches the Studio visual style (dark theme, orange accent).
  */
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAuthContext } from '../../hooks/use-auth';
 import { useSettingsContext } from '../../hooks/use-settings';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
+
+const RESEND_COOLDOWN_SECONDS = 30;
 
 export default function LoginScreen() {
   const { step, loading, error, sendOtp, submitOtp } = useAuthContext();
@@ -20,28 +22,55 @@ export default function LoginScreen() {
   const [email, setEmail] = useState('');
   const [code, setCode] = useState('');
   const [otpSent, setOtpSent] = useState(false);
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  async function handleSendOtp(e: React.FormEvent) {
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, []);
+
+  function startCooldown(): void {
+    setResendCooldown(RESEND_COOLDOWN_SECONDS);
+    intervalRef.current = setInterval(() => {
+      setResendCooldown((prev) => {
+        if (prev <= 1) {
+          clearInterval(intervalRef.current!);
+          intervalRef.current = null;
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }
+
+  async function handleSendOtp(e: React.FormEvent): Promise<void> {
     e.preventDefault();
     if (!email.trim()) return;
     const ok = await sendOtp(settings.apiUrl, email.trim());
     if (ok) {
       setOtpSent(true);
+      startCooldown();
     }
   }
 
-  async function handleVerify(e: React.FormEvent) {
+  async function handleVerify(e: React.FormEvent): Promise<void> {
     e.preventDefault();
     if (!code.trim() || code.length !== 6) return;
     await submitOtp(settings.apiUrl, email.trim(), code.trim());
   }
 
-  async function handleResend() {
+  async function handleResend(): Promise<void> {
     setCode('');
     await sendOtp(settings.apiUrl, email.trim());
+    startCooldown();
   }
 
   const showOtp = step === 'otp' || otpSent;
+  const resendBlocked = resendCooldown > 0;
 
   return (
     <div className="flex h-screen w-screen items-center justify-center bg-neutral-950">
@@ -114,10 +143,10 @@ export default function LoginScreen() {
               <button
                 type="button"
                 onClick={handleResend}
-                disabled={loading}
-                className="text-neutral-500 hover:text-orange-400 disabled:opacity-50"
+                disabled={loading || resendBlocked}
+                className="text-neutral-500 hover:text-orange-400 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                Resend code
+                {resendBlocked ? `Resend in ${resendCooldown}s` : 'Resend code'}
               </button>
               <button
                 type="button"

--- a/apps/studio/src/components/dashboard/DeployDashboard.tsx
+++ b/apps/studio/src/components/dashboard/DeployDashboard.tsx
@@ -89,6 +89,7 @@ export default function DeployDashboard() {
   }
 
   const domain = config?.deploy?.domain;
+  const configLoaded = config !== null;
 
   return (
     <div className="flex flex-col gap-6">
@@ -101,11 +102,20 @@ export default function DeployDashboard() {
         }
       />
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        {services.map((service) => (
-          <HealthCard key={service.label} service={service} />
-        ))}
-      </div>
+      {services.length > 0 ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {services.map((service) => (
+            <HealthCard key={service.label} service={service} />
+          ))}
+        </div>
+      ) : configLoaded ? (
+        <p className="py-6 text-center text-xs text-neutral-600">
+          No services configured.{' '}
+          <span className="text-neutral-500">
+            Add a deploy domain in settings to enable health monitoring.
+          </span>
+        </p>
+      ) : null}
 
       {domain && (
         <div className="rounded-md border border-neutral-700 bg-neutral-900/50 p-4">
@@ -156,7 +166,7 @@ function QuickLink({ label, url }: { label: string; url: string }) {
       rel="noopener noreferrer"
       className="flex items-center gap-2 text-sm text-orange-400 hover:text-orange-300 transition-colors"
     >
-      <span>{'\u2192'}</span>
+      <span>{'→'}</span>
       <span>{label}</span>
       <span className="font-mono text-xs text-neutral-500">{url}</span>
     </a>

--- a/apps/studio/src/components/git/GitPanel.tsx
+++ b/apps/studio/src/components/git/GitPanel.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 const COMMIT_SUCCESS_FEEDBACK_MS = 3_000;
 const REMOTE_SUCCESS_FEEDBACK_MS = 2_000;
-const REMOTE_ERROR_FEEDBACK_MS = 4_000;
 
 import {
   gitCommit,
@@ -26,6 +25,7 @@ import type {
   GitStatusResult,
 } from '../../types';
 import ConfirmDialog from '../ui/ConfirmDialog';
+import ErrorAlert from '../ui/ErrorAlert';
 import DiffView from './DiffView';
 
 // ── Status badge ─────────────────────────────────────────────────────────────
@@ -394,6 +394,7 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
   const [selected, setSelected] = useState<DiffSelection | null>(null);
   const [diffContent, setDiffContent] = useState<GitDiffContent | null>(null);
   const [diffLoading, setDiffLoading] = useState(false);
+  const [diffError, setDiffError] = useState<string | null>(null);
 
   // Branch state
   const [branches, setBranches] = useState<GitBranch[]>([]);
@@ -478,16 +479,15 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
     async (filePath: string, staged: boolean) => {
       setSelected({ filePath, staged });
       setDiffContent(null);
+      setDiffError(null);
       setDiffLoading(true);
       try {
         const content = await gitDiffContent(repoPath, filePath, staged);
         setDiffContent(content);
       } catch (e) {
-        // Show the error as the modified side so the viewer has something to display
-        setDiffContent({
-          original: '',
-          modified: `Error: ${e instanceof Error ? e.message : String(e)}`,
-        });
+        // Surface failures as a distinct error state — rendering them as the
+        // "modified" side made an error look like real diff content.
+        setDiffError(e instanceof Error ? e.message : String(e));
       } finally {
         setDiffLoading(false);
       }
@@ -585,10 +585,8 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
     } catch (e) {
       setPushStatus('error');
       setRemoteError(e instanceof Error ? e.message : String(e));
-      setTimeout(() => {
-        setPushStatus('idle');
-        setRemoteError(null);
-      }, REMOTE_ERROR_FEEDBACK_MS);
+      // A failed push/pull persists until the user dismisses it — a 4s
+      // auto-dismiss meant the operator could miss why the operation failed.
     }
   }, [repoPath, status?.branch]);
 
@@ -603,10 +601,7 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
     } catch (e) {
       setPullStatus('error');
       setRemoteError(e instanceof Error ? e.message : String(e));
-      setTimeout(() => {
-        setPullStatus('idle');
-        setRemoteError(null);
-      }, REMOTE_ERROR_FEEDBACK_MS);
+      // Persist the failure until dismissed — see handlePush.
     }
   }, [repoPath, status?.branch, refresh]);
 
@@ -787,11 +782,23 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
                 {repoPath}
               </button>
 
-              {/* Remote error */}
+              {/* Remote error — persists until the user dismisses it */}
               {remoteError && (
-                <p className="mt-0.5 truncate text-[10px] text-red-400" title={remoteError}>
-                  {remoteError}
-                </p>
+                <div className="mt-0.5 flex items-start gap-1 text-[10px] text-red-400">
+                  <span className="flex-1 break-words">{remoteError}</span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setRemoteError(null);
+                      if (pushStatus === 'error') setPushStatus('idle');
+                      if (pullStatus === 'error') setPullStatus('idle');
+                    }}
+                    className="shrink-0 rounded px-1 leading-none text-red-400 hover:bg-red-950/40 hover:text-red-300"
+                    aria-label="Dismiss error"
+                  >
+                    ×
+                  </button>
+                </div>
               )}
             </>
           )}
@@ -947,6 +954,10 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
             (diffLoading ? (
               <div className="flex h-full items-center justify-center text-sm text-neutral-500">
                 Loading diff…
+              </div>
+            ) : diffError ? (
+              <div className="flex h-full items-start justify-center p-4">
+                <ErrorAlert message={diffError} />
               </div>
             ) : diffContent ? (
               <DiffView

--- a/apps/studio/src/components/settings/SettingsPanel.tsx
+++ b/apps/studio/src/components/settings/SettingsPanel.tsx
@@ -67,6 +67,11 @@ export default function SettingsPanel() {
             }`}
           >
             {tab.label}
+            {tab.key === 'connection' && settings.localMode && (
+              <span className="ml-1.5 inline-block rounded bg-amber-600 px-1 py-0.5 text-[10px] font-semibold leading-none text-white">
+                LOCAL
+              </span>
+            )}
           </button>
         ))}
       </div>
@@ -131,7 +136,14 @@ export default function SettingsPanel() {
               </div>
             </div>
             <div className="flex flex-col gap-1">
-              <span className="text-sm text-neutral-400">Local mode</span>
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-neutral-400">Local mode</span>
+                {settings.localMode && (
+                  <span className="rounded bg-amber-600 px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none text-white">
+                    Active
+                  </span>
+                )}
+              </div>
               <div className="flex gap-2">
                 {LOCAL_MODE_OPTIONS.map((opt) => (
                   <button

--- a/apps/studio/src/components/sync/RepoCard.tsx
+++ b/apps/studio/src/components/sync/RepoCard.tsx
@@ -6,6 +6,7 @@ interface RepoCardProps {
   result: SyncResult;
   onSync: () => void;
   syncing: boolean;
+  error: string | null;
 }
 
 const STATUS_STYLES: Record<string, string> = {
@@ -17,7 +18,7 @@ const STATUS_STYLES: Record<string, string> = {
   error: 'text-red-400',
 };
 
-export default function RepoCard({ result, onSync, syncing }: RepoCardProps) {
+export default function RepoCard({ result, onSync, syncing, error }: RepoCardProps) {
   return (
     <Card variant="default" padding="none" className="flex items-center justify-between px-4 py-3">
       <div>
@@ -31,6 +32,7 @@ export default function RepoCard({ result, onSync, syncing }: RepoCardProps) {
           </span>
           <span className="text-neutral-600">{result.branch}</span>
         </div>
+        {error !== null && <p className="mt-1 text-xs text-red-400">{error}</p>}
       </div>
       <Button variant="ghost" size="sm" onClick={onSync} disabled={syncing}>
         Sync

--- a/apps/studio/src/components/sync/SyncPanel.tsx
+++ b/apps/studio/src/components/sync/SyncPanel.tsx
@@ -6,20 +6,21 @@ import RepoCard from './RepoCard';
 import SyncLog from './SyncLog';
 
 export default function SyncPanel() {
-  const { syncing, results, log, error, syncAll, syncOne } = useSync();
+  const { anySyncing, syncingRepos, globalError, errors, results, log, syncAll, syncOne } =
+    useSync();
 
   return (
     <div className="space-y-6">
       <PanelHeader
         title="Repo Sync"
         action={
-          <Button variant="primary" size="lg" onClick={syncAll} loading={syncing}>
+          <Button variant="primary" size="lg" onClick={syncAll} loading={anySyncing}>
             Sync All
           </Button>
         }
       />
 
-      <ErrorAlert message={error} />
+      <ErrorAlert message={globalError} />
 
       {results.length > 0 && (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -28,13 +29,14 @@ export default function SyncPanel() {
               key={`${result.drive}-${result.repo}`}
               result={result}
               onSync={() => syncOne(result.repo)}
-              syncing={syncing}
+              syncing={syncingRepos.has(result.repo) || syncingRepos.has('__all__')}
+              error={errors[result.repo] ?? null}
             />
           ))}
         </div>
       )}
 
-      {results.length === 0 && !syncing && (
+      {results.length === 0 && !anySyncing && (
         <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
           <div className="flex size-10 items-center justify-center rounded-lg bg-neutral-800">
             <svg

--- a/apps/studio/src/hooks/use-sync.ts
+++ b/apps/studio/src/hooks/use-sync.ts
@@ -3,18 +3,18 @@ import { syncAllRepos, syncRepo } from '../lib/invoke';
 import type { SyncResult } from '../types';
 
 interface SyncState {
-  syncing: boolean;
+  syncingRepos: Set<string>;
   results: SyncResult[];
   log: string[];
-  error: string | null;
+  errors: Record<string, string>;
 }
 
 export function useSync() {
   const [state, setState] = useState<SyncState>({
-    syncing: false,
+    syncingRepos: new Set(),
     results: [],
     log: [],
-    error: null,
+    errors: {},
   });
 
   const appendLog = useCallback(
@@ -23,18 +23,22 @@ export function useSync() {
   );
 
   const syncAll = useCallback(async () => {
-    setState({ syncing: true, results: [], log: [], error: null });
+    setState({ syncingRepos: new Set(['__all__']), results: [], log: [], errors: {} });
     appendLog('Starting full repo sync...');
     try {
       const results = await syncAllRepos();
       appendLog(
         `Sync complete: ${results.filter((r) => r.status === 'ok').length}/${results.length} OK`,
       );
-      setState((prev) => ({ ...prev, syncing: false, results }));
+      setState((prev) => ({ ...prev, syncingRepos: new Set(), results }));
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       appendLog(`Error: ${msg}`);
-      setState((prev) => ({ ...prev, syncing: false, error: msg }));
+      setState((prev) => ({
+        ...prev,
+        syncingRepos: new Set(),
+        errors: { ...prev.errors, __all__: msg },
+      }));
     }
   }, [appendLog]);
 
@@ -42,9 +46,8 @@ export function useSync() {
     async (name: string) => {
       setState((prev) => ({
         ...prev,
-        syncing: true,
-        log: [],
-        error: null,
+        syncingRepos: new Set([...prev.syncingRepos, name]),
+        errors: Object.fromEntries(Object.entries(prev.errors).filter(([k]) => k !== name)),
       }));
       appendLog(`Syncing ${name}...`);
       try {
@@ -52,7 +55,7 @@ export function useSync() {
         appendLog(`${name}: ${result.status}`);
         setState((prev) => ({
           ...prev,
-          syncing: false,
+          syncingRepos: new Set([...prev.syncingRepos].filter((r) => r !== name)),
           results: prev.results.map((r) =>
             r.repo === name && r.drive === result.drive ? result : r,
           ),
@@ -60,11 +63,26 @@ export function useSync() {
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         appendLog(`Error: ${msg}`);
-        setState((prev) => ({ ...prev, syncing: false, error: msg }));
+        setState((prev) => ({
+          ...prev,
+          syncingRepos: new Set([...prev.syncingRepos].filter((r) => r !== name)),
+          errors: { ...prev.errors, [name]: msg },
+        }));
       }
     },
     [appendLog],
   );
 
-  return { ...state, syncAll, syncOne };
+  const anySyncing = state.syncingRepos.size > 0;
+
+  return {
+    syncingRepos: state.syncingRepos,
+    anySyncing,
+    globalError: (state.errors['__all__'] ?? null) as string | null,
+    errors: state.errors,
+    results: state.results,
+    log: state.log,
+    syncAll,
+    syncOne,
+  };
 }


### PR DESCRIPTION
Item **12** (medium/low remainder) of the 2026-06-23 UX & durability audit — the polish tail.

| Area | Change |
|---|---|
| `AgentPanel` | retired `~/projects/RevealUI` hardcoded repo-path default → empty |
| `AppsPanel` | real zero-state ("No apps yet" + hint) for the genuine empty case |
| `DeployDashboard` | zero-state when config is loaded but no services are configured |
| `LoginScreen` | 30s OTP **resend cooldown** with countdown; interval cleaned up on unmount |
| `SettingsPanel` | clearer **local-mode exit** affordance — "LOCAL"/"Active" badges so it's discoverable that local mode is on |
| `SyncPanel` / `RepoCard` / `use-sync` | sync state is now **per-repo** (`syncingRepos` Set + `errors` map keyed by repo) instead of one global flag — syncing/erroring one repo no longer blots the whole panel |
| `GitPanel` | (1) diff-load failures render as a distinct `ErrorAlert` **outside** the diff area instead of fake "modified" diff content; (2) push/pull errors **persist with a dismiss (×)** instead of auto-clearing after 4s |

**Verified-no-issue:** the InferencePanel "locked inputs" finding — those `disabled` states are transient in-flight guards that auto-clear, not a permanent trap. No change made.

## Verification
- Forced clean `tsc -b --force` clean (caught + fixed a latent `globalError` `string` vs `string|null` typing while updating the per-repo refactor's tests) · **551** studio tests green (sync tests updated for the new per-repo contract) · Biome clean.

Base `test`, manual merge (no `--auto`) per the audit's execution rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)