### PR TITLE
fix(studio): #200 error-contract follow-ups (503-body, vault resolve-on-failure, 204, StatusDot)

### DIFF
--- a/apps/studio/src/__tests__/lib/http.test.ts
+++ b/apps/studio/src/__tests__/lib/http.test.ts
@@ -57,6 +57,16 @@ describe('httpRequest', () => {
     });
   });
 
+  it('returns undefined for a 204 No Content response (no parse error)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(emptyResponse(204)));
+    await expect(httpRequest<void>('https://x/revoke')).resolves.toBeUndefined();
+  });
+
+  it('returns undefined for an empty 2xx body (no parse error)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(emptyResponse(200)));
+    await expect(httpRequest<void>('https://x/empty')).resolves.toBeUndefined();
+  });
+
   it('throws a client HttpError carrying the server message on 4xx', async () => {
     vi.stubGlobal(
       'fetch',

--- a/apps/studio/src/__tests__/lib/http.test.ts
+++ b/apps/studio/src/__tests__/lib/http.test.ts
@@ -5,7 +5,21 @@ function jsonResponse(status: number, body: unknown): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
+    // httpRequest reads 2xx bodies via text()+JSON.parse and error bodies via
+    // json(); provide both so the mock matches the real Response surface.
     json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function emptyResponse(status: number): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => {
+      throw new SyntaxError('Unexpected end of JSON input');
+    },
+    text: async () => '',
   } as unknown as Response;
 }
 
@@ -16,6 +30,7 @@ function malformedResponse(status: number): Response {
     json: async () => {
       throw new SyntaxError('Unexpected token < in JSON');
     },
+    text: async () => '<not json>',
   } as unknown as Response;
 }
 

--- a/apps/studio/src/components/agent/AgentTerminalPane.tsx
+++ b/apps/studio/src/components/agent/AgentTerminalPane.tsx
@@ -173,6 +173,7 @@ export default function AgentTerminalPane() {
             >
               <StatusDot
                 status={s.status === 'running' ? 'ok' : s.status === 'errored' ? 'error' : 'off'}
+                decorative
               />
               <div className="min-w-0 flex-1">
                 <div className="truncate text-neutral-200">{s.name}</div>

--- a/apps/studio/src/components/vault/CreateSecretDialog.tsx
+++ b/apps/studio/src/components/vault/CreateSecretDialog.tsx
@@ -5,7 +5,10 @@ import Input from '../ui/Input';
 import Modal from '../ui/Modal';
 
 interface CreateSecretDialogProps {
-  onConfirm: (path: string, value: string) => Promise<void>;
+  // Returns true on success; on false the dialog stays open and preserves input
+  // so a failed save no longer silently closes the form (the #200
+  // resolve-on-failure finding). The error itself is surfaced by the vault hook.
+  onConfirm: (path: string, value: string) => Promise<boolean>;
   onClose: () => void;
 }
 
@@ -21,8 +24,7 @@ export default function CreateSecretDialog({ onConfirm, onClose }: CreateSecretD
     setSaving(true);
     setError(null);
     try {
-      await onConfirm(path.trim(), value.trim());
-      onClose();
+      if (await onConfirm(path.trim(), value.trim())) onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {

--- a/apps/studio/src/hooks/use-vault.ts
+++ b/apps/studio/src/hooks/use-vault.ts
@@ -102,24 +102,29 @@ export function useVault() {
     }
   }, []);
 
+  // Return a success boolean so a caller (e.g. CreateSecretDialog) can keep its
+  // form open + preserve input on failure rather than closing on a resolved
+  // promise that actually failed (the #200 resolve-on-failure finding).
   const createSecret = useCallback(
-    async (path: string, value: string) => {
+    async (path: string, value: string): Promise<boolean> => {
       setState((prev) => ({ ...prev, error: null }));
       try {
         await vaultSet(path, value, false);
         await refresh();
+        return true;
       } catch (err) {
         setState((prev) => ({
           ...prev,
           error: err instanceof Error ? err.message : String(err),
         }));
+        return false;
       }
     },
     [refresh],
   );
 
   const deleteSecret = useCallback(
-    async (path: string) => {
+    async (path: string): Promise<boolean> => {
       setState((prev) => ({ ...prev, error: null }));
       try {
         await vaultDelete(path);
@@ -129,11 +134,13 @@ export function useVault() {
           selectedValue: prev.selectedPath === path ? null : prev.selectedValue,
         }));
         await refresh();
+        return true;
       } catch (err) {
         setState((prev) => ({
           ...prev,
           error: err instanceof Error ? err.message : String(err),
         }));
+        return false;
       }
     },
     [refresh],

--- a/apps/studio/src/lib/health-api.ts
+++ b/apps/studio/src/lib/health-api.ts
@@ -54,7 +54,22 @@ export async function fetchHealth(
       signal: combined,
     });
   } catch (err) {
-    if (err instanceof HttpError) return null;
+    if (err instanceof HttpError) {
+      // A degraded API can answer non-2xx (e.g. 503) yet still carry a valid
+      // HealthResponse body. Surface that detail instead of collapsing the whole
+      // dashboard to "Unreachable"; only a non-health body (HTML error page,
+      // network failure, etc.) becomes null.
+      return isHealthResponse(err.body) ? err.body : null;
+    }
     throw err;
   }
+}
+
+/** Structural guard: a non-2xx body that is still a usable HealthResponse. */
+function isHealthResponse(body: unknown): body is HealthResponse {
+  if (typeof body !== 'object' || body === null) return false;
+  const b = body as Record<string, unknown>;
+  return (
+    (b.status === 'healthy' || b.status === 'degraded' || b.status === 'unhealthy') && 'checks' in b
+  );
 }

--- a/apps/studio/src/lib/http.ts
+++ b/apps/studio/src/lib/http.ts
@@ -79,8 +79,13 @@ export async function httpRequest<T>(url: string, init?: RequestInit): Promise<T
     throw new HttpError(messageFromBody(body) ?? fallback, kind, res.status, body);
   }
 
+  // 204 No Content and other empty 2xx bodies (e.g. token /revoke) carry no
+  // JSON — return undefined rather than throwing a spurious 'parse' error.
+  if (res.status === 204) return undefined as T;
+  const text = await res.text();
+  if (text.length === 0) return undefined as T;
   try {
-    return (await res.json()) as T;
+    return JSON.parse(text) as T;
   } catch {
     throw new HttpError('The server returned a malformed response.', 'parse', res.status);
   }


### PR DESCRIPTION
## fix(studio): #200 error-contract follow-ups

The four #200 error-contract findings from the 2026-06-29 revdev #200 pre-merge review (merged as-is; these were the unfixed MAJOR/MINOR items). Audit-first confirmed the two **#202** nits (GitPanel push/pull status reset, SyncPanel `${drive}/${repo}` keying) are **already fixed on `test`** — so this PR is the #200 set only.

### Fixes
- **`health-api.ts` (MAJOR)** — a reachable-but-degraded API that answers `503` with a valid `HealthResponse` body now renders that detail instead of collapsing the whole dashboard to "Unreachable". On `HttpError`, an `isHealthResponse` structural guard returns the body; only a non-health body (HTML error page, network failure) becomes `null`.
- **`use-vault.ts` + `CreateSecretDialog.tsx` (MAJOR)** — `createSecret`/`deleteSecret` now return a success boolean instead of catching→`setState`→**resolving** on failure. `CreateSecretDialog` closes only on `true`, so a failed save no longer silently closes the form + loses the typed input.
- **`http.ts` (MINOR)** — a `204 No Content` / empty 2xx body returns `undefined` rather than throwing a spurious `'parse'` `HttpError` (reads `text()` first; empty → `undefined`). Only token `/revoke` hits this today.
- **`AgentTerminalPane.tsx` (MINOR)** — `StatusDot` marked `decorative` (the status word is already visible adjacent) to avoid a screen-reader double-announce.

### Validation
- **53 studio tests pass** (http, use-health, use-vault, CreateSecretDialog, VaultPanel, Dashboard), incl. 2 new tests for the 204 / empty-body path. biome clean on all changed files.
- Note: a fresh TS-only worktree can't run `tsc -b` because the **ts-rs `src/generated/` bindings** are a Rust build artifact (emitted by the Tauri crate build) — those pre-existing `Cannot find module './generated/*'` errors are unrelated to this change and resolve in CI, which builds the crate. The 5 changed files have zero type errors.

This is the UX/contract half of the revdev `test→main` gate; the security half is the `agent.*` signature gate (#209). Both should land before the next promotion.
