### PR TITLE
chore(release): promote test -> main (v0.1.1 version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to RevealUI Studio are documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Dates are ISO 8601 (UTC).
 
+## [0.1.1] — 2026-07-03
+
+### Fixed
+
+- Daemon license activation now works with only the license JWT: the vendor
+  public key ships baked into the daemon as the default (override via
+  REVDEV_LICENSE_PUBLIC_KEY unchanged). Previously a fresh install without the
+  public-key env var fell back to the Free tier silently.
+
+### Changed
+
+- Test-suite hardening: resource-aware bounded concurrency and a de-brittled
+  shutdown-drain hang guard.
+
 ## [0.1.0] — 2026-07-01
 
 First public release of RevealUI Studio — a native desktop AI editor and

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Native AI experience — agent coordination hub, local inference management, visual agent dashboard (Tauri 2 + React 19)",
   "private": true,
   "dependencies": {

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "age",
  "arboard",

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "RevealUI Studio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "dev.revealui.studio",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revdev",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "RevDev — Native developer tools for RevealUI",
   "repository": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revdev/daemon",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Harness daemon — AI agent coordination, PTY management, and inter-agent messaging",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Carries the v0.1.1 version bump + CHANGELOG (#229) to main. After this merges, tag studio-v0.1.1 at the main tip to fire studio-release.yml (3 platforms). Merge with a merge commit.