### PR TITLE
fix(daemon): authorize agent.spawn against a project grant (closes P4-IDENTITY TODO)

### DIFF
--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -332,14 +332,30 @@ describe('agent.spawn authorization (project grant)', () => {
     ).rejects.toThrow(/not registered/);
   });
 
-  it('rejects a cwd that escapes the authorized root via ..', async () => {
+  // `join()` normalizes the `..` away, so this string never contains one: the
+  // schema's safePath refinement cannot see it and the HANDLER's within() check
+  // is what rejects it. Pinned to that message so it cannot pass for some other
+  // reason (e.g. a missing directory).
+  it('rejects a cwd that resolves outside the authorized root', async () => {
     await expect(
       signedRpc(owner, 'agent.spawn', {
         command: 'bash',
         repoPath: repoRoot,
         cwd: join(repoRoot, '..'),
       }),
-    ).rejects.toThrow();
+    ).rejects.toThrow(/escapes project root/);
+  });
+
+  // The unnormalized form does carry a literal `..`, and is refused earlier, at
+  // schema validation. Both layers are exercised.
+  it('rejects a literal .. in cwd at the schema boundary', async () => {
+    await expect(
+      signedRpc(owner, 'agent.spawn', {
+        command: 'bash',
+        repoPath: repoRoot,
+        cwd: `${repoRoot}/../etc`,
+      }),
+    ).rejects.toThrow(/Invalid params/);
   });
 
   it('rejects a cwd symlink pointing outside the authorized root', async () => {

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -64,31 +64,17 @@ vi.mock('node-pty', () => ({
   }),
 }));
 
-// ---------------------------------------------------------------------------
-// Mock node:fs/promises stat so cwd validation passes for /tmp paths
-// ---------------------------------------------------------------------------
-
-vi.mock('node:fs/promises', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs/promises')>();
-  return {
-    ...actual,
-    stat: vi.fn(async (p: string) => {
-      if (p === '/tmp' || (p.startsWith('/tmp/') && !p.includes('nonexistent'))) {
-        return { isDirectory: () => true };
-      }
-      const err = Object.assign(new Error(`ENOENT: no such file or directory, stat '${p}'`), {
-        code: 'ENOENT',
-      });
-      throw err;
-    }),
-  };
-});
+// `node:fs/promises` is deliberately NOT mocked. agent.spawn now authorizes its
+// cwd against a registered project root, and that check rests on real inode
+// identity (dev/ino) and real symlink resolution. A stubbed `stat` would fake
+// the filesystem the security boundary is built on, so these tests use real
+// temp directories instead.
 
 // ---------------------------------------------------------------------------
 // Imports (after mock declarations)
 // ---------------------------------------------------------------------------
 
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -187,6 +173,10 @@ const other = makeSigner('spawn-test-other');
 let dataDir: string;
 let socketPath: string;
 let close: () => Promise<void>;
+/** A project root `owner` opens; agent.spawn now authorizes against it. */
+let repoRoot: string;
+/** A root owned by `other`, used to prove cross-agent spawn is refused. */
+let otherRoot: string;
 
 /** Signed RPC that throws on error (the common happy-path wrapper). */
 async function signedRpc(
@@ -229,6 +219,14 @@ beforeAll(async () => {
     });
     if (reg.error) throw new Error(`register ${s.agentId} failed: ${reg.error.message}`);
   }
+
+  // agent.spawn authorizes its cwd against a registered project root, so each
+  // identity opens one. `owner` drives the happy paths; `otherRoot` proves a
+  // signer cannot spawn into a root it neither owns nor was granted.
+  repoRoot = await mkdtemp(join(tmpdir(), 'revdev-spawn-root-'));
+  otherRoot = await mkdtemp(join(tmpdir(), 'revdev-spawn-otherroot-'));
+  await signedRpc(owner, 'project.open', { repoPath: repoRoot });
+  await signedRpc(other, 'project.open', { repoPath: otherRoot });
 });
 
 afterAll(async () => {
@@ -248,7 +246,10 @@ beforeEach(() => {
 
 describe('signature gate', () => {
   it('rejects an UNSIGNED agent.spawn (no Ed25519 envelope)', async () => {
-    const resp = await rpcFrame(socketPath, 'agent.spawn', { command: 'bash', cwd: '/tmp' });
+    const resp = await rpcFrame(socketPath, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+    });
     // The dispatch gate refuses a MUTATING_OR_CONTENT_METHODS call that is not
     // signature-verified — the unsigned host process can no longer exec as the
     // daemon UID. No processId is returned.
@@ -262,7 +263,7 @@ describe('agent.spawn', () => {
     const result = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
       args: ['-i'],
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string; pid: number };
 
     expect(result.processId).toMatch(
@@ -273,16 +274,97 @@ describe('agent.spawn', () => {
   });
 
   it('rejects when command is missing (schema validation)', async () => {
-    await expect(signedRpc(owner, 'agent.spawn', { cwd: '/tmp' })).rejects.toThrow();
+    await expect(signedRpc(owner, 'agent.spawn', { repoPath: repoRoot })).rejects.toThrow();
   });
 
   it('rejects a nonexistent cwd', async () => {
     await expect(
       signedRpc(owner, 'agent.spawn', {
         command: 'bash',
-        cwd: '/tmp/nonexistent/does-not-exist',
+        repoPath: repoRoot,
+        cwd: join(repoRoot, 'nonexistent', 'does-not-exist'),
       }),
     ).rejects.toThrow();
+  });
+});
+
+describe('agent.spawn authorization (project grant)', () => {
+  it('rejects when repoPath is absent — no implicit $HOME cwd', async () => {
+    await expect(signedRpc(owner, 'agent.spawn', { command: 'bash' })).rejects.toThrow();
+  });
+
+  it('rejects an unregistered repoPath', async () => {
+    const stray = await mkdtemp(join(tmpdir(), 'revdev-spawn-stray-'));
+    try {
+      await expect(
+        signedRpc(owner, 'agent.spawn', { command: 'bash', repoPath: stray }),
+      ).rejects.toThrow(/not registered/);
+    } finally {
+      await rm(stray, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects spawning into another agent's root", async () => {
+    await expect(
+      signedRpc(owner, 'agent.spawn', { command: 'bash', repoPath: otherRoot }),
+    ).rejects.toThrow(/not registered/);
+  });
+
+  it('allows spawning into another agent root once granted, and refuses after revoke', async () => {
+    await signedRpc(other, 'project.grant', {
+      repoPath: otherRoot,
+      granteeAgentId: owner.agentId,
+    });
+
+    const granted = (await signedRpc(owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: otherRoot,
+    })) as { processId: string };
+    expect(typeof granted.processId).toBe('string');
+
+    await signedRpc(other, 'project.revoke', {
+      repoPath: otherRoot,
+      granteeAgentId: owner.agentId,
+    });
+
+    await expect(
+      signedRpc(owner, 'agent.spawn', { command: 'bash', repoPath: otherRoot }),
+    ).rejects.toThrow(/not registered/);
+  });
+
+  it('rejects a cwd that escapes the authorized root via ..', async () => {
+    await expect(
+      signedRpc(owner, 'agent.spawn', {
+        command: 'bash',
+        repoPath: repoRoot,
+        cwd: join(repoRoot, '..'),
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects a cwd symlink pointing outside the authorized root', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'revdev-spawn-outside-'));
+    const link = join(repoRoot, 'escape-link');
+    try {
+      await symlink(outside, link, 'dir');
+      await expect(
+        signedRpc(owner, 'agent.spawn', { command: 'bash', repoPath: repoRoot, cwd: link }),
+      ).rejects.toThrow(/escapes project root/);
+    } finally {
+      await rm(link, { force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a real subdirectory of the authorized root', async () => {
+    const sub = join(repoRoot, 'packages', 'nested');
+    await mkdir(sub, { recursive: true });
+    const result = (await signedRpc(owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+      cwd: sub,
+    })) as { processId: string };
+    expect(typeof result.processId).toBe('string');
   });
 });
 
@@ -290,7 +372,7 @@ describe('agent.input', () => {
   it('writes data to the mocked pty', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     const result = await signedRpc(owner, 'agent.input', {
@@ -305,7 +387,7 @@ describe('agent.input', () => {
   it('rejects input to a process owned by another agent', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     await expect(
@@ -321,7 +403,7 @@ describe('agent.resize', () => {
   it('calls pty.resize with the given dimensions', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     const result = (await signedRpc(owner, 'agent.resize', {
@@ -339,7 +421,7 @@ describe('agent.resize', () => {
   it('rejects resize for a process owned by another agent', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     await expect(
@@ -356,7 +438,7 @@ describe('agent.stop', () => {
   it('kills the mocked pty and returns status killed', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     const result = (await signedRpc(owner, 'agent.stop', {
@@ -371,7 +453,7 @@ describe('agent.stop', () => {
   it('rejects stop for a process owned by another agent', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     await expect(
@@ -394,7 +476,7 @@ describe('agent.output', () => {
   it('returns buffered chunks and a cursor', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     _lastPty?._fireData('hello world\r\n');
@@ -422,7 +504,7 @@ describe('agent.output', () => {
   it('rejects output poll for a process owned by another agent', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     await expect(

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -280,6 +280,37 @@ async function resolveInRoot(
 }
 
 /**
+ * Authorize a working directory for a caller: the repo root must be registered
+ * and owned-or-granted by `callerAgentId`, and `cwdRaw` must resolve to a real
+ * directory at or beneath that root.
+ *
+ * Exported for `agent.spawn`, which forks a caller-supplied command as the
+ * daemon UID. Authentication (the Ed25519 signature gate) proves *who* is
+ * asking; this proves they are allowed to run it *there*. Both invariants stay
+ * in this module so the spawn surface cannot drift from the file surface.
+ */
+export async function requireDirInRoot(
+  repoPathRaw: string,
+  cwdRaw: string | undefined,
+  callerAgentId: string | null,
+): Promise<string> {
+  const repoReal = await requireRoot(repoPathRaw, callerAgentId);
+  if (cwdRaw === undefined || cwdRaw === '') return repoReal;
+
+  // mustExist=true realpaths the target itself, so a symlink pointing outside
+  // the root resolves before `within()` sees it.
+  const real = await resolveInRoot(repoReal, cwdRaw, true);
+  let s: Awaited<ReturnType<typeof stat>>;
+  try {
+    s = await stat(real);
+  } catch {
+    throw new Error(`cwd does not exist: ${cwdRaw}`);
+  }
+  if (!s.isDirectory()) throw new Error(`cwd is not a directory: ${cwdRaw}`);
+  return real;
+}
+
+/**
  * Lexical repo-relative path for a git pathspec argument. The repo root is
  * already a realpath'd registered root, and git itself confines pathspecs to
  * the work tree, so a lexical `..`/absolute-escape check is sufficient here

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -598,6 +598,15 @@ registerHandler('project.grant', async (params, _db, ctx) => {
   return { granted: granteeAgentId, root: entry.real };
 });
 
+/**
+ * Revoke a grantee's access to a root.
+ *
+ * NOT a kill-switch. This blocks FUTURE operations, including `agent.spawn`.
+ * PTY processes the grantee already spawned keep running: they are keyed to the
+ * spawning `ownerAgentId`, not to an ongoing grant, and survive until they exit
+ * or the grantee's session ends (see the eviction cascade above). To stop live
+ * work, end the grantee's session.
+ */
 registerHandler('project.revoke', async (params, _db, ctx) => {
   const repoPathRaw = requireStr(params.repoPath, 'repoPath');
   const granteeAgentId = requireStr(params.granteeAgentId, 'granteeAgentId');

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -15,6 +15,14 @@
  *
  * Authorization: agent.spawn additionally requires the signer to hold (own, or
  * have been granted) the project root its command will run in. See the handler.
+ *
+ * This is a least-privilege gate, NOT a sandbox. `command` and `args` are
+ * unconstrained, and buildSafeEnv still passes the operator's HOME and PATH, so
+ * an authorized caller runs arbitrary code as the daemon UID and can read
+ * ~/.age-identity, ~/.ssh, and the revvault store regardless of which cwd it was
+ * granted. The cwd check bounds where a process STARTS, not what it may touch.
+ * The missing control is a command allow-list; until that ships, the trust
+ * anchor deciding who may sign at all is what actually holds this surface.
  */
 
 import { randomUUID } from 'node:crypto';

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -9,13 +9,12 @@
  *   - Enforces per-agent ownership: only the spawning agent may send input,
  *     resize, or stop a process it owns
  *
- * P4-IDENTITY TODO: Once the "B6" identity lane ships its signature-gating
- * rewrite, add 'agent.spawn', 'agent.stop', 'agent.input', 'agent.resize',
- * and 'agent.output' to MUTATING_OR_CONTENT_METHODS in server.ts AND to
- * requires_signature() in signing.rs. Until then these methods accept
- * actorAgentId param auth (same posture as mail.send / files.reserve), which
- * is gated only by the 0600 socket boundary. The deferred grant model
- * (spawned-agent DID + project.grant) should be designed as part of that lane.
+ * Authentication: all five methods are in MUTATING_OR_CONTENT_METHODS and in
+ * signing.rs requires_signature(), so the dispatch gate binds ctx.agentId to a
+ * verified Ed25519 signer. The spoofable actorAgentId param auth is gone.
+ *
+ * Authorization: agent.spawn additionally requires the signer to hold (own, or
+ * have been granted) the project root its command will run in. See the handler.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -238,7 +237,11 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   if (!repoPath) {
     throw new Error('agent.spawn: missing repoPath (call project.open on the root first)');
   }
-  const cwd = await requireDirInRoot(repoPath, stringParam(params, 'cwd') || undefined, ownerAgentId);
+  const cwd = await requireDirInRoot(
+    repoPath,
+    stringParam(params, 'cwd') || undefined,
+    ownerAgentId,
+  );
 
   if (liveCountForAgent(ownerAgentId) >= MAX_PROCESSES_PER_AGENT) {
     throw new Error(

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -19,12 +19,12 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { stat } from 'node:fs/promises';
 import type { PGlite } from '@electric-sql/pglite';
 import { createLogger } from '@revealui/utils/logger';
 import type { IDisposable, IPty } from 'node-pty';
 import * as nodePty from 'node-pty';
 import { onAgentEnded } from './eviction.js';
+import { requireDirInRoot } from './filegit.js';
 import { registerHandler, type SocketContext } from './server.js';
 
 const log = createLogger({ service: 'revdev-daemon/spawn' });
@@ -204,11 +204,16 @@ function safeEnvRecord(v: unknown): Record<string, string> {
  * agent.spawn — fork a PTY child process and return processId + pid.
  *
  * Security:
- *   - cwd is validated to exist via stat() before passing to node-pty.
+ *   - Signature-gated: requireAgent() accepts only a verified Ed25519 signer,
+ *     never a caller-supplied actorAgentId.
+ *   - Authorized: `repoPath` must be a registered root the signer owns or was
+ *     granted, and `cwd` must resolve at or beneath it (requireDirInRoot).
+ *     There is no default cwd; a missing repoPath is a hard error.
  *   - env is built from a minimal baseline (see buildSafeEnv).
  *   - Per-agent concurrency is capped at MAX_PROCESSES_PER_AGENT.
- *   - P4-IDENTITY TODO: signature-gate once B6 ships; add to
- *     MUTATING_OR_CONTENT_METHODS and to signing.rs requires_signature().
+ *
+ * Still open: `command` itself is not constrained to an allow-list, so an
+ * authorized caller may run any binary within a root it holds.
  */
 registerHandler('agent.spawn', async (params, db, ctx) => {
   const ownerAgentId = requireAgent(ctx, params);
@@ -217,19 +222,23 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   if (!command) throw new Error('agent.spawn: missing command');
 
   const args = stringArrayParam(params, 'args');
-  const cwd = stringParam(params, 'cwd') || (process.env.HOME ?? '/tmp');
   const cols = positiveInt(params.cols, 80);
   const rows = positiveInt(params.rows, 24);
   const extraEnv = safeEnvRecord(params.env);
 
-  // Validate cwd exists and is a directory
-  try {
-    const s = await stat(cwd);
-    if (!s.isDirectory()) throw new Error(`agent.spawn: cwd is not a directory: ${cwd}`);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`agent.spawn: cwd not accessible: ${msg}`);
+  // Authorization. The signature gate above proves WHO is asking; this proves
+  // they may run a command THERE. `repoPath` must be a root the signer opened
+  // or was granted via project.grant, and `cwd` must resolve to a real
+  // directory at or beneath it.
+  //
+  // Fail closed: `repoPath` is required. The previous default silently fell
+  // back to $HOME, so any verified agent could fork a command as the daemon UID
+  // anywhere in the operator's home directory.
+  const repoPath = stringParam(params, 'repoPath');
+  if (!repoPath) {
+    throw new Error('agent.spawn: missing repoPath (call project.open on the root first)');
   }
+  const cwd = await requireDirInRoot(repoPath, stringParam(params, 'cwd') || undefined, ownerAgentId);
 
   if (liveCountForAgent(ownerAgentId) >= MAX_PROCESSES_PER_AGENT) {
     throw new Error(

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -500,18 +500,20 @@ export const schemas: Record<string, z.ZodType> = {
     .passthrough(),
 
   // -- Agent process spawning (P4) -------------------------------------------
-  // P4-IDENTITY TODO: once the B6 identity lane ships signature gating, add
-  // all five agent.* methods to MUTATING_OR_CONTENT_METHODS in server.ts and
-  // to requires_signature() in signing.rs. The grant model (spawned-agent DID
-  // + project.grant) is deferred to that lane.
+  // All five agent.* methods are signature-gated (MUTATING_OR_CONTENT_METHODS
+  // in server.ts, requires_signature() in signing.rs), and agent.spawn is
+  // additionally authorized against a project.grant on `repoPath`.
   'agent.spawn': z
     .object({
       command: z.string().min(1).max(MAX_PATH_LENGTH),
       args: z.array(z.string().max(MAX_PATH_LENGTH)).max(128).optional(),
       // Required: the registered project root the caller owns or was granted.
       // Without it the handler cannot authorize where the command runs.
-      repoPath: z.string().min(1).max(MAX_PATH_LENGTH),
-      cwd: z.string().max(MAX_PATH_LENGTH).optional(),
+      // `safePath` for symmetry with every other repoPath-taking method. The
+      // handler's requireDirInRoot is the load-bearing check; this is depth,
+      // and it rejects a `..` cwd before the handler ever resolves it.
+      repoPath: safePath,
+      cwd: safePath.optional(),
       cols: z.number().int().min(1).max(1000).optional(),
       rows: z.number().int().min(1).max(500).optional(),
       // Caller-supplied env overrides (merged onto a minimal safe baseline).

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -508,6 +508,9 @@ export const schemas: Record<string, z.ZodType> = {
     .object({
       command: z.string().min(1).max(MAX_PATH_LENGTH),
       args: z.array(z.string().max(MAX_PATH_LENGTH)).max(128).optional(),
+      // Required: the registered project root the caller owns or was granted.
+      // Without it the handler cannot authorize where the command runs.
+      repoPath: z.string().min(1).max(MAX_PATH_LENGTH),
       cwd: z.string().max(MAX_PATH_LENGTH).optional(),
       cols: z.number().int().min(1).max(1000).optional(),
       rows: z.number().int().min(1).max(500).optional(),


### PR DESCRIPTION
Closes the `P4-IDENTITY TODO` in `agent.spawn`: the handler forked a caller-supplied command as the daemon UID with no authorization at all.

## The hole

`agent.spawn` was already **authenticated**: the dispatch gate binds `ctx.agentId` to a verified Ed25519 signer, and `requireAgent()` refuses anything else. But it was never **authorized**. Any verified agent could exec any binary in any directory, and `cwd` defaulted to `process.env.HOME`:

```ts
const cwd = stringParam(params, 'cwd') || (process.env.HOME ?? '/tmp');
```

The only check was that the path existed and was a directory.

## The change

Authentication proves *who* is asking. This adds the missing half: proof they may run it *there*.

- New `requireDirInRoot(repoPath, cwd, callerAgentId)` in `filegit.ts`, composing the two primitives the file surface already relies on: `requireRoot()` (inode-keyed, owner-or-grantee, with an inode-reuse guard) and `resolveInRoot(..., mustExist=true)` (realpath + `within()`, so a symlink resolves before the containment check sees it). Both invariants stay in one module so the spawn surface cannot drift from the file surface.
- `agent.spawn` now requires `repoPath` and has **no default cwd**. A missing `repoPath` is a hard error, not a fallback to `$HOME`.
- `repoPath` is required in the Zod schema.

## Residual risk, stated plainly

`command` and `args` remain unconstrained, so an authorized caller can still run any binary, and a binary is free to ignore its cwd. This change does **not** sandbox execution. What it does is remove "any verified agent may exec anywhere by default" and replace it with "you may only spawn inside a root you opened or were granted." Command allow-listing is a separate, owner-gated design.

## Tests

The old suite mocked `node:fs/promises` so `stat` returned `{ isDirectory: () => true }` for any `/tmp` path. That mock is **deleted**: the new authorization rests on real inode identity and real symlink resolution, and a stubbed `stat` would fake exactly the filesystem the boundary is built on. The tests now use real temp directories.

Added adversarial cases, all against the real handler over a signed socket:

- missing `repoPath` is rejected (no implicit `$HOME`)
- an unregistered `repoPath` is rejected
- spawning into another agent's root is rejected
- a granted root is spawnable, and refused again after `project.revoke`
- a `cwd` escaping the root via `..` is rejected
- a `cwd` symlink pointing outside the root is rejected
- a real subdirectory of the root is accepted

`pnpm --filter @revdev/daemon test`: 548 passed across 27 files. `pnpm lint` clean, `pnpm typecheck` clean. The `signature-gate` and `adversarial-isolation` suites still pass unchanged.

## Breaking change, and why fail-closed is right

`repoPath` is now required. No live consumer regresses:

- `packages/bridge` and `apps/console` never call `agent.spawn`.
- Studio's desktop path spawns through the native Rust `spawner.rs`, not the daemon.
- Studio's browser+daemon method map (`apps/studio/src/lib/invoke.ts:341`) does route `agent_spawn -> agent.spawn`, but it sends `{name, backend, model, prompt}` and the daemon schema has always required `command`. That call already fails validation today, and the same map lists `agent.list` / `agent.remove`, which the daemon does not implement at all. Nothing that worked is broken.

Fail-closed is the correct posture for an exec surface: an unauthorized spawn should be refused, not defaulted.
