### PR TITLE
feat(daemon): bake default vendor public key so activation needs only the license JWT

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -94,15 +94,18 @@ To unlock Pro features (agent spawning, inference, merge pipeline, memory, coord
 
 1. Purchase a license at [revealui.com/pro](https://revealui.com/pro)
 2. You'll receive a license key starting with `eyJ` — an Ed25519-signed JWT (RFC 7519, `alg: EdDSA`), a three-part `<header>.<payload>.<signature>` token.
-3. Set it, **and the vendor public key the daemon verifies it against**, as environment variables:
+3. Set it as an environment variable:
 
 ```bash
 # Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
 export REVEALUI_LICENSE_KEY="eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ0aWVyIjoicHJvIiwuLi59.<signature>"
+```
 
-# Required to verify the license signature (PEM-encoded Ed25519 public key).
-# Self-host activation cannot succeed without this — the daemon stays in
-# Free mode with reason "REVDEV_LICENSE_PUBLIC_KEY not set" until it is set.
+The daemon ships with the vendor public key baked in, so it verifies your license with no further configuration.
+
+**Advanced (key rotation / override):** `REVDEV_LICENSE_PUBLIC_KEY` overrides the baked-in vendor key with a PEM-encoded Ed25519 public key. You only need it if the vendor signing key has rotated and your build predates the rotation, or you are testing against your own keypair. The current public key is shown on your account page at [revealui.com/account/license](https://revealui.com/account/license).
+
+```bash
 export REVDEV_LICENSE_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEA...
 -----END PUBLIC KEY-----"

--- a/packages/daemon/src/__tests__/license-crypto.test.ts
+++ b/packages/daemon/src/__tests__/license-crypto.test.ts
@@ -116,3 +116,40 @@ describe('verifyLicenseJWT — jti revocation hook', () => {
     expect(result.valid).toBe(true);
   });
 });
+
+describe('getVendorPublicKey — baked default + override', () => {
+  it('falls back to the baked default when REVDEV_LICENSE_PUBLIC_KEY is unset', () => {
+    delete process.env.REVDEV_LICENSE_PUBLIC_KEY;
+    const key = getVendorPublicKey();
+    expect(key).toBe(DEFAULT_VENDOR_PUBLIC_KEY);
+    expect(key.startsWith('-----BEGIN PUBLIC KEY-----')).toBe(true);
+  });
+
+  it('treats an empty/whitespace override as unset and uses the baked default', () => {
+    process.env.REVDEV_LICENSE_PUBLIC_KEY = '   ';
+    expect(getVendorPublicKey()).toBe(DEFAULT_VENDOR_PUBLIC_KEY);
+  });
+
+  it('uses REVDEV_LICENSE_PUBLIC_KEY as an override when set', () => {
+    process.env.REVDEV_LICENSE_PUBLIC_KEY = publicKey;
+    expect(getVendorPublicKey()).toBe(publicKey);
+  });
+
+  it('activation succeeds against the baked default for a token it signed', () => {
+    // A token signed by the key whose public half IS the baked default verifies
+    // with no env var set — the happy path a v0.1.1 buyer hits.
+    const token = makeToken(VALID_PAYLOAD, privateKey);
+    const result = verifyLicenseJWT(token, DEFAULT_VENDOR_PUBLIC_KEY);
+    // The ephemeral test key is not the real vendor key, so this specific token
+    // does NOT validate against the baked default: fail-closed is preserved.
+    expect(result.valid).toBe(false);
+  });
+
+  it('stays fail-closed: a tampered/foreign token degrades to Free under the baked default', () => {
+    delete process.env.REVDEV_LICENSE_PUBLIC_KEY;
+    const token = makeToken(VALID_PAYLOAD, privateKey); // signed by a non-vendor key
+    const result = verifyLicenseJWT(token, getVendorPublicKey());
+    expect(result.valid).toBe(false);
+    expect(result.tier).toBe('free');
+  });
+});

--- a/packages/daemon/src/__tests__/license-crypto.test.ts
+++ b/packages/daemon/src/__tests__/license-crypto.test.ts
@@ -135,16 +135,6 @@ describe('getVendorPublicKey — baked default + override', () => {
     expect(getVendorPublicKey()).toBe(publicKey);
   });
 
-  it('activation succeeds against the baked default for a token it signed', () => {
-    // A token signed by the key whose public half IS the baked default verifies
-    // with no env var set — the happy path a v0.1.1 buyer hits.
-    const token = makeToken(VALID_PAYLOAD, privateKey);
-    const result = verifyLicenseJWT(token, DEFAULT_VENDOR_PUBLIC_KEY);
-    // The ephemeral test key is not the real vendor key, so this specific token
-    // does NOT validate against the baked default: fail-closed is preserved.
-    expect(result.valid).toBe(false);
-  });
-
   it('stays fail-closed: a tampered/foreign token degrades to Free under the baked default', () => {
     delete process.env.REVDEV_LICENSE_PUBLIC_KEY;
     const token = makeToken(VALID_PAYLOAD, privateKey); // signed by a non-vendor key

--- a/packages/daemon/src/__tests__/license-crypto.test.ts
+++ b/packages/daemon/src/__tests__/license-crypto.test.ts
@@ -1,6 +1,7 @@
 import { generateKeyPairSync, sign } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { isRevokedJti, verifyLicenseJWT } from '../license-crypto.js';
+import { getVendorPublicKey, isRevokedJti, verifyLicenseJWT } from '../license-crypto.js';
+import { DEFAULT_VENDOR_PUBLIC_KEY } from '../vendor-public-key.js';
 
 function makeToken(
   payload: Record<string, unknown>,

--- a/packages/daemon/src/license-crypto.ts
+++ b/packages/daemon/src/license-crypto.ts
@@ -27,18 +27,25 @@
  */
 
 import { verify } from 'node:crypto';
+import { DEFAULT_VENDOR_PUBLIC_KEY } from './vendor-public-key.js';
 
 /**
- * Vendor Ed25519 public key (PEM), read from REVDEV_LICENSE_PUBLIC_KEY at
- * call time (tests set the env var after import). To mint a fresh keypair:
+ * Vendor Ed25519 public key (PEM) used to verify license JWTs.
+ *
+ * Falls back to the baked-in DEFAULT_VENDOR_PUBLIC_KEY so activation succeeds
+ * with only REVEALUI_LICENSE_KEY set (no second env var on the happy path).
+ * REVDEV_LICENSE_PUBLIC_KEY overrides the default for key rotation or testing;
+ * an empty/whitespace override is treated as unset and falls back to the default.
+ * To mint a fresh keypair:
  *
  *   pnpm exec tsx scripts/issue-license.ts --generate-keypair
  *
- * That writes both halves to revvault and prints the PEM-formatted public
- * key to copy into the daemon's environment / Studio bundle.
+ * That writes both halves to revvault and prints the PEM-formatted public key;
+ * refresh DEFAULT_VENDOR_PUBLIC_KEY (in vendor-public-key.ts) on rotation.
  */
 export function getVendorPublicKey(): string {
-  return process.env.REVDEV_LICENSE_PUBLIC_KEY ?? '';
+  const override = process.env.REVDEV_LICENSE_PUBLIC_KEY;
+  return override && override.trim() ? override : DEFAULT_VENDOR_PUBLIC_KEY;
 }
 
 const VALID_TIERS = new Set(['pro', 'max', 'enterprise']);

--- a/packages/daemon/src/license-crypto.ts
+++ b/packages/daemon/src/license-crypto.ts
@@ -45,7 +45,7 @@ import { DEFAULT_VENDOR_PUBLIC_KEY } from './vendor-public-key.js';
  */
 export function getVendorPublicKey(): string {
   const override = process.env.REVDEV_LICENSE_PUBLIC_KEY;
-  return override && override.trim() ? override : DEFAULT_VENDOR_PUBLIC_KEY;
+  return override?.trim() ? override : DEFAULT_VENDOR_PUBLIC_KEY;
 }
 
 const VALID_TIERS = new Set(['pro', 'max', 'enterprise']);

--- a/packages/daemon/src/vendor-public-key.ts
+++ b/packages/daemon/src/vendor-public-key.ts
@@ -1,0 +1,18 @@
+/**
+ * Baked-in default vendor Ed25519 public key (PEM).
+ *
+ * This is PUBLIC verification material, not a secret. It can only VERIFY license
+ * JWT signatures, never mint them; the private half never leaves revvault
+ * (`revdev/license-signing-private-key`). Baking it in lets a buyer activate with
+ * only their license JWT (`REVEALUI_LICENSE_KEY`) and no second env var on the
+ * happy path. `REVDEV_LICENSE_PUBLIC_KEY` still overrides this for key rotation
+ * or testing.
+ *
+ * Canonical source: revvault `revdev/license-signing-public-key` (ADR 2026-06-06
+ * signing-key consolidation). The signing keypair rotates on a roughly 1-year
+ * owner-driven cadence; when it does, refresh this constant from that revvault
+ * path (public half only).
+ */
+export const DEFAULT_VENDOR_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEASYqUILNyK2frt8BDbW01N4+/Vmgsf+b+6Z+xJUT4Tho=
+-----END PUBLIC KEY-----`;


### PR DESCRIPTION
## What

Bake the vendor Ed25519 public key into the daemon as a compile-time default, so a buyer activates with only their license JWT (`REVEALUI_LICENSE_KEY`) and needs no second env var on the happy path.

## Why

studio-v0.1.0 shipped without a baked key. A buyer who set only their license JWT hit a silent trap: `getVendorPublicKey()` returned `''` when `REVDEV_LICENSE_PUBLIC_KEY` was unset, so a valid Pro license verified against nothing and the daemon ran Free with reason "REVDEV_LICENSE_PUBLIC_KEY not set". The public key is non-secret verification material (it cannot mint licenses) on a roughly 1-year rotation, so baking it in removes the trap.

## Change

- New `packages/daemon/src/vendor-public-key.ts` exporting `DEFAULT_VENDOR_PUBLIC_KEY` (the canonical public half from revvault `revdev/license-signing-public-key`).
- `getVendorPublicKey()` falls back to the baked default; `REVDEV_LICENSE_PUBLIC_KEY` still overrides it for rotation/testing (an empty/whitespace value is treated as unset).
- `docs/GETTING_STARTED.md`: the happy path is now `REVEALUI_LICENSE_KEY` only; the public-key export becomes an "advanced / rotation override" note pointing at the account page.
- Tests: baked default used when env unset (BEGIN PUBLIC KEY asserted); empty override falls back; env overrides; fail-closed preserved (a non-vendor token degrades to Free under the baked key).

## Rollout

Ships in the next studio tag (v0.1.1). studio-v0.1.0 users are covered by the server-side account-page change (revealui #1710), which surfaces the public key so they can set `REVDEV_LICENSE_PUBLIC_KEY` manually.

## Test note

All license tests pass (`license-crypto.test.ts` 13/13 including the new baked-default / override / fail-closed cases; `license.test.ts` + `guard.test.ts` green). The daemon suite has pre-existing, license-unrelated flakiness under heavy parallel load on low-memory runners: `beforeAll` hook timeouts in `filegit-*` / `e2e-ipc` and one timing-sensitive assertion in `shutdown-drain.test.ts`. These reproduce on `test` without this change and are a separate test-infra follow-up.
