### PR TITLE
docs: point zero-9p isolation ADR tracking at the coordination hub

### DIFF
--- a/docs/decisions/2026-06-24-zero-9p-agent-isolation.md
+++ b/docs/decisions/2026-06-24-zero-9p-agent-isolation.md
@@ -3,7 +3,7 @@
 - **Status:** Accepted (2026-06-24)
 - **Supersedes:** the implicit single-trust-domain assumption in
   `docs/decisions/2026-06-23-daemon-in-wsl-zero-9p.md` (the parent zero-9P ADR).
-- **Tracking:** `docs/lanes/multi-agent-filesystem-isolation/plan.md`
+- **Tracking:** RevealUI Studio internal coordination hub (multi-agent filesystem-isolation lane)
 
 ## Context
 


### PR DESCRIPTION
The **Tracking** pointer in `docs/decisions/2026-06-24-zero-9p-agent-isolation.md` referenced a planning-doc path that does not exist in this repo. Replaced with the internal-coordination-hub phrasing already used by `docs/INDEX.md` and `docs/PLAN.md`.

Doc-only, one line. Repo leak scanner passes locally. Surfaced by an internal audit 2026-07-04. File-disjoint from #237/#238/#239. Manual merge after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
