### PR TITLE
fix(daemon): per-method Pro/Max tier guard on RPC methods (GAP-267)

### DIFF
--- a/packages/daemon/src/__tests__/adversarial-isolation.test.ts
+++ b/packages/daemon/src/__tests__/adversarial-isolation.test.ts
@@ -189,10 +189,12 @@ describe('adversarial agent isolation (B6 §6)', () => {
     // Provision all three agents in the trust anchor.
     anchor = join(dataDir, 'trusted-client-fingerprint');
     await writeFile(anchor, `${agentIdA}:${fpA}\n${agentIdB}:${fpB}\n${agentIdC}:${fpC}\n`);
-    // Pro license: project.grant/revoke, identity.rotate, mail.*, memory.* are
-    // Pro-gated. License OFF tests (§6.g) are covered by the §6.a/§6.d cases
-    // above which use no Pro-gated surface.
-    setTestLicenseEnv(generateTestLicense('pro'));
+    // Max license: project.grant/revoke, identity.rotate, mail.* are Pro-gated,
+    // and memory.* is MAX-gated (GAP-267). A Max license covers both so the
+    // isolation assertions below exercise real handlers rather than tier -32001s.
+    // License OFF tests (§6.g) are covered by the §6.a/§6.d cases above which
+    // use no licensed surface.
+    setTestLicenseEnv(generateTestLicense('max'));
     await startFreshDaemon();
     await registerAgent(agentIdA, kpA.publicKeyPem);
     await registerAgent(agentIdB, kpB.publicKeyPem);

--- a/packages/daemon/src/__tests__/guard.test.ts
+++ b/packages/daemon/src/__tests__/guard.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   guardRpcMethod,
@@ -5,6 +8,7 @@ import {
   licenseErrorResponse,
   refreshLicense,
 } from '../guard.js';
+import { METHOD_MIN_TIER } from '../license.js';
 import {
   clearTestLicenseEnv,
   generateTestLicense,
@@ -42,6 +46,11 @@ describe('guardRpcMethod', () => {
       'session.end',
       'session.list',
       'session.attach',
+      // Local-inference RUN surface (aiLocal = FREE) — split out of the old
+      // "inference.* is Pro" grouping per GAP-267.
+      'inference.status',
+      'inference.chat',
+      'inference.generate',
     ];
 
     for (const method of exemptMethods) {
@@ -52,36 +61,54 @@ describe('guardRpcMethod', () => {
     }
   });
 
-  describe('gated methods on free tier', () => {
-    const gatedMethods = [
+  describe('gated Pro methods on free tier (-32001, requiredTier pro)', () => {
+    const proMethods = [
       'agent.spawn',
       'agent.stop',
       'agent.input',
-      'inference.status',
-      'inference.pull',
       'merge.request',
       'merge.status',
-      'memory.store',
-      'memory.query',
-      'harness.execute',
-      'worktree.create',
       'tasks.create',
       'mail.send',
       'files.reserve',
       'events.query',
+      'worktree.create',
     ];
 
-    for (const method of gatedMethods) {
+    for (const method of proMethods) {
       it(`blocks "${method}" without license`, () => {
         const result = guardRpcMethod(method);
         expect(result.allowed).toBe(false);
         expect(result.tier).toBe('free');
+        expect(result.requiredTier).toBe('pro');
         expect(result.reason).toContain('requires a Pro');
       });
     }
   });
 
-  describe('pro license grants full access', () => {
+  describe('gated Max methods on free tier (-32001, requiredTier max)', () => {
+    // memory.* is the concrete leak GAP-267 closes; inference.pull/start/stop
+    // is local-model MANAGEMENT (Max), distinct from the free run surface.
+    const maxMethods = [
+      'memory.store',
+      'memory.query',
+      'inference.pull',
+      'inference.start',
+      'inference.stop',
+    ];
+
+    for (const method of maxMethods) {
+      it(`blocks "${method}" without license`, () => {
+        const result = guardRpcMethod(method);
+        expect(result.allowed).toBe(false);
+        expect(result.tier).toBe('free');
+        expect(result.requiredTier).toBe('max');
+        expect(result.reason).toContain('requires a Max');
+      });
+    }
+  });
+
+  describe('pro license grants Pro-tier access (but NOT Max)', () => {
     beforeEach(() => {
       setTestLicenseEnv(generateTestLicense('pro'));
       refreshLicense();
@@ -93,7 +120,7 @@ describe('guardRpcMethod', () => {
       expect(result.tier).toBe('pro');
     });
 
-    it('allows inference.status', () => {
+    it('allows inference.status (free run surface)', () => {
       const result = guardRpcMethod('inference.status');
       expect(result.allowed).toBe(true);
     });
@@ -103,31 +130,103 @@ describe('guardRpcMethod', () => {
       expect(result.allowed).toBe(true);
     });
 
-    it('allows memory.store', () => {
+    // GAP-267: the whole point — a $49 Pro JWT must NOT unlock Max-marketed
+    // memory.*. Previously this returned { allowed: true }.
+    it('BLOCKS memory.store (Max-only) with -32001 requiredTier max', () => {
       const result = guardRpcMethod('memory.store');
-      expect(result.allowed).toBe(true);
+      expect(result.allowed).toBe(false);
+      expect(result.tier).toBe('pro');
+      expect(result.requiredTier).toBe('max');
+      expect(result.reason).toContain('requires a Max');
     });
+
+    it('BLOCKS inference.pull (Max-only model management)', () => {
+      const result = guardRpcMethod('inference.pull');
+      expect(result.allowed).toBe(false);
+      expect(result.requiredTier).toBe('max');
+    });
+
+    // Pro keeps the full multi-agent coordination surface.
+    const proCoordination = [
+      'agent.stop',
+      'merge.status',
+      'tasks.create',
+      'tasks.claim',
+      'mail.send',
+      'mail.broadcast',
+      'files.reserve',
+      'files.release',
+      'events.log',
+      'events.query',
+      'harness.health',
+      'harness.prune',
+      'worktree.create',
+    ];
+    for (const method of proCoordination) {
+      it(`allows "${method}" on pro tier`, () => {
+        expect(guardRpcMethod(method).allowed).toBe(true);
+      });
+    }
   });
 
   describe('max/enterprise licenses', () => {
-    it('allows all methods with max license', () => {
+    it('allows Max-tier methods (memory/inference management) with max license', () => {
+      setTestLicenseEnv(generateTestLicense('max'));
+      refreshLicense();
+      expect(guardRpcMethod('memory.store').allowed).toBe(true);
+      expect(guardRpcMethod('memory.store').tier).toBe('max');
+      expect(guardRpcMethod('memory.query').allowed).toBe(true);
+      expect(guardRpcMethod('inference.pull').allowed).toBe(true);
+      expect(guardRpcMethod('inference.start').allowed).toBe(true);
+      expect(guardRpcMethod('inference.stop').allowed).toBe(true);
+    });
+
+    it('allows Pro-tier methods with max license', () => {
       setTestLicenseEnv(generateTestLicense('max'));
       refreshLicense();
       expect(guardRpcMethod('agent.spawn').allowed).toBe(true);
       expect(guardRpcMethod('agent.spawn').tier).toBe('max');
+      expect(guardRpcMethod('merge.request').allowed).toBe(true);
     });
 
-    it('allows all methods with enterprise license', () => {
+    it('allows everything (Pro + Max) with enterprise license', () => {
       setTestLicenseEnv(generateTestLicense('enterprise'));
       refreshLicense();
       expect(guardRpcMethod('merge.request').allowed).toBe(true);
       expect(guardRpcMethod('merge.request').tier).toBe('enterprise');
+      expect(guardRpcMethod('memory.store').allowed).toBe(true);
+      expect(guardRpcMethod('inference.pull').allowed).toBe(true);
     });
   });
 
-  // ADR zero-9P P0: all single-repo file/git I/O is FREE; only multi-agent
-  // coordination stays Pro. This locks the boundary so a future EXEMPT_METHODS
-  // edit can't accidentally exempt a Pro method or re-gate a free one.
+  // Parameterized over the authoritative METHOD_MIN_TIER map: every Max method
+  // is -32001 on Pro (requiredTier max) and allowed on Max. If a method is
+  // added to METHOD_MIN_TIER, it is covered here automatically.
+  describe('per-Max-method tier enforcement (parameterized)', () => {
+    for (const [method, minTier] of METHOD_MIN_TIER) {
+      it(`"${method}" (min ${minTier}) is blocked on Pro`, () => {
+        setTestLicenseEnv(generateTestLicense('pro'));
+        refreshLicense();
+        const result = guardRpcMethod(method);
+        expect(result.allowed).toBe(false);
+        expect(result.requiredTier).toBe(minTier);
+      });
+
+      it(`"${method}" (min ${minTier}) is allowed on ${minTier}`, () => {
+        // METHOD_MIN_TIER never holds 'free' (exempt methods aren't in it); the
+        // guard both documents that and narrows the type for generateTestLicense.
+        if (minTier === 'free') return;
+        setTestLicenseEnv(generateTestLicense(minTier));
+        refreshLicense();
+        expect(guardRpcMethod(method).allowed).toBe(true);
+      });
+    }
+  });
+
+  // ADR zero-9P P0: all single-repo file/git I/O is FREE; multi-agent
+  // coordination stays Pro (memory.* / inference-management are Max). This
+  // locks the boundary so a future EXEMPT_METHODS edit can't accidentally
+  // exempt a gated method or re-gate a free one.
   describe('file/git tier boundary (zero-9P P0)', () => {
     const freeFileGitMethods = [
       'project.open',
@@ -161,18 +260,19 @@ describe('guardRpcMethod', () => {
       });
     }
 
-    const proCoordinationMethods = [
+    // Gated coordination methods still blocked on free (memory.* is now Max,
+    // not Pro, but still -32001 for an unlicensed caller).
+    const gatedCoordinationMethods = [
       'agent.spawn',
       'merge.request',
       'mail.send',
       'tasks.create',
       'files.reserve',
       'memory.store',
-      'inference.status',
     ];
 
-    for (const method of proCoordinationMethods) {
-      it(`still blocks Pro method "${method}" on free tier`, () => {
+    for (const method of gatedCoordinationMethods) {
+      it(`still blocks gated method "${method}" on free tier`, () => {
         const result = guardRpcMethod(method);
         expect(result.allowed).toBe(false);
         expect(result.tier).toBe('free');
@@ -195,6 +295,122 @@ describe('guardRpcMethod', () => {
       const result = guardRpcMethod('agent.spawn');
       expect(result.allowed).toBe(false);
     });
+  });
+});
+
+// CI enumeration guard (GAP-267): every RPC method the daemon actually
+// registers must be classified into exactly one tier bucket — EXEMPT (free),
+// METHOD_MIN_TIER (max), or KNOWN_PRO_METHODS (the pro default). A new handler
+// with no classification fails this test loudly, so tier coverage can never
+// silently regress.
+describe('handler tier-classification coverage', () => {
+  const SRC_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+  // Pin to free tier so guardRpcMethod's allow⇔exempt equivalence holds
+  // regardless of prior tests' cached license state.
+  beforeEach(() => {
+    clearTestLicenseEnv();
+    refreshLicense();
+  });
+  afterEach(() => {
+    clearTestLicenseEnv();
+    refreshLicense();
+  });
+
+  /** Statically scan src for `registerHandler('<method>'` first-arg literals. */
+  function registeredMethods(): Set<string> {
+    const methods = new Set<string>();
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+          continue;
+        }
+        if (!entry.name.endsWith('.ts')) continue;
+        const src = readFileSync(full, 'utf-8');
+        let idx = src.indexOf('registerHandler(');
+        while (idx !== -1) {
+          const open = src.indexOf("'", idx);
+          const close = open === -1 ? -1 : src.indexOf("'", open + 1);
+          // Guard against runaway matches (a comment without a nearby literal).
+          if (open !== -1 && close !== -1 && close - open < 60) {
+            methods.add(src.slice(open + 1, close));
+          }
+          idx = src.indexOf('registerHandler(', idx + 1);
+        }
+      }
+    };
+    walk(SRC_DIR);
+    return methods;
+  }
+
+  // Every non-exempt, non-Max method the daemon registers. Hand-maintained:
+  // adding a handler without adding it here (or to EXEMPT/METHOD_MIN_TIER)
+  // fails the coverage test below — the intended failure mode.
+  const KNOWN_PRO_METHODS = new Set([
+    // agent PTY + lifecycle
+    'agent.spawn',
+    'agent.stop',
+    'agent.input',
+    'agent.output',
+    'agent.resize',
+    // merge pipeline
+    'merge.request',
+    'merge.status',
+    'merge.list',
+    'merge.update',
+    // mailbox
+    'mail.send',
+    'mail.broadcast',
+    'mail.inbox',
+    'mail.markRead',
+    // task board
+    'tasks.create',
+    'tasks.claim',
+    'tasks.complete',
+    'tasks.list',
+    'tasks.release',
+    // file reservations
+    'files.reserve',
+    'files.release',
+    'files.check',
+    'files.list',
+    // event log
+    'events.log',
+    'events.query',
+    // harness housekeeping
+    'harness.health',
+    'harness.prune',
+    // worktrees
+    'worktree.create',
+    'worktree.list',
+    'worktree.remove',
+    // project grant surface (project.open is FREE/exempt)
+    'project.grant',
+    'project.revoke',
+    // agent identity rotation
+    'identity.rotate',
+  ]);
+
+  it('scans a plausible number of registered handlers', () => {
+    // Sanity floor so a broken scanner (finding nothing) can't pass silently.
+    expect(registeredMethods().size).toBeGreaterThanOrEqual(50);
+  });
+
+  it('classifies every registered handler into exactly one tier bucket', () => {
+    const unclassified: string[] = [];
+    for (const method of registeredMethods()) {
+      const exempt = guardRpcMethod(method).allowed; // free-tier pass ⇒ exempt
+      const isMax = METHOD_MIN_TIER.has(method);
+      const isPro = KNOWN_PRO_METHODS.has(method);
+      // Exactly one bucket. (Exempt short-circuits before tier logic; Max/Pro
+      // are mutually exclusive sets.)
+      const buckets = [exempt, isMax, isPro].filter(Boolean).length;
+      if (buckets !== 1) unclassified.push(`${method} (buckets=${buckets})`);
+    }
+    expect(unclassified).toEqual([]);
   });
 });
 
@@ -230,7 +446,12 @@ describe('initLicenseGuard', () => {
 
 describe('licenseErrorResponse', () => {
   it('returns valid JSON-RPC error', () => {
-    const guard = { allowed: false as const, tier: 'free' as const, reason: 'test reason' };
+    const guard = {
+      allowed: false as const,
+      tier: 'pro' as const,
+      requiredTier: 'max' as const,
+      reason: 'test reason',
+    };
     const raw = licenseErrorResponse(1, guard);
     const parsed = JSON.parse(raw);
 
@@ -238,7 +459,8 @@ describe('licenseErrorResponse', () => {
     expect(parsed.id).toBe(1);
     expect(parsed.error.code).toBe(-32001);
     expect(parsed.error.message).toBe('License required');
-    expect(parsed.error.data.tier).toBe('free');
+    expect(parsed.error.data.tier).toBe('pro');
+    expect(parsed.error.data.requiredTier).toBe('max');
     expect(parsed.error.data.reason).toBe('test reason');
     expect(parsed.error.data.upgradeUrl).toBe('https://revealui.com/pro');
   });

--- a/packages/daemon/src/guard.ts
+++ b/packages/daemon/src/guard.ts
@@ -23,13 +23,22 @@ import {
   type LicenseEvaluation,
   LicenseExpiredError,
   type LicenseTier,
+  requiredTier,
+  tierRank,
 } from './license.js';
 import { recordLicenseMetrics } from './observability.js';
 
 export interface RpcGuardResult {
   allowed: boolean;
   tier: LicenseTier;
+  /** Minimum tier the method requires — set on denials so the client can render an accurate upsell. */
+  requiredTier?: LicenseTier;
   reason?: string;
+}
+
+/** Title-case a tier name for human-facing messages ("pro" → "Pro"). */
+function titleTier(tier: LicenseTier): string {
+  return tier.charAt(0).toUpperCase() + tier.slice(1);
 }
 
 /** Cached license state — checked once at startup, refreshable on demand. */
@@ -148,30 +157,53 @@ export function getLicenseState(): { tier: LicenseTier; valid: boolean } {
 /**
  * Guard an RPC method call against the current license tier.
  *
- * Returns { allowed: true } for exempt methods and valid Pro+ licenses.
- * Returns { allowed: false, reason } for gated methods on free tier.
+ * Ordinal enforcement (free < pro < max < enterprise):
+ *   1. Exempt methods (session.*, ping, file/git, local-inference run) always pass.
+ *   2. No valid license → every gated method is blocked (-32001).
+ *   3. Valid license below the method's minimum tier (e.g. a $49 Pro JWT
+ *      calling Max-only `memory.*`) → blocked (-32001), naming the required tier.
+ *   4. Otherwise the license meets/exceeds the minimum → allowed.
+ *
+ * `requiredTier(method)` defaults to 'pro'; Max methods are enumerated in
+ * `METHOD_MIN_TIER`. This replaces the previous BINARY check (any valid JWT =
+ * full access) that let Pro reach Max-marketed methods (GAP-267).
  */
 export function guardRpcMethod(method: string): RpcGuardResult {
   const license = getLicenseState();
 
-  // Exempt methods always pass (session management, ping)
+  // Exempt methods always pass (session management, ping, file/git, local-inference run)
   if (isExemptMethod(method)) {
     return { allowed: true, tier: license.tier };
   }
 
-  // Valid Pro+ license: full access
-  if (license.valid) {
-    return { allowed: true, tier: license.tier };
+  const required = requiredTier(method);
+
+  // No valid license → free/degraded mode: every gated method is blocked.
+  if (!license.valid) {
+    return {
+      allowed: false,
+      tier: 'free',
+      requiredTier: required,
+      reason:
+        `Method "${method}" requires a ${titleTier(required)} or higher license. ` +
+        'Set REVEALUI_LICENSE_KEY or upgrade at https://revealui.com/pro',
+    };
   }
 
-  // Free tier: blocked
-  return {
-    allowed: false,
-    tier: 'free',
-    reason:
-      `Method "${method}" requires a Pro or higher license. ` +
-      'Set REVEALUI_LICENSE_KEY or upgrade at https://revealui.com/pro',
-  };
+  // Valid license but below the method's minimum tier (e.g. Pro → Max method).
+  if (tierRank(license.tier) < tierRank(required)) {
+    return {
+      allowed: false,
+      tier: license.tier,
+      requiredTier: required,
+      reason:
+        `Method "${method}" requires a ${titleTier(required)} license; ` +
+        `your license is ${titleTier(license.tier)}. Upgrade at https://revealui.com/pro`,
+    };
+  }
+
+  // Valid license at or above the required tier: allowed.
+  return { allowed: true, tier: license.tier };
 }
 
 /**
@@ -187,6 +219,7 @@ export function licenseErrorResponse(id: number | string | null, result: RpcGuar
       message: 'License required',
       data: {
         tier: result.tier,
+        requiredTier: result.requiredTier,
         reason: result.reason,
         upgradeUrl: 'https://revealui.com/pro',
       },

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -72,11 +72,16 @@ const EXEMPT_METHODS = new Set([
   'session.attach',
   // Single-repo file + git I/O is FREE: RevDev is meant to be a usable daily
   // driver and dogfood surface, so basic editing/committing of your own repo
-  // is never gated behind Pro. Only MULTI-AGENT COORDINATION stays Pro
-  // (agent.*, merge.*, mail.*, tasks.*, files.* reservations, memory.*,
-  // inference.*). Enumerated explicitly — NO wildcard — so a Pro method can
-  // never be exempted by accident; a CI test asserts each method below
-  // returns success on a free license and that the Pro methods still -32001.
+  // is never gated behind Pro. MULTI-AGENT COORDINATION stays Pro (agent.*,
+  // merge.*, mail.*, tasks.*, files.* reservations, events.*, harness.*).
+  // Two capabilities are MAX, not Pro — see METHOD_MIN_TIER below: full AI
+  // memory (memory.store/query) and heavyweight local-model management
+  // (inference.pull/start/stop). Interacting with an ALREADY-running local
+  // model (inference.status/chat/generate) is the FREE `aiLocal` run surface
+  // and is exempt here alongside file/git. Enumerated explicitly — NO
+  // wildcard — so a gated method can never be exempted by accident; a CI test
+  // asserts each method below returns success on a free license and that
+  // gated methods still -32001 at their required tier.
   'project.open',
   'file.read',
   'file.write',
@@ -98,7 +103,58 @@ const EXEMPT_METHODS = new Set([
   'git.pull',
   'git.readBlobAtHead',
   'git.readBlobAtIndex',
+  // Local inference RUN surface (`aiLocal` = FREE): interacting with an
+  // already-pulled/started model. Model MANAGEMENT (pull/start/stop) is MAX
+  // and lives in METHOD_MIN_TIER, not here.
+  'inference.status',
+  'inference.chat',
+  'inference.generate',
 ]);
+
+/**
+ * Per-method MINIMUM license tier for non-exempt methods that require a tier
+ * ABOVE the default Pro floor. Enumerated explicitly — NO wildcard — so a Max
+ * capability can never be silently down-graded to Pro, mirroring the
+ * EXEMPT_METHODS discipline. A non-exempt method with no entry here defaults
+ * to `'pro'` (see `requiredTier`).
+ *
+ * Authority: `featureTierMap` (features.ts) + the public pricing page — "Full
+ * AI memory" and heavyweight local-model management are Max ($299), not Pro
+ * ($49). This is the fix for the binary guard that let a $49 Pro JWT reach
+ * Max-marketed `memory.*` (GAP-267).
+ *
+ * Only Max-tier methods are listed:
+ *   - memory.store / memory.query   → full AI memory (working + episodic + vector)
+ *   - inference.pull/start/stop     → local-model management (pull / spawn / teardown)
+ * The FREE local-inference RUN surface (inference.status/chat/generate) is in
+ * EXEMPT_METHODS; every other non-exempt method is Pro by default.
+ */
+export const METHOD_MIN_TIER = new Map<string, LicenseTier>([
+  ['memory.store', 'max'],
+  ['memory.query', 'max'],
+  ['inference.pull', 'max'],
+  ['inference.start', 'max'],
+  ['inference.stop', 'max'],
+]);
+
+/**
+ * Ordinal rank of a tier within LICENSE_TIERS (free=0 < pro=1 < max=2 <
+ * enterprise=3) — the array index doubles as the rank. Used by the RPC guard
+ * for `>=` tier comparison. Returns -1 for an unrecognized tier (sorts below
+ * free — fail-closed).
+ */
+export function tierRank(tier: LicenseTier): number {
+  return LICENSE_TIERS.indexOf(tier);
+}
+
+/**
+ * Minimum license tier required to call a non-exempt method. Max-tier methods
+ * are enumerated in METHOD_MIN_TIER; every other non-exempt method defaults to
+ * `'pro'`. Exempt methods never reach here — the guard short-circuits them.
+ */
+export function requiredTier(method: string): LicenseTier {
+  return METHOD_MIN_TIER.get(method) ?? 'pro';
+}
 
 const DAY_SECONDS = 86_400;
 


### PR DESCRIPTION
## Problem

The daemon RPC license guard was **binary** — any valid JWT (Pro, Max, or Enterprise) passed every non-exempt method (`guardRpcMethod` used `license.valid` only; tier was discarded). A **$49 Pro** JWT therefore unlocked **Max-marketed** capabilities:

- **Full AI memory** — `memory.store` / `memory.query` (`featureTierMap` aiMemory=`max`; pricing "Full AI memory" = Max).
- **Local-model management** — `inference.pull` / `start` / `stop`.

Closes the B3 slice of ADR `2026-06-25-unified-49-realignment` ("a $49 Pro JWT must not unlock Max-only methods").

## Decision

- `memory.store` / `memory.query` = **Max** (pricing/`featureTierMap` authority wins over the stale daemon comment, which *was* the bug and is rewritten).
- **inference split** (owner-chosen): `inference.status/chat/generate` = **Free** (the `aiLocal` local-model RUN surface → `EXEMPT_METHODS`); `inference.pull/start/stop` = **Max** (management → `METHOD_MIN_TIER`).
- Everything else non-exempt (`agent.*`, `merge.*`, `mail.*`, `tasks.*`, `files.*`, `events.*`, `harness.health/prune`, `worktree.*`, `project.grant/revoke`, `identity.rotate`) = **Pro** (default).

## Changes

**`license.ts`**
- `METHOD_MIN_TIER: Map<string, LicenseTier>` (exported) next to `EXEMPT_METHODS` — the 5 Max methods, enumerated, **no wildcard**.
- `tierRank()` (`LICENSE_TIERS.indexOf`, ordinal already existed) + `requiredTier()` (non-exempt default `'pro'`).
- Moved `inference.status/chat/generate` into `EXEMPT_METHODS`; rewrote the false comment that classed memory/inference as Pro.

**`guard.ts`**
- `guardRpcMethod`: exempt → allow; no valid license → deny `-32001`; `tierRank(tier) < tierRank(required)` → deny `-32001` naming the required tier; else allow.
- `requiredTier` added to `RpcGuardResult` and the `-32001` error `data`.

## Scope guard for reviewers

**Pure license-layer change.** `MUTATING_OR_CONTENT_METHODS` (server.ts:150), `signing.rs`, `IDENTITY_EXEMPT` (server.ts:111), and the dispatch site (server.ts:1755) are **untouched** — `memory.*`/`inference.*` are not signature-required, so the **Rust signing mirror stays byte-identical** (do not expect a `signing.rs` diff).

## Tests

- Tier-aware guard cases: Pro `-32001` on Max methods (`requiredTier: 'max'`); Max/Enterprise allowed; Pro retains the full coordination surface.
- **Parameterized** coverage over `METHOD_MIN_TIER`.
- **New CI enumeration test** — every `registerHandler` name must be in exactly one of `EXEMPT ∪ METHOD_MIN_TIER ∪ KNOWN_PRO_METHODS`, else fail (fail-closed guarantee).
- `adversarial-isolation` memory test bumped pro→max.

## Verification

- Daemon vitest **531/531 green**.
- `tsc --noEmit` clean (only pre-existing `node-pty`/`spawn.ts` optional-native-dep errors, present on base — node-pty isn't installed in this WSL checkout).
- Biome `format` + `check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)