### PR TITLE
fix(studio): #202 review nits (re-deliver — missed the merge race)

### DIFF
--- a/apps/studio/src/__tests__/components/SyncPanel.test.tsx
+++ b/apps/studio/src/__tests__/components/SyncPanel.test.tsx
@@ -84,4 +84,46 @@ describe('SyncPanel', () => {
     render(<SyncPanel />);
     expect(screen.getByText('Sync failed')).toBeInTheDocument();
   });
+
+  it('shows a per-repo error under only the affected card', () => {
+    vi.mocked(useSync).mockReturnValue({
+      syncingRepos: new Set<string>(),
+      anySyncing: false,
+      results: [
+        { drive: 'C', repo: 'RevealUI', status: 'error', branch: 'main' },
+        { drive: 'E', repo: 'my-private-repo', status: 'ok', branch: 'main' },
+      ],
+      log: [],
+      globalError: null,
+      errors: { 'C/RevealUI': 'Dirty working tree' },
+      syncAll: vi.fn(),
+      syncOne: vi.fn(),
+    });
+    render(<SyncPanel />);
+    // The error appears exactly once — only the keyed card renders it.
+    expect(screen.getAllByText('Dirty working tree')).toHaveLength(1);
+  });
+
+  it('isolates syncing state between same-named repos on different drives', () => {
+    vi.mocked(useSync).mockReturnValue({
+      syncingRepos: new Set<string>(['C/shared']),
+      anySyncing: true,
+      results: [
+        { drive: 'C', repo: 'shared', status: 'ok', branch: 'main' },
+        { drive: 'E', repo: 'shared', status: 'ok', branch: 'main' },
+      ],
+      log: [],
+      globalError: null,
+      errors: {},
+      syncAll: vi.fn(),
+      syncOne: vi.fn(),
+    });
+    render(<SyncPanel />);
+    // Both cards render the same repo name…
+    expect(screen.getAllByText('shared')).toHaveLength(2);
+    // …but only the C/shared card's Sync button is disabled (syncing); E/shared stays actionable.
+    const syncButtons = screen.getAllByText('Sync').map((el) => el.closest('button'));
+    expect(syncButtons[0]).toBeDisabled();
+    expect(syncButtons[1]).not.toBeDisabled();
+  });
 });

--- a/apps/studio/src/__tests__/hooks/use-sync.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-sync.test.ts
@@ -78,7 +78,7 @@ describe('useSync', () => {
     });
 
     await act(async () => {
-      await result.current.syncOne('RevealUI');
+      await result.current.syncOne('C', 'RevealUI');
     });
 
     expect(syncRepo).toHaveBeenCalledWith('RevealUI');
@@ -93,11 +93,11 @@ describe('useSync', () => {
     const { result } = renderHook(() => useSync());
 
     await act(async () => {
-      await result.current.syncOne('RevealUI');
+      await result.current.syncOne('C', 'RevealUI');
     });
 
     expect(result.current.anySyncing).toBe(false);
-    expect(result.current.errors.RevealUI).toBe('Dirty working tree');
+    expect(result.current.errors['C/RevealUI']).toBe('Dirty working tree');
     expect(result.current.globalError).toBeNull();
   });
 

--- a/apps/studio/src/components/git/GitPanel.tsx
+++ b/apps/studio/src/components/git/GitPanel.tsx
@@ -578,6 +578,10 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
   const handlePush = useCallback(async () => {
     setPushStatus('loading');
     setRemoteError(null);
+    // Starting an op clears the shared error banner, so clear a stale sibling
+    // error icon too — else a prior failed pull's red icon contradicts the
+    // now-cleared banner.
+    setPullStatus((s) => (s === 'error' ? 'idle' : s));
     try {
       await gitPush(repoPath, 'origin', status?.branch ?? 'main');
       setPushStatus('ok');
@@ -593,6 +597,8 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
   const handlePull = useCallback(async () => {
     setPullStatus('loading');
     setRemoteError(null);
+    // Clear a stale push-error icon when starting a pull — see handlePush.
+    setPushStatus((s) => (s === 'error' ? 'idle' : s));
     try {
       await gitPull(repoPath, 'origin', status?.branch ?? 'main');
       setPullStatus('ok');

--- a/apps/studio/src/components/sync/SyncPanel.tsx
+++ b/apps/studio/src/components/sync/SyncPanel.tsx
@@ -24,15 +24,18 @@ export default function SyncPanel() {
 
       {results.length > 0 && (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          {results.map((result) => (
-            <RepoCard
-              key={`${result.drive}-${result.repo}`}
-              result={result}
-              onSync={() => syncOne(result.repo)}
-              syncing={syncingRepos.has(result.repo) || syncingRepos.has('__all__')}
-              error={errors[result.repo] ?? null}
-            />
-          ))}
+          {results.map((result) => {
+            const key = `${result.drive}/${result.repo}`;
+            return (
+              <RepoCard
+                key={key}
+                result={result}
+                onSync={() => syncOne(result.drive, result.repo)}
+                syncing={syncingRepos.has(key) || syncingRepos.has('__all__')}
+                error={errors[key] ?? null}
+              />
+            );
+          })}
         </div>
       )}
 

--- a/apps/studio/src/hooks/use-sync.ts
+++ b/apps/studio/src/hooks/use-sync.ts
@@ -43,30 +43,31 @@ export function useSync() {
   }, [appendLog]);
 
   const syncOne = useCallback(
-    async (name: string) => {
+    // Keyed on the drive/repo composite — rows are unique by (drive, repo), so a
+    // repo present on two drives must not share one spinner/error or collide.
+    async (drive: string, repo: string) => {
+      const key = `${drive}/${repo}`;
       setState((prev) => ({
         ...prev,
-        syncingRepos: new Set([...prev.syncingRepos, name]),
-        errors: Object.fromEntries(Object.entries(prev.errors).filter(([k]) => k !== name)),
+        syncingRepos: new Set([...prev.syncingRepos, key]),
+        errors: Object.fromEntries(Object.entries(prev.errors).filter(([k]) => k !== key)),
       }));
-      appendLog(`Syncing ${name}...`);
+      appendLog(`Syncing ${repo}...`);
       try {
-        const result = await syncRepo(name);
-        appendLog(`${name}: ${result.status}`);
+        const result = await syncRepo(repo);
+        appendLog(`${repo}: ${result.status}`);
         setState((prev) => ({
           ...prev,
-          syncingRepos: new Set([...prev.syncingRepos].filter((r) => r !== name)),
-          results: prev.results.map((r) =>
-            r.repo === name && r.drive === result.drive ? result : r,
-          ),
+          syncingRepos: new Set([...prev.syncingRepos].filter((r) => r !== key)),
+          results: prev.results.map((r) => (r.drive === drive && r.repo === repo ? result : r)),
         }));
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         appendLog(`Error: ${msg}`);
         setState((prev) => ({
           ...prev,
-          syncingRepos: new Set([...prev.syncingRepos].filter((r) => r !== name)),
-          errors: { ...prev.errors, [name]: msg },
+          syncingRepos: new Set([...prev.syncingRepos].filter((r) => r !== key)),
+          errors: { ...prev.errors, [key]: msg },
         }));
       }
     },


### PR DESCRIPTION
Re-delivers the `agent-win-host` MERGE-AFTER-NITS fixes for #202. They were committed (`c852cfb`) and force-pushed to `chore/ux-polish`, but #202 was merged at the prior tip (`0eea496`) **before that push landed**, so the fix was orphaned — the 3 flagged bugs are currently live on `test`.

Cherry-picks the orphaned commit onto current `test`:
1. **GitPanel** — starting either remote op clears a stale sibling error icon (push icon no longer stays red after a later pull succeeds, now that the 4s auto-reset is gone).
2. **SyncPanel/use-sync** — per-repo state re-keyed on the `${drive}/${repo}` composite (same-name-different-drive collision fixed); `syncOne(drive, repo)`.
3. **Tests** — `use-sync.test` updated for the new signature + composite key; two `SyncPanel` isolation tests added.

Verification on current `test` base: forced `tsc -b --force` clean · 24 sync/git tests green (full studio suite 553) · Biome clean.

Base `test`, manual merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)