### PR TITLE
fix(daemon): session.end lets any unsigned peer kill another agent's PTYs

### DIFF
--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -520,6 +520,7 @@ mod tests {
         assert!(requires_signature("agent.input"));
         assert!(requires_signature("agent.resize"));
         assert!(requires_signature("agent.output"));
+        assert!(requires_signature("session.end"));
         assert!(!requires_signature("ping"));
         assert!(!requires_signature("session.list"));
     }

--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -84,6 +84,10 @@ pub fn requires_signature(method: &str) -> bool {
             | "agent.input"
             | "agent.resize"
             | "agent.output"
+            // session.end evicts the target's project roots and kills its PTYs.
+            // Signature-required so the daemon can self-scope it to the verified
+            // signer instead of a caller-supplied `sessionId`.
+            | "session.end"
     )
 }
 

--- a/packages/daemon/src/__tests__/adversarial-isolation.test.ts
+++ b/packages/daemon/src/__tests__/adversarial-isolation.test.ts
@@ -551,7 +551,12 @@ describe('adversarial agent isolation (B6 §6)', () => {
       await writeFile(anchor, `${anchorContent}${victimId}:${fpVictim}\n`);
 
       const rpcVictim = (method: string, params: Record<string, unknown>) =>
-        rpcFrame(socketPath, method, params, signFor(victimId, didVictim, fpVictim, kpVictim, method, params));
+        rpcFrame(
+          socketPath,
+          method,
+          params,
+          signFor(victimId, didVictim, fpVictim, kpVictim, method, params),
+        );
 
       try {
         await rpcFrame(socketPath, 'session.register', {
@@ -594,7 +599,12 @@ describe('adversarial agent isolation (B6 §6)', () => {
       await writeFile(anchor, `${anchorContent}${victimId}:${fpVictim}\n`);
 
       const rpcVictim = (method: string, params: Record<string, unknown>) =>
-        rpcFrame(socketPath, method, params, signFor(victimId, didVictim, fpVictim, kpVictim, method, params));
+        rpcFrame(
+          socketPath,
+          method,
+          params,
+          signFor(victimId, didVictim, fpVictim, kpVictim, method, params),
+        );
 
       try {
         await rpcFrame(socketPath, 'session.register', {

--- a/packages/daemon/src/__tests__/adversarial-isolation.test.ts
+++ b/packages/daemon/src/__tests__/adversarial-isolation.test.ts
@@ -536,6 +536,88 @@ describe('adversarial agent isolation (B6 §6)', () => {
         await rm(repo, { recursive: true, force: true });
       }
     });
+
+    it('an unsigned peer cannot end another agent’s session (no eviction, no kill)', async () => {
+      // The hole: session.end used to read `params.sessionId` verbatim while the
+      // identity gate was satisfied by any `actorAgentId` string. One unsigned
+      // call evicted the victim's roots and killed its PTYs.
+      const repo = await initRepo('iso-j-crossagent-');
+      const victimId = 'iso-j-victim-agent';
+      const kpVictim = generateAgentKeypair();
+      const fpVictim = computeFingerprint(kpVictim.publicKeyRaw);
+      const didVictim = formatDid(victimId, fpVictim);
+
+      const anchorContent = await readFile(anchor, 'utf8');
+      await writeFile(anchor, `${anchorContent}${victimId}:${fpVictim}\n`);
+
+      const rpcVictim = (method: string, params: Record<string, unknown>) =>
+        rpcFrame(socketPath, method, params, signFor(victimId, didVictim, fpVictim, kpVictim, method, params));
+
+      try {
+        await rpcFrame(socketPath, 'session.register', {
+          agentId: victimId,
+          agentName: victimId,
+          backend: 'studio',
+          publicKeyPem: kpVictim.publicKeyPem,
+        });
+        expect((await rpcVictim('project.open', { repoPath: repo })).error).toBeUndefined();
+
+        // The attack, verbatim: unsigned, `actorAgentId` to pass the identity
+        // gate, `sessionId` naming the victim.
+        const attack = await rpcFrame(socketPath, 'session.end', {
+          actorAgentId: 'iso-j-attacker',
+          sessionId: victimId,
+        });
+        expect(attack.error).toBeDefined();
+        expect(attack.result).toBeUndefined();
+
+        // And the victim's root is still owned: C still hits a conflict, which
+        // it would not if notifyAgentEnded had run.
+        const cAfter = await rpcC('project.open', { repoPath: repo });
+        expect(cAfter.error?.message).toContain('conflict');
+      } finally {
+        await rm(repo, { recursive: true, force: true });
+      }
+    });
+
+    it('a signed agent cannot end a different agent’s session', async () => {
+      // C is a verified signer, so it clears the signature gate. It still must
+      // not be able to name someone else as the target: session.end self-scopes
+      // to ctx.agentId and ignores params entirely.
+      const repo = await initRepo('iso-j-signedcross-');
+      const victimId = 'iso-j-victim2-agent';
+      const kpVictim = generateAgentKeypair();
+      const fpVictim = computeFingerprint(kpVictim.publicKeyRaw);
+      const didVictim = formatDid(victimId, fpVictim);
+
+      const anchorContent = await readFile(anchor, 'utf8');
+      await writeFile(anchor, `${anchorContent}${victimId}:${fpVictim}\n`);
+
+      const rpcVictim = (method: string, params: Record<string, unknown>) =>
+        rpcFrame(socketPath, method, params, signFor(victimId, didVictim, fpVictim, kpVictim, method, params));
+
+      try {
+        await rpcFrame(socketPath, 'session.register', {
+          agentId: victimId,
+          agentName: victimId,
+          backend: 'studio',
+          publicKeyPem: kpVictim.publicKeyPem,
+        });
+        expect((await rpcVictim('project.open', { repoPath: repo })).error).toBeUndefined();
+
+        // C signs, but names the victim. The call succeeds as C ending C, and
+        // the victim is untouched.
+        const res = await rpcC('session.end', { sessionId: victimId, agentId: victimId });
+        expect(res.error).toBeUndefined();
+        expect((res.result as { ended: string }).ended).not.toBe(victimId);
+
+        // Victim still owns its root.
+        const cAfter = await rpcC('project.open', { repoPath: repo });
+        expect(cAfter.error?.message).toContain('conflict');
+      } finally {
+        await rm(repo, { recursive: true, force: true });
+      }
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -387,11 +387,15 @@ describe('GAP-153: stale-session prune', () => {
       agentName: 'hard-delete-test',
       backend: 'test',
     });
-    await rpc(socketPath, 'session.end', {
-      actorAgentId: 'hard-delete-test',
-      sessionId: 'hard-delete-test',
-      summary: 'test end',
-    });
+    // session.end is signature-required and self-scopes to the signer, so it is
+    // signed as the session's own identity and passes no target.
+    const ender = await seedIdentity('hard-delete-test');
+    await signedRpc(
+      socketPath,
+      'session.end',
+      { summary: 'test end' },
+      { did: ender.did, fingerprint: ender.fingerprint, privateKeyPem: ender.privateKeyPem },
+    );
     await new Promise((r) => setTimeout(r, 1100));
 
     const result = (await rpc(socketPath, 'harness.prune', {

--- a/packages/daemon/src/__tests__/neon-sync.test.ts
+++ b/packages/daemon/src/__tests__/neon-sync.test.ts
@@ -16,9 +16,43 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { formatDid } from '@revdev/protocol/did';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  generateNonce,
+  hashParams,
+  serializeEnvelope,
+  signEnvelope,
+} from '../agent-identity-crypto.js';
 import { _resetForTesting, setNeonClientForTesting } from '../neon.js';
 import { startDaemon } from '../server.js';
+
+/**
+ * `session.end` is signature-required (it evicts roots and kills PTYs), so the
+ * test that exercises its Neon dual-write has to sign like a real client.
+ */
+function makeSigner(agentId: string) {
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid(agentId, fingerprint);
+  const sign = (method: string, params: Record<string, unknown>): string =>
+    serializeEnvelope(
+      signEnvelope(
+        {
+          did,
+          kid: fingerprint,
+          nonce: generateNonce(),
+          ts: Math.floor(Date.now() / 1000),
+          method,
+          paramsHash: hashParams(method, params),
+        },
+        kp.privateKeyPem,
+      ),
+    );
+  return { agentId, fingerprint, publicKeyPem: kp.publicKeyPem, sign };
+}
 
 function rpc(
   socketPath: string,

--- a/packages/daemon/src/__tests__/neon-sync.test.ts
+++ b/packages/daemon/src/__tests__/neon-sync.test.ts
@@ -94,6 +94,9 @@ interface RecordedCall {
   values: unknown[];
 }
 
+/** Client-owned identity used by the signature-required session.end test. */
+const ender = makeSigner('sync-test-4');
+
 let dataDir: string;
 let socketPath: string;
 let close: () => Promise<void>;

--- a/packages/daemon/src/__tests__/neon-sync.test.ts
+++ b/packages/daemon/src/__tests__/neon-sync.test.ts
@@ -219,18 +219,19 @@ describe('GAP-154: daemon → Neon dual-write wiring', () => {
   });
 
   it('session.end triggers UPDATE setting ended_at + status=ended + summary in metadata', async () => {
+    // Register the client-owned key so the daemon can verify the signature.
     await rpc(socketPath, 'session.register', {
-      agentId: 'sync-test-4',
-      agentName: 'sync-test-4',
+      agentId: ender.agentId,
+      agentName: ender.agentId,
       backend: 'test',
+      publicKeyPem: ender.publicKeyPem,
     });
     recordedCalls = [];
 
-    await rpc(socketPath, 'session.end', {
-      actorAgentId: 'sync-test-4',
-      sessionId: 'sync-test-4',
-      summary: 'all done',
-    });
+    // session.end is signature-required and self-scopes to the signer, so no
+    // sessionId is passed: the signer IS the target.
+    const endParams = { summary: 'all done' };
+    await rpc(socketPath, 'session.end', endParams, ender.sign('session.end', endParams));
 
     expect(recordedCalls.length).toBe(1);
     const [endRecord] = recordedCalls;

--- a/packages/daemon/src/__tests__/neon-sync.test.ts
+++ b/packages/daemon/src/__tests__/neon-sync.test.ts
@@ -24,11 +24,14 @@ function rpc(
   socketPath: string,
   method: string,
   params: Record<string, unknown> = {},
+  signature?: string,
 ): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const sock: Socket = connect(socketPath);
     let buf = '';
-    const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
+    const frame: Record<string, unknown> = { jsonrpc: '2.0', id: 1, method, params };
+    if (signature) frame['x-revdev-signature'] = signature;
+    const req = `${JSON.stringify(frame)}\n`;
     sock.on('connect', () => sock.write(req));
     sock.on('data', (d) => {
       buf += d.toString();

--- a/packages/daemon/src/__tests__/neon-sync.test.ts
+++ b/packages/daemon/src/__tests__/neon-sync.test.ts
@@ -12,7 +12,7 @@ import { vi } from 'vitest';
 
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/packages/daemon/src/__tests__/neon-sync.test.ts
+++ b/packages/daemon/src/__tests__/neon-sync.test.ts
@@ -107,8 +107,17 @@ beforeAll(async () => {
   setTestLicenseEnv(generateTestLicense('enterprise'));
   dataDir = await mkdtemp(join(tmpdir(), 'revdev-neon-'));
   socketPath = join(dataDir, 'harness.sock');
+  // Provision the signer's fingerprint so it can enroll a client-owned key.
+  const anchor = join(dataDir, 'trusted-client-fingerprint');
+  await writeFile(anchor, `${ender.agentId}:${ender.fingerprint}\n`);
   // Disable periodic prune so it doesn't touch the test DB unexpectedly.
-  const d = await startDaemon({ socketPath, dataDir, pruneIntervalMs: 0 });
+  const d = await startDaemon({
+    socketPath,
+    dataDir,
+    pruneIntervalMs: 0,
+    trustedClientFingerprintPath: anchor,
+    trustedAnchorRequireRootOwned: false,
+  });
   close = d.close;
 });
 

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -57,6 +57,9 @@ const SIGNED = [
   'agent.input',
   'agent.resize',
   'agent.output',
+  // session.end evicts the target's roots and kills its PTYs, and is self-scoped
+  // to the verified signer. Signature-required so the signer IS the target.
+  'session.end',
 ];
 
 // Only payload-free, repo-agnostic coordination methods stay signature-OPTIONAL.

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -209,6 +209,14 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   'agent.input',
   'agent.resize',
   'agent.output',
+  // session.end fans out to notifyAgentEnded, which evicts the target's project
+  // roots and kills every PTY it owns. It used to take a caller-supplied target
+  // and sat OUTSIDE this set, so any socket peer could end an arbitrary agent's
+  // session unsigned: the identity gate is satisfied by a bare `actorAgentId`
+  // string, while the handler read `sessionId`. Signature-REQUIRED so the target
+  // is the verified signer and nothing else. Cross-language contract: signing.rs
+  // requires_signature() must mark this too.
+  'session.end',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1028,9 +1028,21 @@ registerHandler('session.list', async (params, db) => {
 });
 
 registerHandler('session.end', async (params, db, ctx) => {
-  // Prefer caller's own session, but allow explicit override (e.g. admin cleanup).
-  const target = strOrNull(params.sessionId) ?? strOrNull(params.agentId) ?? ctx.agentId;
-  if (!target) throw new Error('No session to end');
+  // Self-scoped to the VERIFIED signer. session.end is in
+  // MUTATING_OR_CONTENT_METHODS, so the dispatch gate has already bound
+  // ctx.agentId via boundVia==='signature' before this runs; the check below is
+  // the defense-in-depth backstop, mirroring agent.spawn's requireAgent.
+  //
+  // The old `params.sessionId ?? params.agentId` override ("admin cleanup") had
+  // NO caller: harness.prune reaps aged sessions by calling notifyAgentEnded
+  // directly, and every real caller passes its own id. It existed only as the
+  // attack surface, so it is gone rather than gated behind an unused admin role.
+  if (ctx.boundVia !== 'signature' || !ctx.agentId) {
+    throw new Error(
+      'session.end requires a signed request (verified Ed25519 signature); unsigned or param-bound actor rejected',
+    );
+  }
+  const target = ctx.agentId;
   // Canonical: exitSummary (matches DB column `exit_summary`).
   // Compat alias: summary (for callers using shorter name).
   const exitSummary = strOrNull(params.exitSummary) ?? strOrNull(params.summary);


### PR DESCRIPTION
Closes the HIGH cross-agent eviction in GAP-288 work-step 4. This is reachable **unsigned, by any socket peer**, today.

## The bug

`session.end` (`server.ts:1022`) resolved its target as `params.sessionId ?? params.agentId ?? ctx.agentId`, and was **not** in `MUTATING_OR_CONTENT_METHODS`. The dispatch identity gate is satisfied by any bare `actorAgentId` string, while the handler read `sessionId`. So one unsigned call:

```
session.end { actorAgentId: "anything", sessionId: "<victim>" }
```

reaches `notifyAgentEnded(victim)`, which evicts the victim's registered project roots (`filegit.ts` `evictRootsForAgent`) and kills every PTY it owns (`spawn.ts` `onAgentEnded`).

Only signed, client-owned identities can own roots and PTYs, so the destructive payload only ever lands on exactly the identities that were supposed to be protected.

## The fix

- `session.end` added to `MUTATING_OR_CONTENT_METHODS`, and to `signing.rs requires_signature()` in lockstep (both drift tests updated).
- The handler now **self-scopes to the verified signer** (`ctx.agentId`, guaranteed `boundVia === 'signature'` by the dispatch gate) and ignores caller-supplied targets entirely.
- The `params.sessionId ?? params.agentId` override is **deleted, not gated behind an admin role**. It had no caller: `harness.prune` reaps aged sessions by calling `notifyAgentEnded` directly (`server.ts:273`), and every real caller passes its own id. It existed only as the attack surface.

## Two things GAP-288 got wrong

The gap file's step 4 is right about the mechanism and wrong about the reasoning, so recording it here.

1. **"Hooks can't sign, so adding this to the signed set would stop sessions being ended."** `~/.claude/hooks/stop.js:107` calls `session.end` on a one-shot unsigned socket with no `actorAgentId`, so it already returns `-32002` and the hook swallows it. The hook's call has been a no-op for some time, and row cleanup was never its job (the GAP-153 periodic prune does that). No new breakage: `-32002` before, `-32003` after.
2. **"Or gate a cross-agent override behind an explicit admin role."** There is no admin caller. Building the role would be YAGNI on an attack surface.

The real reason the signed-set route is correct is a consumer the gap never mentions: **Studio**. It is client-owned and auto-signs exactly the methods in `requires_signature` (`harness.rs:158`). Adding `session.end` there makes Studio sign it with **zero Studio code change**.

## How I know that, rather than assume it

My first attempt self-scoped via `requireVerifiedAgent` *without* adding `session.end` to the signed set, on the theory that it would preserve the unsigned hook call. `pnpm --filter @revdev/daemon test` passed 541/541. Then `cargo test --test harness_integration` failed:

```
session.end succeeds: "client-owned identity studio-… requires a signed request for this method"
```

That approach would have broken Studio's live "end session" path, and the daemon suite could never have caught it. Reverted and rebuilt along the route above.

## Tests

Two new adversarial regressions in `adversarial-isolation.test.ts` §6.j:

- an unsigned peer cannot end another agent's session, **and the victim's root is still owned afterward** (proving `notifyAgentEnded` never ran)
- a *signed* agent naming a different target ends only its own session; the victim is untouched

**Both were verified to fail against the vulnerable handler** and pass against the fix. A regression test that cannot fail is not a regression test.

Two existing tests (`neon-sync`, `coordination` prune) called `session.end` in exactly the vulnerable shape (`actorAgentId` + `sessionId`, unsigned). They now sign. Notably `coordination.test.ts:925` already contained the comment *"the session.end cross-agent hole must NOT be recreated"* — the codebase knew.

`pnpm --filter @revdev/daemon test`: 544 passed, 27 files. `cargo test --lib signing` (drift test) green. `harness_integration`, `daemon_ctl_integration`, `ssh_output_pump` green. `pnpm lint` and `pnpm typecheck` clean.

## Deliberately not included

- **`session.update`'s cross-agent `task`/`files` write** (`server.ts:1048`, same pattern). It is knowingly deferred in a code comment, and `coordination.test.ts` explicitly asserts a signed caller *can* update a peer's task while `state` self-scopes. That is intentional behavior with a test behind it, so changing it is a decision, not a cleanup. I tried it, broke that test, and reverted. Flagged for GAP-288 rather than changed unilaterally.
- **`events.log` attribution spoof** (`server.ts:1492`) — log attribution only, no capability. Same reasoning: flagged, not folded in.
- The **command allow-list** (GAP-288 work-step 2) remains behind its owner design gate.

## Review

This is an exec/identity surface and I authored it. The guardrail-2 checker flags it (`signing.rs`). Not self-merging; it needs a recorded verdict from someone who is not me.
