### PR TITLE
chore(ci): drop dead .leakignore confinement entries superseded by #265

### DIFF
--- a/.leakignore
+++ b/.leakignore
@@ -12,12 +12,6 @@
 apps/studio/src/__tests__/hooks/use-local-shell.test.ts   abs-home-path
 apps/studio/src/__tests__/hooks/use-ssh.test.ts           abs-home-path
 
-# Phase-1 agent.spawn confinement test fixtures use a synthetic operator
-# username (/home/<op>) — same placeholder case as the two entries above;
-# not a real developer path.
-packages/daemon/src/__tests__/confinement.test.ts         abs-home-path
-packages/daemon/src/__tests__/spawn.test.ts               abs-home-path
-
 # Test fixture: the license-key shape matches the regex but the body is a
 # repeating hex pattern (abcdef-0123456789 doubled). Not a real key.
 packages/daemon/src/__tests__/flows.test.ts               license-key


### PR DESCRIPTION
## What

Removes two now-**dead** `.leakignore` entries that #266 added for the confinement test fixtures:

```
packages/daemon/src/__tests__/confinement.test.ts   abs-home-path
packages/daemon/src/__tests__/spawn.test.ts         abs-home-path
```

## Why they are dead

#265 (merged ~3 min before #266) already fixed the same Private Leak Scan red by removing the synthetic `/home/op` fixtures **at the source** (`/home/op` → `/base/op`). So these two file-scoped allowlist entries now match nothing.

A dead file-scoped `abs-home-path` allowlist entry is not harmless: it silently suppresses **all** future `abs-home-path` hits in that file, including a real `/home/<user>` leak. Removing them restores full scanner strength on both files. (This is the collision flagged in the consolidation handoff jv#392 next-actions §5.)

## Verification

- `scripts/check-no-private-leaks.sh` → clean, exit 0 with the entries gone (the fixtures pass on their own merit via #265's `/base/op`).
- Fleet checker `security-pr-review-check.js --diff` → no security-sensitive files, no coordinator gate.
- The other `.leakignore` entries (studio hooks, `flows.test.ts`, `INDEX.md`, `.gitleaks.issues.toml`) are untouched.
