### PR TITLE
docs: reconcile studio release status + macOS caveat, scrub private-key store paths from KEY_GENERATION

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -1,6 +1,6 @@
 # RevealUI Studio
 
-> **Status:** Functional in dev — connects to the harness daemon, 506 frontend tests passing. Prebuilt binary release is **not** yet shipped (Tauri `studio-release.yml` CI in progress). Run locally via `pnpm tauri:dev` for now.
+> **Status:** Functional — connects to the harness daemon, 506 frontend tests passing. **Prebuilt binaries are published** on [GitHub Releases](https://github.com/RevealUIStudio/revdev/releases) (first release `studio-v0.1.0`, 2026-07-02; macOS · Linux · Windows). macOS builds are currently **unsigned / ad-hoc**, so Gatekeeper blocks the first launch — **right-click the app → Open** (or `System Settings → Privacy & Security → Open Anyway`) once to run it. In-app auto-update is **configured but not yet live** (the `releases.revealui.com` update endpoint is not serving manifests yet), so update by downloading the latest release manually for now. To run from source instead: `pnpm tauri:dev`.
 
 Native AI experience — agent coordination hub, local inference management, visual agent dashboard, DevPod manager, and secret vault.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -33,6 +33,8 @@ Download the latest release for your platform from [GitHub Releases](https://git
 | Linux (AppImage) | `RevealUI-Studio_x.x.x_amd64.AppImage` |
 | Windows | `RevealUI-Studio_x.x.x_x64-setup.exe` |
 
+> **macOS note:** the macOS `.dmg` builds are currently unsigned / ad-hoc, so Gatekeeper blocks the first launch. **Right-click the app → Open** (or approve it under `System Settings → Privacy & Security → Open Anyway`) once; subsequent launches work normally. Signed/notarized macOS builds are planned. In-app auto-update is not live yet — grab new versions from the Releases page manually for now.
+
 ### 2. Install the Harness Daemon
 
 The daemon is the coordination brain — Studio connects to it for all agent operations.

--- a/docs/KEY_GENERATION.md
+++ b/docs/KEY_GENERATION.md
@@ -21,10 +21,11 @@ openssl rand -base64 24 > "$D/pw"
 cd ~/revfleet/revdev/apps/studio
 node_modules/.bin/tauri signer generate -w "$D/revdev-studio.key" --password "$(cat "$D/pw")"
 
-# Vault all three (revvault set reads stdin)
-revvault set revdev/tauri-signing-private-key          < "$D/revdev-studio.key"
-revvault set revdev/tauri-signing-private-key-password < "$D/pw"
-revvault set revdev/tauri-signing-public-key           < "$D/revdev-studio.key.pub"
+# Vault all three (revvault set reads stdin). Substitute the real revvault
+# paths from the internal key index for the placeholders below.
+revvault set <tauri-signing-private-key path>          < "$D/revdev-studio.key"
+revvault set <tauri-signing-private-key-password path> < "$D/pw"
+revvault set <tauri-signing-public-key path>           < "$D/revdev-studio.key.pub"
 
 # Mirror to CI secrets, then shred
 gh secret set TAURI_SIGNING_PRIVATE_KEY          -R RevealUIStudio/revdev < "$D/revdev-studio.key"

--- a/docs/KEY_GENERATION.md
+++ b/docs/KEY_GENERATION.md
@@ -9,7 +9,7 @@ All keys are stored in revvault (encrypted at rest).
 
 Signs Studio desktop binaries for auto-update verification.
 
-> **STATUS: DONE 2026-06-11.** The keypair exists. Private key, password, and public key live in revvault at `revdev/tauri-signing-{private-key,private-key-password,public-key}`; the public key is embedded in `apps/studio/src-tauri/tauri.conf.json` → `plugins.updater.pubkey`; the `TAURI_SIGNING_PRIVATE_KEY{,_PASSWORD}` repo secrets are set.
+> **STATUS: DONE 2026-06-11.** The keypair exists and is stored in revvault (exact store paths are kept in the internal key index, not this public runbook); the public key is embedded in `apps/studio/src-tauri/tauri.conf.json` → `plugins.updater.pubkey`; the `TAURI_SIGNING_PRIVATE_KEY{,_PASSWORD}` repo secrets are set.
 >
 > **Re-running this section ROTATES the key.** Installed Studio builds verify updates against the embedded public key — a new keypair orphans every existing install until it manually reinstalls. Only rotate on compromise, and treat it as a breaking release event.
 

--- a/docs/KEY_GENERATION.md
+++ b/docs/KEY_GENERATION.md
@@ -42,8 +42,8 @@ shred -u "$D/pw" "$D/revdev-studio.key" && rm -rf "$D"
 Signs customer license keys (Ed25519-signed JWTs — the daemon rejects legacy `RVUI.v2.*` / `RVUI-*` formats) so the daemon can verify them. <!-- doclint:allow-legacy-format -->
 
 ```bash
-# Mint Ed25519 keypair; auto-stores both halves in revvault at
-# revdev/license-signing-{private,public}-key and prints the public PEM.
+# Mint Ed25519 keypair; auto-stores both halves in revvault (exact store paths
+# are kept in the internal key index) and prints the public PEM.
 # No plaintext key files ever land on disk.
 cd ~/revfleet/revdev
 npx tsx scripts/issue-license.ts --generate-keypair

--- a/docs/KEY_GENERATION.md
+++ b/docs/KEY_GENERATION.md
@@ -95,8 +95,8 @@ Add these to RevealUIStudio/revdev → Settings → Secrets → Actions:
 
 | Secret | Value Source | Status |
 |--------|-------------|--------|
-| `TAURI_SIGNING_PRIVATE_KEY` | `revvault get --full revdev/tauri-signing-private-key` | ✅ set 2026-06-11 |
-| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | `revvault get --full revdev/tauri-signing-private-key-password` | ✅ set 2026-06-11 |
+| `TAURI_SIGNING_PRIVATE_KEY` | revvault — Tauri signing private key (see internal key index) | ✅ set 2026-06-11 |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | revvault — Tauri signing private-key password (see internal key index) | ✅ set 2026-06-11 |
 
 macOS-only (when ready for Apple distribution):
 | Secret | Value Source |


### PR DESCRIPTION
## What

Doc-currency + hygiene pass on three docs, surfaced by an internal audit (2026-07-03):

**`docs/KEY_GENERATION.md`** — the runbook named concrete revvault store paths for the binary/code-signing **private** keys. Genericized those to placeholders and pointers to the internal key index, so the public runbook no longer discloses exact private-key store locations. Public-key wiring steps are unchanged. No secret values were ever present or added.

**`apps/studio/README.md`** — the status line claimed "prebuilt binary release is **not** yet shipped." Reconciled to reality: prebuilt binaries are published on GitHub Releases (first release `studio-v0.1.0`, 2026-07-02; macOS · Linux · Windows). Documented the macOS **unsigned / ad-hoc** first-launch caveat (right-click → Open). In-app auto-update is described as **configured but not yet live** — verified the `releases.revealui.com` update endpoint returns 404 for the update manifests, so it is not presented as working.

**`docs/GETTING_STARTED.md`** — added the same macOS ad-hoc first-launch caveat next to the download table, and the note that in-app auto-update is not live yet. (The release link and the four-tier Free/Pro/Max/Enterprise list were already current.)

## Verification

- `studio-v0.1.0` confirmed published (2026-07-02) with macOS/Linux/Windows assets; `studio-v0.1.1` is now the latest.
- Auto-update endpoint probed: `releases.revealui.com/studio/<target>/<arch>/latest.json` → HTTP 404 (not serving manifests) → documented as "not yet live," not as working.
- No private-key revvault store paths remain in `docs/KEY_GENERATION.md`.

File-disjoint from the companion PR that removes an internal audit doc (#233).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
