### PR TITLE
feat(daemon): GAP-257 session activity-state — self-scoped state + active-window (daemon surface)

### DIFF
--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -967,11 +967,15 @@ describe('GAP-257: session activity-state', () => {
     expect(rowB?.blocked_since).toBeFalsy();
   });
 
-  it('an unbound (unsigned) caller cannot set state for a named session', async () => {
+  it('a caller that passes the identity gate but is NOT bound cannot set state', async () => {
+    // actorAgentId clears the dispatch identity gate, but does NOT bind
+    // ctx.agentId — so the handler's self-scope check must still reject. This
+    // proves state requires register/attach/sign, never just a claimed id.
     await seedIdentity('gap257-unbound-target');
     await expect(
       rpc(socketPath, 'session.update', {
-        agentId: 'gap257-unbound-target',
+        actorAgentId: 'gap257-unbound-target',
+        sessionId: 'gap257-unbound-target',
         state: 'blocked',
       }),
     ).rejects.toThrow(/requires a bound session/);

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -917,3 +917,113 @@ describe('signature acceptance', () => {
     expect(err?.code).toBe(-32002);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GAP-257 — session activity-state (self-scoped state + active-window).
+//
+// Proves: (1) state is SELF-SCOPED — a signed caller cannot flip another
+// session's state via the params override (the session.end cross-agent hole
+// must NOT be recreated); (2) the active-window derivation drops a session
+// out of "active" once updated_at ages past the window; (3) blocked → active
+// clears blocked_since; (4) unbound/invalid state calls are rejected.
+// ---------------------------------------------------------------------------
+
+type ListedSession = {
+  id: string;
+  activity_state?: string;
+  blocked_reason?: string | null;
+  blocked_since?: string | null;
+  active?: boolean;
+  staleSeconds?: number;
+};
+
+async function listLocal(): Promise<ListedSession[]> {
+  const r = (await rpc(socketPath, 'session.list')) as { sessions: ListedSession[] };
+  return r.sessions;
+}
+
+describe('GAP-257: session activity-state', () => {
+  it('state is self-scoped — a signed caller cannot set ANOTHER session state', async () => {
+    const a = await seedIdentity('gap257-self-a');
+    await seedIdentity('gap257-self-b');
+
+    // Signed as A, but naming B in the override params. State must land on A.
+    const res = (await signedRpc(
+      socketPath,
+      'session.update',
+      { sessionId: 'gap257-self-b', agentId: 'gap257-self-b', state: 'blocked' },
+      { did: a.did, fingerprint: a.fingerprint, privateKeyPem: a.privateKeyPem },
+    )) as { updated: string; stateScopedTo: string };
+    expect(res.stateScopedTo).toBe('gap257-self-a');
+
+    const sessions = await listLocal();
+    const rowA = sessions.find((s) => s.id === 'gap257-self-a');
+    const rowB = sessions.find((s) => s.id === 'gap257-self-b');
+    // A (the signer) is blocked; B (the named target) is untouched.
+    expect(rowA?.activity_state).toBe('blocked');
+    expect(rowA?.blocked_reason).toBe('permission');
+    expect(rowA?.blocked_since).toBeTruthy();
+    expect(rowB?.activity_state).toBe('active');
+    expect(rowB?.blocked_since).toBeFalsy();
+  });
+
+  it('an unbound (unsigned) caller cannot set state for a named session', async () => {
+    await seedIdentity('gap257-unbound-target');
+    await expect(
+      rpc(socketPath, 'session.update', {
+        agentId: 'gap257-unbound-target',
+        state: 'blocked',
+      }),
+    ).rejects.toThrow(/requires a bound session/);
+
+    const sessions = await listLocal();
+    expect(sessions.find((s) => s.id === 'gap257-unbound-target')?.activity_state).toBe('active');
+  });
+
+  it('rejects an invalid state value', async () => {
+    const a = await seedIdentity('gap257-invalid');
+    await expect(
+      signedRpc(
+        socketPath,
+        'session.update',
+        { state: 'wat' },
+        { did: a.did, fingerprint: a.fingerprint, privateKeyPem: a.privateKeyPem },
+      ),
+    ).rejects.toThrow(/invalid state/);
+  });
+
+  it('derives active=false once updated_at ages past the active window', async () => {
+    await seedIdentity('gap257-window');
+    // Freshly seeded → within the window → active.
+    let row = (await listLocal()).find((s) => s.id === 'gap257-window');
+    expect(row?.active).toBe(true);
+    expect(typeof row?.staleSeconds).toBe('number');
+
+    // Age updated_at well past the default 120s window (the row still declares
+    // activity_state='active'; only the heartbeat fallback drops it).
+    await db.query(
+      `UPDATE agent_sessions SET updated_at = NOW() - INTERVAL '500 seconds' WHERE id = $1`,
+      ['gap257-window'],
+    );
+    row = (await listLocal()).find((s) => s.id === 'gap257-window');
+    expect(row?.activity_state).toBe('active');
+    expect(row?.active).toBe(false);
+    expect(row?.staleSeconds).toBeGreaterThanOrEqual(500);
+  });
+
+  it('blocked → active clears blocked_since and blocked_reason', async () => {
+    const a = await seedIdentity('gap257-trans');
+    const keys = { did: a.did, fingerprint: a.fingerprint, privateKeyPem: a.privateKeyPem };
+
+    await signedRpc(socketPath, 'session.update', { state: 'blocked' }, keys);
+    let row = (await listLocal()).find((s) => s.id === 'gap257-trans');
+    expect(row?.activity_state).toBe('blocked');
+    expect(row?.blocked_since).toBeTruthy();
+
+    await signedRpc(socketPath, 'session.update', { state: 'active' }, keys);
+    row = (await listLocal()).find((s) => s.id === 'gap257-trans');
+    expect(row?.activity_state).toBe('active');
+    expect(row?.blocked_since).toBeFalsy();
+    expect(row?.blocked_reason).toBeFalsy();
+  });
+});

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -984,8 +984,10 @@ describe('GAP-257: session activity-state', () => {
     expect(sessions.find((s) => s.id === 'gap257-unbound-target')?.activity_state).toBe('active');
   });
 
-  it('rejects an invalid state value', async () => {
+  it('rejects an invalid state value (schema enum + handler guard)', async () => {
     const a = await seedIdentity('gap257-invalid');
+    // Rejected at the validation edge (-32602) by the schema enum; the
+    // handler keeps a defensive VALID_ACTIVITY_STATES guard behind it.
     await expect(
       signedRpc(
         socketPath,
@@ -993,7 +995,7 @@ describe('GAP-257: session activity-state', () => {
         { state: 'wat' },
         { did: a.did, fingerprint: a.fingerprint, privateKeyPem: a.privateKeyPem },
       ),
-    ).rejects.toThrow(/invalid state/);
+    ).rejects.toThrow();
   });
 
   it('derives active=false once updated_at ages past the active window', async () => {

--- a/packages/daemon/src/migrations/0005-session-activity-state.ts
+++ b/packages/daemon/src/migrations/0005-session-activity-state.ts
@@ -1,0 +1,34 @@
+/**
+ * Migration 0005 — session activity-state (GAP-257).
+ *
+ * Adds a coarse `activity_state` to `agent_sessions` so coordination
+ * consumers can distinguish a session that is actively working from one
+ * that is blocked on an unanswered permission prompt (which is otherwise
+ * byte-identical in shape to a live row). Default 'active' so every
+ * pre-existing row keeps its current meaning.
+ *
+ * `blocked_since` is `TIMESTAMP` (not the spec's `TIMESTAMPTZ`) to match
+ * the existing `agent_sessions` columns (started_at/updated_at/ended_at
+ * are all `TIMESTAMP` — schema.ts) and the NOW()-relative comparisons the
+ * prune + active-window logic already use.
+ */
+
+import type { Migration } from '../storage/migrate.js';
+
+const SQL = `
+  ALTER TABLE agent_sessions
+    ADD COLUMN IF NOT EXISTS activity_state TEXT NOT NULL DEFAULT 'active';
+  ALTER TABLE agent_sessions
+    ADD COLUMN IF NOT EXISTS blocked_reason TEXT;
+  ALTER TABLE agent_sessions
+    ADD COLUMN IF NOT EXISTS blocked_since  TIMESTAMP;
+
+  CREATE INDEX IF NOT EXISTS idx_agent_sessions_activity
+    ON agent_sessions (activity_state);
+`;
+
+export const MIGRATION_0005: Migration = {
+  version: 5,
+  name: 'session-activity-state',
+  sql: SQL,
+};

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -20,10 +20,12 @@ import { MIGRATION_0001 } from './0001-initial-schema.js';
 import { MIGRATION_0002 } from './0002-key-origin.js';
 import { MIGRATION_0003 } from './0003-project-roots.js';
 import { MIGRATION_0004 } from './0004-agent-processes.js';
+import { MIGRATION_0005 } from './0005-session-activity-state.js';
 
 export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0001,
   MIGRATION_0002,
   MIGRATION_0003,
   MIGRATION_0004,
+  MIGRATION_0005,
 ];

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1002,7 +1002,28 @@ registerHandler('session.update', async (params, db, ctx) => {
   const task = strOrNull(params.task);
   const files = strOrNull(params.files);
 
-  // Build the update dynamically but keep values parameterized.
+  // Activity-state (GAP-257) is SELF-SCOPED: it mutates the caller's OWN
+  // bound session (ctx.agentId) ONLY — never the caller-supplied `target`
+  // override. Routing `state` through `target` (params.sessionId/agentId)
+  // would recreate the cross-agent eviction hole session.end carries (MED,
+  // 2026-06-28 agent.* review) — here a cross-agent liveness/coordination
+  // DoS (any socket-reachable caller marks a PEER 'blocked'/'idle'). The
+  // pre-existing task/files override is unchanged and remains separately
+  // tracked. Validate up-front so a bad/unbound state call throws before
+  // any DB write.
+  const state = strOrNull(params.state);
+  if (state !== null) {
+    if (!ctx.agentId) {
+      throw new Error(
+        'session.update: state change requires a bound session — register/attach/sign first',
+      );
+    }
+    if (!VALID_ACTIVITY_STATES.has(state)) {
+      throw new Error(`session.update: invalid state '${state}' (active|blocked|idle)`);
+    }
+  }
+
+  // Build the task/files update dynamically but keep values parameterized.
   const sets: string[] = ['updated_at = NOW()'];
   const vals: unknown[] = [];
   let i = 1;
@@ -1016,13 +1037,34 @@ registerHandler('session.update', async (params, db, ctx) => {
   }
   vals.push(target);
   await db.query(`UPDATE agent_sessions SET ${sets.join(', ')} WHERE id = $${i}`, vals);
+
+  // State mutation — separate statement, scoped to ctx.agentId ONLY.
+  // `blocked_since` is server-authoritative (NOW(), preserved across repeat
+  // 'blocked' calls via COALESCE) and cleared on any non-blocked state, so
+  // it's never trusted from the caller's clock.
+  if (state !== null && ctx.agentId) {
+    const blockedReason =
+      state === 'blocked' ? (strOrNull(params.blockedReason) ?? 'permission') : null;
+    await db.query(
+      `UPDATE agent_sessions
+          SET activity_state = $1,
+              blocked_reason = $2,
+              blocked_since  = CASE WHEN $1 = 'blocked'
+                                    THEN COALESCE(blocked_since, NOW())
+                                    ELSE NULL END,
+              updated_at     = NOW()
+        WHERE id = $3`,
+      [state, blockedReason, ctx.agentId],
+    );
+  }
+
   // Best-effort dual-write — task is the only column the Neon-side
   // session row exposes from the daemon's update; files / updated_at
   // are daemon-only concerns. See GAP-154 §E.
   if (task !== null) {
     await syncSessionUpdate({ sessionId: target, task });
   }
-  return { updated: target };
+  return state !== null ? { updated: target, stateScopedTo: ctx.agentId } : { updated: target };
 });
 
 // -- Identity ---------------------------------------------------------------

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -920,6 +920,36 @@ registerHandler('session.attach', async (params, db, ctx) => {
   return { attached: true, sessionId, agentId: sessionId };
 });
 
+// -- Session activity-state (GAP-257) ---------------------------------------
+//
+// A session blocked on an unanswered permission prompt is, in the raw
+// `agent_sessions` shape, byte-identical to one actively working. `state`
+// makes that distinction explicit (Signal 1), and the active-window
+// derivation below is the heartbeat fallback (Signal 2): a blocked session
+// stops emitting PostToolUse, so its `updated_at` ages past the window and it
+// drops out of "active" even when Signal 1 never fired (older CLI, disabled
+// hook, wedged process). The seconds-scale liveness window is independent of
+// the days-scale GAP-153 stale-prune.
+const VALID_ACTIVITY_STATES = new Set(['active', 'blocked', 'idle']);
+const ACTIVE_WINDOW_SECONDS = (() => {
+  const raw = Number(process.env.REVDEV_ACTIVE_WINDOW_SECONDS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 120;
+})();
+
+/** Annotate a session row with derived `active` + `staleSeconds`. */
+function enrichSessionActivity(
+  row: Record<string, unknown>,
+  nowMs: number,
+): Record<string, unknown> {
+  const updatedMs = new Date(String(row.updated_at ?? '')).getTime();
+  const staleSeconds = Number.isNaN(updatedMs)
+    ? Number.MAX_SAFE_INTEGER
+    : Math.max(0, Math.round((nowMs - updatedMs) / 1000));
+  const state = typeof row.activity_state === 'string' ? row.activity_state : 'active';
+  const active = state === 'active' && staleSeconds < ACTIVE_WINDOW_SECONDS;
+  return { ...row, staleSeconds, active };
+}
+
 registerHandler('session.list', async (params, db) => {
   // Default scope is 'local' — query the daemon's own PGlite, which is
   // fast (in-process) and authoritative for this machine.
@@ -936,7 +966,9 @@ registerHandler('session.list', async (params, db) => {
   const result = await db.query<Record<string, unknown>>(
     `SELECT * FROM agent_sessions WHERE ended_at IS NULL ORDER BY started_at DESC`,
   );
-  return { sessions: result.rows, scope: 'local' };
+  const now = Date.now();
+  const sessions = result.rows.map((row) => enrichSessionActivity(row, now));
+  return { sessions, scope: 'local', activeWindowSeconds: ACTIVE_WINDOW_SECONDS };
 });
 
 registerHandler('session.end', async (params, db, ctx) => {

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -936,20 +936,6 @@ const ACTIVE_WINDOW_SECONDS = (() => {
   return Number.isFinite(raw) && raw > 0 ? raw : 120;
 })();
 
-/** Annotate a session row with derived `active` + `staleSeconds`. */
-function enrichSessionActivity(
-  row: Record<string, unknown>,
-  nowMs: number,
-): Record<string, unknown> {
-  const updatedMs = new Date(String(row.updated_at ?? '')).getTime();
-  const staleSeconds = Number.isNaN(updatedMs)
-    ? Number.MAX_SAFE_INTEGER
-    : Math.max(0, Math.round((nowMs - updatedMs) / 1000));
-  const state = typeof row.activity_state === 'string' ? row.activity_state : 'active';
-  const active = state === 'active' && staleSeconds < ACTIVE_WINDOW_SECONDS;
-  return { ...row, staleSeconds, active };
-}
-
 registerHandler('session.list', async (params, db) => {
   // Default scope is 'local' — query the daemon's own PGlite, which is
   // fast (in-process) and authoritative for this machine.
@@ -963,12 +949,21 @@ registerHandler('session.list', async (params, db) => {
     const fleet = await listFleetSessions();
     return { sessions: fleet, scope: 'fleet', neonSyncActive: isNeonSyncActive() };
   }
+  // `active` + `staleSeconds` are derived SERVER-SIDE (NOW() vs updated_at)
+  // so the comparison never depends on the client clock or on JS parsing a
+  // naive PGlite TIMESTAMP — the same NOW()-relative basis the GAP-153 prune
+  // uses. Quoted alias preserves the camelCase `staleSeconds` key.
   const result = await db.query<Record<string, unknown>>(
-    `SELECT * FROM agent_sessions WHERE ended_at IS NULL ORDER BY started_at DESC`,
+    `SELECT *,
+            GREATEST(0, FLOOR(EXTRACT(EPOCH FROM (NOW() - updated_at))))::int AS "staleSeconds",
+            (activity_state = 'active'
+             AND updated_at > NOW() - make_interval(secs => $1)) AS active
+       FROM agent_sessions
+      WHERE ended_at IS NULL
+      ORDER BY started_at DESC`,
+    [ACTIVE_WINDOW_SECONDS],
   );
-  const now = Date.now();
-  const sessions = result.rows.map((row) => enrichSessionActivity(row, now));
-  return { sessions, scope: 'local', activeWindowSeconds: ACTIVE_WINDOW_SECONDS };
+  return { sessions: result.rows, scope: 'local', activeWindowSeconds: ACTIVE_WINDOW_SECONDS };
 });
 
 registerHandler('session.end', async (params, db, ctx) => {

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -149,6 +149,10 @@ export const schemas: Record<string, z.ZodType> = {
     .object({
       task: z.string().max(MAX_BODY_LENGTH).optional(),
       files: z.string().max(MAX_BODY_LENGTH).optional(),
+      // Activity-state (GAP-257). The handler self-scopes `state` to
+      // ctx.agentId — sessionId/agentId override task/files only, never state.
+      state: z.enum(['active', 'blocked', 'idle']).optional(),
+      blockedReason: z.string().max(MAX_NAME_LENGTH).optional(),
       // Compat: handler accepts sessionId or agentId for cross-session targeting.
       sessionId: z.string().max(MAX_NAME_LENGTH).optional(),
       agentId: z.string().max(MAX_NAME_LENGTH).optional(),


### PR DESCRIPTION
## GAP-257 — session activity-state (daemon surface)

Closes the daemon half of [GAP-257](https://github.com/RevealUIStudio/revealui-jv/blob/test/docs/gap-specs/GAP-257-session-blocked-activity-state.md): a session blocked on an unanswered permission prompt is, in the raw `agent_sessions` shape, byte-identical to one actively working — so a stalled-awaiting-human session reads as "active" to every coordination consumer (the real 2026-06-28 monitoring miss).

### Audit-first
Audited `origin/test` @ `d08edd1`: `server.ts` `session.update` (967) / `session.list` (923) / `session.end` (942); `MUTATING_OR_CONTENT_METHODS` (session.* are **not** signature-gated — `ctx.agentId` binds via `session.register`/`attach`/signature); migrations `0001`–`0004` + `index.ts`; `validation/schemas.ts` `session.update`; the dispatch identity gate (1887) + signature gate (1862). Confirmed the existing `agent_sessions` columns are `TIMESTAMP` (not `TIMESTAMPTZ`).

### What's in this PR (daemon only)
- **Migration `0005-session-activity-state`** — adds `activity_state TEXT NOT NULL DEFAULT 'active'` (`active|blocked|idle`), `blocked_reason`, `blocked_since` + an index. Default `'active'` keeps every pre-existing row's meaning. `blocked_since` is `TIMESTAMP` to match the existing columns (spec said `TIMESTAMPTZ`; noted in the migration).
- **`session.update` — self-scoped `state`** (Signal 1). New optional `state` + `blockedReason`. **The state mutation targets `ctx.agentId` ONLY**, never the caller-supplied `sessionId`/`agentId` override. Routing state through that override would recreate the cross-agent eviction hole `session.end` carries (MED, 2026-06-28 agent.* review) — here a cross-agent liveness/coordination DoS (any socket-reachable caller marking a **peer** `blocked`). A state call from an unbound socket throws before any DB write. `blocked_since` is server-authoritative (`NOW()`, preserved across repeat `blocked` calls, cleared on any non-blocked state). The existing `task`/`files` override is **untouched** — it stays the separately-tracked MED, out of scope here.
- **`session.list` — derived `active` + `staleSeconds`** (Signal 2, heartbeat fallback). `active = activity_state='active' AND updated_at > NOW() - REVDEV_ACTIVE_WINDOW_SECONDS` (default 120s). Derived **server-side in SQL** (same `NOW()`-relative basis as the GAP-153 prune) so it never depends on the client clock or on JS parsing a naive PGlite `TIMESTAMP`. A blocked session stops emitting `PostToolUse`, so it ages out of "active" even if Signal 1 never fired (older CLI, disabled hook, wedged process). Seconds-scale liveness window, independent of the days-scale GAP-153 garbage-collection threshold.
- **Schema** — `state` enum + `blockedReason` typed in `validation/schemas.ts`.

### Tests
`coordination.test.ts` (full daemon suite **502/502** passing serially; typecheck + Biome clean):
- **self-scope** — signer A cannot flip session B's state via the `sessionId`/`agentId` override (state lands on A; B untouched).
- **bound-required** — a caller that passes the identity gate via `actorAgentId` but is not bound still cannot set state.
- **active-window** — a freshly-updated row is `active:true`; once `updated_at` ages past the window it's `active:false` while `activity_state` stays `active`.
- **blocked → active** clears `blocked_since` + `blocked_reason`.
- **invalid state** rejected (schema enum + handler guard).

> Note: the full daemon suite shows flaky `beforeAll` **timeouts** under parallel file execution (26 daemon-spawning suites contending on keygen + socket bind) — zero assertion failures, and the set shifts run-to-run. `vitest run --no-file-parallelism` → 26 files / 502 tests pass.

### Deferred (paired follow-ups — NOT in this PR)
- **Hooks surface (Signal 1 producer)** — `notification.js` (`Notification`/`PermissionRequest`) sets `blocked`; `track-tools.js`/`user-prompt-submit.js`/a `PermissionDenied` hook clear it. Lives in the `.jv` hooks suite (`~/.claude/hooks/*`) + local `settings.json`, and requires verifying the exact CLI event names against the installed `claude` (spec §Caveat) + a restart — different ship mechanics from this daemon PR, so it's a separate reviewed unit. Without it, **Signal 2 (this PR) still works** (heartbeat ages blocked sessions out of "active").
- **Consumer updates** — `scripts/jv-single-writer-check.js`, `scripts/workboard-sweep.js`, `coordination.md` peer-detection list (treat `blocked | !active` as non-contending). `.jv` follow-up.
- **Pre-existing `task`/`files` override MED** — the spec's "ideally fix in the same change" — left as the separately-tracked agent.* review MED to keep this change minimal-blast.

Spec: `revealui-jv:docs/gap-specs/GAP-257-session-blocked-activity-state.md`
