### PR TITLE
chore(release): promote test -> main (baked vendor public key + test hardening + scanner patterns)

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -94,15 +94,18 @@ To unlock Pro features (agent spawning, inference, merge pipeline, memory, coord
 
 1. Purchase a license at [revealui.com/pro](https://revealui.com/pro)
 2. You'll receive a license key starting with `eyJ` — an Ed25519-signed JWT (RFC 7519, `alg: EdDSA`), a three-part `<header>.<payload>.<signature>` token.
-3. Set it, **and the vendor public key the daemon verifies it against**, as environment variables:
+3. Set it as an environment variable:
 
 ```bash
 # Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
 export REVEALUI_LICENSE_KEY="eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ0aWVyIjoicHJvIiwuLi59.<signature>"
+```
 
-# Required to verify the license signature (PEM-encoded Ed25519 public key).
-# Self-host activation cannot succeed without this — the daemon stays in
-# Free mode with reason "REVDEV_LICENSE_PUBLIC_KEY not set" until it is set.
+The daemon ships with the vendor public key baked in, so it verifies your license with no further configuration.
+
+**Advanced (key rotation / override):** `REVDEV_LICENSE_PUBLIC_KEY` overrides the baked-in vendor key with a PEM-encoded Ed25519 public key. You only need it if the vendor signing key has rotated and your build predates the rotation, or you are testing against your own keypair. The current public key is shown on your account page at [revealui.com/account/license](https://revealui.com/account/license).
+
+```bash
 export REVDEV_LICENSE_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEA...
 -----END PUBLIC KEY-----"

--- a/packages/daemon/src/__tests__/license-crypto.test.ts
+++ b/packages/daemon/src/__tests__/license-crypto.test.ts
@@ -1,6 +1,7 @@
 import { generateKeyPairSync, sign } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { isRevokedJti, verifyLicenseJWT } from '../license-crypto.js';
+import { getVendorPublicKey, isRevokedJti, verifyLicenseJWT } from '../license-crypto.js';
+import { DEFAULT_VENDOR_PUBLIC_KEY } from '../vendor-public-key.js';
 
 function makeToken(
   payload: Record<string, unknown>,
@@ -113,5 +114,32 @@ describe('verifyLicenseJWT — jti revocation hook', () => {
     const token = makeToken({ ...VALID_PAYLOAD, jti: 'clean-jti-1234' }, privateKey);
     const result = verifyLicenseJWT(token, publicKey);
     expect(result.valid).toBe(true);
+  });
+});
+
+describe('getVendorPublicKey — baked default + override', () => {
+  it('falls back to the baked default when REVDEV_LICENSE_PUBLIC_KEY is unset', () => {
+    delete process.env.REVDEV_LICENSE_PUBLIC_KEY;
+    const key = getVendorPublicKey();
+    expect(key).toBe(DEFAULT_VENDOR_PUBLIC_KEY);
+    expect(key.startsWith('-----BEGIN PUBLIC KEY-----')).toBe(true);
+  });
+
+  it('treats an empty/whitespace override as unset and uses the baked default', () => {
+    process.env.REVDEV_LICENSE_PUBLIC_KEY = '   ';
+    expect(getVendorPublicKey()).toBe(DEFAULT_VENDOR_PUBLIC_KEY);
+  });
+
+  it('uses REVDEV_LICENSE_PUBLIC_KEY as an override when set', () => {
+    process.env.REVDEV_LICENSE_PUBLIC_KEY = publicKey;
+    expect(getVendorPublicKey()).toBe(publicKey);
+  });
+
+  it('stays fail-closed: a tampered/foreign token degrades to Free under the baked default', () => {
+    delete process.env.REVDEV_LICENSE_PUBLIC_KEY;
+    const token = makeToken(VALID_PAYLOAD, privateKey); // signed by a non-vendor key
+    const result = verifyLicenseJWT(token, getVendorPublicKey());
+    expect(result.valid).toBe(false);
+    expect(result.tier).toBe('free');
   });
 });

--- a/packages/daemon/src/__tests__/shutdown-drain.test.ts
+++ b/packages/daemon/src/__tests__/shutdown-drain.test.ts
@@ -136,10 +136,14 @@ describe('startDaemon().close() — drain integration', () => {
     const start = Date.now();
     await d.close();
     const elapsed = Date.now() - start;
-    // Should pass the 100 ms drain deadline plus db.close() + unlink time,
-    // but shouldn't hang indefinitely.
+    // Behavioral assertion: close() honored the 100ms drain deadline before
+    // proceeding past the stuck handler.
     expect(elapsed).toBeGreaterThanOrEqual(100);
-    expect(elapsed).toBeLessThan(3000);
+    // Hang-guard only: close() must terminate, not wait on the stuck handler
+    // forever. This is a generous ceiling (db.close() + unlink + scheduling under
+    // parallel-test load), NOT a perf bound — a true indefinite hang is caught by
+    // the vitest testTimeout. A tight wall-clock ceiling here flaked under load.
+    expect(elapsed).toBeLessThan(15000);
     // Counter is still 1 (we never decremented it from the test side).
     // Reset for afterEach.
     _setActiveHandlerCountForTest(0);

--- a/packages/daemon/src/license-crypto.ts
+++ b/packages/daemon/src/license-crypto.ts
@@ -27,18 +27,25 @@
  */
 
 import { verify } from 'node:crypto';
+import { DEFAULT_VENDOR_PUBLIC_KEY } from './vendor-public-key.js';
 
 /**
- * Vendor Ed25519 public key (PEM), read from REVDEV_LICENSE_PUBLIC_KEY at
- * call time (tests set the env var after import). To mint a fresh keypair:
+ * Vendor Ed25519 public key (PEM) used to verify license JWTs.
+ *
+ * Falls back to the baked-in DEFAULT_VENDOR_PUBLIC_KEY so activation succeeds
+ * with only REVEALUI_LICENSE_KEY set (no second env var on the happy path).
+ * REVDEV_LICENSE_PUBLIC_KEY overrides the default for key rotation or testing;
+ * an empty/whitespace override is treated as unset and falls back to the default.
+ * To mint a fresh keypair:
  *
  *   pnpm exec tsx scripts/issue-license.ts --generate-keypair
  *
- * That writes both halves to revvault and prints the PEM-formatted public
- * key to copy into the daemon's environment / Studio bundle.
+ * That writes both halves to revvault and prints the PEM-formatted public key;
+ * refresh DEFAULT_VENDOR_PUBLIC_KEY (in vendor-public-key.ts) on rotation.
  */
 export function getVendorPublicKey(): string {
-  return process.env.REVDEV_LICENSE_PUBLIC_KEY ?? '';
+  const override = process.env.REVDEV_LICENSE_PUBLIC_KEY;
+  return override?.trim() ? override : DEFAULT_VENDOR_PUBLIC_KEY;
 }
 
 const VALID_TIERS = new Set(['pro', 'max', 'enterprise']);

--- a/packages/daemon/src/vendor-public-key.ts
+++ b/packages/daemon/src/vendor-public-key.ts
@@ -1,0 +1,18 @@
+/**
+ * Baked-in default vendor Ed25519 public key (PEM).
+ *
+ * This is PUBLIC verification material, not a secret. It can only VERIFY license
+ * JWT signatures, never mint them; the private half never leaves revvault
+ * (`revdev/license-signing-private-key`). Baking it in lets a buyer activate with
+ * only their license JWT (`REVEALUI_LICENSE_KEY`) and no second env var on the
+ * happy path. `REVDEV_LICENSE_PUBLIC_KEY` still overrides this for key rotation
+ * or testing.
+ *
+ * Canonical source: revvault `revdev/license-signing-public-key` (ADR 2026-06-06
+ * signing-key consolidation). The signing keypair rotates on a roughly 1-year
+ * owner-driven cadence; when it does, refresh this constant from that revvault
+ * path (public half only).
+ */
+export const DEFAULT_VENDOR_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEASYqUILNyK2frt8BDbW01N4+/Vmgsf+b+6Z+xJUT4Tho=
+-----END PUBLIC KEY-----`;

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -1,0 +1,30 @@
+import { freemem } from 'node:os';
+import { defineConfig } from 'vitest/config';
+
+// ---------------------------------------------------------------------------
+// Resource-aware daemon test configuration.
+//
+// The daemon integration tests each spin up a FULL daemon in `beforeAll`/`beforeEach`
+// (Unix socket + PGlite DB + git/PTY): filegit-*, e2e-ipc, shutdown-drain, spawn.
+// Running many of those files concurrently on a low-memory machine starves
+// CPU/RAM, and the daemon boot blows past vitest's default hook timeout
+// (observed: 30s `beforeAll` timeouts under load; 0 assertions fail — the suite
+// is correct, just starved).
+//
+// The durable fix is to BOUND how many heavy daemons boot at once rather than to
+// keep inflating the timeout. Mirrors the revealui root vitest.config.ts
+// resource-aware worker cap. The timeouts below are modest safety margins for a
+// genuine (no-longer-starved) daemon boot + teardown, not the primary lever.
+// ---------------------------------------------------------------------------
+
+const availableMb = Math.floor(freemem() / 1024 / 1024);
+const maxWorkers = availableMb > 4096 ? 4 : 2;
+
+export default defineConfig({
+  test: {
+    maxWorkers,
+    minWorkers: 1,
+    hookTimeout: 45_000,
+    testTimeout: 30_000,
+  },
+});

--- a/scripts/check-no-private-leaks.sh
+++ b/scripts/check-no-private-leaks.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # check-no-private-leaks.sh
 #
-# Scans a public-facing directory (default: the revskills repo root) for
+# Scans a public-facing directory (default: the revdev repo root) for
 # references to private filesystem paths, private repos, or machine-local
 # user homes that must not appear in public artifacts.
 #
@@ -37,8 +37,10 @@ unset _path
 # Each entry: tag|ERE_regex|reason
 # Anchored where possible to keep false-positive noise low.
 PATTERNS=(
+  "lit-username|joshua[-]v-dev|literal developer username; use a placeholder"
   "abs-home-path|/home/[a-z][a-z0-9_-]+|absolute user home path (/home/<username>/...)"
   "abs-windows-user|[Cc]:[\\\\/]Users[\\\\/][A-Za-z0-9_-]+|absolute Windows user path (C:\\\\Users\\\\<name>)"
+  "abs-wsl-windows-user|/mnt/[a-z]/Users/[A-Za-z0-9_-]+|WSL mount of a Windows user path (/mnt/c/Users/<name>)"
   "private-jv-repo|/?revfleet/\\.jv|private repo path (~/revfleet/.jv/...)"
   "private-jv-name|revealui-jv|private repo name (revealui-jv)"
   "lts-drive|/mnt/e/|LTS drive mount path"


### PR DESCRIPTION
Promotes 6 commits: baked DEFAULT_VENDOR_PUBLIC_KEY so activation needs only the license JWT (#224, byte-verified against the vaulted signing key), resource-aware test concurrency + shutdown-drain de-brittle (#225), leak-scanner pattern backports. Correctness-cleared for release; v0.1.1 tag follows at the fixed main. Merge with a merge commit.