### PR TITLE
fix(daemon): signature-gate harness.prune + floor its thresholds (GAP-312)

### DIFF
--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -88,6 +88,13 @@ pub fn requires_signature(method: &str) -> bool {
             // Signature-required so the daemon can self-scope it to the verified
             // signer instead of a caller-supplied `sessionId`.
             | "session.end"
+            // harness.prune reaches the SAME eviction primitive as session.end,
+            // but fans it across every matched session rather than one. It was
+            // identity-exempt and unsigned, so one frame from any same-UID
+            // socket peer ended the whole fleet's sessions and killed every PTY
+            // (`staleDays: 0` selects `started_at < NOW()`). GAP-312.
+            // MUST mirror server.ts MUTATING_OR_CONTENT_METHODS.
+            | "harness.prune"
     )
 }
 
@@ -521,7 +528,12 @@ mod tests {
         assert!(requires_signature("agent.resize"));
         assert!(requires_signature("agent.output"));
         assert!(requires_signature("session.end"));
+        // GAP-312: same eviction primitive as session.end, fleet-wide fan-out.
+        assert!(requires_signature("harness.prune"));
         assert!(!requires_signature("ping"));
         assert!(!requires_signature("session.list"));
+        // harness.health is a read; it stays unsigned. Guards against a
+        // copy-paste that gates the wrong half of the harness.* surface.
+        assert!(!requires_signature("harness.health"));
     }
 }

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -344,36 +344,43 @@ describe('GAP-153: stale-session prune', () => {
     expect(typeof health.prune?.lastDeletedCount).toBe('number');
   });
 
+  // harness.prune is signature-required (GAP-312). These tests sign the call,
+  // and because the threshold is now floored at 1 day they age rows by
+  // BACKDATING `started_at` / `ended_at` through the _db handle rather than by
+  // passing a sub-day threshold and sleeping. Backdating is both correct (it is
+  // what a genuinely stale session looks like) and faster (no real-time waits,
+  // no flake).
+
   it('ages out a session whose age exceeds the stale threshold', async () => {
-    // Register a stable-id session, then wait briefly so its started_at
-    // is older than the threshold we'll pass to prune.
     await rpc(socketPath, 'session.register', {
       agentId: 'stale-test',
       agentName: 'stale-test',
       backend: 'test',
     });
 
-    // Sanity: row is currently active in session.list (which filters
-    // to ended_at IS NULL).
+    // Sanity: row is active in session.list (filters to ended_at IS NULL).
     const before = (await rpc(socketPath, 'session.list')) as {
       sessions: Array<{ id: string }>;
     };
     expect(before.sessions.find((s) => s.id === 'stale-test')).toBeDefined();
 
-    await new Promise((r) => setTimeout(r, 1100));
+    // Make it genuinely stale: started 10 days ago.
+    await db.query(
+      "UPDATE agent_sessions SET started_at = NOW() - INTERVAL '10 days' WHERE id = $1",
+      ['stale-test'],
+    );
 
-    // staleDays = 0.00001 → ≈ 0.86s. With the 1.1s sleep above, the
-    // session is past the threshold.
-    const result = (await rpc(socketPath, 'harness.prune', {
-      staleDays: 0.00001,
-      hardDeleteDays: 365,
-    })) as { aged: number; deleted: number };
+    const pruner = await seedIdentity('pruner-stale');
+    const result = (await signedRpc(
+      socketPath,
+      'harness.prune',
+      { staleDays: 7, hardDeleteDays: 365 },
+      { did: pruner.did, fingerprint: pruner.fingerprint, privateKeyPem: pruner.privateKeyPem },
+    )) as { aged: number; deleted: number };
     expect(result.aged).toBeGreaterThanOrEqual(1);
     expect(result.deleted).toBe(0);
 
-    // After prune, the row is no longer in session.list (proof its
-    // ended_at + exit_summary were populated by runPrune; session.list
-    // hides any row with ended_at IS NOT NULL).
+    // After prune the row leaves session.list (its ended_at was populated).
     const after = (await rpc(socketPath, 'session.list')) as {
       sessions: Array<{ id: string }>;
     };
@@ -381,14 +388,12 @@ describe('GAP-153: stale-session prune', () => {
   });
 
   it('hard-deletes a session ended longer than hardDeleteDays', async () => {
-    // Register, end, then prune with a tiny hardDeleteDays.
     await rpc(socketPath, 'session.register', {
       agentId: 'hard-delete-test',
       agentName: 'hard-delete-test',
       backend: 'test',
     });
-    // session.end is signature-required and self-scopes to the signer, so it is
-    // signed as the session's own identity and passes no target.
+    // session.end is signature-required and self-scopes to the signer.
     const ender = await seedIdentity('hard-delete-test');
     await signedRpc(
       socketPath,
@@ -396,12 +401,19 @@ describe('GAP-153: stale-session prune', () => {
       { summary: 'test end' },
       { did: ender.did, fingerprint: ender.fingerprint, privateKeyPem: ender.privateKeyPem },
     );
-    await new Promise((r) => setTimeout(r, 1100));
+    // Backdate the end so it is older than hardDeleteDays.
+    await db.query(
+      "UPDATE agent_sessions SET ended_at = NOW() - INTERVAL '40 days' WHERE id = $1",
+      ['hard-delete-test'],
+    );
 
-    const result = (await rpc(socketPath, 'harness.prune', {
-      staleDays: 365,
-      hardDeleteDays: 0.00001,
-    })) as { aged: number; deleted: number };
+    const pruner = await seedIdentity('pruner-hard');
+    const result = (await signedRpc(
+      socketPath,
+      'harness.prune',
+      { staleDays: 365, hardDeleteDays: 30 },
+      { did: pruner.did, fingerprint: pruner.fingerprint, privateKeyPem: pruner.privateKeyPem },
+    )) as { aged: number; deleted: number };
 
     expect(result.deleted).toBeGreaterThanOrEqual(1);
 
@@ -412,7 +424,13 @@ describe('GAP-153: stale-session prune', () => {
   });
 
   it('harness.health reports prune state after a prune run', async () => {
-    await rpc(socketPath, 'harness.prune', { staleDays: 365, hardDeleteDays: 365 });
+    const pruner = await seedIdentity('pruner-health');
+    await signedRpc(
+      socketPath,
+      'harness.prune',
+      { staleDays: 365, hardDeleteDays: 365 },
+      { did: pruner.did, fingerprint: pruner.fingerprint, privateKeyPem: pruner.privateKeyPem },
+    );
     const health = (await rpc(socketPath, 'harness.health')) as {
       prune: { lastRunAt: string | null; lastAgedCount: number; lastDeletedCount: number };
     };
@@ -423,23 +441,60 @@ describe('GAP-153: stale-session prune', () => {
     expect(health.prune.lastDeletedCount).toBe(0);
   });
 
-  it('clamps negative thresholds to zero (defensive)', async () => {
-    // staleDays=0 → "older than NOW" → matches every session with
-    // ended_at IS NULL. We need at least one such session to verify
-    // the clamp is wider than negative-would-be (which Postgres
-    // semantics handle the same way as 0 here, but the explicit
-    // clamp is what we're checking the call doesn't error on).
+  // GAP-312 adversarial isolation. The prior test here ("clamps negative
+  // thresholds to zero (defensive)") asserted the VULNERABILITY as intended:
+  // it fired an UNSIGNED prune with staleDays: -100, expected it to succeed,
+  // and expected it to age every unended session. That is exactly the
+  // fleet-wide kill switch. It is replaced by the two properties the fix must
+  // hold. Both were shown red against the pre-fix handler before landing.
+
+  it('rejects an UNSIGNED harness.prune and evicts nothing (GAP-312)', async () => {
+    // A live session the attacker would try to reap.
     await rpc(socketPath, 'session.register', {
-      agentId: 'clamp-test',
-      agentName: 'clamp-test',
+      agentId: 'victim-unsigned',
+      agentName: 'victim-unsigned',
       backend: 'test',
     });
-    const result = (await rpc(socketPath, 'harness.prune', {
-      staleDays: -100,
-      hardDeleteDays: 365,
-    })) as { aged: number };
-    // Negative was clamped to 0 → matches all unended sessions.
-    expect(result.aged).toBeGreaterThanOrEqual(1);
+
+    // A valid-schema threshold, so this isolates the SIGNATURE gate rather than
+    // the floor: an unsigned caller is rejected with -32003 before the handler.
+    // (The staleDays: 0 exploit frame is covered by the floor test below, where
+    // the schema rejects it with -32602 first.)
+    await expect(
+      rpc(socketPath, 'harness.prune', { staleDays: 7, hardDeleteDays: 30 }),
+    ).rejects.toThrow(/-32003|[Ss]ignature required/);
+
+    // The victim is untouched: still active in session.list.
+    const listing = (await rpc(socketPath, 'session.list')) as {
+      sessions: Array<{ id: string }>;
+    };
+    expect(listing.sessions.find((s) => s.id === 'victim-unsigned')).toBeDefined();
+  });
+
+  it('rejects a SIGNED harness.prune with a sub-day threshold (GAP-312 floor)', async () => {
+    await rpc(socketPath, 'session.register', {
+      agentId: 'victim-floor',
+      agentName: 'victim-floor',
+      backend: 'test',
+    });
+
+    // Even a validly signed caller cannot select "every session": the schema
+    // floors staleDays at 1, so 0 (and any value < 1) is rejected as invalid
+    // params before the handler runs.
+    const pruner = await seedIdentity('pruner-floor');
+    await expect(
+      signedRpc(
+        socketPath,
+        'harness.prune',
+        { staleDays: 0 },
+        { did: pruner.did, fingerprint: pruner.fingerprint, privateKeyPem: pruner.privateKeyPem },
+      ),
+    ).rejects.toThrow();
+
+    const listing = (await rpc(socketPath, 'session.list')) as {
+      sessions: Array<{ id: string }>;
+    };
+    expect(listing.sessions.find((s) => s.id === 'victim-floor')).toBeDefined();
   });
 });
 

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -60,6 +60,9 @@ const SIGNED = [
   // session.end evicts the target's roots and kills its PTYs, and is self-scoped
   // to the verified signer. Signature-required so the signer IS the target.
   'session.end',
+  // harness.prune reaches the same eviction primitive as session.end but fans
+  // it across every matched session. Was unsigned + identity-exempt (GAP-312).
+  'harness.prune',
 ];
 
 // Only payload-free, repo-agnostic coordination methods stay signature-OPTIONAL.

--- a/packages/daemon/src/__tests__/signature-telemetry.test.ts
+++ b/packages/daemon/src/__tests__/signature-telemetry.test.ts
@@ -254,9 +254,14 @@ describe('P2 signature-status telemetry', () => {
        VALUES ($1, 'identity.signature_status', '{}'::jsonb, NOW())`,
       ['prune-fresh-marker'],
     );
-    // harness.prune is IDENTITY_EXEMPT — no signature needed. Default
-    // hardDeleteDays is 30, so the 40-day row is dropped, the fresh one kept.
-    await rpcFrame(socketPath, 'harness.prune', {});
+    // harness.prune is signature-required (GAP-312), so it must be signed.
+    // Default hardDeleteDays is 30, so the 40-day row is dropped, fresh kept.
+    await rpcFrame(
+      socketPath,
+      'harness.prune',
+      {},
+      sign('harness.prune', {}, did, fingerprint, kp.privateKeyPem),
+    );
     const remaining = await db.query<{ agent_id: string }>(
       `SELECT agent_id FROM events
         WHERE event_type = 'identity.signature_status'

--- a/packages/daemon/src/__tests__/validation.test.ts
+++ b/packages/daemon/src/__tests__/validation.test.ts
@@ -352,12 +352,27 @@ describe('harness.prune validation', () => {
     expect(validateParams('harness.prune', { staleDays: 7, hardDeleteDays: 30 }).valid).toBe(true);
   });
 
-  it('accepts fractional days (test helpers use these to avoid long sleeps)', () => {
-    expect(validateParams('harness.prune', { staleDays: 0.00001 }).valid).toBe(true);
+  it('accepts a fractional threshold >= 1 day', () => {
+    // The floor is 1, not "integer". A fractional day at or above the floor is
+    // harmless, and keeping the constraint minimal is intentional.
+    expect(validateParams('harness.prune', { staleDays: 1.5 }).valid).toBe(true);
   });
 
-  it('accepts negative days (handler defensive clamp is the safety net)', () => {
-    expect(validateParams('harness.prune', { staleDays: -1, hardDeleteDays: -7 }).valid).toBe(true);
+  it('REJECTS a sub-day staleDays (GAP-312 floor)', () => {
+    // staleDays: 0.00001 selected ≈0.86s of age, and staleDays: 0 selected
+    // every live session. The schema floors at 1 day so neither reaches the
+    // handler. Test helpers that once shrank time now backdate started_at.
+    expect(validateParams('harness.prune', { staleDays: 0.00001 }).valid).toBe(false);
+    expect(validateParams('harness.prune', { staleDays: 0 }).valid).toBe(false);
+  });
+
+  it('REJECTS negative days (GAP-312 floor; no clamp-to-zero)', () => {
+    // Previously accepted on the theory that the handler's Math.max(0, ...) was
+    // "the safety net". A zero floor is not a net: it is the fleet-wide
+    // selector. Rejected at the boundary now.
+    expect(validateParams('harness.prune', { staleDays: -1, hardDeleteDays: -7 }).valid).toBe(
+      false,
+    );
   });
 
   it('rejects non-numeric staleDays', () => {

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -114,7 +114,10 @@ const IDENTITY_EXEMPT = new Set([
   'session.attach',
   'session.list',
   'harness.health',
-  'harness.prune',
+  // `harness.prune` was here. It reaches notifyAgentEnded for EVERY matched
+  // session, so an identity-exempt, unsigned caller could evict every agent's
+  // roots and kill every agent's PTY with one frame. See GAP-312 and the
+  // MUTATING_OR_CONTENT_METHODS entry below.
   'inference.status',
   'inference.pull',
   'inference.start',
@@ -217,6 +220,19 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   // is the verified signer and nothing else. Cross-language contract: signing.rs
   // requires_signature() must mark this too.
   'session.end',
+  // harness.prune reaches the SAME eviction primitive as session.end
+  // (notifyAgentEnded → evictRootsForAgent + the spawn.ts PTY-kill hook), but
+  // fans it out across EVERY matched session rather than one. It was
+  // IDENTITY_EXEMPT and absent from this set, so a single unsigned frame from
+  // any same-UID socket peer ended the whole fleet's sessions and killed every
+  // PTY. `staleDays` is the amplifier: it had no floor, so 0 (or any negative,
+  // which clamped to 0) selected `started_at < NOW()`, i.e. all live sessions.
+  // Signature-REQUIRED, and the schema now floors both thresholds at 1 day so
+  // no caller can select "everything". The periodic internal sweep is
+  // unaffected: it calls runPrune directly, never through this RPC.
+  // Cross-language contract: signing.rs requires_signature() must mark this too.
+  // GAP-312. Sibling of the session.end fix (GAP-288, revdev#261).
+  'harness.prune',
 ]);
 
 // ---------------------------------------------------------------------------
@@ -261,11 +277,17 @@ async function runPrune(
   staleDays: number,
   hardDeleteDays: number,
 ): Promise<{ aged: number; deleted: number }> {
-  // Clamp non-negative + finite. Defends against bad caller input — a
-  // negative or NaN threshold would otherwise widen the WHERE clause to
-  // include all-or-no rows depending on Postgres semantics.
-  const stale = Number.isFinite(staleDays) ? Math.max(0, staleDays) : 7;
-  const hard = Number.isFinite(hardDeleteDays) ? Math.max(0, hardDeleteDays) : 30;
+  // Floor at ONE DAY, not zero. The previous Math.max(0, ...) let a caller pass
+  // staleDays: 0 (or any negative, which clamped to 0), turning the WHERE
+  // clause into `started_at < NOW()`, every live session, and fanning
+  // notifyAgentEnded across the whole fleet. A zero threshold has no
+  // legitimate meaning for a reaper of *stale* sessions. NaN still falls back
+  // to the defaults. This is the last line of defense: the RPC schema floors
+  // these too, and it also covers the env-var path
+  // (REVDEV_STALE_THRESHOLD_DAYS / REVDEV_HARD_DELETE_DAYS to cfg to here).
+  // GAP-312.
+  const stale = Number.isFinite(staleDays) ? Math.max(1, staleDays) : 7;
+  const hard = Number.isFinite(hardDeleteDays) ? Math.max(1, hardDeleteDays) : 30;
 
   // Parameterized interval avoids SQL injection on the days value.
   const aged = await db.query<{ id: string }>(
@@ -1591,11 +1613,23 @@ registerHandler('harness.health', async (_params, db) => {
   };
 });
 
-registerHandler('harness.prune', async (params, db) => {
-  // Allow ops / tests to run a prune pass on demand. Defaults match
-  // DAEMON_DEFAULTS so callers can invoke with no params.
-  const staleDays = num(params.staleDays, DAEMON_DEFAULTS.staleSessionDays);
-  const hardDeleteDays = num(params.hardDeleteDays, DAEMON_DEFAULTS.hardDeleteDays);
+registerHandler('harness.prune', async (params, db, ctx) => {
+  // Allow ops to run a prune pass on demand. Defaults match DAEMON_DEFAULTS so
+  // callers can invoke with no params.
+  //
+  // Signature-REQUIRED (GAP-312). This RPC reaches notifyAgentEnded for every
+  // matched session, so it must not be drivable by an unsigned socket peer.
+  // The dispatch gate already rejects unsigned callers before we get here;
+  // this is the defense-in-depth backstop, mirroring spawn.ts requireAgent.
+  if (ctx.boundVia !== 'signature' || !ctx.agentId) {
+    throw new Error(
+      'harness.prune requires a signed request (verified Ed25519 signature); unsigned or param-bound caller rejected',
+    );
+  }
+  // The schema floors both thresholds at 1 day. Re-floor here so a schema
+  // regression cannot hand runPrune a fleet-wide selector.
+  const staleDays = Math.max(1, num(params.staleDays, DAEMON_DEFAULTS.staleSessionDays));
+  const hardDeleteDays = Math.max(1, num(params.hardDeleteDays, DAEMON_DEFAULTS.hardDeleteDays));
   const result = await runPrune(db, staleDays, hardDeleteDays);
   return {
     aged: result.aged,

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -346,15 +346,25 @@ export const schemas: Record<string, z.ZodType> = {
   // `harness.prune`) previously bypassed `validateParams` because no
   // schema existed in the registry. Adding them here completes the
   // Option A direction (schemas as canonical) shipped by GAP-173 —
-  // every live handler should have a schema entry. Schemas are
-  // intentionally TYPE-ONLY (no integer / non-negative / upper-bound
-  // constraints on `staleDays` / `hardDeleteDays`): the prune handler
-  // already runs a defensive clamp via `Number.isFinite` + `Math.max(0,
-  // ...)`, AND the integration tests legitimately pass fractional days
-  // (e.g. `staleDays: 0.00001` ≈ 0.86s) to exercise the prune logic
-  // without 24h sleeps + negative days to verify the defensive clamp.
-  // Adding `int()` / `min(0)` here would break those tests and move
-  // safety enforcement away from the handler where it belongs.
+  // every live handler should have a schema entry.
+  //
+  // These schemas WERE intentionally type-only, delegating safety to the
+  // handler's `Math.max(0, ...)` clamp so that integration tests could pass
+  // fractional days (`staleDays: 0.00001`) and negative days. That reasoning
+  // was wrong, and GAP-312 is the bill: a clamp whose floor is ZERO is not a
+  // defense. `staleDays: 0` (and every negative, which clamped to 0) turns
+  // prune's WHERE clause into `started_at < NOW()`, every live session, and
+  // runPrune fans `notifyAgentEnded` across all of them, evicting each agent's
+  // project roots and killing each agent's PTYs. Fleet-wide, from one frame.
+  //
+  // The threshold is now floored at ONE DAY here, at the untrusted boundary,
+  // and again in runPrune. A reaper of *stale* sessions has no legitimate
+  // sub-day threshold. The tests that needed one were testing a time-based
+  // reaper by shrinking time; they now backdate `started_at` instead, which is
+  // both correct and faster (no sleeps, no flake).
+  //
+  // Not `.int()`: a fractional threshold >= 1 is harmless, and the floor is
+  // the security property. Keep the constraint minimal and legible.
   'harness.health': z
     .object({
       actorAgentId,
@@ -363,8 +373,8 @@ export const schemas: Record<string, z.ZodType> = {
 
   'harness.prune': z
     .object({
-      staleDays: z.number().optional(),
-      hardDeleteDays: z.number().optional(),
+      staleDays: z.number().min(1).optional(),
+      hardDeleteDays: z.number().min(1).optional(),
       actorAgentId,
     })
     .passthrough(),


### PR DESCRIPTION
Closes the fleet-wide eviction hole in `harness.prune` (GAP-312).

## The hole

`harness.prune` reaches the **same** eviction primitive as `session.end`, `notifyAgentEnded`, which fires `evictRootsForAgent` (`filegit.ts`) and the PTY-kill hook (`spawn.ts`). But it fans that across **every matched session**, not one. And it was:

- `IDENTITY_EXEMPT` (`server.ts`), so the dispatch identity gate returned early,
- absent from `MUTATING_OR_CONTENT_METHODS`, so the signature gate never fired, and
- schema-permissive: `staleDays` was `z.number().optional()`, the handler clamped only with `Math.max(0, staleDays)`.

So one unsigned frame from any same-UID socket peer (on a dev box: any dependency postinstall, any tool running as the operator):

```
{"jsonrpc":"2.0","id":1,"method":"harness.prune","params":{"staleDays":0}}
```

set the WHERE clause to `started_at < NOW()`, ended **every live session**, and killed **every PTY**. A negative `staleDays` clamped to 0 and did the same; `hardDeleteDays: 0` also hard-deleted the rows.

This is the exact blast radius revdev#261 closed for `session.end` (one victim), left open fleet-wide through the sibling door. The primitive, not the individual RPC, is the surface, which is why `session.end` alone was not enough.

## The fix

- **Signature-gate it.** Moved out of `IDENTITY_EXEMPT`, into `MUTATING_OR_CONTENT_METHODS`, mirrored in `signing.rs requires_signature()` (the cross-language contract the daemon set requires). Dispatch now rejects unsigned callers with `-32003` before the handler; the handler adds a `boundVia==='signature'` backstop, mirroring `spawn.ts requireAgent`.
- **Floor the thresholds at 1 day** in both the schema (`z.number().min(1)`) and `runPrune` (`Math.max(1, ...)`). A zero floor is not a defense, it is the fleet-wide selector. The `runPrune` floor also covers the env-var path (`REVDEV_STALE_THRESHOLD_DAYS` / `REVDEV_HARD_DELETE_DAYS`).
- The **periodic internal sweep is unaffected**: it calls `runPrune` directly (`server.ts:1718,1724`), never through the RPC.

## Tests, proven red first

Per `feedback-prove-tests-fail-without-the-fix`, the two new adversarial tests were shown **red against the pre-fix handler** before landing:

- an UNSIGNED `harness.prune` (valid-schema threshold) is rejected `-32003` and evicts nothing;
- a SIGNED `harness.prune` with `staleDays: 0` is rejected by the schema floor and evicts nothing.

The prior test `clamps negative thresholds to zero (defensive)` asserted the vulnerability as intended behavior (unsigned `staleDays: -100`, expected to age every session). It is removed. It was the same species as the mocked-`node:fs.stat` test revdev#260 deleted.

The three existing prune tests (age-out, hard-delete, health) now sign the call and age rows by **backdating** `started_at`/`ended_at` through the `_db` handle instead of sub-day thresholds + sleeps (faster, no flake). `validation.test.ts`, `signature-gate.test.ts`, and `signature-telemetry.test.ts` updated for the new behavior.

## Verification

- `@revdev/daemon`: **555/555** green.
- `cargo test --test harness_integration`: **4/4** green (serial; one parallel-only socket-timing flake on the unrelated `ping`/restart test, confirmed not caused by this change and passing in isolation and serially).
- `signing.rs`: `requires_signature_matches_daemon_set` asserts `harness.prune` signed and `harness.health` unsigned.

Studio never calls `harness.prune`, so adding it to `requires_signature()` is pure hardening with no client-path change.

## Review gate

This touches `signing.rs` and the daemon eviction surface, so it is **security-sensitive under guardrail 2** (`dup-work-and-review-gates.md`). It was authored by a Fable session; **it must not be self-cleared.** It needs a recorded verdict from a non-author reviewer (`sec-review:approved`, applied by the owner or a non-author coordinator) before merge. Merges to `test`, per branch flow.

Refs GAP-312. Sibling of GAP-288 (session.end, revdev#261).
