### PR TITLE
fix(ci): allowlist synthetic /home/op confinement fixtures — unbreak leak scan on test

### DIFF
--- a/.leakignore
+++ b/.leakignore
@@ -12,6 +12,12 @@
 apps/studio/src/__tests__/hooks/use-local-shell.test.ts   abs-home-path
 apps/studio/src/__tests__/hooks/use-ssh.test.ts           abs-home-path
 
+# Phase-1 agent.spawn confinement test fixtures use a synthetic operator
+# username (/home/<op>) — same placeholder case as the two entries above;
+# not a real developer path.
+packages/daemon/src/__tests__/confinement.test.ts         abs-home-path
+packages/daemon/src/__tests__/spawn.test.ts               abs-home-path
+
 # Test fixture: the license-key shape matches the regex but the body is a
 # repeating hex pattern (abcdef-0123456789 doubled). Not a real key.
 packages/daemon/src/__tests__/flows.test.ts               license-key


### PR DESCRIPTION
The Private Leak Scan is RED on `test` (run on 0969b8c = failure): #264 merged the Phase-1 confinement fixtures (confinement.test.ts, spawn.test.ts) whose synthetic operator home `/home/op` trips the abs-home-path pattern, but the allowlist entry did not merge with it. Every PR into test now inherits this red merge base.

This is the 2-line `.leakignore` allowlist the Opus #264 reviewer already diagnosed as a false positive (op is a synthetic username, not a real path) — same placeholder case already allowlisted for the use-local-shell / use-ssh studio fixtures. Scoped to the abs-home-path tag on exactly those two files; any other tag or any other /home path still fails. Local scan verified clean.

Fix-forward to unbreak test. Your merge.
