### PR TITLE
ci: add prove-red gate (verification-enforcement Phase 1a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,36 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
+  prove-red:
+    name: Prove-Red (changed tests must fail against base)
+    runs-on: ubuntu-latest
+    needs: quality
+    # PR-only: a merge-base is meaningless on a direct push to test/main.
+    if: github.event_name == 'pull_request'
+    steps:
+      # Check out the PR head (not the synthetic merge commit) with full history
+      # so scripts/ci/prove-red.mjs can compute the merge base and revert the
+      # source diff. See docs (verification-enforcement lane) for the mechanism.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Changed daemon tests import @revdev/protocol and @revdev/daemon; build
+      # them from source first, exactly as the root `test` script does, or the
+      # per-file vitest runs fail to resolve imports rather than on assertions.
+      - run: pnpm --filter @revdev/protocol build
+      - run: pnpm --filter @revdev/daemon build
+      - name: Prove changed tests are red against base
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/ci/prove-red.mjs
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/scripts/ci/prove-red.mjs
+++ b/scripts/ci/prove-red.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+// Prove-red gate (verification-enforcement lane, spec 2026-07-10).
+//
+// A test that passes whether or not the fix is present proves nothing. This
+// gate mechanises "prove red": on a PR that changes BOTH product source and
+// test files, it reverts the source changes to the merge base, re-runs each
+// CHANGED test file, and REQUIRES each to be red against the base. A changed
+// test file that stays green without the source change is inert, and the gate
+// blocks it.
+//
+// Honest limits (kept in lockstep with the spec §4.2):
+//   - It proves "the changed test file does not PASS against base", which is
+//     weaker than "fails on an assertion": a file that fails to import because
+//     it references a symbol the PR added counts as red here. So the gate kills
+//     the worthless regression guard but does not certify test STRENGTH.
+//   - Granularity is the FILE, not the individual test case. A changed file
+//     whose NEW test is inert but whose OLD test goes red against base still
+//     passes. Raising this to per-test needs diff-hunk attribution; deferred.
+//   - TypeScript/vitest only in Phase 1a. Rust (`cargo test`) and Go
+//     (`go test`) changed-test prove-red is NOT covered and is logged loudly
+//     below rather than silently skipped.
+//
+// Zero authored regex (fleet rule): path classification is suffix/substring
+// membership only.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+
+const REPO_ROOT = process.cwd();
+
+// --- path classification (suffix/substring only) ---------------------------
+
+const TEST_SUFFIXES = [
+  '.test.ts',
+  '.test.tsx',
+  '.test.js',
+  '.test.mjs',
+  '.spec.ts',
+  '.spec.tsx',
+  '.spec.js',
+  '.spec.mjs',
+];
+const CODE_SUFFIXES = ['.ts', '.tsx', '.js', '.mjs', '.cjs'];
+
+function isTestFile(p) {
+  if (p.includes('/__tests__/')) return true;
+  for (const s of TEST_SUFFIXES) if (p.endsWith(s)) return true;
+  return false;
+}
+
+function isCodeSource(p) {
+  if (isTestFile(p)) return false;
+  if (p.endsWith('.d.ts')) return false;
+  for (const s of CODE_SUFFIXES) if (p.endsWith(s)) return true;
+  return false;
+}
+
+// Non-TS test files we cannot prove-red yet, surfaced rather than silently dropped.
+function isUncoveredTestFile(p) {
+  if (p.endsWith('_test.go')) return true;
+  if (p.includes('/tests/') && p.endsWith('.rs')) return true;
+  return false;
+}
+
+// --- git helpers -----------------------------------------------------------
+
+function git(args) {
+  return execFileSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8' });
+}
+
+function mergeBase(baseRef) {
+  return git(['merge-base', baseRef, 'HEAD']).trim();
+}
+
+// `--no-renames` so a rename shows as add+delete, which the revert logic below
+// handles without a separate R-status branch.
+function changedFiles(base) {
+  const out = git(['diff', '--no-renames', '--name-status', base, 'HEAD']).trim();
+  if (!out) return [];
+  return out.split('\n').map((line) => {
+    const tab = line.indexOf('\t');
+    return { status: line.slice(0, tab).trim(), path: line.slice(tab + 1).trim() };
+  });
+}
+
+// --- package resolution ----------------------------------------------------
+
+function nearestPackage(fileAbs) {
+  let dir = dirname(fileAbs);
+  while (dir.startsWith(REPO_ROOT)) {
+    const pkg = join(dir, 'package.json');
+    if (existsSync(pkg)) {
+      try {
+        const name = JSON.parse(readFileSync(pkg, 'utf8')).name;
+        if (name) return { name, dir };
+      } catch {
+        // unreadable or nameless package.json; keep walking up
+      }
+    }
+    if (dir === REPO_ROOT) break;
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+// --- main ------------------------------------------------------------------
+
+function fail(msg) {
+  console.error(`\n✗ prove-red: ${msg}`);
+  process.exit(1);
+}
+
+function skip(msg) {
+  console.log(`\n○ prove-red: ${msg}. Gate does not apply.`);
+  process.exit(0);
+}
+
+const baseRef = process.env.BASE_REF || process.env.BASE_SHA;
+if (!baseRef) fail('BASE_REF is not set (pass the PR base sha).');
+
+const base = mergeBase(baseRef);
+console.log(`prove-red: merge base = ${base}`);
+
+const changed = changedFiles(base);
+const changedSource = changed.filter((c) => isCodeSource(c.path));
+const changedTests = changed.filter((c) => isTestFile(c.path) && c.status !== 'D');
+const uncovered = changed.filter((c) => isUncoveredTestFile(c.path) && c.status !== 'D');
+
+if (uncovered.length > 0) {
+  console.log(
+    `prove-red: NOTE: ${uncovered.length} changed Rust/Go test file(s) are NOT prove-red covered in Phase 1a:`,
+  );
+  for (const u of uncovered) console.log(`    - ${u.path}`);
+}
+
+// Fire only when product CODE source AND test files both change. Test-only,
+// source-only, and docs/config-only PRs are out of scope by design.
+if (changedSource.length === 0 || changedTests.length === 0) {
+  skip(
+    `changed source files = ${changedSource.length}, changed TS test files = ${changedTests.length}`,
+  );
+}
+
+console.log(`prove-red: reverting ${changedSource.length} source file(s) to base ${base}`);
+for (const { status, path } of changedSource) {
+  if (status === 'A') {
+    // Added in the PR, absent at base. Remove it.
+    execFileSync('rm', ['-f', path], { cwd: REPO_ROOT });
+  } else {
+    // Modified or deleted in the PR; restore base content.
+    git(['checkout', base, '--', path]);
+  }
+}
+
+// Group changed test files by their owning package.
+const byPackage = new Map();
+for (const { path } of changedTests) {
+  const abs = join(REPO_ROOT, path);
+  const pkg = nearestPackage(abs);
+  if (!pkg) {
+    console.log(`prove-red: NOTE: no package.json owns ${path}; skipping it.`);
+    continue;
+  }
+  if (!byPackage.has(pkg.name)) byPackage.set(pkg.name, { dir: pkg.dir, files: [] });
+  byPackage.get(pkg.name).files.push(relative(pkg.dir, abs));
+}
+
+if (byPackage.size === 0) skip('no packaged TS test files to run');
+
+// Run each changed test file against the reverted base and classify it.
+//
+// PASS requires AT LEAST ONE changed test file to be red against base: the PR
+// must carry a failing-first test that genuinely depends on the change. A file
+// that stays green is either a legitimate compatibility update to an existing
+// test or an inert new one; the gate cannot tell those apart at file
+// granularity, so it REPORTS them but does not block on them. It blocks only
+// when NO changed test file is red, a source change with zero failing-first
+// evidence, which is exactly the "a passing test proves nothing until it fails
+// against the old code" failure this gate exists to catch.
+const redFiles = [];
+const greenFiles = [];
+for (const [name, { files }] of byPackage) {
+  for (const file of files) {
+    console.log(`\nprove-red: running ${name} :: ${file} against base`);
+    let exit = 0;
+    try {
+      execFileSync('pnpm', ['--filter', name, 'exec', 'vitest', 'run', '--no-coverage', file], {
+        cwd: REPO_ROOT,
+        stdio: 'inherit',
+      });
+    } catch (e) {
+      exit = typeof e.status === 'number' ? e.status : 1;
+    }
+    if (exit === 0) {
+      greenFiles.push(`${name} :: ${file}`);
+      console.log(`prove-red: · ${file} PASSED against base (compat update or inert)`);
+    } else {
+      redFiles.push(`${name} :: ${file}`);
+      console.log(`prove-red: ✓ ${file} is red against base, proves the change`);
+    }
+  }
+}
+
+if (greenFiles.length > 0) {
+  console.log('\nprove-red: NOTE: these changed test files passed WITHOUT the source change:');
+  for (const f of greenFiles) console.log(`    - ${f}`);
+  console.log(
+    '    They may be legitimate compatibility updates, or they may be inert.\n' +
+      '    The gate does not block on them; a reviewer should confirm which they are.',
+  );
+}
+
+if (redFiles.length === 0) {
+  console.error(
+    '\n✗ prove-red: NONE of the changed test files fail against the base. This PR\n' +
+      'changes product source but carries no failing-first test that depends on the\n' +
+      'change. Add a test that is red without the fix, or, for a genuine\n' +
+      'behavior-preserving refactor, carry the recorded verify:no-behavior-change\n' +
+      'label (applied by a non-author, per the verification-enforcement lane).',
+  );
+  process.exit(1);
+}
+
+console.log(`\n✓ prove-red: ${redFiles.length} changed test file(s) red against base.`);
+process.exit(0);


### PR DESCRIPTION
Phase 1a of the verification-enforcement lane. Makes "prove red" a machine-checked CI gate.

## What it does

A test that passes whether or not the fix is present proves nothing. On a PR that changes **both** product source and TS test files, the `prove-red` job reverts the source diff to the merge base, re-runs each changed test file, and requires **at least one to be red against the base**. A PR that changes source but carries no failing-first test is blocked.

## Design, and its honest limits

- **Partition** by path suffix, zero authored regex: TS test files vs code-source files. Fires only when both change (test-only, source-only, and docs PRs pass through).
- **Revert** code-source files to the merge base (added → `rm`, modified/deleted → `checkout base`), then run each changed test file per its owning package with vitest.
- **PASS iff ≥1 changed test file is red against base.** Green files are *reported* (compat update or inert) but do not block, because the gate cannot distinguish a legitimate compatibility update from an inert test at file granularity. Requiring *every* file to be red would falsely block PRs like GAP-312's, which legitimately updated an existing test for API compatibility.
- **Documented limits** (matched to the lane spec §4.2): file granularity, not per-test; a compile-failure-against-base counts as red, so it kills the worthless regression guard without certifying test *strength*; Rust/Go changed-test prove-red is **not** covered in Phase 1a and is logged loudly, never silently skipped.

## Validated both directions against the real GAP-312 branch (#262)

- **Positive:** 3 of 4 changed daemon test files red against base (they prove the fix); `signature-telemetry.test.ts` correctly reported as a compat update, not blocked; exit 0.
- **Negative:** a synthetic inert test (`expect(1 + 1).toBe(2)`, independent of its source change) is blocked, exit 1, "NONE of the changed test files fail against the base."

The prove-red tool was itself proven red and green, which is the discipline it enforces.

## Not in this PR (owner-gated)

Added as a **non-required** check. Making it a **required status check with admin bypass off** is the ruling that turns it from advisory to enforced (lane Phase 1c). This PR does not flip it, and the verification block (Phase 1b) is separate.

## Review

The fleet security checker reports this as not security-sensitive (CI + test tooling, no sensitive path). But it changes how the fleet verifies, so a non-author read before merge is worthwhile even though no gate requires it.

Lane + spec live in `revealui-jv` (`docs/lanes/verification-enforcement/plan.md`, `docs/specs/2026-07-10-verification-enforcement-prove-red-gate.md`).
