### PR TITLE
ci(prove-red): extend the prove-red gate to Rust and Go changed tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - run: pnpm test
 
   prove-red:
-    name: Prove-Red (changed tests must fail against base)
+    name: Prove-Red (TypeScript changed tests must fail against base)
     runs-on: ubuntu-latest
     needs: quality
     # PR-only: a merge-base is meaningless on a direct push to test/main.
@@ -130,9 +130,42 @@ jobs:
       # per-file vitest runs fail to resolve imports rather than on assertions.
       - run: pnpm --filter @revdev/protocol build
       - run: pnpm --filter @revdev/daemon build
-      - name: Prove changed tests are red against base
+      # Scoped to TypeScript: this runner installs only Node/pnpm. The Rust and
+      # Go languages the gate also covers run in their own jobs (prove-red-go
+      # here; prove-red-rust in studio-rust-tests.yml) so each installs only its
+      # own toolchain. Default (no PROVE_RED_LANGS) is all three, for local runs.
+      - name: Prove changed TypeScript tests are red against base
         env:
           BASE_REF: ${{ github.event.pull_request.base.sha }}
+          PROVE_RED_LANGS: typescript
+        run: node scripts/ci/prove-red.mjs
+
+  prove-red-go:
+    name: Prove-Red (Go changed tests must fail against base)
+    runs-on: ubuntu-latest
+    needs: quality
+    # PR-only: a merge-base is meaningless on a direct push to test/main.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: apps/console/go.mod
+          cache-dependency-path: apps/console/go.sum
+      # Node runs the gate script itself (Node stdlib only, no pnpm needed here).
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+      # Reverts the changed Go source to base, then runs each changed test's
+      # package (`go test ./pkg/`) and requires >=1 red. Package granularity is
+      # inherent to `go test`; see scripts/ci/prove-red.mjs header.
+      - name: Prove changed Go tests are red against base
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+          PROVE_RED_LANGS: go
         run: node scripts/ci/prove-red.mjs
 
   build:

--- a/.github/workflows/studio-rust-tests.yml
+++ b/.github/workflows/studio-rust-tests.yml
@@ -110,3 +110,67 @@ jobs:
       # tests drive the real built binary against a mock socket.
       - name: Build + test the WSL relay
         run: cargo test --manifest-path apps/studio/relay/Cargo.toml --release
+
+  # Prove-red for the Rust surface (verification-enforcement lane item 1d). Lives
+  # here rather than in ci.yml because it reuses this workflow's heavy Rust/tauri
+  # toolchain + path filter: it only runs when the Rust surface (or the daemon it
+  # talks to) changes, and it self-skips inside the script unless the PR touches
+  # BOTH Rust source and a Rust integration test. Like the ci.yml prove-red jobs
+  # it is a NON-required check (the required-check flip is lane item 1c, owner-gated).
+  prove-red-rust:
+    name: Prove-Red (Rust changed tests must fail against base)
+    runs-on: ubuntu-latest
+    # PR-only: a merge-base is meaningless on a direct push to test/main.
+    if: github.event_name == 'pull_request'
+    steps:
+      # PR head + full history so prove-red.mjs can compute the merge base.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: apps/studio/src-tauri -> target
+
+      - run: pnpm install --frozen-lockfile
+
+      # A changed test that legitimately compiles + runs green against base needs
+      # the daemon it spawns; build it so green-detection is faithful (a failing
+      # test still reds at compile/assert without it).
+      - name: Build daemon (integration tests spawn packages/daemon/dist/cli.js)
+        run: |
+          pnpm --filter @revdev/protocol build
+          pnpm --filter @revdev/daemon build
+
+      # tauri-build's codegen requires the configured frontendDist path to exist.
+      - name: Satisfy tauri-build frontendDist
+        run: mkdir -p apps/studio/dist
+
+      # Reverts the changed Rust source to base, then runs each changed
+      # integration test (`cargo test --test <name>`) and requires >=1 red.
+      - name: Prove changed Rust tests are red against base
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+          PROVE_RED_LANGS: rust
+        run: node scripts/ci/prove-red.mjs

--- a/scripts/ci/prove-red.mjs
+++ b/scripts/ci/prove-red.mjs
@@ -1,31 +1,50 @@
 #!/usr/bin/env node
-// Prove-red gate (verification-enforcement lane, spec 2026-07-10).
+// Prove-red gate (verification-enforcement lane, spec 2026-07-10; language
+// coverage extended per lane item 1d).
 //
 // A test that passes whether or not the fix is present proves nothing. This
 // gate mechanises "prove red": on a PR that changes BOTH product source and
 // test files, it reverts the source changes to the merge base, re-runs each
-// CHANGED test file, and REQUIRES each to be red against the base. A changed
-// test file that stays green without the source change is inert, and the gate
-// blocks it.
+// CHANGED test, and REQUIRES at least one to be red against the base. A changed
+// test that stays green without the source change is inert, and the gate
+// blocks a PR whose only evidence is inert tests.
 //
-// Honest limits (kept in lockstep with the spec §4.2):
-//   - It proves "the changed test file does not PASS against base", which is
-//     weaker than "fails on an assertion": a file that fails to import because
+// The gate covers three toolchains. Each fires independently: a language is
+// "active" only when the PR changes BOTH that language's source AND its tests,
+// and each active language must produce >=1 red test of its own. Scope with
+// PROVE_RED_LANGS (comma list of: typescript, go, rust); default is all three.
+// CI runs one language per job so each job installs only the toolchain it needs.
+//
+// Coverage unit per language — stated honestly, because the granularity differs:
+//   - TypeScript/vitest — the test FILE. Each changed `*.test.ts` runs via
+//     `pnpm --filter <pkg> exec vitest run <file>` against reverted source.
+//   - Go/`go test` — the PACKAGE. `go test` compiles and runs a whole package;
+//     a single test FILE cannot be run in isolation (its funcs share the
+//     package's other files). So a changed `*_test.go` is proven at package
+//     granularity: the package, built from base non-test source plus the PR's
+//     test files, must have >=1 failing test.
+//   - Rust/`cargo test` — the integration-test FILE (`cargo test --test <name>`
+//     per crate manifest). Inline `#[cfg(test)]` unit tests inside `src/*.rs`
+//     are NOT covered: they compile together with the source they test, so
+//     reverting the source removes the very tests, and proving them needs
+//     per-hunk attribution. Same shape as the TS per-test deferral below.
+//
+// Honest limits shared by all three (kept in lockstep with the spec §4.2):
+//   - It proves "the changed test does not PASS against base", which is weaker
+//     than "fails on an assertion": a test that fails to compile/import because
 //     it references a symbol the PR added counts as red here. So the gate kills
 //     the worthless regression guard but does not certify test STRENGTH.
-//   - Granularity is the FILE, not the individual test case. A changed file
-//     whose NEW test is inert but whose OLD test goes red against base still
-//     passes. Raising this to per-test needs diff-hunk attribution; deferred.
-//   - TypeScript/vitest only in Phase 1a. Rust (`cargo test`) and Go
-//     (`go test`) changed-test prove-red is NOT covered and is logged loudly
-//     below rather than silently skipped.
+//   - Granularity is the unit above (file/package), not the individual test
+//     case. A changed unit whose NEW test is inert but whose OLD test goes red
+//     against base still passes. Raising this to per-test needs diff-hunk
+//     attribution; deferred.
 //
 // Zero authored regex (fleet rule): path classification is suffix/substring
 // membership only.
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join, relative } from 'node:path';
+import { basename, dirname, join, relative } from 'node:path';
 
 const REPO_ROOT = process.cwd();
 
@@ -43,24 +62,41 @@ const TEST_SUFFIXES = [
 ];
 const CODE_SUFFIXES = ['.ts', '.tsx', '.js', '.mjs', '.cjs'];
 
-function isTestFile(p) {
+// TypeScript / JavaScript ---------------------------------------------------
+function tsIsTest(p) {
   if (p.includes('/__tests__/')) return true;
   for (const s of TEST_SUFFIXES) if (p.endsWith(s)) return true;
   return false;
 }
-
-function isCodeSource(p) {
-  if (isTestFile(p)) return false;
+function tsIsSource(p) {
+  if (tsIsTest(p)) return false;
   if (p.endsWith('.d.ts')) return false;
   for (const s of CODE_SUFFIXES) if (p.endsWith(s)) return true;
   return false;
 }
 
-// Non-TS test files we cannot prove-red yet, surfaced rather than silently dropped.
-function isUncoveredTestFile(p) {
-  if (p.endsWith('_test.go')) return true;
-  if (p.includes('/tests/') && p.endsWith('.rs')) return true;
-  return false;
+// Go ------------------------------------------------------------------------
+function goIsTest(p) {
+  return p.endsWith('_test.go');
+}
+function goIsSource(p) {
+  return p.endsWith('.go') && !p.endsWith('_test.go');
+}
+
+// Rust — an integration test is a `.rs` whose parent directory is `tests`
+// (`<crate>/tests/<name>.rs`), run per-file with `cargo test --test <name>`.
+// Everything else under a crate (`src/**`) is source; inline `#[cfg(test)]`
+// unit tests inside src are not separable (see header). The parent-dir check
+// works whether the crate is the repo root (`tests/it.rs`) or nested
+// (`apps/studio/src-tauri/tests/harness_integration.rs`).
+function rustParentIsTests(p) {
+  return basename(dirname(p)) === 'tests';
+}
+function rustIsTest(p) {
+  return p.endsWith('.rs') && rustParentIsTests(p);
+}
+function rustIsSource(p) {
+  return p.endsWith('.rs') && !rustParentIsTests(p);
 }
 
 // --- git helpers -----------------------------------------------------------
@@ -84,8 +120,31 @@ function changedFiles(base) {
   });
 }
 
-// --- package resolution ----------------------------------------------------
+// Restore each file to its base content (added-in-PR files are removed).
+function revertToBase(files, base) {
+  for (const { status, path } of files) {
+    if (status === 'A') {
+      execFileSync('rm', ['-f', path], { cwd: REPO_ROOT });
+    } else {
+      git(['checkout', base, '--', path]);
+    }
+  }
+}
 
+// --- manifest resolution ---------------------------------------------------
+
+// Nearest ancestor dir (inclusive) containing `filename`.
+function nearestDirWith(startDir, filename) {
+  let dir = startDir;
+  while (dir.startsWith(REPO_ROOT)) {
+    if (existsSync(join(dir, filename))) return dir;
+    if (dir === REPO_ROOT) break;
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+// Nearest package.json with a `name`, walking up from a file.
 function nearestPackage(fileAbs) {
   let dir = dirname(fileAbs);
   while (dir.startsWith(REPO_ROOT)) {
@@ -104,7 +163,7 @@ function nearestPackage(fileAbs) {
   return null;
 }
 
-// --- main ------------------------------------------------------------------
+// --- command runner --------------------------------------------------------
 
 function fail(msg) {
   console.error(`\n✗ prove-red: ${msg}`);
@@ -116,111 +175,233 @@ function skip(msg) {
   process.exit(0);
 }
 
+// Run a test command; return its exit code (0 = green, non-zero = red). A
+// missing toolchain is an ENVIRONMENT error, not a red — it must fail the gate
+// loudly rather than be miscounted as failing-first evidence.
+function runCmd(file, args, opts) {
+  try {
+    execFileSync(file, args, { stdio: 'inherit', ...opts });
+    return 0;
+  } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      fail(
+        `toolchain '${file}' not found — cannot run \`${file} ${args.join(' ')}\`. ` +
+          'Install it or scope the run with PROVE_RED_LANGS.',
+      );
+    }
+    return typeof e.status === 'number' ? e.status : 1;
+  }
+}
+
+// --- per-language run plans -------------------------------------------------
+// Each plan turns changed test files into runnable "units" ({ label, exec }).
+
+function planTypescript(tests) {
+  const byPackage = new Map();
+  for (const { path } of tests) {
+    const abs = join(REPO_ROOT, path);
+    const pkg = nearestPackage(abs);
+    if (!pkg) {
+      console.log(`prove-red: NOTE: no package.json owns ${path}; skipping it.`);
+      continue;
+    }
+    if (!byPackage.has(pkg.name)) byPackage.set(pkg.name, { dir: pkg.dir, files: [] });
+    byPackage.get(pkg.name).files.push(relative(pkg.dir, abs));
+  }
+  const units = [];
+  for (const [name, { files }] of byPackage) {
+    for (const file of files) {
+      units.push({
+        label: `${name} :: ${file}`,
+        exec: () =>
+          runCmd('pnpm', ['--filter', name, 'exec', 'vitest', 'run', '--no-coverage', file], {
+            cwd: REPO_ROOT,
+          }),
+      });
+    }
+  }
+  return units;
+}
+
+function planGo(tests) {
+  // Group by owning module, then by package dir (relative to the module root).
+  const byModule = new Map(); // moduleDir -> Set<relPkg>
+  for (const { path } of tests) {
+    const abs = join(REPO_ROOT, path);
+    const moduleDir = nearestDirWith(dirname(abs), 'go.mod');
+    if (!moduleDir) {
+      console.log(`prove-red: NOTE: no go.mod owns ${path}; skipping it.`);
+      continue;
+    }
+    const rel = relative(moduleDir, dirname(abs)) || '.';
+    if (!byModule.has(moduleDir)) byModule.set(moduleDir, new Set());
+    byModule.get(moduleDir).add(rel);
+  }
+  const units = [];
+  for (const [moduleDir, pkgs] of byModule) {
+    for (const rel of pkgs) {
+      const target = rel === '.' ? './' : `./${rel}/`;
+      units.push({
+        label: `go ${relative(REPO_ROOT, moduleDir) || '.'} :: ${target}`,
+        exec: () => runCmd('go', ['test', target], { cwd: moduleDir }),
+      });
+    }
+  }
+  return units;
+}
+
+function planRust(tests) {
+  const units = [];
+  for (const { path } of tests) {
+    const abs = join(REPO_ROOT, path);
+    const manifestDir = nearestDirWith(dirname(abs), 'Cargo.toml');
+    if (!manifestDir) {
+      console.log(`prove-red: NOTE: no Cargo.toml owns ${path}; skipping it.`);
+      continue;
+    }
+    const stem = basename(path).slice(0, -'.rs'.length);
+    const manifest = relative(REPO_ROOT, join(manifestDir, 'Cargo.toml'));
+    units.push({
+      label: `cargo ${manifest} :: --test ${stem}`,
+      // --test-threads=1: the src-tauri integration tests route the harness
+      // client through process-global env and race in parallel (mirrors
+      // studio-rust-tests.yml). Harmless for the others.
+      exec: () =>
+        runCmd(
+          'cargo',
+          ['test', '--manifest-path', manifest, '--test', stem, '--', '--test-threads=1'],
+          { cwd: REPO_ROOT },
+        ),
+    });
+  }
+  return units;
+}
+
+const LANGS = {
+  typescript: {
+    label: 'TypeScript/vitest (unit: test FILE)',
+    isTest: tsIsTest,
+    isSource: tsIsSource,
+    plan: planTypescript,
+  },
+  go: {
+    label: 'Go/go test (unit: PACKAGE)',
+    isTest: goIsTest,
+    isSource: goIsSource,
+    plan: planGo,
+  },
+  rust: {
+    label: 'Rust/cargo test (unit: integration-test FILE)',
+    isTest: rustIsTest,
+    isSource: rustIsSource,
+    plan: planRust,
+  },
+};
+
+// --- main ------------------------------------------------------------------
+
 const baseRef = process.env.BASE_REF || process.env.BASE_SHA;
 if (!baseRef) fail('BASE_REF is not set (pass the PR base sha).');
 
+const ALL_LANGS = Object.keys(LANGS);
+const requested = (process.env.PROVE_RED_LANGS || ALL_LANGS.join(','))
+  .split(',')
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
+for (const id of requested) {
+  if (!LANGS[id]) {
+    fail(`unknown language '${id}' in PROVE_RED_LANGS (valid: ${ALL_LANGS.join(', ')})`);
+  }
+}
+
 const base = mergeBase(baseRef);
 console.log(`prove-red: merge base = ${base}`);
+console.log(`prove-red: languages requested = ${requested.join(', ')}`);
 
 const changed = changedFiles(base);
-const changedSource = changed.filter((c) => isCodeSource(c.path));
-const changedTests = changed.filter((c) => isTestFile(c.path) && c.status !== 'D');
-const uncovered = changed.filter((c) => isUncoveredTestFile(c.path) && c.status !== 'D');
 
-if (uncovered.length > 0) {
-  console.log(
-    `prove-red: NOTE: ${uncovered.length} changed Rust/Go test file(s) are NOT prove-red covered in Phase 1a:`,
-  );
-  for (const u of uncovered) console.log(`    - ${u.path}`);
-}
-
-// Fire only when product CODE source AND test files both change. Test-only,
-// source-only, and docs/config-only PRs are out of scope by design.
-if (changedSource.length === 0 || changedTests.length === 0) {
-  skip(
-    `changed source files = ${changedSource.length}, changed TS test files = ${changedTests.length}`,
-  );
-}
-
-console.log(`prove-red: reverting ${changedSource.length} source file(s) to base ${base}`);
-for (const { status, path } of changedSource) {
-  if (status === 'A') {
-    // Added in the PR, absent at base. Remove it.
-    execFileSync('rm', ['-f', path], { cwd: REPO_ROOT });
+// A language is active only when the PR changes BOTH its source and its tests.
+const active = [];
+for (const id of requested) {
+  const L = LANGS[id];
+  const source = changed.filter((c) => L.isSource(c.path));
+  const tests = changed.filter((c) => L.isTest(c.path) && c.status !== 'D');
+  if (source.length > 0 && tests.length > 0) {
+    active.push({ id, L, source, tests, units: L.plan(tests) });
   } else {
-    // Modified or deleted in the PR; restore base content.
-    git(['checkout', base, '--', path]);
+    console.log(
+      `prove-red: ${id}: source=${source.length} test=${tests.length} — inactive, skipping`,
+    );
   }
 }
 
-// Group changed test files by their owning package.
-const byPackage = new Map();
-for (const { path } of changedTests) {
-  const abs = join(REPO_ROOT, path);
-  const pkg = nearestPackage(abs);
-  if (!pkg) {
-    console.log(`prove-red: NOTE: no package.json owns ${path}; skipping it.`);
+if (active.length === 0) {
+  skip(`no requested language changed BOTH source and tests (requested: ${requested.join(', ')})`);
+}
+
+const totalUnits = active.reduce((n, a) => n + a.units.length, 0);
+if (totalUnits === 0) skip('no runnable test units resolved from the changed test files');
+
+// Revert every active language's source to base up front, then run each
+// language's changed tests against it and require >=1 red per language.
+for (const a of active) {
+  console.log(`\nprove-red [${a.id}]: reverting ${a.source.length} source file(s) to base ${base}`);
+  revertToBase(a.source, base);
+}
+
+let anyFail = false;
+for (const a of active) {
+  console.log(`\n=== prove-red [${a.id}] — ${a.L.label} ===`);
+  if (a.units.length === 0) {
+    // Activated but nothing runnable resolved (e.g. no owning manifest). Cannot
+    // prove; report rather than silently pass.
+    console.log(`prove-red [${a.id}]: no runnable test units resolved; no evidence produced.`);
     continue;
   }
-  if (!byPackage.has(pkg.name)) byPackage.set(pkg.name, { dir: pkg.dir, files: [] });
-  byPackage.get(pkg.name).files.push(relative(pkg.dir, abs));
-}
 
-if (byPackage.size === 0) skip('no packaged TS test files to run');
-
-// Run each changed test file against the reverted base and classify it.
-//
-// PASS requires AT LEAST ONE changed test file to be red against base: the PR
-// must carry a failing-first test that genuinely depends on the change. A file
-// that stays green is either a legitimate compatibility update to an existing
-// test or an inert new one; the gate cannot tell those apart at file
-// granularity, so it REPORTS them but does not block on them. It blocks only
-// when NO changed test file is red, a source change with zero failing-first
-// evidence, which is exactly the "a passing test proves nothing until it fails
-// against the old code" failure this gate exists to catch.
-const redFiles = [];
-const greenFiles = [];
-for (const [name, { files }] of byPackage) {
-  for (const file of files) {
-    console.log(`\nprove-red: running ${name} :: ${file} against base`);
-    let exit = 0;
-    try {
-      execFileSync('pnpm', ['--filter', name, 'exec', 'vitest', 'run', '--no-coverage', file], {
-        cwd: REPO_ROOT,
-        stdio: 'inherit',
-      });
-    } catch (e) {
-      exit = typeof e.status === 'number' ? e.status : 1;
-    }
+  const redFiles = [];
+  const greenFiles = [];
+  for (const unit of a.units) {
+    console.log(`\nprove-red [${a.id}]: running ${unit.label} against base`);
+    const exit = unit.exec();
     if (exit === 0) {
-      greenFiles.push(`${name} :: ${file}`);
-      console.log(`prove-red: · ${file} PASSED against base (compat update or inert)`);
+      greenFiles.push(unit.label);
+      console.log(
+        `prove-red [${a.id}]: · ${unit.label} PASSED against base (compat update or inert)`,
+      );
     } else {
-      redFiles.push(`${name} :: ${file}`);
-      console.log(`prove-red: ✓ ${file} is red against base, proves the change`);
+      redFiles.push(unit.label);
+      console.log(`prove-red [${a.id}]: ✓ ${unit.label} is red against base, proves the change`);
     }
+  }
+
+  if (greenFiles.length > 0) {
+    console.log(
+      `\nprove-red [${a.id}]: NOTE: these changed tests passed WITHOUT the source change:`,
+    );
+    for (const f of greenFiles) console.log(`    - ${f}`);
+    console.log(
+      '    They may be legitimate compatibility updates, or they may be inert.\n' +
+        '    The gate does not block on them; a reviewer should confirm which they are.',
+    );
+  }
+
+  if (redFiles.length === 0) {
+    anyFail = true;
+    console.error(
+      `\n✗ prove-red [${a.id}]: NONE of the changed ${a.id} tests fail against the base. This PR\n` +
+        `changes ${a.id} product source but carries no failing-first test that depends on the\n` +
+        'change. Add a test that is red without the fix, or, for a genuine\n' +
+        'behavior-preserving refactor, carry the recorded verify:no-behavior-change\n' +
+        'label (applied by a non-author, per the verification-enforcement lane).',
+    );
+  } else {
+    console.log(
+      `\n✓ prove-red [${a.id}]: ${redFiles.length} changed test unit(s) red against base.`,
+    );
   }
 }
 
-if (greenFiles.length > 0) {
-  console.log('\nprove-red: NOTE: these changed test files passed WITHOUT the source change:');
-  for (const f of greenFiles) console.log(`    - ${f}`);
-  console.log(
-    '    They may be legitimate compatibility updates, or they may be inert.\n' +
-      '    The gate does not block on them; a reviewer should confirm which they are.',
-  );
-}
-
-if (redFiles.length === 0) {
-  console.error(
-    '\n✗ prove-red: NONE of the changed test files fail against the base. This PR\n' +
-      'changes product source but carries no failing-first test that depends on the\n' +
-      'change. Add a test that is red without the fix, or, for a genuine\n' +
-      'behavior-preserving refactor, carry the recorded verify:no-behavior-change\n' +
-      'label (applied by a non-author, per the verification-enforcement lane).',
-  );
-  process.exit(1);
-}
-
-console.log(`\n✓ prove-red: ${redFiles.length} changed test file(s) red against base.`);
+if (anyFail) process.exit(1);
+console.log('\n✓ prove-red: all active languages carry failing-first evidence.');
 process.exit(0);


### PR DESCRIPTION
## What

Extends the prove-red CI gate from TypeScript/vitest-only to also cover **Rust (`cargo test`)** and **Go (`go test`)** changed-test coverage. This is item **1d** of the verification-enforcement lane (`.jv docs/lanes/verification-enforcement/plan.md`).

Phase 1a (revdev#263) already *detected* changed Rust (`tests/*.rs`) and Go (`*_test.go`) test files via `isUncoveredTestFile()` and logged them as "NOT covered in Phase 1a." This makes them **enforced**, same contract as TypeScript: on a PR that changes BOTH a language's source AND its tests, revert the source to the merge base and require at least one changed test to be red against it.

## How

**`scripts/ci/prove-red.mjs` is now language-aware** (`PROVE_RED_LANGS` = comma list of `typescript,go,rust`; default all three). Each language activates independently, only when the PR changes both that language's source and its tests, and each active language must carry `>=1` red test of its own.

Honest coverage unit per language (documented in the script header, matching Phase 1a's candor):

| Language | Unit | Command | Note |
|---|---|---|---|
| TypeScript | test **FILE** | `pnpm --filter <pkg> exec vitest run <file>` | unchanged from 1a |
| Go | **PACKAGE** | `go test ./pkg/` | `go test` compiles a whole package; a single file cannot run in isolation |
| Rust | integration-test **FILE** | `cargo test --manifest-path <crate> --test <name>` | inline `#[cfg(test)]` unit tests inside `src/*.rs` are **out of scope** (reverting the source removes them; needs per-hunk attribution) |

Zero authored regex: classification is suffix / parent-dir membership only. A missing toolchain is treated as an environment error (loud fail), never miscounted as a red.

**CI wiring** (one language per job so each installs only its own toolchain):
- `ci.yml` `prove-red` job scoped to `typescript` (behavior identical to today).
- `ci.yml` new `prove-red-go` job (setup-go).
- `studio-rust-tests.yml` new `prove-red-rust` job, reusing that workflow's Rust/tauri toolchain and **path filter** (only runs when the Rust surface or the daemon changes).

All three remain **NON-required** status checks. The required-check flip is lane item **1c** (owner-gated, needs GAP-313 ruled first) and is deliberately **not** touched here; no ruleset changes.

## Verification

Proven with a synthetic red-first harness against **real `cargo` and real `go`** (throwaway git repos, base commit green, head commit either failing-first or inert):

```
PASS  rust-red   (exit 0)   failing-first Rust PR passes the gate
PASS  rust-inert (exit 1)   inert Rust test is blocked
PASS  go-red     (exit 0)   failing-first Go PR passes the gate
PASS  go-inert   (exit 1)   inert Go test is blocked
PASS  ts-red     (exit 0)   TS enforcement path (exit-driven runner)
PASS  ts-inert   (exit 1)   TS inert test is blocked
PASS  go-srconly (skip)     source-only change correctly skips
RESULT: 7 passed, 0 failed
```

`biome check` clean; both workflow YAMLs parse.

## Scope fence

Builds 1d (language coverage) only. Does **not** do 1c (the required-check flip, owner-gated) and touches no ruleset. Fleet security self-check (`security-pr-review-check.js --diff`): no security-sensitive files, no coordinator gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
