### PR TITLE
fix(studio): wire theme preference to DOM

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -42,6 +42,15 @@ function AuthGatedApp() {
   const { settings } = useSettingsContext();
   const auth = useAuth(settings.apiUrl, settings.localMode);
 
+  useEffect(() => {
+    const el = document.documentElement;
+    if (settings.theme === 'system') {
+      el.removeAttribute('data-theme');
+    } else {
+      el.setAttribute('data-theme', settings.theme);
+    }
+  }, [settings.theme]);
+
   return (
     <AuthContext.Provider value={auth}>
       {auth.loading && auth.step === 'idle' ? (


### PR DESCRIPTION
## Summary

- The settings panel saved theme (dark/light/system) to localStorage but never applied it to the DOM
- Adds a `useEffect` in `AuthGatedApp` that sets `data-theme` on `<html>`, enabling the `@revealui/presentation` tokens.css light mode declarations
- `'system'` removes the attribute, letting `prefers-color-scheme` media query control the theme

## Test plan

- [ ] Open Settings → Appearance → click "light" → UI switches to light mode
- [ ] Click "dark" → UI switches back to dark mode
- [ ] Click "system" → follows OS preference
- [ ] Reload app → persisted theme preference is re-applied on mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)