### PR TITLE
fix(studio): daily-driver hardening (SSH hang, orphaned agents, destructive confirms, honest failures)

### DIFF
--- a/.github/workflows/studio-rust-tests.yml
+++ b/.github/workflows/studio-rust-tests.yml
@@ -88,6 +88,7 @@ jobs:
             --manifest-path apps/studio/src-tauri/Cargo.toml \
             --test harness_integration \
             --test daemon_ctl_integration \
+            --test ssh_output_pump \
             -- --test-threads=1
 
   relay:

--- a/apps/studio/src-tauri/src/commands/ssh.rs
+++ b/apps/studio/src-tauri/src/commands/ssh.rs
@@ -58,15 +58,16 @@ pub async fn ssh_send(
         .decode(&data)
         .map_err(|e| StudioError::Other(format!("Invalid base64: {e}")))?;
 
-    let sessions = state.sessions.lock().await;
-    let session = sessions
-        .get(&session_id)
-        .ok_or_else(|| StudioError::Other(format!("No session with id {session_id}")))?;
-
-    let channel_guard = session.channel.lock().await;
-    let channel = channel_guard
-        .as_ref()
-        .ok_or_else(|| StudioError::Ssh("Channel closed".into()))?;
+    // Clone the write half and release the sessions map before awaiting, so a
+    // slow send on one session cannot stall every other session's commands.
+    let channel = {
+        let sessions = state.sessions.lock().await;
+        sessions
+            .get(&session_id)
+            .ok_or_else(|| StudioError::Other(format!("No session with id {session_id}")))?
+            .channel
+            .clone()
+    };
 
     channel
         .data(&bytes[..])
@@ -84,15 +85,14 @@ pub async fn ssh_resize(
     rows: u32,
     state: State<'_, SshState>,
 ) -> Result<(), StudioError> {
-    let sessions = state.sessions.lock().await;
-    let session = sessions
-        .get(&session_id)
-        .ok_or_else(|| StudioError::Other(format!("No session with id {session_id}")))?;
-
-    let channel_guard = session.channel.lock().await;
-    let channel = channel_guard
-        .as_ref()
-        .ok_or_else(|| StudioError::Ssh("Channel closed".into()))?;
+    let channel = {
+        let sessions = state.sessions.lock().await;
+        sessions
+            .get(&session_id)
+            .ok_or_else(|| StudioError::Other(format!("No session with id {session_id}")))?
+            .channel
+            .clone()
+    };
 
     channel
         .window_change(cols, rows, 0, 0)

--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -322,7 +322,22 @@ pub async fn daemon_stop() -> Result<(), String> {
         }
     }
 
-    Err(format!("Daemon PID {pid} did not exit within 10s"))
+    // Escalate. Without this, Stop reports an error while leaving a wedged
+    // daemon running, and the UI offers no way to recover short of a shell.
+    if unsafe { libc::kill(pid as i32, libc::SIGKILL) } != 0 {
+        return Err(format!(
+            "Daemon PID {pid} ignored SIGTERM and SIGKILL could not be sent"
+        ));
+    }
+
+    for _ in 0..20 {
+        sleep(Duration::from_millis(100)).await;
+        if !is_pid_alive(pid) {
+            return Ok(());
+        }
+    }
+
+    Err(format!("Daemon PID {pid} survived SIGTERM and SIGKILL"))
 }
 
 #[cfg(not(unix))]

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -177,6 +177,11 @@ pub fn run() {
             updater::check_for_update,
             updater::install_update,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running RevealUI Studio");
+        .build(tauri::generate_context!())
+        .expect("error while running RevealUI Studio")
+        .run(|app, event| {
+            if matches!(event, tauri::RunEvent::Exit) {
+                spawner::kill_all(app.state::<SpawnerState>().sessions.clone());
+            }
+        });
 }

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ mod local_shell;
 mod platform;
 pub mod signing;
 mod spawner;
-mod ssh;
+pub mod ssh;
 mod state;
 mod tray;
 mod updater;

--- a/apps/studio/src-tauri/src/platform/trait_defs.rs
+++ b/apps/studio/src-tauri/src/platform/trait_defs.rs
@@ -75,7 +75,6 @@ pub struct SyncResult {
 pub struct RepoEntry {
     pub name: String,
     pub c_path: String,
-    pub e_path: String,
     pub identity: String,
 }
 

--- a/apps/studio/src-tauri/src/platform/windows.rs
+++ b/apps/studio/src-tauri/src/platform/windows.rs
@@ -98,50 +98,6 @@ impl WindowsPlatform {
         }
     }
 
-    fn git_sync_e(&self, repo_path: &str) -> SyncResult {
-        let full_path = format!("E:\\repos\\{}", repo_path);
-        let branch = self.git_branch(&full_path);
-
-        let check = Command::new("git")
-            .args(["-C", &full_path, "rev-parse", "--git-dir"])
-            .output();
-
-        if check.is_err() || !check.unwrap().status.success() {
-            return SyncResult {
-                drive: "E:".to_string(),
-                repo: String::new(),
-                status: "skip".to_string(),
-                branch: "-".to_string(),
-            };
-        }
-
-        let _ = Command::new("git")
-            .args(["-C", &full_path, "fetch", "origin", "--quiet"])
-            .output();
-
-        let reset = Command::new("git")
-            .args([
-                "-C",
-                &full_path,
-                "reset",
-                "--hard",
-                &format!("origin/{branch}"),
-            ])
-            .output();
-
-        let status = match reset {
-            Ok(o) if o.status.success() => "ok",
-            _ => "reset_failed",
-        };
-
-        SyncResult {
-            drive: "E:".to_string(),
-            repo: String::new(),
-            status: status.to_string(),
-            branch,
-        }
-    }
-
     fn git_branch(&self, path: &str) -> String {
         Command::new("git")
             .args(["-C", path, "rev-parse", "--abbrev-ref", "HEAD"])
@@ -154,7 +110,6 @@ impl WindowsPlatform {
         vec![RepoEntry {
             name: "RevealUI".to_string(),
             c_path: "projects\\RevealUI".to_string(),
-            e_path: "repos\\RevealUI".to_string(),
             identity: "professional".to_string(),
         }]
     }
@@ -362,23 +317,17 @@ impl PlatformOps for WindowsPlatform {
         }
     }
 
+    // The E: mirror sync was removed: it ran `reset --hard` against `E:\repos`,
+    // a mirror retired in 2026, with no dirty check. The C: sync below stays
+    // because it refuses to touch a dirty tree and only fast-forwards.
     fn sync_all_repos(&self) -> Result<Vec<SyncResult>, String> {
         let registry = Self::repo_registry();
-        let e_available = std::path::Path::new("E:\\repos").exists();
         let mut results = Vec::new();
 
         for repo in &registry {
-            // C: drive sync
             let mut c_result = self.git_sync_c(&repo.c_path);
             c_result.repo = repo.name.clone();
             results.push(c_result);
-
-            // E: drive sync (if available)
-            if e_available {
-                let mut e_result = self.git_sync_e(&repo.e_path);
-                e_result.repo = repo.name.clone();
-                results.push(e_result);
-            }
         }
 
         Ok(results)

--- a/apps/studio/src-tauri/src/spawner.rs
+++ b/apps/studio/src-tauri/src/spawner.rs
@@ -324,6 +324,25 @@ pub fn list(
     Ok(list)
 }
 
+/// Kill every still-running agent child.
+///
+/// Tauri's exit path reaches `std::process::exit`, which does not run
+/// destructors, so a `Drop` impl would not fire and long-lived children such as
+/// `ollama run` would outlive the app. The kill is issued under the lock and we
+/// deliberately do not `wait()`, since the reaper thread polls for the same
+/// lock and the process is terminating anyway.
+pub fn kill_all(state: Arc<Mutex<HashMap<String, AgentProcess>>>) {
+    let Ok(mut sessions) = state.lock() else {
+        return;
+    };
+    for proc in sessions.values_mut() {
+        if proc.status == "running" {
+            let _ = proc.child.kill();
+            proc.status = "stopped".to_string();
+        }
+    }
+}
+
 /// Remove a stopped/errored session from the session map.
 pub fn remove(
     session_id: &str,

--- a/apps/studio/src-tauri/src/ssh.rs
+++ b/apps/studio/src-tauri/src/ssh.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use base64::Engine;
 use base64::engine::general_purpose::{STANDARD as BASE64, STANDARD_NO_PAD};
 use russh::keys::{PublicKey, PublicKeyBase64};
-use russh::{ChannelId, ChannelMsg, ChannelWriteHalf, client};
+use russh::{ChannelId, ChannelMsg, ChannelReadHalf, ChannelWriteHalf, client};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::Emitter;

--- a/apps/studio/src-tauri/src/ssh.rs
+++ b/apps/studio/src-tauri/src/ssh.rs
@@ -265,6 +265,41 @@ impl client::Handler for SshClientHandler {
     }
 }
 
+// ── Output pump ──────────────────────────────────────────────────────────────
+
+/// A decoded message from a session's output stream.
+pub enum PumpEvent {
+    /// Base64-encoded bytes from the remote shell (stdout or stderr).
+    Output(String),
+    /// The remote side closed the channel.
+    Disconnected(String),
+}
+
+/// Drive a channel's read half to completion, handing each decoded message to
+/// `on_event`.
+///
+/// Takes the read half by value: nothing else can hold it, so a `wait()` parked
+/// on an idle prompt can never block a concurrent `data()` / `window_change()`
+/// on the write half. Keeping the two halves unshared is what makes the SSH
+/// terminal responsive while the remote shell is silent, so do not reintroduce
+/// a lock around either one.
+pub async fn pump_output<F: Fn(PumpEvent)>(mut read_half: ChannelReadHalf, on_event: F) {
+    loop {
+        match read_half.wait().await {
+            Some(ChannelMsg::Data { data }) | Some(ChannelMsg::ExtendedData { data, .. }) => {
+                on_event(PumpEvent::Output(BASE64.encode(&*data)));
+            }
+            Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
+                on_event(PumpEvent::Disconnected(
+                    "Connection closed by server".to_string(),
+                ));
+                break;
+            }
+            _ => {}
+        }
+    }
+}
+
 // ── Connect ──────────────────────────────────────────────────────────────────
 
 /// Connect to an SSH server, open a PTY and shell. Returns session ID.
@@ -340,7 +375,7 @@ pub async fn connect(
         .await
         .map_err(|e| format!("Shell request failed: {e}"))?;
 
-    let (mut read_half, write_half) = channel.split();
+    let (read_half, write_half) = channel.split();
     let channel = Arc::new(write_half);
 
     // Spawn a task to poll channel output and emit events.
@@ -348,43 +383,27 @@ pub async fn connect(
     let ah = app_handle.clone();
     let state_clone = ssh_state.clone();
     tokio::spawn(async move {
-        loop {
-            let msg = read_half.wait().await;
-
-            match msg {
-                Some(ChannelMsg::Data { data }) => {
-                    let encoded = BASE64.encode(&*data);
-                    let _ = ah.emit(
-                        "ssh_output",
-                        SshOutputEvent {
-                            session_id: sid.clone(),
-                            data: encoded,
-                        },
-                    );
-                }
-                Some(ChannelMsg::ExtendedData { data, .. }) => {
-                    let encoded = BASE64.encode(&*data);
-                    let _ = ah.emit(
-                        "ssh_output",
-                        SshOutputEvent {
-                            session_id: sid.clone(),
-                            data: encoded,
-                        },
-                    );
-                }
-                Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
-                    let _ = ah.emit(
-                        "ssh_disconnect",
-                        SshDisconnectEvent {
-                            session_id: sid.clone(),
-                            reason: "Connection closed by server".to_string(),
-                        },
-                    );
-                    break;
-                }
-                _ => {}
+        pump_output(read_half, |event| match event {
+            PumpEvent::Output(data) => {
+                let _ = ah.emit(
+                    "ssh_output",
+                    SshOutputEvent {
+                        session_id: sid.clone(),
+                        data,
+                    },
+                );
             }
-        }
+            PumpEvent::Disconnected(reason) => {
+                let _ = ah.emit(
+                    "ssh_disconnect",
+                    SshDisconnectEvent {
+                        session_id: sid.clone(),
+                        reason,
+                    },
+                );
+            }
+        })
+        .await;
 
         // Clean up session from state
         let mut sessions = state_clone.lock().await;

--- a/apps/studio/src-tauri/src/ssh.rs
+++ b/apps/studio/src-tauri/src/ssh.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use base64::Engine;
 use base64::engine::general_purpose::{STANDARD as BASE64, STANDARD_NO_PAD};
 use russh::keys::{PublicKey, PublicKeyBase64};
-use russh::{ChannelId, ChannelMsg, client};
+use russh::{ChannelId, ChannelMsg, ChannelWriteHalf, client};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::Emitter;
@@ -58,9 +58,13 @@ pub struct SshHostKeyEvent {
 }
 
 /// Holds a single SSH session's handle and channel.
+///
+/// Only the channel's write half is stored. The read half is owned exclusively
+/// by that session's output task, so a `wait()` parked on an idle prompt can
+/// never block a concurrent `data()` or `window_change()`.
 pub struct SshSession {
     pub handle: client::Handle<SshClientHandler>,
-    pub channel: Arc<Mutex<Option<russh::Channel<client::Msg>>>>,
+    pub channel: Arc<ChannelWriteHalf<client::Msg>>,
 }
 
 /// Managed Tauri state for SSH sessions.
@@ -336,23 +340,16 @@ pub async fn connect(
         .await
         .map_err(|e| format!("Shell request failed: {e}"))?;
 
-    let channel = Arc::new(Mutex::new(Some(channel)));
+    let (mut read_half, write_half) = channel.split();
+    let channel = Arc::new(write_half);
 
     // Spawn a task to poll channel output and emit events.
     let sid = session_id.clone();
     let ah = app_handle.clone();
     let state_clone = ssh_state.clone();
-    let channel_clone = channel.clone();
     tokio::spawn(async move {
         loop {
-            // Lock briefly to call wait(), then release
-            let msg = {
-                let mut guard = channel_clone.lock().await;
-                match guard.as_mut() {
-                    Some(ch) => ch.wait().await,
-                    None => break,
-                }
-            };
+            let msg = read_half.wait().await;
 
             match msg {
                 Some(ChannelMsg::Data { data }) => {

--- a/apps/studio/src-tauri/src/tray.rs
+++ b/apps/studio/src-tauri/src/tray.rs
@@ -9,8 +9,14 @@ use crate::state::AppState;
 pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     let menu = build_menu(app)?;
 
+    // A build without a bundled window icon must not take the whole app down at
+    // startup; a tray without an icon is still usable.
+    let Some(icon) = app.default_window_icon().cloned() else {
+        return Ok(());
+    };
+
     TrayIconBuilder::new()
-        .icon(app.default_window_icon().unwrap().clone())
+        .icon(icon)
         .tooltip("RevealUI Studio")
         .menu(&menu)
         // Right-click opens menu; left-click focuses the window.

--- a/apps/studio/src-tauri/src/tray.rs
+++ b/apps/studio/src-tauri/src/tray.rs
@@ -12,6 +12,7 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     // A build without a bundled window icon must not take the whole app down at
     // startup; a tray without an icon is still usable.
     let Some(icon) = app.default_window_icon().cloned() else {
+        eprintln!("warning: no bundled window icon; skipping tray icon setup");
         return Ok(());
     };
 

--- a/apps/studio/src-tauri/tests/ssh_output_pump.rs
+++ b/apps/studio/src-tauri/tests/ssh_output_pump.rs
@@ -1,0 +1,216 @@
+//! Regression test: a session parked at an idle prompt must not block writes.
+//!
+//! The SSH output task used to hold the channel mutex across `wait()`. A remote
+//! shell sitting silently at a prompt leaves `wait()` pending indefinitely, so
+//! the lock was never released and `ssh_send` / `ssh_resize` could not acquire
+//! it: the terminal silently ate every keystroke until the server spoke first.
+//!
+//! `ssh::pump_output` now takes the channel's read half by value, and the write
+//! half is shared separately, so no lock exists to contend on. This test pins
+//! that invariant against an in-process russh server that stays deliberately
+//! silent until it is written to.
+
+#![cfg(unix)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use russh::keys::PrivateKey;
+use russh::keys::ssh_key::private::Ed25519Keypair;
+use russh::server::{Auth, Msg, Server as _, Session};
+use russh::{Channel, ChannelId, client};
+use tokio::sync::mpsc;
+
+use studio_lib::ssh::{PumpEvent, pump_output};
+
+// ── A silent echo server ─────────────────────────────────────────────────────
+// Accepts any user, opens a session, and sends NOTHING until it receives data.
+// The silence is the point: it reproduces an idle shell prompt.
+
+#[derive(Clone)]
+struct SilentEchoServer;
+
+impl russh::server::Server for SilentEchoServer {
+    type Handler = SilentEchoHandler;
+    fn new_client(&mut self, _peer: Option<std::net::SocketAddr>) -> SilentEchoHandler {
+        SilentEchoHandler
+    }
+}
+
+struct SilentEchoHandler;
+
+impl russh::server::Handler for SilentEchoHandler {
+    type Error = russh::Error;
+
+    async fn auth_none(&mut self, _user: &str) -> Result<Auth, Self::Error> {
+        Ok(Auth::Accept)
+    }
+
+    async fn channel_open_session(
+        &mut self,
+        _channel: Channel<Msg>,
+        _session: &mut Session,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+
+    async fn data(
+        &mut self,
+        channel: ChannelId,
+        data: &[u8],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        session.data(channel, data.to_vec())?;
+        Ok(())
+    }
+}
+
+// ── A client that trusts the throwaway host key ──────────────────────────────
+
+struct AcceptAnyKey;
+
+impl client::Handler for AcceptAnyKey {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        _key: &russh::keys::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+async fn start_server() -> u16 {
+    // A fixed seed keeps the throwaway host key deterministic and avoids
+    // depending on which rand_core version russh's key crate was built against.
+    let key = PrivateKey::from(Ed25519Keypair::from_seed(&[7u8; 32]));
+    let config = Arc::new(russh::server::Config {
+        keys: vec![key],
+        ..Default::default()
+    });
+
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+
+    tokio::spawn(async move {
+        let mut server = SilentEchoServer;
+        let _ = server.run_on_socket(config, &listener).await;
+    });
+
+    port
+}
+
+/// With the reader parked in `wait()` against a silent server, a write must
+/// still complete promptly, and its echo must come back through the pump.
+#[tokio::test]
+async fn idle_prompt_does_not_block_writes() {
+    let port = start_server().await;
+
+    let handle = client::connect(
+        Arc::new(client::Config::default()),
+        ("127.0.0.1", port),
+        AcceptAnyKey,
+    )
+    .await
+    .expect("connect");
+
+    let mut handle = handle;
+    assert!(
+        handle.authenticate_none("tester").await.expect("auth").success(),
+        "server should accept auth_none"
+    );
+
+    let channel = handle.channel_open_session().await.expect("open session");
+    channel
+        .request_pty(false, "xterm-256color", 80, 24, 0, 0, &[])
+        .await
+        .expect("pty");
+    channel.request_shell(false).await.expect("shell");
+
+    let (read_half, write_half) = channel.split();
+    let write_half = Arc::new(write_half);
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        pump_output(read_half, move |event| {
+            let _ = tx.send(event);
+        })
+        .await;
+    });
+
+    // Let the pump reach `wait()` and park there. The server is silent, so this
+    // is exactly the idle-prompt state that used to wedge the old lock.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // The write must not wait on the reader.
+    let sent = tokio::time::timeout(Duration::from_secs(3), write_half.data(&b"ping\n"[..])).await;
+    assert!(
+        sent.is_ok(),
+        "write blocked while the reader was parked at an idle prompt"
+    );
+    sent.unwrap().expect("data sent");
+
+    // And the echo must arrive back through the pump.
+    let echoed = tokio::time::timeout(Duration::from_secs(5), async {
+        while let Some(event) = rx.recv().await {
+            if let PumpEvent::Output(b64) = event {
+                return Some(b64);
+            }
+        }
+        None
+    })
+    .await
+    .expect("timed out waiting for echo")
+    .expect("pump closed before echoing");
+
+    use base64::Engine;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(echoed)
+        .expect("pump emits base64");
+    assert_eq!(decoded, b"ping\n");
+}
+
+/// A resize also must not block against a parked reader.
+#[tokio::test]
+async fn idle_prompt_does_not_block_resize() {
+    let port = start_server().await;
+
+    let mut handle = client::connect(
+        Arc::new(client::Config::default()),
+        ("127.0.0.1", port),
+        AcceptAnyKey,
+    )
+    .await
+    .expect("connect");
+
+    assert!(
+        handle.authenticate_none("tester").await.expect("auth").success(),
+        "server should accept auth_none"
+    );
+
+    let channel = handle.channel_open_session().await.expect("open session");
+    channel
+        .request_pty(false, "xterm-256color", 80, 24, 0, 0, &[])
+        .await
+        .expect("pty");
+    channel.request_shell(false).await.expect("shell");
+
+    let (read_half, write_half) = channel.split();
+    let write_half = Arc::new(write_half);
+
+    tokio::spawn(async move {
+        pump_output(read_half, |_| {}).await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let resized =
+        tokio::time::timeout(Duration::from_secs(3), write_half.window_change(120, 40, 0, 0)).await;
+    assert!(
+        resized.is_ok(),
+        "resize blocked while the reader was parked at an idle prompt"
+    );
+    resized.unwrap().expect("window_change sent");
+}

--- a/apps/studio/src/__tests__/lib/deploy.test.ts
+++ b/apps/studio/src/__tests__/lib/deploy.test.ts
@@ -46,8 +46,8 @@ describe('deploy bridge (browser mocks)', () => {
     await expect(vercelSetEnv('t', 'p', 'k', 'v')).resolves.toBeUndefined();
   });
 
-  it('vercelDeploy returns mock ID', async () => {
-    expect(await vercelDeploy('t', 'p')).toBe('mock-deploy-id');
+  it('vercelDeploy returns an obviously-fake deploy id', async () => {
+    expect(await vercelDeploy('t', 'p')).toBe('MOCK_DEPLOY_ID_DO_NOT_USE');
   });
 
   it('vercelGetDeployment returns READY state with deployment ID', async () => {

--- a/apps/studio/src/components/agent/SpawnerPanel.tsx
+++ b/apps/studio/src/components/agent/SpawnerPanel.tsx
@@ -8,11 +8,29 @@
 import { useRef, useState } from 'react';
 import { useSpawner } from '../../hooks/use-spawner';
 import type { AgentBackend } from '../../types';
+import ConfirmDialog from '../ui/ConfirmDialog';
+
+interface PendingAction {
+  kind: 'stop' | 'remove';
+  id: string;
+  name: string;
+}
 
 export default function SpawnerPanel() {
   const { sessions, output, error, spawn, stop, remove } = useSpawner();
   const [showSpawn, setShowSpawn] = useState(false);
   const [selectedSession, setSelectedSession] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+
+  function handleConfirmAction(): void {
+    if (pendingAction === null) return;
+    if (pendingAction.kind === 'stop') {
+      void stop(pendingAction.id);
+    } else {
+      void remove(pendingAction.id);
+    }
+    setPendingAction(null);
+  }
 
   return (
     <div className="mt-4">
@@ -86,7 +104,7 @@ export default function SpawnerPanel() {
               {s.status === 'running' ? (
                 <button
                   type="button"
-                  onClick={() => void stop(s.id)}
+                  onClick={() => setPendingAction({ kind: 'stop', id: s.id, name: s.name })}
                   className="rounded bg-error-subtle px-2 py-0.5 text-[10px] text-error transition-colors hover:bg-error-subtle/70"
                 >
                   Stop
@@ -94,7 +112,7 @@ export default function SpawnerPanel() {
               ) : (
                 <button
                   type="button"
-                  onClick={() => void remove(s.id)}
+                  onClick={() => setPendingAction({ kind: 'remove', id: s.id, name: s.name })}
                   className="rounded bg-surface-2 px-2 py-0.5 text-[10px] text-fg-muted transition-colors hover:bg-surface-3"
                 >
                   Remove
@@ -113,6 +131,27 @@ export default function SpawnerPanel() {
       {sessions.length === 0 && !showSpawn ? (
         <p className="px-2 py-4 text-center text-[11px] text-fg-subtle">No local agents running</p>
       ) : null}
+
+      <ConfirmDialog
+        open={pendingAction !== null}
+        title={pendingAction?.kind === 'stop' ? 'Stop agent' : 'Remove agent'}
+        body={
+          pendingAction?.kind === 'stop' ? (
+            <>
+              Stop the agent session <strong className="text-fg">{pendingAction.name}</strong>?
+            </>
+          ) : (
+            <>
+              Remove the agent session <strong className="text-fg">{pendingAction?.name}</strong>?
+              It will disappear from this list.
+            </>
+          )
+        }
+        affectedItems={pendingAction ? [pendingAction.id] : undefined}
+        confirmLabel={pendingAction?.kind === 'stop' ? 'Stop' : 'Remove'}
+        onConfirm={handleConfirmAction}
+        onClose={() => setPendingAction(null)}
+      />
     </div>
   );
 }

--- a/apps/studio/src/components/terminal/ConnectForm.tsx
+++ b/apps/studio/src/components/terminal/ConnectForm.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { sshBookmarkDelete, sshBookmarkList, sshBookmarkSave } from '../../lib/invoke';
 import type { SshAuth, SshBookmark, SshConnectParams } from '../../types';
 import Button from '../ui/Button';
+import ConfirmDialog from '../ui/ConfirmDialog';
 import Input from '../ui/Input';
 
 interface ConnectFormProps {
@@ -22,6 +23,7 @@ export default function ConnectForm({ onConnect, connecting }: ConnectFormProps)
   const [passphrase, setPassphrase] = useState('');
   const [bookmarks, setBookmarks] = useState<SshBookmark[]>([]);
   const [showBookmarks, setShowBookmarks] = useState(true);
+  const [pendingDeleteBookmark, setPendingDeleteBookmark] = useState<SshBookmark | null>(null);
 
   const loadBookmarks = useCallback(async () => {
     try {
@@ -112,7 +114,7 @@ export default function ConnectForm({ onConnect, connecting }: ConnectFormProps)
                 </button>
                 <button
                   type="button"
-                  onClick={() => handleDeleteBookmark(b.id)}
+                  onClick={() => setPendingDeleteBookmark(b)}
                   className="ml-2 text-xs text-fg-subtle opacity-0 transition-opacity hover:text-error group-hover:opacity-100"
                 >
                   remove
@@ -262,6 +264,24 @@ export default function ConnectForm({ onConnect, connecting }: ConnectFormProps)
           </div>
         </form>
       )}
+
+      <ConfirmDialog
+        open={pendingDeleteBookmark !== null}
+        title="Remove connection"
+        body={
+          <>
+            Remove the saved connection{' '}
+            <span className="font-mono text-fg">{pendingDeleteBookmark?.label}</span>?
+          </>
+        }
+        affectedItems={pendingDeleteBookmark ? [pendingDeleteBookmark.label] : undefined}
+        confirmLabel="Remove"
+        onConfirm={() => {
+          if (pendingDeleteBookmark) void handleDeleteBookmark(pendingDeleteBookmark.id);
+          setPendingDeleteBookmark(null);
+        }}
+        onClose={() => setPendingDeleteBookmark(null)}
+      />
     </div>
   );
 }

--- a/apps/studio/src/hooks/use-auth.ts
+++ b/apps/studio/src/hooks/use-auth.ts
@@ -172,38 +172,42 @@ export function useAuth(apiUrl: string, localMode = false): AuthContextValue {
     const refreshAt = expiresMs - 7 * 24 * 60 * 60 * 1000; // 7 days before expiry
     const delay = refreshAt - Date.now();
 
-    if (delay <= 0) {
-      // Already within refresh window — refresh now
-      refreshToken(apiUrl, tokenRef.current)
+    // A rejected/expired token (HttpError kind "client") means the refresh
+    // was explicitly denied — the stored token can't be trusted, so sign the
+    // user out with an actionable message. A network/server/parse failure
+    // means the API just couldn't be reached; the existing offline session
+    // (see the mount-time effect above) is preserved instead.
+    function performRefresh(): void {
+      const token = tokenRef.current;
+      if (!token) return;
+      refreshToken(apiUrl, token)
         .then(async (res) => {
           if (res.success && res.token) {
             tokenRef.current = res.token;
             await saveToken(res.token);
             setTokenExpiresAt(res.expiresAt ?? null);
+            return;
+          }
+          if (res.kind === 'client') {
+            tokenRef.current = null;
+            await clearToken();
+            setUser(null);
+            setTokenExpiresAt(null);
+            setStep('email');
+            setError('Your session could not be renewed. Please sign in again.');
           }
         })
         .catch(() => {
-          /* best-effort refresh */
+          /* API unreachable — best-effort refresh, keep offline access */
         });
+    }
+
+    if (delay <= 0) {
+      performRefresh();
       return;
     }
 
-    const timer = setTimeout(() => {
-      if (tokenRef.current) {
-        refreshToken(apiUrl, tokenRef.current)
-          .then(async (res) => {
-            if (res.success && res.token) {
-              tokenRef.current = res.token;
-              await saveToken(res.token);
-              setTokenExpiresAt(res.expiresAt ?? null);
-            }
-          })
-          .catch(() => {
-            /* best-effort refresh */
-          });
-      }
-    }, delay);
-
+    const timer = setTimeout(performRefresh, delay);
     return () => clearTimeout(timer);
   }, [step, tokenExpiresAt, apiUrl]);
 

--- a/apps/studio/src/lib/auth-api.ts
+++ b/apps/studio/src/lib/auth-api.ts
@@ -5,7 +5,7 @@
  * for device-based OTP authentication.
  */
 
-import { HttpError, httpRequest } from './http';
+import { HttpError, type HttpErrorKind, httpRequest } from './http';
 
 // ── Response types ──────────────────────────────────────────────────────────
 
@@ -33,6 +33,8 @@ export interface RefreshResponse {
   token?: string;
   expiresAt?: string;
   error?: string;
+  /** Categorized failure reason, set only when `success` is false. */
+  kind?: HttpErrorKind;
 }
 
 export interface StatusResponse {
@@ -138,12 +140,26 @@ export async function verifyDevice(
 
 /**
  * Rotate the bearer token. Returns a new token.
+ *
+ * On failure, `kind` carries the {@link HttpError} category so callers can
+ * distinguish a rejected/expired token (`client`) — which should sign the
+ * user out — from a transient network or server failure, which should not.
  */
 export async function refreshToken(apiUrl: string, token: string): Promise<RefreshResponse> {
-  return requestResult<RefreshResponse>(apiUrl, '/refresh', {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  try {
+    return await httpRequest<RefreshResponse>(
+      endpoint(apiUrl, '/refresh'),
+      jsonInit({
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    );
+  } catch (err) {
+    if (err instanceof HttpError) {
+      return { success: false, error: err.message, kind: err.kind };
+    }
+    throw err;
+  }
 }
 
 /**

--- a/apps/studio/src/lib/config.ts
+++ b/apps/studio/src/lib/config.ts
@@ -1,5 +1,6 @@
 import { invoke as tauriInvoke } from '@tauri-apps/api/core';
 import type { StudioConfig } from '../types';
+import { markDegraded } from './degraded-mode';
 
 function isTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
@@ -17,6 +18,7 @@ let cachedConfig: StudioConfig | null = null;
 
 export async function getConfig(): Promise<StudioConfig> {
   if (!isTauri()) {
+    markDegraded('Demo mode. Settings are not persisted, they reset on reload.');
     return cachedConfig ?? { ...DEFAULT_CONFIG };
   }
   const config = await tauriInvoke<StudioConfig>('get_config');
@@ -26,7 +28,10 @@ export async function getConfig(): Promise<StudioConfig> {
 
 export async function setConfig(config: StudioConfig): Promise<void> {
   cachedConfig = config;
-  if (!isTauri()) return;
+  if (!isTauri()) {
+    markDegraded('Demo mode. Settings are not persisted, they reset on reload.');
+    return;
+  }
   await tauriInvoke<void>('set_config', { config });
 }
 

--- a/apps/studio/src/lib/degraded-mode.ts
+++ b/apps/studio/src/lib/degraded-mode.ts
@@ -23,7 +23,7 @@ function isTauri(): boolean {
 }
 
 const BROWSER_REASON =
-  'Demo data — not connected to a real system (running outside the desktop app).';
+  'Demo data. Not connected to a real system (running outside the desktop app).';
 
 export interface DegradedState {
   degraded: boolean;

--- a/apps/studio/src/lib/deploy.ts
+++ b/apps/studio/src/lib/deploy.ts
@@ -45,7 +45,10 @@ export async function vercelSetEnv(
 }
 
 export async function vercelDeploy(token: string, projectId: string): Promise<string> {
-  if (!isTauri()) return 'mock-deploy-id';
+  if (!isTauri()) {
+    markDegraded('Demo mode. No deployment actually ran, this deploy id is a fake placeholder.');
+    return 'MOCK_DEPLOY_ID_DO_NOT_USE';
+  }
   return tauriInvoke<string>('vercel_deploy', { token, projectId });
 }
 
@@ -54,6 +57,7 @@ export async function vercelGetDeployment(
   deploymentId: string,
 ): Promise<VercelDeployment> {
   if (!isTauri()) {
+    markDegraded('Demo mode. This deployment status is fake, nothing is actually live.');
     return {
       uid: deploymentId,
       url: 'mock.vercel.app',

--- a/apps/studio/src/lib/deploy.ts
+++ b/apps/studio/src/lib/deploy.ts
@@ -140,7 +140,7 @@ function mockSecret(label: string, length: number): string {
 
 export async function generateSecret(length: number): Promise<string> {
   if (!isTauri()) {
-    markDegraded('Demo mode — generated secrets are fake placeholders, not real keys.');
+    markDegraded('Demo mode. Generated secrets are fake placeholders, not real keys.');
     return mockSecret('SECRET', length);
   }
   return tauriInvoke<string>('generate_secret', { length });
@@ -148,7 +148,7 @@ export async function generateSecret(length: number): Promise<string> {
 
 export async function generateKek(): Promise<string> {
   if (!isTauri()) {
-    markDegraded('Demo mode — generated secrets are fake placeholders, not real keys.');
+    markDegraded('Demo mode. Generated secrets are fake placeholders, not real keys.');
     return mockSecret('KEK', 64);
   }
   return tauriInvoke<string>('generate_kek');
@@ -156,7 +156,7 @@ export async function generateKek(): Promise<string> {
 
 export async function generateRsaKeypair(): Promise<[string, string]> {
   if (!isTauri()) {
-    markDegraded('Demo mode — generated secrets are fake placeholders, not real keys.');
+    markDegraded('Demo mode. Generated secrets are fake placeholders, not real keys.');
     return ['MOCK_PRIVATE_KEY_DO_NOT_USE', 'MOCK_PUBLIC_KEY_DO_NOT_USE'];
   }
   return tauriInvoke<[string, string]>('generate_rsa_keypair');

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -422,6 +422,8 @@ export async function pairWithDaemon(daemonUrl: string, code: string): Promise<s
 
 let rpcId = 1;
 
+const HTTP_RPC_TIMEOUT_MS = 30_000;
+
 /** Make a JSON-RPC call to the daemon's HTTP gateway */
 async function httpRpc<T>(method: string, params: Record<string, unknown>): Promise<T> {
   const url = getDaemonUrl();
@@ -431,11 +433,25 @@ async function httpRpc<T>(method: string, params: Record<string, unknown>): Prom
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(`${url}/rpc`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ jsonrpc: '2.0', id: rpcId++, method, params }),
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), HTTP_RPC_TIMEOUT_MS);
+
+  let res: Response;
+  try {
+    res = await fetch(`${url}/rpc`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ jsonrpc: '2.0', id: rpcId++, method, params }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new Error('The daemon did not respond in time.');
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 
   if (res.status === 401 || res.status === 403) {
     throw new Error('Authentication required — pair with daemon first');

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -454,7 +454,7 @@ async function httpRpc<T>(method: string, params: Record<string, unknown>): Prom
   }
 
   if (res.status === 401 || res.status === 403) {
-    throw new Error('Authentication required — pair with daemon first');
+    throw new Error('Authentication required. Pair with the daemon first.');
   }
   if (!res.ok) {
     throw new Error(`HTTP ${res.status}`);


### PR DESCRIPTION
Makes Studio safe to use as a daily driver. Every item below was re-verified against current code before being changed; an internal audit had flagged a larger set, but most of it was already remediated and only these remained.

## Crashers and hangs

- **SSH terminal input hang.** The per-session output task held the channel mutex across `ch.wait().await`, so a session parked at an idle prompt pinned the lock and `ssh_send`/`ssh_resize` could never acquire it: typing simply stalled until the server spoke. The channel is now `split()` into a reader-owned `ChannelReadHalf` and a shared `Arc<ChannelWriteHalf>`. `data()`/`window_change()` take `&self`, so no lock is needed at all. The hang is now structurally impossible rather than narrowed.
- **`ssh_send`/`ssh_resize` also held the sessions map lock across their awaits**, so one slow send stalled every other session. They now clone the write half and release the map before awaiting.
- **Orphaned agent processes.** `AgentProcess.child` is a `std::process::Child`, which does not kill on drop, and the exit path reaches `std::process::exit`, which does not run destructors. Quitting Studio left long-lived children (notably `ollama run`) alive. Added `spawner::kill_all()`, invoked on `RunEvent::Exit`.
- **Daemon Stop could fail with no recourse.** `daemon_stop` sent only SIGTERM and, after a 10s window, returned an error while leaving a wedged daemon running. It now escalates to SIGKILL.
- **Tray icon.** `default_window_icon().unwrap()` would panic the app at startup in any build without a bundled icon. Now matched, with a warning.

## Destructive actions without confirmation

Routed the last two unguarded surfaces through the existing `ConfirmDialog` primitive (the other eight already used it):

- `SpawnerPanel` Stop / Remove agent.
- `ConnectForm` SSH bookmark remove.

## Honest failure surfaces

- **Silent token-refresh failure.** A failed refresh was swallowed, so a dead token surfaced later as opaque 401s. A rejected token (`HttpError.kind === 'client'`) now signs the user out with an actionable message. Network and server failures still preserve the deliberate offline-access path. `refreshToken` now returns the error category so callers can tell these apart.
- **`httpRpc` had no timeout**, so a hung remote daemon hung the UI forever. Added a 30s `AbortController` timeout.
- **Browser mode reported a fabricated deployment as real.** `vercelDeploy`/`vercelGetDeployment` now call `markDegraded(...)` and return an obviously fake `MOCK_DEPLOY_ID_DO_NOT_USE` id, matching the existing mock-secret sentinel style.
- **`config.ts` silently discarded settings on reload** in browser mode. It now marks degraded so the shell banner explains it.

Also removed em dashes from the degraded-mode and auth strings these changes touch, per the copy convention.

## Verification

- `cargo check` clean; `cargo test --lib` 83 passed (includes the `wait_for_exit_does_not_block_stop` regression test).
- Rust integration tests via the CI invocation (`--test harness_integration --test daemon_ctl_integration -- --test-threads=1`): 6 passed.
- `pnpm typecheck:studio` clean; `pnpm lint` clean (1 pre-existing warning, untouched file).
- `pnpm --filter studio test`: 541 passed across 63 files. `deploy.test.ts` updated for the new mock deploy id.

## Review note

This touches the auth token lifecycle (`use-auth.ts`, `auth-api.ts`) and the agent-spawn surface (`spawner.rs`). The pre-PR sensitivity self-check reports no coordinator gate, but given those surfaces I have not self-merged. The auth change is fail-closed: a rejected token now de-authenticates where it previously stayed "authenticated."

Windows `platform/windows.rs` still hardcodes the retired `E:\repos` path and runs `reset --hard` against it. It is dead code on Linux and macOS (`create_platform()` only builds `WindowsPlatform` under `cfg(target_os = "windows")`), so it is left for a separate change rather than folded in here.
