### PR TITLE
fix(daemon): signature-gate agent.* — close unsigned-RCE + cross-agent PTY-hijack

### DIFF
--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -511,6 +511,11 @@ mod tests {
         assert!(requires_signature("git.log"));
         assert!(requires_signature("worktree.create"));
         assert!(requires_signature("worktree.remove"));
+        assert!(requires_signature("agent.spawn"));
+        assert!(requires_signature("agent.stop"));
+        assert!(requires_signature("agent.input"));
+        assert!(requires_signature("agent.resize"));
+        assert!(requires_signature("agent.output"));
         assert!(!requires_signature("ping"));
         assert!(!requires_signature("session.list"));
     }

--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -74,6 +74,16 @@ pub fn requires_signature(method: &str) -> bool {
             // mirror the daemon's MUTATING_OR_CONTENT_METHODS set (server.ts).
             | "worktree.create"
             | "worktree.remove"
+            // agent.* PTY/exec surface — `agent.spawn` forks a caller-supplied
+            // command as the daemon UID (unsigned-RCE) and stop/input/resize/
+            // output drive another agent's live PTY. Signature-required so the
+            // native client signs them and the daemon binds the verified signer.
+            // MUST mirror server.ts MUTATING_OR_CONTENT_METHODS.
+            | "agent.spawn"
+            | "agent.stop"
+            | "agent.input"
+            | "agent.resize"
+            | "agent.output"
     )
 }
 

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -48,6 +48,15 @@ const SIGNED = [
   // Grant/revoke cross-agent root access: owner-only, signature-required.
   'project.grant',
   'project.revoke',
+  // agent.* PTY/exec surface: agent.spawn forks a caller-supplied command as the
+  // daemon UID (unsigned-RCE) and stop/input/resize/output drive another agent's
+  // live PTY. Signature-required so the actor is the verified signer, not a
+  // spoofable actorAgentId (2026-06-29 Part B findings).
+  'agent.spawn',
+  'agent.stop',
+  'agent.input',
+  'agent.resize',
+  'agent.output',
 ];
 
 // Only payload-free, repo-agnostic coordination methods stay signature-OPTIONAL.

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -1,9 +1,13 @@
 /**
  * Unit tests for the agent.* PTY spawn handler group (spawn.ts).
  *
- * node-pty is mocked so no real processes are spawned. Tests drive the
- * daemon via a real Unix socket (same pattern as coordination.test.ts) so
- * the full dispatch + schema validation + identity gate stack is exercised.
+ * agent.* is signature-gated: every method is in server.ts
+ * MUTATING_OR_CONTENT_METHODS and in signing.rs requires_signature(). Every call
+ * therefore carries an Ed25519 `x-revdev-signature` envelope; the daemon binds
+ * ctx.agentId to the VERIFIED signer, and process ownership is checked against
+ * that verified signer — never a spoofable actorAgentId param. node-pty is mocked
+ * so no real processes are spawned; tests drive the daemon over a real Unix
+ * socket so the full dispatch + signature gate + schema + identity stack runs.
  *
  * @vitest-environment node
  */
@@ -84,16 +88,24 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 // Imports (after mock declarations)
 // ---------------------------------------------------------------------------
 
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { formatDid } from '@revdev/protocol/did';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  generateNonce,
+  hashParams,
+  serializeEnvelope,
+  signEnvelope,
+} from '../agent-identity-crypto.js';
 import { startDaemon } from '../server.js';
 // Side-effect import: registers agent.* handlers with the daemon's handler Map.
-// Must be imported here (not via index.ts / cli.ts entrypoints) since tests
-// import startDaemon directly from server.js. Vitest hoists vi.mock() above
-// all static imports, so the node-pty mock is in place before spawn.ts loads.
+// Vitest hoists vi.mock() above all static imports, so the node-pty mock is in
+// place before spawn.ts loads.
 import '../spawn.js';
 import {
   clearTestLicenseEnv,
@@ -102,31 +114,34 @@ import {
 } from './test-license-helper.js';
 
 // ---------------------------------------------------------------------------
-// JSON-RPC client helper — one request per socket (stateless)
+// Signed JSON-RPC client — one request per socket (stateless). agent.* is in
+// MUTATING_OR_CONTENT_METHODS, so each call MUST carry an Ed25519 envelope.
 // ---------------------------------------------------------------------------
 
-function rpc(
+interface RpcResult {
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+function rpcFrame(
   socketPath: string,
   method: string,
-  params: Record<string, unknown> = {},
-): Promise<unknown> {
+  params: Record<string, unknown>,
+  signature?: string,
+): Promise<RpcResult> {
   return new Promise((resolve, reject) => {
     const sock: Socket = connect(socketPath);
     let buf = '';
-    const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
-    sock.on('connect', () => sock.write(req));
+    const req: Record<string, unknown> = { jsonrpc: '2.0', id: 1, method, params };
+    if (signature) req['x-revdev-signature'] = signature;
+    sock.on('connect', () => sock.write(`${JSON.stringify(req)}\n`));
     sock.on('data', (d) => {
       buf += d.toString();
       const nl = buf.indexOf('\n');
       if (nl === -1) return;
       sock.end();
       try {
-        const resp = JSON.parse(buf.slice(0, nl)) as {
-          result?: unknown;
-          error?: { code: number; message: string };
-        };
-        if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
-        else resolve(resp.result);
+        resolve(JSON.parse(buf.slice(0, nl)) as RpcResult);
       } catch (e) {
         reject(e instanceof Error ? e : new Error(String(e)));
       }
@@ -134,10 +149,36 @@ function rpc(
     sock.on('error', reject);
     sock.setTimeout(5000, () => {
       sock.destroy();
-      reject(new Error(`RPC timeout: ${method}`));
+      reject(new Error(`rpc timeout: ${method}`));
     });
   });
 }
+
+/** A client-held identity (mirrors the key Studio keeps in its Windows vault). */
+function makeSigner(agentId: string) {
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid(agentId, fingerprint);
+  const sign = (method: string, params: Record<string, unknown>): string =>
+    serializeEnvelope(
+      signEnvelope(
+        {
+          did,
+          kid: fingerprint,
+          nonce: generateNonce(),
+          ts: Math.floor(Date.now() / 1000),
+          method,
+          paramsHash: hashParams(method, params),
+        },
+        kp.privateKeyPem,
+      ),
+    );
+  return { agentId, fingerprint, did, sign };
+}
+
+// owner drives the happy paths; other proves cross-agent ownership rejection.
+const owner = makeSigner('spawn-test-owner');
+const other = makeSigner('spawn-test-other');
 
 // ---------------------------------------------------------------------------
 // Setup
@@ -146,13 +187,34 @@ function rpc(
 let dataDir: string;
 let socketPath: string;
 let close: () => Promise<void>;
-let agentId: string;
+
+/** Signed RPC that throws on error (the common happy-path wrapper). */
+async function signedRpc(
+  signer: { sign: (m: string, p: Record<string, unknown>) => string },
+  method: string,
+  params: Record<string, unknown> = {},
+): Promise<unknown> {
+  const resp = await rpcFrame(socketPath, method, params, signer.sign(method, params));
+  if (resp.error) throw new Error(`${resp.error.code}: ${resp.error.message}`);
+  return resp.result;
+}
 
 beforeAll(async () => {
   setTestLicenseEnv(generateTestLicense('enterprise'));
   dataDir = await mkdtemp(join(tmpdir(), 'revdev-spawn-test-'));
   socketPath = join(dataDir, 'harness.sock');
-  const d = await startDaemon({ socketPath, dataDir });
+  // Provision both client fingerprints into the trust anchor (fixture).
+  const anchor = join(dataDir, 'trusted-client-fingerprint');
+  await writeFile(
+    anchor,
+    `${owner.agentId}:${owner.fingerprint}\n${other.agentId}:${other.fingerprint}\n`,
+  );
+  const d = await startDaemon({
+    socketPath,
+    dataDir,
+    trustedClientFingerprintPath: anchor,
+    trustedAnchorRequireRootOwned: false,
+  });
   close = d.close;
 });
 
@@ -162,13 +224,7 @@ afterAll(async () => {
   clearTestLicenseEnv();
 });
 
-beforeEach(async () => {
-  const r = (await rpc(socketPath, 'session.register', {
-    agentName: 'spawn-test-agent',
-    workDir: '/tmp',
-    backend: 'test',
-  })) as { sessionId: string };
-  agentId = r.sessionId;
+beforeEach(() => {
   _lastPty = null;
   _pidCounter = 1000;
 });
@@ -177,10 +233,20 @@ beforeEach(async () => {
 // Tests
 // ---------------------------------------------------------------------------
 
+describe('signature gate', () => {
+  it('rejects an UNSIGNED agent.spawn (no Ed25519 envelope)', async () => {
+    const resp = await rpcFrame(socketPath, 'agent.spawn', { command: 'bash', cwd: '/tmp' });
+    // The dispatch gate refuses a MUTATING_OR_CONTENT_METHODS call that is not
+    // signature-verified — the unsigned host process can no longer exec as the
+    // daemon UID. No processId is returned.
+    expect(resp.error).toBeDefined();
+    expect(resp.result).toBeUndefined();
+  });
+});
+
 describe('agent.spawn', () => {
   it('returns a processId (UUID) and numeric pid', async () => {
-    const result = (await rpc(socketPath, 'agent.spawn', {
-      actorAgentId: agentId,
+    const result = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
       args: ['-i'],
       cwd: '/tmp',
@@ -194,18 +260,12 @@ describe('agent.spawn', () => {
   });
 
   it('rejects when command is missing (schema validation)', async () => {
-    await expect(
-      rpc(socketPath, 'agent.spawn', {
-        actorAgentId: agentId,
-        cwd: '/tmp',
-      }),
-    ).rejects.toThrow();
+    await expect(signedRpc(owner, 'agent.spawn', { cwd: '/tmp' })).rejects.toThrow();
   });
 
   it('rejects a nonexistent cwd', async () => {
     await expect(
-      rpc(socketPath, 'agent.spawn', {
-        actorAgentId: agentId,
+      signedRpc(owner, 'agent.spawn', {
         command: 'bash',
         cwd: '/tmp/nonexistent/does-not-exist',
       }),
@@ -215,14 +275,12 @@ describe('agent.spawn', () => {
 
 describe('agent.input', () => {
   it('writes data to the mocked pty', async () => {
-    const { processId } = (await rpc(socketPath, 'agent.spawn', {
-      actorAgentId: agentId,
+    const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
       cwd: '/tmp',
     })) as { processId: string };
 
-    const result = await rpc(socketPath, 'agent.input', {
-      actorAgentId: agentId,
+    const result = await signedRpc(owner, 'agent.input', {
       processId,
       data: 'echo hello\n',
     });
@@ -232,21 +290,13 @@ describe('agent.input', () => {
   });
 
   it('rejects input to a process owned by another agent', async () => {
-    const { processId } = (await rpc(socketPath, 'agent.spawn', {
-      actorAgentId: agentId,
+    const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
       cwd: '/tmp',
     })) as { processId: string };
 
-    const other = (await rpc(socketPath, 'session.register', {
-      agentName: 'input-other',
-      workDir: '/tmp',
-      backend: 'test',
-    })) as { sessionId: string };
-
     await expect(
-      rpc(socketPath, 'agent.input', {
-        actorAgentId: other.sessionId,
+      signedRpc(other, 'agent.input', {
         processId,
         data: 'whoami\n',
       }),
@@ -256,14 +306,12 @@ describe('agent.input', () => {
 
 describe('agent.resize', () => {
   it('calls pty.resize with the given dimensions', async () => {
-    const { processId } = (await rpc(socketPath, 'agent.spawn', {
-      actorAgentId: agentId,
+    const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
       cwd: '/tmp',
     })) as { processId: string };
 
-    const result = (await rpc(socketPath, 'agent.resize', {
-      actorAgentId: agentId,
+    const result = (await signedRpc(owner, 'agent.resize', {
       processId,
       cols: 120,
       rows: 40,
@@ -276,21 +324,13 @@ describe('agent.resize', () => {
   });
 
   it('rejects resize for a process owned by another agent', async () => {
-    const { processId } = (await rpc(socketPath, 'agent.spawn', {
-      actorAgentId: agentId,
+    const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
       cwd: '/tmp',
     })) as { processId: string };
 
-    const other = (await rpc(socketPath, 'session.register', {
-      agentName: 'resize-other',
-      workDir: '/tmp',
-      backend: 'test',
-    })) as { sessionId: string };
-
     await expect(
-      rpc(socketPath, 'agent.resize', {
-        actorAgentId: other.sessionId,
+      signedRpc(other, 'agent.resize', {
         processId,
         cols: 80,
         rows: 24,
@@ -301,14 +341,12 @@ describe('agent.resize', () => {
 
 describe('agent.stop', () => {
   it('kills the mocked pty and returns status killed', async () => {
-    const { processId } = (await rpc(socketPath, 'agent.spawn', {
-      actorAgentId: agentId,
+    const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
       cwd: '/tmp',
     })) as { processId: string };
 
-    const result = (await rpc(socketPath, 'agent.stop', {
-      actorAgentId: agentId,
+    const result = (await signedRpc(owner, 'agent.stop', {
       processId,
     })) as { stopped: string; status: string };
 
@@ -318,21 +356,13 @@ describe('agent.stop', () => {
   });
 
   it('rejects stop for a process owned by another agent', async () => {
-    const { processId } = (await rpc(socketPath, 'agent.spawn', {
-      actorAgentId: agentId,
+    const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
       cwd: '/tmp',
     })) as { processId: string };
 
-    const other = (await rpc(socketPath, 'session.register', {
-      agentName: 'stop-other',
-      workDir: '/tmp',
-      backend: 'test',
-    })) as { sessionId: string };
-
     await expect(
-      rpc(socketPath, 'agent.stop', {
-        actorAgentId: other.sessionId,
+      signedRpc(other, 'agent.stop', {
         processId,
       }),
     ).rejects.toThrow(/not owned by caller/);
@@ -340,8 +370,7 @@ describe('agent.stop', () => {
 
   it('rejects stop for an unknown processId', async () => {
     await expect(
-      rpc(socketPath, 'agent.stop', {
-        actorAgentId: agentId,
+      signedRpc(owner, 'agent.stop', {
         processId: '00000000-0000-0000-0000-000000000000',
       }),
     ).rejects.toThrow(/unknown processId/);
@@ -350,8 +379,7 @@ describe('agent.stop', () => {
 
 describe('agent.output', () => {
   it('returns buffered chunks and a cursor', async () => {
-    const { processId } = (await rpc(socketPath, 'agent.spawn', {
-      actorAgentId: agentId,
+    const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
       cwd: '/tmp',
     })) as { processId: string };
@@ -361,8 +389,7 @@ describe('agent.output', () => {
     // Allow the async DB write from bufferOutput to land
     await new Promise((r) => setTimeout(r, 100));
 
-    const result = (await rpc(socketPath, 'agent.output', {
-      actorAgentId: agentId,
+    const result = (await signedRpc(owner, 'agent.output', {
       processId,
       cursor: '0',
     })) as {
@@ -380,21 +407,13 @@ describe('agent.output', () => {
   });
 
   it('rejects output poll for a process owned by another agent', async () => {
-    const { processId } = (await rpc(socketPath, 'agent.spawn', {
-      actorAgentId: agentId,
+    const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
       cwd: '/tmp',
     })) as { processId: string };
 
-    const other = (await rpc(socketPath, 'session.register', {
-      agentName: 'output-other',
-      workDir: '/tmp',
-      backend: 'test',
-    })) as { sessionId: string };
-
     await expect(
-      rpc(socketPath, 'agent.output', {
-        actorAgentId: other.sessionId,
+      signedRpc(other, 'agent.output', {
         processId,
         cursor: '0',
       }),
@@ -403,8 +422,7 @@ describe('agent.output', () => {
 
   it('rejects output poll for an unknown processId', async () => {
     await expect(
-      rpc(socketPath, 'agent.output', {
-        actorAgentId: agentId,
+      signedRpc(owner, 'agent.output', {
         processId: '00000000-0000-0000-0000-000000000001',
         cursor: '0',
       }),

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -216,6 +216,19 @@ beforeAll(async () => {
     trustedAnchorRequireRootOwned: false,
   });
   close = d.close;
+
+  // Persist each client's public key so the daemon can Ed25519-verify their
+  // signed agent.* calls (the trust anchor only holds the fingerprint). One-time
+  // session.register per identity — the same bootstrap the Studio client does.
+  for (const s of [owner, other]) {
+    const reg = await rpcFrame(socketPath, 'session.register', {
+      agentId: s.agentId,
+      agentName: s.agentId,
+      backend: 'test',
+      publicKeyPem: s.publicKeyPem,
+    });
+    if (reg.error) throw new Error(`register ${s.agentId} failed: ${reg.error.message}`);
+  }
 });
 
 afterAll(async () => {

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -173,7 +173,7 @@ function makeSigner(agentId: string) {
         kp.privateKeyPem,
       ),
     );
-  return { agentId, fingerprint, did, sign };
+  return { agentId, fingerprint, did, publicKeyPem: kp.publicKeyPem, sign };
 }
 
 // owner drives the happy paths; other proves cross-agent ownership rejection.

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -197,6 +197,18 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   // requires_signature() must mark these too.
   'project.grant',
   'project.revoke',
+  // agent.* PTY/exec surface. `agent.spawn` forks a caller-supplied command as
+  // the daemon UID — an unsigned, Pro-tier-reachable RCE — and stop/input/
+  // resize/output drive or read another agent's live PTY. Signature-REQUIRED so
+  // the actor is the VERIFIED signer (ctx.agentId via boundVia==='signature'),
+  // never a spoofable params.actorAgentId. Closes the 2026-06-29 Part B
+  // unsigned-RCE + cross-agent PTY-hijack findings. Cross-language contract:
+  // signing.rs requires_signature() must mark these too.
+  'agent.spawn',
+  'agent.stop',
+  'agent.input',
+  'agent.resize',
+  'agent.output',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -149,15 +149,21 @@ function buildSafeEnv(extraEnv: Record<string, string>): Record<string, string> 
 // Local parameter extraction helpers
 // ---------------------------------------------------------------------------
 
-function requireAgent(ctx: SocketContext, params: Record<string, unknown>): string {
-  if (ctx.agentId) return ctx.agentId;
-  const actor = params.actorAgentId;
-  if (typeof actor === 'string' && actor.length > 0) {
-    ctx.agentId = actor;
-    ctx.boundVia = 'param';
-    return actor;
-  }
-  throw new Error('Not registered: call session.register or pass actorAgentId');
+// agent.* is signature-gated: every method is in server.ts
+// MUTATING_OR_CONTENT_METHODS and in signing.rs requires_signature(), so the
+// dispatch gate has already verified the Ed25519 signature and bound ctx.agentId
+// to the VERIFIED signer (boundVia==='signature') before this handler runs.
+// Trust ONLY that binding. The old spoofable params.actorAgentId fallback is
+// removed — it let a client name another agent as the PTY/exec owner (the
+// 2026-06-29 Part B cross-agent PTY-hijack finding) and let an unsigned host
+// process drive agent.spawn as the daemon UID (the unsigned-RCE finding). The
+// dispatch gate rejects unsigned calls with -32003 before we get here; this is
+// the defense-in-depth backstop. `_params` is retained for call-site parity.
+function requireAgent(ctx: SocketContext, _params: Record<string, unknown>): string {
+  if (ctx.boundVia === 'signature' && ctx.agentId) return ctx.agentId;
+  throw new Error(
+    'agent.* requires a signed request (verified Ed25519 signature); unsigned or param-bound actor rejected',
+  );
 }
 
 function stringParam(params: Record<string, unknown>, key: string): string {


### PR DESCRIPTION
## fix(daemon): signature-gate `agent.*` — close the unsigned-RCE + cross-agent PTY-hijack

Closes the highest-severity finding from the 2026-06-29 Part B post-merge security audit: on a Pro daemon, `agent.spawn` forked a **caller-supplied command as the daemon UID with no signature** (unsigned RCE reachable over the local `0600` socket), and `agent.stop/input/resize/output` drove/read another agent's live PTY keyed on a **spoofable `params.actorAgentId`**.

### The gate (cross-language contract, both sides)
- **`server.ts`** — add `agent.spawn/stop/input/resize/output` to `MUTATING_OR_CONTENT_METHODS`. The dispatch gate (`server.ts:1777`) now rejects any unsigned/unverified `agent.*` call with `-32003` before the handler runs.
- **`signing.rs` `requires_signature()`** — mirror the same five methods so the **native Tauri client signs them** (lockstep with the daemon requirement → the native path does not break).
- **`spawn.ts` `requireAgent`** — trust ONLY the verified-signer binding (`ctx.boundVia === 'signature'`); **remove the spoofable `params.actorAgentId` fallback**. Process ownership is now checked against the Ed25519-verified principal, killing the cross-agent PTY hijack.

### Tests
- `signature-gate.test.ts` — `agent.*` added to the SIGNED contract set (the exact-set assertion enforces the cross-language mirror).
- `signing.rs` unit test — asserts `requires_signature("agent.*")`.
- `spawn.test.ts` — **migrated to signed RPC** (two registered identities: `owner` drives happy paths; `other` proves cross-agent ownership rejection still works under signatures) + a new test that an **unsigned `agent.spawn` is rejected** (no `processId` returned). 48/48 pass; daemon typecheck + biome clean.

### Verified safe — no live caller breaks
The audit + a code verification confirmed the only **live** `agent.*` caller is the native Tauri → local-socket path, which now signs (signing.rs). The browser/remote-daemon `httpRpc` path (`apps/studio/src/lib/invoke.ts`) is **not a live surface** — the HTTP gateway defaults to `httpPort: 0` (disabled, pinned by `flows.test.ts:259`) and no UI wires up `pairWithDaemon`. So requiring signatures on `agent.*` breaks no real user.

### Deferred follow-ups (tracked, not in this PR)
1. **httpRpc signing** — before the HTTP gateway is ever enabled for `agent.*`, `httpRpc` must attach an `x-revdev-signature` envelope (mirror `agent-identity-crypto signEnvelope`), or `agent.*` over HTTP will be (correctly) rejected. Prerequisite to shipping browser/remote mode.
2. **`requireRoot` on `agent.spawn`** — evaluate whether PTY/exec should additionally require a registered root (B6), weighed against legitimate terminal spawns not tied to a root.

The #200 error-contract + #202 nits are intentionally a **separate PR** (UX/contract, not security).

> Draft until the Rust `cargo test` confirms locally + CI is green.
