### PR TITLE
chore(release): v0.1.1 — baked-key release version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to RevealUI Studio are documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Dates are ISO 8601 (UTC).
 
+## [0.1.1] — 2026-07-03
+
+### Fixed
+
+- Daemon license activation now works with only the license JWT: the vendor
+  public key ships baked into the daemon as the default (override via
+  REVDEV_LICENSE_PUBLIC_KEY unchanged). Previously a fresh install without the
+  public-key env var fell back to the Free tier silently.
+
+### Changed
+
+- Test-suite hardening: resource-aware bounded concurrency and a de-brittled
+  shutdown-drain hang guard.
+
 ## [0.1.0] — 2026-07-01
 
 First public release of RevealUI Studio — a native desktop AI editor and

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Native AI experience — agent coordination hub, local inference management, visual agent dashboard (Tauri 2 + React 19)",
   "private": true,
   "dependencies": {

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "age",
  "arboard",

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "RevealUI Studio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "dev.revealui.studio",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revdev",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "RevDev — Native developer tools for RevealUI",
   "repository": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revdev/daemon",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Harness daemon — AI agent coordination, PTY management, and inter-agent messaging",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prepares the v0.1.1 release the fleet docs have been pointing at (the baked vendor-public-key daemon fix, #224, is already on main via promotion #227 — but every version field still said 0.1.0, and no release workflow fires on a bare v* tag).

## What

- 0.1.0 → 0.1.1 across: root package.json, @revdev/daemon, studio (package.json + tauri.conf.json + Cargo.toml + Cargo.lock — the lock edit is exactly what cargo would write).
- CHANGELOG entry: Fixed = daemon activates Pro with only the license JWT (baked default vendor key; was silent-Free without the env var); Changed = test-suite hardening (#225).
- Patch (not minor) per versioning.md: this is a bugfix release — the silent-Free activation was broken-by-default behavior.

## Tag-namespace recommendation

**Cut `studio-v0.1.1`** at the fixed main after this promotes — the only buyer-facing release line with a workflow (studio-release.yml on `studio-v*`; the prior release is studio-v0.1.0). `console-v*` exists but console is unchanged. A bare `v0.1.1` tag fires nothing.

**Flagged for the owner (not blocking):** @revdev/daemon is `private: true` with no release line of its own — Studio *resolves* the daemon on the system (daemon_ctl.rs), it does not bundle it. If buyers are meant to get the daemon fix without building from source, a `daemon-v*` release line (or bundling) is a follow-up decision.

## Release sequence after merge

1. Merge this to `test` (CI green).
2. Promotion PR `test → main` (merge commit).
3. `git tag studio-v0.1.1 <main-sha> && git push origin studio-v0.1.1` — fires studio-release.yml (3 platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)