### PR TITLE
feat(daemon): confine agent.spawn in a bwrap sandbox (Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,12 @@ jobs:
     needs: quality
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install bubblewrap (agent.spawn confinement integration tests)
+        # The real-bwrap adversarial-read tests (confinement-integration.test.ts)
+        # need bwrap present AND able to create unprivileged namespaces. When it
+        # cannot, the suite self-skips via its bwrapUsable() probe — the install
+        # is what lets the boundary be proven for real on CI rather than skipped.
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/packages/daemon/src/__tests__/confinement-integration.test.ts
+++ b/packages/daemon/src/__tests__/confinement-integration.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration tests for confinement — REAL bwrap, real filesystem, real child
+ * processes. Proves the boundary actually holds (spec §10 tests 1, 2, 5, 6) and
+ * that the daily driver survives (test 6, repo read).
+ *
+ * Hermetic: a temp directory stands in for the operator home, seeded with fake
+ * secrets. This runs on any bwrap-capable Linux/WSL2 host without touching the
+ * real ~/.ssh, and is reproducible in CI. (§10's literal reads against the real
+ * operator paths are additionally verified by hand on WSL2 — see the PR body.)
+ *
+ * PROVE-RED is built in: each adversarial read is run first WITHOUT the sandbox
+ * (the `control` helper = the pre-fix behavior) and shown to LEAK, then WITH the
+ * sandbox and shown DENIED. A test that can only pass because the sandbox exists.
+ *
+ * The whole suite is skipped when bwrap cannot create unprivileged namespaces
+ * on the host (WSL1, hardened kernels, restricted CI) — that is the fail-closed
+ * platform, and there is nothing to prove there.
+ *
+ * @vitest-environment node
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { linuxBubblewrapBackend, resolveBwrapAbsPath } from '../confinement.js';
+
+const bwrapAbs = process.platform === 'linux' ? resolveBwrapAbsPath() : null;
+
+/**
+ * Probe whether bwrap can actually create unprivileged namespaces here. Presence
+ * of the binary is not enough (WSL1 / hardened kernels have it but it fails), so
+ * we run a trivial real sandbox and require exit 0.
+ */
+function bwrapUsable(): boolean {
+  if (!bwrapAbs) return false;
+  // Mirror the backend's merged-usr symlinks — WITHOUT /lib and /lib64 the ELF
+  // loader is missing inside and every exec fails ENOENT (a false negative).
+  const r = spawnSync(
+    bwrapAbs,
+    [
+      '--unshare-user',
+      '--unshare-pid',
+      '--ro-bind',
+      '/usr',
+      '/usr',
+      '--symlink',
+      'usr/bin',
+      '/bin',
+      '--symlink',
+      'usr/lib',
+      '/lib',
+      '--symlink',
+      'usr/lib64',
+      '/lib64',
+      '--proc',
+      '/proc',
+      '--dev',
+      '/dev',
+      '--',
+      '/bin/true',
+    ],
+    { timeout: 10_000 },
+  );
+  return r.status === 0;
+}
+
+const RUN = bwrapUsable();
+
+describe.skipIf(!RUN)('confinement integration (real bwrap)', () => {
+  const backend = linuxBubblewrapBackend(bwrapAbs as string);
+
+  let operatorHome: string;
+  let repoReal: string;
+  let agentHome: string;
+  let sshSecret: string;
+  let ageSecret: string;
+
+  beforeAll(async () => {
+    operatorHome = await mkdtemp(join(tmpdir(), 'confine-op-'));
+    repoReal = join(operatorHome, 'repo');
+    agentHome = join(operatorHome, 'agent');
+    sshSecret = join(operatorHome, '.ssh', 'id_secret');
+    ageSecret = join(operatorHome, '.age-identity');
+
+    await mkdir(join(operatorHome, '.ssh'), { recursive: true });
+    await writeFile(sshSecret, 'TOPSECRET-SSH-KEY\n', { mode: 0o600 });
+    await writeFile(ageSecret, 'AGE-SECRET-IDENTITY\n', { mode: 0o600 });
+    await mkdir(repoReal, { recursive: true });
+    await writeFile(join(repoReal, 'hello.txt'), 'REPO-VISIBLE\n');
+    await mkdir(agentHome, { recursive: true });
+    // A symlink inside the granted repo pointing at the ssh secret (§4.4 escape).
+    await symlink(sshSecret, join(repoReal, 'escape-link'));
+  });
+
+  afterAll(async () => {
+    await rm(operatorHome, { recursive: true, force: true });
+  });
+
+  /** Run `sh -c script` INSIDE the sandbox; return combined stdout. */
+  function confined(script: string): { status: number | null; out: string } {
+    const { file, argv } = backend.spawnConfined('/bin/sh', ['-c', script], {
+      repoReal,
+      cwd: repoReal,
+      agentHome,
+      operatorHome,
+    });
+    const r = spawnSync(file, argv, { encoding: 'utf8', timeout: 15_000 });
+    return { status: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+  }
+
+  /** Run `sh -c script` WITHOUT the sandbox (the pre-fix control = prove-red). */
+  function control(script: string): { status: number | null; out: string } {
+    const r = spawnSync('/bin/sh', ['-c', script], {
+      cwd: repoReal,
+      encoding: 'utf8',
+      timeout: 15_000,
+    });
+    return { status: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+  }
+
+  const readProbe = (p: string) => `cat '${p}' 2>/dev/null && echo __LEAK__ || echo __DENIED__`;
+
+  it('CONTROL: the ssh secret is readable WITHOUT the sandbox (prove-red)', () => {
+    const { out } = control(readProbe(sshSecret));
+    expect(out).toContain('TOPSECRET-SSH-KEY');
+    expect(out).toContain('__LEAK__');
+  });
+
+  it('denies reading ~/.ssh inside the sandbox (§10 test 1)', () => {
+    const { out } = confined(readProbe(sshSecret));
+    expect(out).not.toContain('TOPSECRET-SSH-KEY');
+    expect(out).toContain('__DENIED__');
+  });
+
+  it('denies reading ~/.age-identity inside the sandbox (§10 test 2)', () => {
+    expect(control(readProbe(ageSecret)).out).toContain('AGE-SECRET-IDENTITY'); // prove-red
+    const { out } = confined(readProbe(ageSecret));
+    expect(out).not.toContain('AGE-SECRET-IDENTITY');
+    expect(out).toContain('__DENIED__');
+  });
+
+  it('cannot read a secret THROUGH a repo symlink (§10 test 5, §4.4)', () => {
+    const link = join(repoReal, 'escape-link');
+    expect(control(readProbe(link)).out).toContain('TOPSECRET-SSH-KEY'); // prove-red: link works unsandboxed
+    const { out } = confined(readProbe(link));
+    expect(out).not.toContain('TOPSECRET-SSH-KEY');
+    expect(out).toContain('__DENIED__');
+  });
+
+  it('DAILY DRIVER: the granted repo IS readable inside the sandbox (§10 test 6)', () => {
+    const { out } = confined(`cat '${join(repoReal, 'hello.txt')}'`);
+    expect(out).toContain('REPO-VISIBLE');
+  });
+
+  it('HOME points at the agent home, not the operator home', () => {
+    const { out } = confined('echo "HOME=$HOME"');
+    expect(out).toContain(`HOME=${agentHome}`);
+  });
+
+  it('an ABSOLUTE command is still confined — PATH was never the control (§10 test 4)', () => {
+    // /bin/cat by absolute path; the ssh secret is still denied.
+    const { out } = confined(
+      `/bin/cat '${sshSecret}' 2>/dev/null && echo __LEAK__ || echo __DENIED__`,
+    );
+    expect(out).not.toContain('TOPSECRET-SSH-KEY');
+    expect(out).toContain('__DENIED__');
+  });
+});

--- a/packages/daemon/src/__tests__/confinement.test.ts
+++ b/packages/daemon/src/__tests__/confinement.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Unit tests for the confinement module (confinement.ts) — pure argv/env/backend
+ * logic, no real spawn and no socket. The real-bwrap adversarial reads live in
+ * confinement-integration.test.ts.
+ *
+ * @vitest-environment node
+ */
+
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  buildConfinedEnv,
+  ensureAgentHome,
+  filterCallerEnv,
+  linuxBubblewrapBackend,
+  resolveBwrapAbsPath,
+  resolveConfinementBackend,
+} from '../confinement.js';
+
+// ---------------------------------------------------------------------------
+// filterCallerEnv — the allow-list (spec §7, §10 test 3)
+// ---------------------------------------------------------------------------
+
+describe('filterCallerEnv', () => {
+  it('accepts the exact allow-list keys', () => {
+    const out = filterCallerEnv({ TERM: 'xterm', LANG: 'en_US.UTF-8', CI: '1', NO_COLOR: '1' });
+    expect(out).toEqual({ TERM: 'xterm', LANG: 'en_US.UTF-8', CI: '1', NO_COLOR: '1' });
+  });
+
+  it('accepts the namespaced prefixes (LC_*, REVDEV_*)', () => {
+    const out = filterCallerEnv({ LC_ALL: 'C', LC_TIME: 'C', REVDEV_FOO: 'bar' });
+    expect(out).toEqual({ LC_ALL: 'C', LC_TIME: 'C', REVDEV_FOO: 'bar' });
+  });
+
+  it('rejects HOME by name (the escape the tmpfs would otherwise absorb)', () => {
+    expect(() => filterCallerEnv({ HOME: '/home/op' })).toThrow(/"HOME" is not caller-settable/);
+  });
+
+  it('rejects PATH', () => {
+    expect(() => filterCallerEnv({ PATH: '/evil/bin' })).toThrow(/"PATH" is not caller-settable/);
+  });
+
+  it.each([
+    'LD_PRELOAD',
+    'LD_AUDIT',
+    'LD_LIBRARY_PATH',
+    'NODE_OPTIONS',
+    'GIT_SSH_COMMAND',
+    'BASH_ENV',
+    'PYTHONSTARTUP',
+  ])('rejects the loader/hook key %s', (key) => {
+    expect(() => filterCallerEnv({ [key]: 'x' })).toThrow(
+      new RegExp(`"${key}" is not caller-settable`),
+    );
+  });
+
+  it('names the FIRST offending key when several are present', () => {
+    // A near-miss (GIT_ prefix is NOT allow-listed; only LC_/REVDEV_ are).
+    expect(() => filterCallerEnv({ GIT_CONFIG_GLOBAL: '/tmp/x' })).toThrow(/"GIT_CONFIG_GLOBAL"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildConfinedEnv — deny-by-default baseline, no process.env leak
+// ---------------------------------------------------------------------------
+
+describe('buildConfinedEnv', () => {
+  it('points HOME at the agent home and pins PATH', () => {
+    const env = buildConfinedEnv({}, '/data/agent-homes/abc');
+    expect(env.HOME).toBe('/data/agent-homes/abc');
+    expect(env.PATH).toBe('/usr/bin:/bin');
+    expect(env.GIT_CONFIG_NOSYSTEM).toBe('1');
+  });
+
+  it('does not inherit process.env (no secret leak)', () => {
+    process.env.CONFINEMENT_SECRET_PROBE = 'leak-me';
+    try {
+      const env = buildConfinedEnv({}, '/data/agent');
+      expect(env.CONFINEMENT_SECRET_PROBE).toBeUndefined();
+    } finally {
+      delete process.env.CONFINEMENT_SECRET_PROBE;
+    }
+  });
+
+  it('layers allow-listed caller env on top', () => {
+    const env = buildConfinedEnv({ TERM: 'screen-256color', REVDEV_X: '1' }, '/data/agent');
+    expect(env.TERM).toBe('screen-256color');
+    expect(env.REVDEV_X).toBe('1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// linuxBubblewrapBackend — argv construction (spec §4.3, §4.4, §10 test 4)
+// ---------------------------------------------------------------------------
+
+describe('linuxBubblewrapBackend.spawnConfined', () => {
+  const backend = linuxBubblewrapBackend('/usr/bin/bwrap');
+  const opts = {
+    repoReal: '/home/op/repo',
+    cwd: '/home/op/repo/packages/x',
+    agentHome: '/home/op/.local/share/revealui/agent-homes/deadbeef',
+    operatorHome: '/home/op',
+  };
+
+  it('execs bwrap, not the raw command', () => {
+    const { file } = backend.spawnConfined('bash', ['-i'], opts);
+    expect(file).toBe('/usr/bin/bwrap');
+  });
+
+  it('still wraps an ABSOLUTE command — PATH was never the control (§10 test 4)', () => {
+    const { file, argv } = backend.spawnConfined('/bin/bash', [], opts);
+    expect(file).toBe('/usr/bin/bwrap');
+    // The command sits AFTER the `--` separator, never as the exec file.
+    const sep = argv.indexOf('--');
+    expect(sep).toBeGreaterThan(0);
+    expect(argv[sep + 1]).toBe('/bin/bash');
+  });
+
+  it('tmpfs-hides the operator home and re-binds only the granted root + agent home', () => {
+    const { argv } = backend.spawnConfined('bash', [], opts);
+    const s = argv.join(' ');
+    expect(s).toContain('--tmpfs /home/op');
+    expect(s).toContain(`--bind ${opts.repoReal} ${opts.repoReal}`);
+    expect(s).toContain(`--bind ${opts.agentHome} ${opts.agentHome}`);
+    // The operator-home tmpfs must come BEFORE the re-binds, or the binds get wiped.
+    const tmpfsIdx = argv.indexOf('/home/op'); // the --tmpfs operand
+    const repoBindIdx = argv.indexOf(opts.repoReal);
+    expect(tmpfsIdx).toBeLessThan(repoBindIdx);
+  });
+
+  it('never binds a secret path', () => {
+    const { argv } = backend.spawnConfined('bash', [], opts);
+    const s = argv.join(' ');
+    for (const secret of [
+      '.ssh',
+      '.age-identity',
+      'passage-store',
+      '.config/gh',
+      '.npmrc',
+      '.aws',
+    ]) {
+      expect(s).not.toContain(secret);
+    }
+  });
+
+  it('sets HOME + PATH authoritatively inside the sandbox', () => {
+    const { argv } = backend.spawnConfined('bash', [], opts);
+    const s = argv.join(' ');
+    expect(s).toContain(`--setenv HOME ${opts.agentHome}`);
+    expect(s).toContain('--setenv PATH /usr/bin:/bin');
+  });
+
+  it('unshares user/pid/ipc/uts/cgroup but NOT net, and dies with parent', () => {
+    const { argv } = backend.spawnConfined('bash', [], opts);
+    expect(argv).toContain('--unshare-user');
+    expect(argv).toContain('--unshare-pid');
+    expect(argv).toContain('--unshare-cgroup');
+    expect(argv).not.toContain('--unshare-net');
+    expect(argv).not.toContain('--new-session'); // §4.3 — breaks interactive job control
+    expect(argv).toContain('--die-with-parent');
+  });
+
+  it('starts in the granted cwd', () => {
+    const { argv } = backend.spawnConfined('bash', [], opts);
+    const s = argv.join(' ');
+    expect(s).toContain(`--chdir ${opts.cwd}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveConfinementBackend — fail-closed + escape hatch (spec §8)
+// ---------------------------------------------------------------------------
+
+describe('resolveConfinementBackend', () => {
+  it('linux + usable bwrap → linux-bubblewrap', () => {
+    const r = resolveConfinementBackend({
+      platform: 'linux',
+      bwrapPath: '/usr/bin/bwrap',
+      escapeHatchEnv: '',
+    });
+    expect(r.mode).toBe('linux-bubblewrap');
+    expect(r.backend).not.toBeNull();
+    expect(r.escapeHatch).toBe(false);
+  });
+
+  it('linux WITHOUT usable bwrap → fail closed (backend null, not escape hatch)', () => {
+    const r = resolveConfinementBackend({ platform: 'linux', bwrapPath: null, escapeHatchEnv: '' });
+    expect(r.mode).toBe('none');
+    expect(r.backend).toBeNull();
+    expect(r.escapeHatch).toBe(false);
+    expect(r.reason).toMatch(/fails closed/);
+  });
+
+  it.each(['darwin', 'win32'] as const)('%s → fail closed (no backend)', (platform) => {
+    const r = resolveConfinementBackend({ platform, bwrapPath: null, escapeHatchEnv: '' });
+    expect(r.backend).toBeNull();
+    expect(r.escapeHatch).toBe(false);
+    expect(r.reason).toMatch(/fails closed/);
+  });
+
+  it('escape hatch overrides every platform → unconfined, recorded', () => {
+    const r = resolveConfinementBackend({
+      platform: 'linux',
+      bwrapPath: '/usr/bin/bwrap',
+      escapeHatchEnv: 'none',
+    });
+    expect(r.mode).toBe('none');
+    expect(r.backend).toBeNull();
+    expect(r.escapeHatch).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveBwrapAbsPath
+// ---------------------------------------------------------------------------
+
+describe('resolveBwrapAbsPath', () => {
+  it('returns null for a nonexistent candidate', () => {
+    expect(resolveBwrapAbsPath('/nonexistent/bwrap-xyz')).toBeNull();
+  });
+
+  it('rejects a non-root-owned candidate (any user-writable file in tmp)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'bwrap-probe-'));
+    try {
+      const fake = join(dir, 'bwrap');
+      await writeFile(fake, '#!/bin/sh\n', { mode: 0o755 });
+      // Owned by the test user, not root → refused.
+      expect(resolveBwrapAbsPath(fake)).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureAgentHome (spec §5, §6)
+// ---------------------------------------------------------------------------
+
+describe('ensureAgentHome', () => {
+  let dataDir: string;
+
+  beforeAll(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'agent-home-test-'));
+  });
+  afterAll(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it('creates a hashed home with a signing-OFF gitconfig and no signingkey', async () => {
+    const home = await ensureAgentHome(dataDir, 'did:key:zSignerABC');
+    expect(home).toContain(join(dataDir, 'agent-homes'));
+    // Hashed — the raw agentId never appears in the path.
+    expect(home).not.toContain('zSignerABC');
+
+    const gitconfig = await readFile(join(home, '.gitconfig'), 'utf8');
+    expect(gitconfig).toContain('gpgsign = false');
+    expect(gitconfig).not.toContain('signingkey');
+
+    // Writable scaffold dirs exist.
+    for (const d of ['.cache', '.config', join('.local', 'share')]) {
+      const s = await stat(join(home, d));
+      expect(s.isDirectory()).toBe(true);
+    }
+  });
+
+  it('is idempotent and stable per agentId', async () => {
+    const a = await ensureAgentHome(dataDir, 'did:key:zStable');
+    const b = await ensureAgentHome(dataDir, 'did:key:zStable');
+    expect(a).toBe(b);
+  });
+
+  it('gives different agents different homes', async () => {
+    const a = await ensureAgentHome(dataDir, 'did:key:zOne');
+    const b = await ensureAgentHome(dataDir, 'did:key:zTwo');
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -78,6 +78,7 @@ import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { PGlite } from '@electric-sql/pglite';
 import { formatDid } from '@revdev/protocol/did';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import {
@@ -173,6 +174,7 @@ const other = makeSigner('spawn-test-other');
 let dataDir: string;
 let socketPath: string;
 let close: () => Promise<void>;
+let db: PGlite;
 /** A project root `owner` opens; agent.spawn now authorizes against it. */
 let repoRoot: string;
 /** A root owned by `other`, used to prove cross-agent spawn is refused. */
@@ -190,6 +192,13 @@ async function signedRpc(
 }
 
 beforeAll(async () => {
+  // These tests exercise the signature gate, ownership, and project-grant
+  // authorization — NOT the OS sandbox (that is proven with real bwrap in
+  // confinement-integration.test.ts). node-pty is mocked here, so an actual
+  // bwrap wrap is neither observable nor desirable, and the daemon must not
+  // fail closed on a CI runner without bwrap. Run these under the operator
+  // escape hatch: spawns are unconfined and record confinement='none'.
+  process.env.REVDEV_SPAWN_CONFINEMENT = 'none';
   setTestLicenseEnv(generateTestLicense('enterprise'));
   dataDir = await mkdtemp(join(tmpdir(), 'revdev-spawn-test-'));
   socketPath = join(dataDir, 'harness.sock');
@@ -206,6 +215,7 @@ beforeAll(async () => {
     trustedAnchorRequireRootOwned: false,
   });
   close = d.close;
+  db = d._db;
 
   // Persist each client's public key so the daemon can Ed25519-verify their
   // signed agent.* calls (the trust anchor only holds the fingerprint). One-time
@@ -233,6 +243,7 @@ afterAll(async () => {
   await close?.();
   await rm(dataDir, { recursive: true, force: true });
   clearTestLicenseEnv();
+  delete process.env.REVDEV_SPAWN_CONFINEMENT;
 });
 
 beforeEach(() => {
@@ -285,6 +296,46 @@ describe('agent.spawn', () => {
         cwd: join(repoRoot, 'nonexistent', 'does-not-exist'),
       }),
     ).rejects.toThrow();
+  });
+
+  // Under the escape hatch a spawn is unconfined, but it leaves a receipt: the
+  // audit row records confinement='none' (spec §8.1).
+  it("records confinement='none' on the row under the escape hatch", async () => {
+    const { processId } = (await signedRpc(owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+    })) as { processId: string };
+    const row = await db.query<{ confinement: string | null }>(
+      `SELECT confinement FROM agent_processes WHERE id = $1`,
+      [processId],
+    );
+    expect(row.rows[0]?.confinement).toBe('none');
+    // Release the live-count slot — mock ptys never exit on their own, and the
+    // per-agent cap (10) is shared across every owner spawn in this file.
+    _lastPty?._fireExit(0);
+  });
+
+  // The env allow-list (spec §7) runs regardless of confinement mode, so it is
+  // enforced even under the escape hatch. A non-allow-listed key is rejected by
+  // name (§10 test 3).
+  it('rejects a caller env key outside the allow-list', async () => {
+    await expect(
+      signedRpc(owner, 'agent.spawn', {
+        command: 'bash',
+        repoPath: repoRoot,
+        env: { HOME: '/home/op' },
+      }),
+    ).rejects.toThrow(/not caller-settable/);
+  });
+
+  it('accepts an allow-listed caller env key (TERM)', async () => {
+    const result = (await signedRpc(owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+      env: { TERM: 'screen-256color' },
+    })) as { processId: string };
+    expect(typeof result.processId).toBe('string');
+    _lastPty?._fireExit(0);
   });
 });
 

--- a/packages/daemon/src/confinement.ts
+++ b/packages/daemon/src/confinement.ts
@@ -1,0 +1,387 @@
+/**
+ * agent.spawn confinement — the kernel boundary (Phase 1).
+ *
+ * Spec: `.jv` docs/specs/2026-07-10-agent-spawn-confinement-phase-1.md (GAP-288).
+ *
+ * A verified, authorized `agent.spawn` still runs as the daemon UID with the
+ * daemon's entire filesystem view. Env-scoping (a curated HOME + minimal PATH)
+ * does NOT contain it: `open("/home/<op>/.ssh/id")` never consults $HOME, so a
+ * deliberate reader ignores it. The only real boundary is an OS one.
+ *
+ * This module resolves the actual argv handed to node-pty. On Linux and WSL2 it
+ * wraps the command in `bwrap` (bubblewrap) with a deny-by-default bind set:
+ * nothing is visible inside the sandbox unless explicitly bound, and the
+ * operator's home is tmpfs'd so `~/.ssh`, `~/.age-identity`, and the revvault
+ * store are gone. On platforms with no backend it FAILS CLOSED — a caller can
+ * never tell an absent sandbox from a broken one, so the absent case refuses.
+ *
+ * Confinement does NOT replace authorization. `requireDirInRoot` still decides
+ * WHICH root is bound; a defect here must never grant a root the caller was not
+ * granted (spec §4.2 invariant 3).
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, realpathSync, statSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createLogger } from '@revealui/utils/logger';
+
+const log = createLogger({ service: 'revdev-daemon/confinement' });
+
+// ---------------------------------------------------------------------------
+// Backend interface
+// ---------------------------------------------------------------------------
+
+export interface ConfinementOpts {
+  /** Realpath'd granted root (from requireRootAndDir) — bound read-write. */
+  repoReal: string;
+  /** Directory the sandboxed process starts in (at or beneath repoReal). */
+  cwd: string;
+  /** Per-agent persistent home (§5), bound read-write; HOME points here. */
+  agentHome: string;
+  /** The operator's real home; tmpfs'd to hide everything beneath it. */
+  operatorHome: string;
+}
+
+export interface ConfinementResult {
+  /** The binary node-pty execs: the resolved bwrap abspath (confined), or the raw command (escape hatch). */
+  file: string;
+  /** Full argv. For bwrap: every sandbox flag, then `--`, then command + args. */
+  argv: string[];
+}
+
+export interface ConfinementBackend {
+  readonly name: string;
+  spawnConfined(command: string, args: string[], opts: ConfinementOpts): ConfinementResult;
+}
+
+// ---------------------------------------------------------------------------
+// bwrap resolution — once, to an absolute realpath, verified trustworthy
+// ---------------------------------------------------------------------------
+
+const BWRAP_CANDIDATE = '/usr/bin/bwrap';
+
+/**
+ * Resolve `bwrap` to an absolute realpath and verify it is root-owned and not
+ * group- or other-writable (spec §4.2 invariant 1). Never resolved through a
+ * caller-influenced PATH — a bare-name reference is shadowable, so the parent
+ * spec's finding forbids it. Returns the abspath, or null if bwrap is absent,
+ * not a regular file, not root-owned, or writable by non-root.
+ */
+export function resolveBwrapAbsPath(candidate: string = BWRAP_CANDIDATE): string | null {
+  let real: string;
+  try {
+    real = realpathSync(candidate);
+  } catch {
+    return null;
+  }
+  let st: ReturnType<typeof statSync>;
+  try {
+    st = statSync(real);
+  } catch {
+    return null;
+  }
+  if (!st.isFile()) return null;
+  if (st.uid !== 0) {
+    log.warn('bwrap is not root-owned; refusing to use it', { path: real, uid: st.uid });
+    return null;
+  }
+  // Group-writable (0o020) or other-writable (0o002) means a non-root principal
+  // could replace the boundary binary. Reject.
+  if ((st.mode & 0o022) !== 0) {
+    log.warn('bwrap is group- or other-writable; refusing to use it', {
+      path: real,
+      mode: (st.mode & 0o777).toString(8),
+    });
+    return null;
+  }
+  return real;
+}
+
+// ---------------------------------------------------------------------------
+// Caller env allow-list (spec §7)
+// ---------------------------------------------------------------------------
+
+/** Exact keys a caller may set. */
+const CALLER_ENV_EXACT = new Set(['TERM', 'LANG', 'CI', 'NO_COLOR']);
+/** Namespaced prefixes a caller may set. */
+const CALLER_ENV_PREFIXES = ['LC_', 'REVDEV_'] as const;
+
+/**
+ * Filter caller-supplied env to the allow-list. A deny-list of dangerous keys
+ * always loses eventually, so this is an allow-list: `HOME`, `PATH`, the loader
+ * set (`LD_PRELOAD`, `LD_AUDIT`, `LD_LIBRARY_PATH`, `NODE_OPTIONS`,
+ * `GIT_CONFIG_GLOBAL`, `GIT_SSH_COMMAND`, `BASH_ENV`, `PYTHONSTARTUP`, …) are
+ * simply not on it and are rejected by name. Zero authored regex — a Set
+ * membership test plus `startsWith` for the namespaces.
+ *
+ * @throws naming the first disallowed key.
+ */
+export function filterCallerEnv(extraEnv: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(extraEnv)) {
+    if (CALLER_ENV_EXACT.has(k)) {
+      out[k] = v;
+      continue;
+    }
+    let allowed = false;
+    for (const prefix of CALLER_ENV_PREFIXES) {
+      if (k.startsWith(prefix)) {
+        allowed = true;
+        break;
+      }
+    }
+    if (allowed) {
+      out[k] = v;
+      continue;
+    }
+    throw new Error(
+      `agent.spawn: env key "${k}" is not caller-settable. Allowed: TERM, LANG, LC_*, CI, NO_COLOR, REVDEV_*.`,
+    );
+  }
+  return out;
+}
+
+/**
+ * Build the environment node-pty is given (and, without --clearenv, that bwrap
+ * inherits before its own --setenv). `process.env` is deliberately NOT
+ * inherited — the daemon's revvault secrets, signing material, and API keys
+ * never reach the child. HOME points at the per-agent home; PATH is fixed.
+ * Allow-listed caller env layers on top but can never contain HOME or PATH
+ * (filterCallerEnv rejected them upstream).
+ */
+export function buildConfinedEnv(
+  callerEnv: Record<string, string>,
+  agentHome: string,
+): Record<string, string> {
+  const env: Record<string, string> = {
+    HOME: agentHome,
+    PATH: '/usr/bin:/bin',
+    TERM: 'xterm-color',
+    LANG: 'C.UTF-8',
+    GIT_CONFIG_NOSYSTEM: '1',
+  };
+  for (const [k, v] of Object.entries(callerEnv)) env[k] = v;
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// linux-bubblewrap backend (spec §4.3)
+// ---------------------------------------------------------------------------
+
+/** /etc entries bound read-only for DNS, TLS, and name resolution (only if present). */
+const ETC_RO_BINDS = [
+  '/etc/resolv.conf',
+  '/etc/ssl',
+  '/etc/ca-certificates',
+  '/etc/passwd',
+  '/etc/group',
+  '/etc/nsswitch.conf',
+  '/etc/alternatives',
+] as const;
+
+/**
+ * The Linux/WSL2 backend. Builds a deny-by-default bwrap argv:
+ *   - /usr read-only, the merged-usr symlinks, minimal /etc, /proc, /dev, /tmp;
+ *   - the operator home tmpfs'd (hides everything beneath it), THEN the granted
+ *     root and the per-agent home re-bound read-write on top;
+ *   - shared caches (pnpm store, cargo registry/git) bound by EXACT subdirectory,
+ *     never the secret-bearing parent, and only when they exist on the host;
+ *   - HOME and PATH set authoritatively inside the sandbox;
+ *   - user/pid/ipc/uts/cgroup namespaces unshared (NOT net — pnpm/cargo/claude
+ *     need egress; NOT --new-session — it setsid()s and breaks interactive job
+ *     control, and node-pty already hands a dedicated pty slave, spec §4.3).
+ *
+ * A symlink inside the repo pointing at ~/.ssh resolves against the SANDBOX
+ * root, where ~/.ssh does not exist — symlink escape is closed for free (§4.4).
+ */
+export function linuxBubblewrapBackend(bwrapAbs: string): ConfinementBackend {
+  return {
+    name: 'linux-bubblewrap',
+    spawnConfined(command, args, opts): ConfinementResult {
+      const { repoReal, cwd, agentHome, operatorHome } = opts;
+      const a: string[] = [];
+
+      // System, read-only + merged-usr symlinks.
+      a.push('--ro-bind', '/usr', '/usr');
+      a.push('--symlink', 'usr/bin', '/bin');
+      a.push('--symlink', 'usr/sbin', '/sbin');
+      a.push('--symlink', 'usr/lib', '/lib');
+      a.push('--symlink', 'usr/lib64', '/lib64');
+
+      // Minimal /etc (each only if present on the host).
+      for (const p of ETC_RO_BINDS) {
+        if (existsSync(p)) a.push('--ro-bind', p, p);
+      }
+
+      // Kernel + device surfaces, and a private /tmp.
+      a.push('--proc', '/proc');
+      a.push('--dev', '/dev');
+      a.push('--tmpfs', '/tmp');
+
+      // Hide the entire operator home. Everything the caller is allowed to see
+      // beneath it is re-bound AFTER this line (bwrap applies args in order).
+      a.push('--tmpfs', operatorHome);
+
+      // The granted root and the per-agent home, read-write.
+      a.push('--bind', repoReal, repoReal);
+      a.push('--bind', agentHome, agentHome);
+
+      // Shared caches — bound by exact subdirectory, never `~/.cargo` (which may
+      // hold `credentials`) or `~/.local/share` (which holds the daemon's own
+      // DB). Only when present.
+      const sharedCaches = [
+        join(operatorHome, '.local/share/pnpm/store'),
+        join(operatorHome, '.cargo/registry'),
+        join(operatorHome, '.cargo/git'),
+      ];
+      for (const p of sharedCaches) {
+        if (existsSync(p)) a.push('--bind', p, p);
+      }
+
+      // Authoritative in-sandbox HOME + PATH.
+      a.push('--setenv', 'HOME', agentHome);
+      a.push('--setenv', 'PATH', '/usr/bin:/bin');
+
+      // Namespaces. NOT --unshare-net (kept: pnpm, cargo, claude need egress).
+      a.push(
+        '--unshare-user',
+        '--unshare-pid',
+        '--unshare-ipc',
+        '--unshare-uts',
+        '--unshare-cgroup',
+      );
+      a.push('--die-with-parent');
+
+      // Start in the granted cwd (bound above), then the command.
+      a.push('--chdir', cwd);
+      a.push('--', command, ...args);
+
+      return { file: bwrapAbs, argv: a };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Backend resolution — fail-closed, with an operator escape hatch (spec §8)
+// ---------------------------------------------------------------------------
+
+export type ConfinementMode = 'linux-bubblewrap' | 'none';
+
+export interface ResolvedConfinement {
+  /** The value persisted in the `agent_processes.confinement` audit column. */
+  mode: ConfinementMode;
+  /** The active backend, or null when spawns must fail closed / run unconfined. */
+  backend: ConfinementBackend | null;
+  /** True only when confinement is deliberately disabled via the operator escape hatch. */
+  escapeHatch: boolean;
+  /** Human-readable reason, for the startup log and the fail-closed error. */
+  reason: string;
+}
+
+/**
+ * Resolve the confinement backend for this host. Called once at daemon start
+ * and cached. Optional injections make it unit-testable without touching the
+ * real filesystem or `process.platform`.
+ *
+ *   - `REVDEV_SPAWN_CONFINEMENT=none` in the DAEMON's own env (never a caller
+ *     param): spawns run UNCONFINED, each logged at warn, each row recording
+ *     `confinement='none'`. If an agent did it, there is a receipt.
+ *   - Linux/WSL2 with a usable bwrap: `linux-bubblewrap`.
+ *   - Linux without a usable bwrap, or macOS/Windows: no backend — agent.spawn
+ *     FAILS CLOSED. An unimplemented platform refuses to spawn; it never
+ *     silently spawns unprotected (spec §8.1).
+ */
+export function resolveConfinementBackend(opts?: {
+  platform?: NodeJS.Platform;
+  /** Resolved bwrap abspath or null. `undefined` (default) resolves for real. */
+  bwrapPath?: string | null;
+  /** The escape-hatch env value. `undefined` (default) reads process.env. */
+  escapeHatchEnv?: string;
+}): ResolvedConfinement {
+  const platform = opts?.platform ?? process.platform;
+  const escapeHatchValue =
+    opts?.escapeHatchEnv !== undefined ? opts.escapeHatchEnv : process.env.REVDEV_SPAWN_CONFINEMENT;
+
+  if (escapeHatchValue === 'none') {
+    return {
+      mode: 'none',
+      backend: null,
+      escapeHatch: true,
+      reason: 'REVDEV_SPAWN_CONFINEMENT=none — spawns run UNCONFINED (operator escape hatch)',
+    };
+  }
+
+  if (platform === 'linux') {
+    const bwrapAbs = opts?.bwrapPath !== undefined ? opts.bwrapPath : resolveBwrapAbsPath();
+    if (bwrapAbs) {
+      return {
+        mode: 'linux-bubblewrap',
+        backend: linuxBubblewrapBackend(bwrapAbs),
+        escapeHatch: false,
+        reason: `linux-bubblewrap (${bwrapAbs})`,
+      };
+    }
+    return {
+      mode: 'none',
+      backend: null,
+      escapeHatch: false,
+      reason:
+        'no usable bwrap found (absent, not root-owned, or writable); agent.spawn fails closed',
+    };
+  }
+
+  // macOS: the darwin-seatbelt backend is staged but disabled until its
+  // acceptance suite is green on a macos-latest runner (spec §8.2/§8.3), so it
+  // resolves to fail-closed today. Windows native: no backend.
+  return {
+    mode: 'none',
+    backend: null,
+    escapeHatch: false,
+    reason: `no confinement backend for platform "${platform}"; agent.spawn fails closed (spec §8)`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent persistent home (spec §5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure the per-agent home exists at `<dataDir>/agent-homes/<hash(agentId)>/`
+ * and return its path. Persistent (NOT per-spawn tmpfs — that would discard the
+ * pnpm store links and node_modules state every spawn and make the daily driver
+ * unusable; the sandbox is the per-spawn unit, the home is durable).
+ *
+ * `agentId` is the VERIFIED signer (requireAgent returns it only when
+ * boundVia==='signature'), a signing-key identity — not the hook-side
+ * `agent-system` string, so this does not inherit GAP-311's collision. The path
+ * is hashed so a DID cannot traverse.
+ *
+ * Contains a synthesized minimal `.gitconfig` (identity present, signing OFF,
+ * no signingkey — spec §6) and writable `.cache`, `.config`, `.local/share`.
+ * Never contains anything on the never-bound list of §4.3.
+ */
+export async function ensureAgentHome(dataDir: string, agentId: string): Promise<string> {
+  const hash = createHash('sha256').update(agentId).digest('hex').slice(0, 32);
+  const home = join(dataDir, 'agent-homes', hash);
+  await mkdir(join(home, '.cache'), { recursive: true });
+  await mkdir(join(home, '.config'), { recursive: true });
+  await mkdir(join(home, '.local', 'share'), { recursive: true });
+
+  // Synthesized gitconfig: a spawned agent commits locally and UNSIGNED. It has
+  // no ~/.ssh and no signing key, so it cannot forge a commit GitHub marks
+  // Verified as the operator (spec §6 — "signing must break, and that is the
+  // correct outcome"). commit.gpgsign is pinned false and user.signingkey omitted.
+  const gitconfig = `${[
+    '[user]',
+    '\tname = RevealUI Agent',
+    '\temail = agent@revealui.local',
+    '[commit]',
+    '\tgpgsign = false',
+    '[tag]',
+    '\tgpgsign = false',
+  ].join('\n')}\n`;
+  await writeFile(join(home, '.gitconfig'), gitconfig, { mode: 0o600 });
+
+  return home;
+}

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -294,8 +294,23 @@ export async function requireDirInRoot(
   cwdRaw: string | undefined,
   callerAgentId: string | null,
 ): Promise<string> {
+  return (await requireRootAndDir(repoPathRaw, cwdRaw, callerAgentId)).cwd;
+}
+
+/**
+ * Like `requireDirInRoot`, but returns BOTH the realpath'd granted root and the
+ * resolved cwd. `agent.spawn` confinement binds the whole root read-write and
+ * then chdirs into the (at-or-beneath) cwd, so it needs both — the root to
+ * bind, the cwd to start in. Same authorization; a single realpath+ownership
+ * check backs both values so the two surfaces cannot drift.
+ */
+export async function requireRootAndDir(
+  repoPathRaw: string,
+  cwdRaw: string | undefined,
+  callerAgentId: string | null,
+): Promise<{ repoReal: string; cwd: string }> {
   const repoReal = await requireRoot(repoPathRaw, callerAgentId);
-  if (cwdRaw === undefined || cwdRaw === '') return repoReal;
+  if (cwdRaw === undefined || cwdRaw === '') return { repoReal, cwd: repoReal };
 
   // mustExist=true realpaths the target itself, so a symlink pointing outside
   // the root resolves before `within()` sees it.
@@ -307,7 +322,7 @@ export async function requireDirInRoot(
     throw new Error(`cwd does not exist: ${cwdRaw}`);
   }
   if (!s.isDirectory()) throw new Error(`cwd is not a directory: ${cwdRaw}`);
-  return real;
+  return { repoReal, cwd: real };
 }
 
 /**

--- a/packages/daemon/src/migrations/0006-agent-process-confinement.ts
+++ b/packages/daemon/src/migrations/0006-agent-process-confinement.ts
@@ -1,0 +1,23 @@
+/**
+ * Migration 0006 — agent process confinement audit column.
+ *
+ * Adds `agent_processes.confinement` recording the confinement mode a PTY
+ * process ran under ('linux-bubblewrap' when sandboxed, 'none' when the
+ * operator escape hatch REVDEV_SPAWN_CONFINEMENT=none was set). Nullable: rows
+ * written before this migration predate the column and carry NULL. The
+ * agent.spawn handler always writes it for new rows. "If an agent did it, there
+ * is a receipt" (spec §8.1).
+ */
+
+import type { Migration } from '../storage/migrate.js';
+
+const SQL = `
+  ALTER TABLE agent_processes
+    ADD COLUMN IF NOT EXISTS confinement TEXT;
+`;
+
+export const MIGRATION_0006: Migration = {
+  version: 6,
+  name: 'agent-process-confinement',
+  sql: SQL,
+};

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -21,6 +21,7 @@ import { MIGRATION_0002 } from './0002-key-origin.js';
 import { MIGRATION_0003 } from './0003-project-roots.js';
 import { MIGRATION_0004 } from './0004-agent-processes.js';
 import { MIGRATION_0005 } from './0005-session-activity-state.js';
+import { MIGRATION_0006 } from './0006-agent-process-confinement.js';
 
 export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0001,
@@ -28,4 +29,5 @@ export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0003,
   MIGRATION_0004,
   MIGRATION_0005,
+  MIGRATION_0006,
 ];

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -16,13 +16,15 @@
  * Authorization: agent.spawn additionally requires the signer to hold (own, or
  * have been granted) the project root its command will run in. See the handler.
  *
- * This is a least-privilege gate, NOT a sandbox. `command` and `args` are
- * unconstrained, and buildSafeEnv still passes the operator's HOME and PATH, so
- * an authorized caller runs arbitrary code as the daemon UID and can read
- * ~/.age-identity, ~/.ssh, and the revvault store regardless of which cwd it was
- * granted. The cwd check bounds where a process STARTS, not what it may touch.
- * The missing control is a command allow-list; until that ships, the trust
- * anchor deciding who may sign at all is what actually holds this surface.
+ * Containment (Phase 1, GAP-288, spec 2026-07-10-agent-spawn-confinement-phase-1):
+ * on Linux and WSL2 the command runs inside a `bwrap` sandbox with a
+ * deny-by-default bind set — the operator home is tmpfs'd, so ~/.ssh,
+ * ~/.age-identity, and the revvault store are unreadable even though the process
+ * still runs as the daemon UID. Only the granted root and a per-agent home are
+ * bound read-write. On platforms with no backend, agent.spawn FAILS CLOSED (an
+ * absent sandbox is indistinguishable from a broken one, so it refuses). The
+ * operator escape hatch REVDEV_SPAWN_CONFINEMENT=none spawns unconfined and
+ * records confinement='none' on the row. See confinement.ts.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -30,9 +32,16 @@ import type { PGlite } from '@electric-sql/pglite';
 import { createLogger } from '@revealui/utils/logger';
 import type { IDisposable, IPty } from 'node-pty';
 import * as nodePty from 'node-pty';
-import { onAgentEnded } from './eviction.js';
-import { requireDirInRoot } from './filegit.js';
-import { registerHandler, type SocketContext } from './server.js';
+import {
+  buildConfinedEnv,
+  ensureAgentHome,
+  filterCallerEnv,
+  type ResolvedConfinement,
+  resolveConfinementBackend,
+} from './confinement.js';
+import { onAgentEnded, onDaemonStarted } from './eviction.js';
+import { requireRootAndDir } from './filegit.js';
+import { getDaemonConfig, registerHandler, type SocketContext } from './server.js';
 
 const log = createLogger({ service: 'revdev-daemon/spawn' });
 
@@ -127,30 +136,30 @@ onAgentEnded((agentId: string) => {
 });
 
 // ---------------------------------------------------------------------------
-// Minimal safe environment for spawned processes
+// Confinement backend — resolved ONCE at daemon start (spec §4.2 invariant 1),
+// cached module-level. bwrap is realpath'd + ownership-checked here, never
+// through a caller-influenced PATH.
 // ---------------------------------------------------------------------------
 
-/**
- * Build a minimal environment for a spawned PTY process. We do NOT inherit
- * `process.env` blindly because that would pass revvault secrets, API keys,
- * and signing material to the child.
- *
- * P4-IDENTITY TODO: once the B6 project.grant model ships, gate which env
- * keys a spawned-agent DID may request against the grant.
- */
-function buildSafeEnv(extraEnv: Record<string, string>): Record<string, string> {
-  const base: Record<string, string> = {
-    GIT_CONFIG_NOSYSTEM: '1',
-    HOME: process.env.HOME ?? '/tmp',
-    PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
-    TERM: 'xterm-color',
-    LANG: 'C.UTF-8',
-  };
-  for (const [k, v] of Object.entries(extraEnv)) {
-    base[k] = v;
+let _confinement: ResolvedConfinement | null = null;
+
+onDaemonStarted(async () => {
+  _confinement = resolveConfinementBackend();
+  if (_confinement.backend) {
+    log.info('agent.spawn confinement active', {
+      mode: _confinement.mode,
+      reason: _confinement.reason,
+    });
+  } else if (_confinement.escapeHatch) {
+    log.warn('agent.spawn confinement DISABLED via escape hatch — spawns run unconfined', {
+      reason: _confinement.reason,
+    });
+  } else {
+    log.warn('agent.spawn has NO confinement backend — spawns will fail closed', {
+      reason: _confinement.reason,
+    });
   }
-  return base;
-}
+});
 
 // ---------------------------------------------------------------------------
 // Local parameter extraction helpers
@@ -214,13 +223,17 @@ function safeEnvRecord(v: unknown): Record<string, string> {
  *   - Signature-gated: requireAgent() accepts only a verified Ed25519 signer,
  *     never a caller-supplied actorAgentId.
  *   - Authorized: `repoPath` must be a registered root the signer owns or was
- *     granted, and `cwd` must resolve at or beneath it (requireDirInRoot).
+ *     granted, and `cwd` must resolve at or beneath it (requireRootAndDir).
  *     There is no default cwd; a missing repoPath is a hard error.
- *   - env is built from a minimal baseline (see buildSafeEnv).
+ *   - Confined: on Linux/WSL2 the command runs inside a bwrap sandbox; on
+ *     platforms with no backend the spawn fails closed (confinement.ts).
+ *   - env is an allow-list (filterCallerEnv) over a deny-by-default baseline
+ *     with HOME pointed at the per-agent home (buildConfinedEnv).
  *   - Per-agent concurrency is capped at MAX_PROCESSES_PER_AGENT.
  *
- * Still open: `command` itself is not constrained to an allow-list, so an
- * authorized caller may run any binary within a root it holds.
+ * `command` is not constrained to an allow-list — an authorized caller may run
+ * any binary — but the sandbox bounds what that binary can touch to the granted
+ * root and the agent home. A command allow-list is out of Phase 1 scope.
  */
 registerHandler('agent.spawn', async (params, db, ctx) => {
   const ownerAgentId = requireAgent(ctx, params);
@@ -231,12 +244,12 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   const args = stringArrayParam(params, 'args');
   const cols = positiveInt(params.cols, 80);
   const rows = positiveInt(params.rows, 24);
-  const extraEnv = safeEnvRecord(params.env);
 
   // Authorization. The signature gate above proves WHO is asking; this proves
   // they may run a command THERE. `repoPath` must be a root the signer opened
   // or was granted via project.grant, and `cwd` must resolve to a real
-  // directory at or beneath it.
+  // directory at or beneath it. We keep BOTH the realpath'd root (bound
+  // read-write) and the resolved cwd (started in) — see requireRootAndDir.
   //
   // Fail closed: `repoPath` is required. The previous default silently fell
   // back to $HOME, so any verified agent could fork a command as the daemon UID
@@ -245,11 +258,16 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   if (!repoPath) {
     throw new Error('agent.spawn: missing repoPath (call project.open on the root first)');
   }
-  const cwd = await requireDirInRoot(
+  const { repoReal, cwd } = await requireRootAndDir(
     repoPath,
     stringParam(params, 'cwd') || undefined,
     ownerAgentId,
   );
+
+  // Env allow-list (spec §7). A non-allow-listed caller key (HOME, PATH, any
+  // LD_*/GIT_*/NODE_OPTIONS loader key) is rejected by name here, before any
+  // home is built or process spawned.
+  const callerEnv = filterCallerEnv(safeEnvRecord(params.env));
 
   if (liveCountForAgent(ownerAgentId) >= MAX_PROCESSES_PER_AGENT) {
     throw new Error(
@@ -257,12 +275,44 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
     );
   }
 
-  const processId = randomUUID();
-  const env = buildSafeEnv(extraEnv);
+  // Per-agent persistent home (spec §5); HOME points here inside the sandbox.
+  const agentHome = await ensureAgentHome(getDaemonConfig().dataDir, ownerAgentId);
+  const env = buildConfinedEnv(callerEnv, agentHome);
 
-  // P4-IDENTITY TODO: before spawning, verify the caller holds a project.grant
-  // for the command/cwd combination. Requires the grant model from the B6 lane.
-  const pty = nodePty.spawn(command, args, {
+  // Resolve the confinement backend (cached at daemon start; lazy fallback for
+  // a handler somehow invoked before the startDaemon hook fired).
+  const conf = _confinement ?? resolveConfinementBackend();
+  const operatorHome = process.env.HOME ?? '/root';
+
+  let file: string;
+  let argv: string[];
+  let confinement: string;
+  if (conf.backend) {
+    // Confined: node-pty execs bwrap, which execs the command inside the sandbox.
+    ({ file, argv } = conf.backend.spawnConfined(command, args, {
+      repoReal,
+      cwd,
+      agentHome,
+      operatorHome,
+    }));
+    confinement = conf.mode;
+  } else if (conf.escapeHatch) {
+    // Operator explicitly disabled confinement. Spawn unconfined, but leave a
+    // receipt: warn, and persist confinement='none' on the row.
+    file = command;
+    argv = args;
+    confinement = 'none';
+    log.warn('agent.spawn running UNCONFINED via escape hatch', { command, ownerAgentId, cwd });
+  } else {
+    // No backend and no escape hatch — refuse rather than spawn unprotected.
+    throw new Error(
+      `agent.spawn: refusing to spawn without confinement (${conf.reason}). ` +
+        'Set REVDEV_SPAWN_CONFINEMENT=none in the daemon environment to override (audited).',
+    );
+  }
+
+  const processId = randomUUID();
+  const pty = nodePty.spawn(file, argv, {
     name: 'xterm-color',
     cols,
     rows,
@@ -271,9 +321,9 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   });
 
   await db.query(
-    `INSERT INTO agent_processes (id, owner_agent, command, args, cwd, pid, status)
-     VALUES ($1, $2, $3, $4::jsonb, $5, $6, 'running')`,
-    [processId, ownerAgentId, command, JSON.stringify(args), cwd, pty.pid],
+    `INSERT INTO agent_processes (id, owner_agent, command, args, cwd, pid, status, confinement)
+     VALUES ($1, $2, $3, $4::jsonb, $5, $6, 'running', $7)`,
+    [processId, ownerAgentId, command, JSON.stringify(args), cwd, pty.pid, confinement],
   );
 
   const entry: ProcessEntry = {

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -526,8 +526,11 @@ export const schemas: Record<string, z.ZodType> = {
       cwd: safePath.optional(),
       cols: z.number().int().min(1).max(1000).optional(),
       rows: z.number().int().min(1).max(500).optional(),
-      // Caller-supplied env overrides (merged onto a minimal safe baseline).
-      // Values must be strings; non-string values are dropped by the handler.
+      // Caller-supplied env. The handler enforces an ALLOW-LIST (filterCallerEnv,
+      // spec §7): only TERM, LANG, LC_*, CI, NO_COLOR, REVDEV_* are accepted; any
+      // other key (HOME, PATH, LD_*/GIT_*/NODE_OPTIONS loader keys) is rejected by
+      // name. The schema stays permissive so the rejection is a clear handler
+      // error naming the offending key, not a generic schema failure.
       env: z.record(z.string(), z.string()).optional(),
       actorAgentId,
     })


### PR DESCRIPTION
## agent.spawn confinement, Phase 1: the kernel boundary

Implements the merged spec [`2026-07-10-agent-spawn-confinement-phase-1`](https://github.com/RevealUIStudio/revealui-jv/blob/test/docs/specs/2026-07-10-agent-spawn-confinement-phase-1.md) (GAP-288, jv#369 §8/§10). Crown-jewel surface: **`agent.spawn` forks a caller-supplied command as the daemon UID.** Requesting the Fable adversarial review before merge; no gate labels applied, owner merges (disposition discipline).

### What this closes

Authentication (the Ed25519 dispatch gate) and authorization (`requireDirInRoot`, revdev#260) already held. The residual was **containment**: a verified, authorized spawn ran with the daemon's entire filesystem view, so it could read `~/.age-identity` (the single revvault encryption boundary), `~/.ssh` (incl. the commit-signing key), and the passage-store regardless of the granted cwd. Env-scoping does not fix this: `open("/home/op/.ssh/id")` never consults `$HOME`.

### Mechanism

On Linux/WSL2 the command runs inside `bwrap` with a **deny-by-default** bind set (spec §4.3):

- `/usr` read-only + merged-usr symlinks, minimal `/etc`, `/proc`, `/dev`, a private `/tmp`.
- The **operator home is tmpfs'd**, hiding everything beneath it; only the granted root and a per-agent home are re-bound read-write on top. Shared caches (pnpm store, cargo registry/git) are bound by exact subdirectory, never a secret-bearing parent.
- `HOME`/`PATH` set authoritatively inside; user/pid/ipc/uts/cgroup namespaces unshared (NOT net — pnpm/cargo/claude need egress; NOT `--new-session` — it breaks interactive job control, §4.3).
- Symlink escape closed for free (§4.4): a repo symlink to `~/.ssh` resolves against the sandbox root where it does not exist.

**bwrap is resolved once at daemon start** to an absolute realpath and verified root-owned + not group/other-writable (§4.2 inv 1), never through a caller-influenced PATH.

**Env allow-list (§7):** caller env is an allow-list (`TERM`, `LANG`, `LC_*`, `CI`, `NO_COLOR`, `REVDEV_*`); `HOME`, `PATH`, and the loader set (`LD_PRELOAD`, `NODE_OPTIONS`, `GIT_SSH_COMMAND`, …) are rejected by name. Zero authored regex (Set + `startsWith`).

**Fail-closed (§8):** platforms with no backend (macOS/Windows/WSL1) refuse to spawn — an absent sandbox is indistinguishable from a broken one. The operator escape hatch `REVDEV_SPAWN_CONFINEMENT=none` (daemon env only, never a caller param) spawns unconfined and records `confinement='none'` on the `agent_processes` row. If an agent did it, there is a receipt.

### Deliberate functional loss (§6)

git signing **breaks by design**: a spawned agent has no `~/.ssh`, no `SSH_AUTH_SOCK`, and a synthesized `gpgsign=false` gitconfig with no signingkey, so it cannot forge a commit GitHub marks Verified as the operator, and cannot `git push` over SSH. A broken signature is strictly safer than a forgeable one. The credential proxy (§6 option 2) is the top Phase 1b thread.

### Files

| File | Change |
|---|---|
| `packages/daemon/src/confinement.ts` | new — backend interface, linux-bubblewrap argv, bwrap resolution, env allow-list, per-agent home, fail-closed resolution |
| `packages/daemon/src/spawn.ts` | handler wiring: allow-list → confined env → backend argv → `confinement` audit column |
| `packages/daemon/src/filegit.ts` | `requireRootAndDir` (returns root + cwd) reused by the handler; `requireDirInRoot` delegates to it |
| `packages/daemon/src/migrations/0006-*` | `agent_processes.confinement` audit column |
| `packages/daemon/src/validation/schemas.ts` | comment: env is handler-allow-listed |
| `.github/workflows/ci.yml` | install bubblewrap so the integration reads run for real in CI |

### Evidence

- **Both suites green:** daemon `597/597` (28 new confinement tests), `cargo test --test harness_integration` `4/4` (daemon boots with migration 0006 over a real socket; Studio not broken).
- **Prove-red (per `feedback-prove-tests-fail-without-the-fix`):** neutering `spawnConfined` to a passthrough turns the 5 adversarial-read/escape assertions red (secrets leak, symlink escapes, absolute command reads through); the 2 sandbox-independent assertions (unsandboxed control, repo daily-driver read) stay green. Restored to green.
- **Literal §10 reads against the REAL operator home on WSL2** (kernel `6.6.114.1-microsoft-standard-WSL2`): `.ssh`, `.age-identity`, `.revealui/passage-store`, `.config/gh`, `.aws` all `denied` inside the sandbox; granted repo `package.json` readable.
- `confinement-integration.test.ts` runs real bwrap hermetically (temp home + fake secrets), each adversarial read paired with an unsandboxed prove-red control; self-skips via a `bwrapUsable()` probe on hosts without unprivileged namespaces (the fail-closed platform).

### Reviewer notes (Fable)

- Argv construction and the tmpfs-before-rebind ordering are the load-bearing correctness points (§4.3). `confinement.test.ts` pins the ordering.
- `confinement='none'` under the escape hatch is the audit contract (§8.1); `spawn.test.ts` asserts it.
- Out of scope for Phase 1 (spec §11): network egress, the credential proxy, seccomp, per-root rw scoping, cgroup limits, the macOS `darwin-seatbelt` backend (staged, disabled until CI-green on a Mac runner).

Refs: GAP-288
