### PR TITLE
test(daemon): clear the Private Leak Scan on confinement fixtures

### DIFF
--- a/packages/daemon/src/__tests__/confinement.test.ts
+++ b/packages/daemon/src/__tests__/confinement.test.ts
@@ -35,7 +35,7 @@ describe('filterCallerEnv', () => {
   });
 
   it('rejects HOME by name (the escape the tmpfs would otherwise absorb)', () => {
-    expect(() => filterCallerEnv({ HOME: '/home/op' })).toThrow(/"HOME" is not caller-settable/);
+    expect(() => filterCallerEnv({ HOME: '/base/op' })).toThrow(/"HOME" is not caller-settable/);
   });
 
   it('rejects PATH', () => {
@@ -98,10 +98,10 @@ describe('buildConfinedEnv', () => {
 describe('linuxBubblewrapBackend.spawnConfined', () => {
   const backend = linuxBubblewrapBackend('/usr/bin/bwrap');
   const opts = {
-    repoReal: '/home/op/repo',
-    cwd: '/home/op/repo/packages/x',
-    agentHome: '/home/op/.local/share/revealui/agent-homes/deadbeef',
-    operatorHome: '/home/op',
+    repoReal: '/base/op/repo',
+    cwd: '/base/op/repo/packages/x',
+    agentHome: '/base/op/.local/share/revealui/agent-homes/deadbeef',
+    operatorHome: '/base/op',
   };
 
   it('execs bwrap, not the raw command', () => {
@@ -121,11 +121,11 @@ describe('linuxBubblewrapBackend.spawnConfined', () => {
   it('tmpfs-hides the operator home and re-binds only the granted root + agent home', () => {
     const { argv } = backend.spawnConfined('bash', [], opts);
     const s = argv.join(' ');
-    expect(s).toContain('--tmpfs /home/op');
+    expect(s).toContain('--tmpfs /base/op');
     expect(s).toContain(`--bind ${opts.repoReal} ${opts.repoReal}`);
     expect(s).toContain(`--bind ${opts.agentHome} ${opts.agentHome}`);
     // The operator-home tmpfs must come BEFORE the re-binds, or the binds get wiped.
-    const tmpfsIdx = argv.indexOf('/home/op'); // the --tmpfs operand
+    const tmpfsIdx = argv.indexOf('/base/op'); // the --tmpfs operand
     const repoBindIdx = argv.indexOf(opts.repoReal);
     expect(tmpfsIdx).toBeLessThan(repoBindIdx);
   });

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -323,7 +323,7 @@ describe('agent.spawn', () => {
       signedRpc(owner, 'agent.spawn', {
         command: 'bash',
         repoPath: repoRoot,
-        env: { HOME: '/home/op' },
+        env: { HOME: '/base/op' },
       }),
     ).rejects.toThrow(/not caller-settable/);
   });


### PR DESCRIPTION
## What

Clears the red **Private Leak Scan** that #264 merged with. The confinement Phase 1 unit fixtures used a literal `/home/op` operator-home path (a synthetic username), which the scanner flags via its `/home/<user>/` pattern.

No real path was ever disclosed `op` is fabricated. But a lone red scan is a gate that blocks the next `test`->`main` promotion and any PR that re-runs it, so the false positive has to go.

## How

Swap the opaque fixture constant `/home/op` -> `/base/op` in `confinement.test.ts` and `spawn.test.ts`. The value is only ever asserted as an argv/env **string**, so the substitution is behavior-preserving.

Chosen over a `.leakignore` allowlist deliberately: an allowlist entry is keyed by (path-glob, tag), so it would suppress **every** `abs-home-path` hit in those files including a future *real* leak. Fixing the source keeps the guard fully active.

## Verification

- `bash scripts/check-no-private-leaks.sh <both files>` -> OK (exit 0); no `/home/` refs remain.
- `vitest run confinement.test.ts spawn.test.ts` -> **57/57 pass**.
- Fleet checker `security-pr-review-check.js --diff origin/test` -> no security-sensitive files, no coordinator gate.

Follow-up to #264 (bwrap confinement Phase 1).
