### PR TITLE
chore(ci): refresh .gitleaksignore fingerprints after history rewrite

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -37,3 +37,18 @@
 # the real format; it trips the default generic-api-key rule but is illustrative,
 # not an issued credential. (Audit item 1, 2026-06-24.)
 713404b3093f98b258f82d4245049e36a66bc87b:docs/TROUBLESHOOTING.md:generic-api-key:97
+
+# --- Pre-rewrite lineage (2026-07-04 history rewrite) ---
+# The same findings under their PRE-rewrite commit SHAs. Inert on the
+# rewritten history (those SHAs no longer exist there), but they keep
+# gitleaks green on clones/refs that still carry the pre-rewrite lineage
+# (gitleaks scans all refs). Drop this section once all pre-rewrite
+# branches are re-cut and stale refs are pruned.
+5afa81cc5e5a4614ce9b1748172caaa9ab4e7752:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:102
+5afa81cc5e5a4614ce9b1748172caaa9ab4e7752:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:109
+173d460359d0378cd2b6d2aeb6526c5149437b31:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:102
+173d460359d0378cd2b6d2aeb6526c5149437b31:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:109
+173d460359d0378cd2b6d2aeb6526c5149437b31:packages/daemon/src/__tests__/coordination.test.ts:generic-api-key:69
+5afa81cc5e5a4614ce9b1748172caaa9ab4e7752:packages/daemon/src/__tests__/coordination.test.ts:generic-api-key:69
+0e06d76a51d3705228a49be6c928c6f59cfb2046:packages/daemon/src/__tests__/e2e-ipc.test.ts:generic-api-key:80
+59dc05ae1bb76770159111480c681ea74936e735:docs/TROUBLESHOOTING.md:generic-api-key:97

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -8,29 +8,32 @@
 # but the format is regex-validated only — no cryptographic binding
 # (tracked for upgrade to Ed25519 signatures in packages/daemon/src/license.ts).
 # So the test strings cannot unlock anything a forged string couldn't
-# also unlock, by design. They exist in history from two commits.
+# also unlock, by design.
+#
+# NOTE: fingerprints are keyed by commit SHA, so any history rewrite
+# invalidates them all. SHAs below were refreshed after the 2026-07-04
+# rewrite (same files/rules/lines; findings re-verified as the same
+# documented fixtures — no new suppressions added).
 
 # guard.test.ts — test license keys for max/enterprise tier paths
-5afa81cc5e5a4614ce9b1748172caaa9ab4e7752:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:102
-5afa81cc5e5a4614ce9b1748172caaa9ab4e7752:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:109
-173d460359d0378cd2b6d2aeb6526c5149437b31:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:102
-173d460359d0378cd2b6d2aeb6526c5149437b31:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:109
+6efe00441ca42be580df209a6848f340b0f9c3c9:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:102
+6efe00441ca42be580df209a6848f340b0f9c3c9:packages/daemon/src/__tests__/guard.test.ts:generic-api-key:109
 
 # coordination.test.ts — test license key required for license-gated coordination RPCs
-173d460359d0378cd2b6d2aeb6526c5149437b31:packages/daemon/src/__tests__/coordination.test.ts:generic-api-key:69
-5afa81cc5e5a4614ce9b1748172caaa9ab4e7752:packages/daemon/src/__tests__/coordination.test.ts:generic-api-key:69
+6efe00441ca42be580df209a6848f340b0f9c3c9:packages/daemon/src/__tests__/coordination.test.ts:generic-api-key:69
 
 # e2e-ipc.test.ts — test license key set in beforeAll() for end-to-end IPC suite.
-# Historical: commit 0e06d76 (PR #18, 2026-04-20) had a literal REVEALUI_LICENSE_KEY
-# assignment at line 80 with a fake test-fixture value matching the RVUI-{tier}-{32-hex}
-# format. Subsequent commits refactored this into test-license-helper.ts; the literal
-# no longer exists in the current file. This fingerprint suppresses the historical-only
-# finding so wide-range pull_request gitleaks scans (e.g. test->main promotion sync PRs)
-# don't trip on it.
-0e06d76a51d3705228a49be6c928c6f59cfb2046:packages/daemon/src/__tests__/e2e-ipc.test.ts:generic-api-key:80
+# Historical: commit 0e06d76 (PR #18, 2026-04-20; 2a00283 after the 2026-07-04
+# history rewrite) had a literal REVEALUI_LICENSE_KEY assignment at line 80 with
+# a fake test-fixture value matching the RVUI-{tier}-{32-hex} format. Subsequent
+# commits refactored this into test-license-helper.ts; the literal no longer
+# exists in the current file. This fingerprint suppresses the historical-only
+# finding so wide-range pull_request gitleaks scans (e.g. test->main promotion
+# sync PRs) don't trip on it.
+2a00283dbcc9dfb4fcc1cd3426eb37960319e391:packages/daemon/src/__tests__/e2e-ipc.test.ts:generic-api-key:80
 
 # TROUBLESHOOTING.md — documentation example license key. The eyJ-prefixed
 # EdDSA-JWT example value for REVEALUI_LICENSE_KEY is shown so users recognize
 # the real format; it trips the default generic-api-key rule but is illustrative,
 # not an issued credential. (Audit item 1, 2026-06-24.)
-59dc05ae1bb76770159111480c681ea74936e735:docs/TROUBLESHOOTING.md:generic-api-key:97
+713404b3093f98b258f82d4245049e36a66bc87b:docs/TROUBLESHOOTING.md:generic-api-key:97


### PR DESCRIPTION
The Security workflow (gitleaks) fails on every push/PR since the 2026-07-04 history rewrite: `.gitleaksignore` fingerprints are keyed by commit SHA, so the rewrite invalidated all existing suppressions and the five documented test-fixture/doc-example findings re-fired (the job is red on the `test` tip itself, e.g. run 28710610048's sibling on `c32ad82`).

- Refreshes the five fingerprints to their rewritten SHAs. Verified 1:1 by comparing `file:rule:line` with SHAs stripped: the post-rewrite findings are a strict subset of the previously-suppressed set (the rewrite collapsed duplicate second-commit entries) — same files, same rules, same lines, **no new suppressions**.
- Retains the pre-rewrite fingerprints in a clearly-labeled section: gitleaks scans all refs, so clones that still carry pre-rewrite lineages (e.g. the stale `chore/issue-leak-scan` branch pending its re-cut) would otherwise go red locally. Inert on the rewritten history; drop the section once stale refs are pruned.
- Verified: `gitleaks detect --config .gitleaks.toml` exits 0 both on a full local clone carrying both lineages and on a single-branch clean clone simulating CI checkout; `scripts/check-no-private-leaks.sh` clean.

After this merges to `test`, re-run the failed Security check on #238 (pull_request checks out the merge ref, so it picks up the fix from base) — that unblocks its merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
