### PR TITLE
ci(studio-release): build macOS ad-hoc/unsigned (interim) so the release completes on all platforms

### DIFF
--- a/.github/workflows/studio-release.yml
+++ b/.github/workflows/studio-release.yml
@@ -76,12 +76,11 @@ jobs:
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # macOS ships ad-hoc/unsigned until Apple Developer ID + notarization are provisioned (tracked internally).
+          # With APPLE_* absent, tauri's bundler skips code-signing (keychain -> None) and produces an unsigned
+          # .app/.dmg; passing an invalid/unprovisioned APPLE_CERTIFICATE instead hard-fails the bundle at `security
+          # import`. Restore the 6 APPLE_* secrets here once a real Developer ID cert lands. Same unsigned posture as
+          # Windows (SmartScreen). Does NOT touch TAURI_SIGNING_* (updater key, workflow env above) or license signing.
         with:
           projectPath: apps/studio
           tauriScript: pnpm tauri


### PR DESCRIPTION
## What

Make the two macOS matrix legs in `studio-release.yml` build **ad-hoc/unsigned** by removing the six `APPLE_*` env vars from the `tauri-apps/tauri-action` step. This brings macOS to the same unsigned posture Windows already ships (SmartScreen), so a `studio-v*` tag can produce artifacts on **all three** desktop platforms at $0.

## Why

The `studio-v0.1.0` release run built and released **Linux** and **Windows** cleanly, but **both macOS legs failed** at the Tauri bundle step with:

```
security import: failed to import keychain certificate
```

The `APPLE_CERTIFICATE` secret is invalid/unprovisioned, so the bundler's keychain import aborts the whole macOS bundle. No OS app code-signing is provisioned anywhere yet (`bundle.windows` and `bundle.macOS` are both empty in `tauri.conf.json`), so signing on macOS was never actually functional — it only ever hard-failed the job.

Verified against the tauri bundler source: when `APPLE_CERTIFICATE` / `APPLE_SIGNING_IDENTITY` are **absent**, the keychain helper returns "no identity" and signing is **skipped** — producing an unsigned `.app`/`.dmg` and a successful job. The hard failure only happens when a cert *is* set but can't be imported. Removing the env vars is therefore the correct fix (not a workaround).

## Scope

One file, `.github/workflows/studio-release.yml`:

- Removed the 6 `APPLE_*` env lines from the tauri-action step; kept `GITHUB_TOKEN`.
- Added a comment documenting the interim posture and how to restore signing once a Developer ID cert lands.

Deliberately unchanged:

- `TAURI_SIGNING_*` (the updater/auto-update signing key) — still set at workflow level.
- The daemon's license signing — untouched.
- `fail-fast: false`, the app version, and `tauri.conf.json` — untouched.
- All four matrix legs remain (macOS legs now build unsigned rather than being dropped).

## Interim, not permanent

This is OS **app** code-signing only. macOS ships ad-hoc/unsigned until a proper Apple Developer ID + notarization (and Windows Authenticode) are provisioned post-revenue — tracked internally. Restoring the six `APPLE_*` secrets in this step re-enables signing with no other change.

## Testing

- Workflow YAML re-parsed: the build step's `env` now contains only `GITHUB_TOKEN`; all four matrix legs and workflow-level `TAURI_SIGNING_*` intact; `fail-fast: false` preserved.
- Runtime validation happens on the next `studio-v*` tag / `workflow_dispatch` (re-cut is owner-gated).
