### PR TITLE
refactor(studio): migrate remaining hardcoded colors to design tokens

### DIFF
--- a/apps/studio/src/__tests__/components/Badge.test.tsx
+++ b/apps/studio/src/__tests__/components/Badge.test.tsx
@@ -11,8 +11,8 @@ describe('Badge', () => {
   it('applies default variant styles', () => {
     render(<Badge>Default</Badge>);
     const badge = screen.getByText('Default');
-    expect(badge.className).toContain('bg-white/5');
-    expect(badge.className).toContain('text-zinc-400');
+    expect(badge.className).toContain('bg-surface-2');
+    expect(badge.className).toContain('text-fg-subtle');
   });
 
   it('applies success variant styles', () => {
@@ -42,7 +42,7 @@ describe('Badge', () => {
   it('applies brand variant styles', () => {
     render(<Badge variant="brand">Pro</Badge>);
     const badge = screen.getByText('Pro');
-    expect(badge.className).toContain('text-emerald-400');
+    expect(badge.className).toContain('text-brand-text');
   });
 
   it('applies sm size styles', () => {

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -218,7 +218,7 @@ function HarnessSessionCard({ session }: { session: import('../../types').Harnes
       <div className="flex items-center gap-2">
         <span
           className={`size-2 shrink-0 rounded-full ${
-            isEnded ? 'bg-surface-3' : 'animate-pulse bg-cyan-500'
+            isEnded ? 'bg-surface-3' : 'animate-pulse bg-info'
           }`}
         />
         <span className="min-w-0 flex-1 truncate text-xs font-semibold text-fg">{session.id}</span>
@@ -528,7 +528,7 @@ export default function AgentPanel() {
           {/* Remote agents */}
           {remoteAgents.length > 0 ? (
             <div className="mt-4">
-              <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-violet-400">
+              <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-accent">
                 <span>Cloud Agents</span>
                 <span className="rounded bg-surface-2 px-1.5 py-0.5 text-fg-muted">
                   {remoteAgents.length}
@@ -825,7 +825,7 @@ function RemoteAgentCard({ agent }: { agent: AgentCard }) {
   return (
     <div className="rounded-lg border border-edge bg-surface-1/60 p-2.5">
       <div className="flex items-center gap-2">
-        <span className="size-2 shrink-0 rounded-full bg-violet-500" />
+        <span className="size-2 shrink-0 rounded-full bg-accent" />
         <span className="min-w-0 flex-1 truncate text-xs font-semibold text-fg">{agent.name}</span>
         {agent.version ? (
           <span className="shrink-0 rounded bg-surface-2 px-1.5 py-0.5 text-[10px] text-fg-subtle">

--- a/apps/studio/src/components/dashboard/SubscriptionCard.tsx
+++ b/apps/studio/src/components/dashboard/SubscriptionCard.tsx
@@ -14,14 +14,14 @@ const TIER_LABELS: Record<string, string> = {
   free: 'Free',
   pro: 'Pro',
   max: 'Max',
-  enterprise: 'Forge',
+  enterprise: 'Enterprise',
 };
 
 const TIER_COLORS: Record<string, string> = {
   free: 'text-fg-muted bg-surface-2 border-edge',
   pro: 'text-brand-text bg-brand/20 border-brand/30',
   max: 'text-accent bg-accent/20 border-accent/30',
-  enterprise: 'text-violet-400 bg-violet-600/20 border-violet-600/30',
+  enterprise: 'text-accent bg-accent-soft border-accent/30',
 };
 
 const STATUS_LABELS: Record<string, { label: string; color: string }> = {

--- a/apps/studio/src/components/deploy/StepVercel.tsx
+++ b/apps/studio/src/components/deploy/StepVercel.tsx
@@ -142,7 +142,7 @@ export default function StepVercel({
         </div>
 
         {validated && Object.keys(linkedProjects).length > 0 && (
-          <ul className="mt-2 flex flex-col gap-1 text-sm text-zinc-300">
+          <ul className="mt-2 flex flex-col gap-1 text-sm text-fg-muted">
             {REQUIRED_PROJECTS.map((req) => (
               <li key={req.key} className="flex items-center gap-2">
                 <span className="text-success">&#10003;</span>

--- a/apps/studio/src/components/gallery/Tile.tsx
+++ b/apps/studio/src/components/gallery/Tile.tsx
@@ -27,7 +27,7 @@ export default function Tile({ tile, hidden, editing, running, onLaunch, onToggl
         hidden
           ? 'border-edge/50 bg-surface-1/30 text-fg-subtle'
           : running
-            ? 'border-emerald-800/60 bg-surface-1 text-fg-muted hover:border-emerald-700 hover:bg-surface-2 hover:text-fg'
+            ? 'border-success/60 bg-surface-1 text-fg-muted hover:border-success hover:bg-surface-2 hover:text-fg'
             : 'border-edge bg-surface-1 text-fg-muted hover:border-edge hover:bg-surface-2 hover:text-fg'
       }`}
       title={
@@ -51,7 +51,7 @@ export default function Tile({ tile, hidden, editing, running, onLaunch, onToggl
           <TileIcon tileId={tile.id} />
         </span>
         {running && !editing && (
-          <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-emerald-500" />
+          <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-success" />
         )}
       </span>
       <span className="truncate font-medium">{tile.label}</span>

--- a/apps/studio/src/components/ui/Badge.tsx
+++ b/apps/studio/src/components/ui/Badge.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode } from 'react';
 
 const variantClasses = {
-  default: 'bg-white/5 text-zinc-400',
+  default: 'bg-surface-2 text-fg-subtle',
   success: 'bg-success-subtle text-success',
   warning: 'bg-warning-subtle text-warning',
   error: 'bg-error-subtle text-error',
   info: 'bg-info/15 text-info',
-  brand: 'bg-emerald-500/10 text-emerald-400',
+  brand: 'bg-brand-subtle text-brand-text',
 } as const;
 
 const sizeClasses = {


### PR DESCRIPTION
## Summary

- Completes the design token migration started in #253
- Replaces all remaining emerald/violet/cyan/zinc Tailwind colors with semantic `--rvui-*` design tokens
- Fixes stale tier label `'Forge'` → `'Enterprise'` per naming convention

**Components migrated:**
- `Badge` — default/brand variants
- `SubscriptionCard` — enterprise tier color
- `Tile` — running state border + indicator dot
- `AgentPanel` — active session pulse + cloud agents label/dot
- `StepVercel` — project list text color

Terminal ANSI palette (xterm standard in TerminalView) is intentionally untouched.

## Test plan

- [ ] `pnpm typecheck:studio` passes (requires Tauri codegen)
- [ ] Visual check: Badge variants render correctly
- [ ] Visual check: Tile running state shows success-colored border/dot
- [ ] Visual check: AgentPanel cloud agents section uses accent color
- [ ] Visual check: SubscriptionCard enterprise badge uses amber accent

🤖 Generated with [Claude Code](https://claude.com/claude-code)