### PR TITLE
fix(daemon): GAP-320 confinement Phase 1b — refuse secret-overlapping grants, deny REVDEV_SPAWN_CONFINEMENT passthrough

### DIFF
--- a/packages/daemon/src/__tests__/confinement-integration.test.ts
+++ b/packages/daemon/src/__tests__/confinement-integration.test.ts
@@ -105,6 +105,7 @@ describe.skipIf(!RUN)('confinement integration (real bwrap)', () => {
       cwd: repoReal,
       agentHome,
       operatorHome,
+      dataDir: join(operatorHome, 'daemon-data'),
     });
     const r = spawnSync(file, argv, { encoding: 'utf8', timeout: 15_000 });
     return { status: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
@@ -160,12 +161,14 @@ describe.skipIf(!RUN)('confinement integration (real bwrap)', () => {
     // name before any sandbox is built — while the sibling happy-path spawn above
     // still succeeds (DAILY DRIVER). The guard fires in spawnConfined, so this
     // exercises the real entrypoint with a real secret-bearing home on disk.
+    const dataDir = join(operatorHome, 'daemon-data');
     expect(() =>
       backend.spawnConfined('/bin/sh', ['-c', 'true'], {
         repoReal: operatorHome,
         cwd: operatorHome,
         agentHome,
         operatorHome,
+        dataDir,
       }),
     ).toThrow(/is or contains the operator home/);
     expect(() =>
@@ -174,6 +177,7 @@ describe.skipIf(!RUN)('confinement integration (real bwrap)', () => {
         cwd: join(operatorHome, '.ssh'),
         agentHome,
         operatorHome,
+        dataDir,
       }),
     ).toThrow(/overlaps the never-bound secret path/);
   });

--- a/packages/daemon/src/__tests__/confinement-integration.test.ts
+++ b/packages/daemon/src/__tests__/confinement-integration.test.ts
@@ -154,6 +154,30 @@ describe.skipIf(!RUN)('confinement integration (real bwrap)', () => {
     expect(out).toContain('REPO-VISIBLE');
   });
 
+  it('refuses a spawn whose granted root overlaps a real fixture secret (GAP-320a §5.D)', () => {
+    // End-to-end against the seeded operator-home layout: a granted root that IS
+    // the operator home, or that lives inside the seeded ~/.ssh, is refused by
+    // name before any sandbox is built — while the sibling happy-path spawn above
+    // still succeeds (DAILY DRIVER). The guard fires in spawnConfined, so this
+    // exercises the real entrypoint with a real secret-bearing home on disk.
+    expect(() =>
+      backend.spawnConfined('/bin/sh', ['-c', 'true'], {
+        repoReal: operatorHome,
+        cwd: operatorHome,
+        agentHome,
+        operatorHome,
+      }),
+    ).toThrow(/is or contains the operator home/);
+    expect(() =>
+      backend.spawnConfined('/bin/sh', ['-c', 'true'], {
+        repoReal: join(operatorHome, '.ssh'),
+        cwd: join(operatorHome, '.ssh'),
+        agentHome,
+        operatorHome,
+      }),
+    ).toThrow(/overlaps the never-bound secret path/);
+  });
+
   it('HOME points at the agent home, not the operator home', () => {
     const { out } = confined('echo "HOME=$HOME"');
     expect(out).toContain(`HOME=${agentHome}`);

--- a/packages/daemon/src/__tests__/confinement.test.ts
+++ b/packages/daemon/src/__tests__/confinement.test.ts
@@ -115,6 +115,7 @@ describe('linuxBubblewrapBackend.spawnConfined', () => {
     cwd: '/base/op/repo/packages/x',
     agentHome: '/base/op/.local/share/revealui/agent-homes/deadbeef',
     operatorHome: '/base/op',
+    dataDir: '/base/op/.local/share/revealui',
   };
 
   it('execs bwrap, not the raw command', () => {
@@ -297,33 +298,34 @@ describe('ensureAgentHome', () => {
 
 describe('assertGrantedRootBindable', () => {
   const HOME = '/base/op';
+  const DATADIR = '/base/op/.local/share/revealui';
 
   it('refuses the operator home itself', () => {
-    expect(() => assertGrantedRootBindable(HOME, HOME)).toThrow(/is or contains the operator home/);
+    expect(() => assertGrantedRootBindable(HOME, HOME, DATADIR)).toThrow(/is or contains the operator home/);
   });
 
   it('refuses an ANCESTOR of the operator home', () => {
     // repoReal = /base contains /base/op — the tmpfs-then-bind would carry the home.
-    expect(() => assertGrantedRootBindable('/base', HOME)).toThrow(
+    expect(() => assertGrantedRootBindable('/base', HOME, DATADIR)).toThrow(
       /is or contains the operator home/,
     );
   });
 
   it('refuses a granted root that IS a secret path', () => {
-    expect(() => assertGrantedRootBindable(join(HOME, '.ssh'), HOME)).toThrow(
+    expect(() => assertGrantedRootBindable(join(HOME, '.ssh'), HOME, DATADIR)).toThrow(
       /overlaps the never-bound secret path/,
     );
   });
 
   it('refuses a granted root INSIDE a secret path', () => {
-    expect(() => assertGrantedRootBindable(join(HOME, '.ssh', 'sub'), HOME)).toThrow(
+    expect(() => assertGrantedRootBindable(join(HOME, '.ssh', 'sub'), HOME, DATADIR)).toThrow(
       /overlaps the never-bound secret path/,
     );
   });
 
   it('refuses a granted root that CONTAINS a secret path (.revealui over passage-store)', () => {
     // repoReal = <home>/.revealui contains <home>/.revealui/passage-store.
-    expect(() => assertGrantedRootBindable(join(HOME, '.revealui'), HOME)).toThrow(
+    expect(() => assertGrantedRootBindable(join(HOME, '.revealui'), HOME, DATADIR)).toThrow(
       /overlaps the never-bound secret path/,
     );
   });
@@ -333,27 +335,51 @@ describe('assertGrantedRootBindable', () => {
     // itself (equal direction). Fixtures avoid the Windows-user and trailing-slash
     // mount shapes the private-leak scanner flags — the refusal is identical for
     // any path on those mounts.
-    expect(() => assertGrantedRootBindable('/mnt/c/project', HOME)).toThrow(
+    expect(() => assertGrantedRootBindable('/mnt/c/project', HOME, DATADIR)).toThrow(
       /overlaps the never-bound secret path/,
     );
-    expect(() => assertGrantedRootBindable('/mnt/e', HOME)).toThrow(
+    expect(() => assertGrantedRootBindable('/mnt/e', HOME, DATADIR)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('refuses a granted root that IS the daemon data dir', () => {
+    expect(() => assertGrantedRootBindable(DATADIR, HOME, DATADIR)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('refuses a granted root that CONTAINS the daemon data dir', () => {
+    // repoReal = <home>/.local/share contains the daemon dir under it.
+    expect(() => assertGrantedRootBindable(join(HOME, '.local', 'share'), HOME, DATADIR)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('refuses the daemon data dir even when it is configured OUTSIDE the home', () => {
+    const outHome = '/var/lib/revealui-daemon';
+    expect(() => assertGrantedRootBindable(outHome, HOME, outHome)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+    // A root beneath it (e.g. the grants DB dir) is refused too.
+    expect(() => assertGrantedRootBindable(`${outHome}/pglite`, HOME, outHome)).toThrow(
       /overlaps the never-bound secret path/,
     );
   });
 
   it('does NOT refuse the normal case: a project root beneath the home', () => {
     // The supported shape — ~/revfleet/<repo>. Must NOT throw.
-    expect(() => assertGrantedRootBindable(join(HOME, 'revfleet', 'revealui'), HOME)).not.toThrow();
+    expect(() => assertGrantedRootBindable(join(HOME, 'revfleet', 'revealui'), HOME, DATADIR)).not.toThrow();
   });
 
   it('does NOT refuse a sibling of the home that shares a name prefix (separator-safe)', () => {
     // /base/op-scratch must not match /base/op via a naive startsWith.
-    expect(() => assertGrantedRootBindable('/base/op-scratch/repo', HOME)).not.toThrow();
+    expect(() => assertGrantedRootBindable('/base/op-scratch/repo', HOME, DATADIR)).not.toThrow();
   });
 
   it('does NOT refuse a repo whose name merely prefixes a secret name (.sshkeep)', () => {
     // <home>/.sshkeep is not <home>/.ssh — separator-safe within() must not match.
-    expect(() => assertGrantedRootBindable(join(HOME, '.sshkeep'), HOME)).not.toThrow();
+    expect(() => assertGrantedRootBindable(join(HOME, '.sshkeep'), HOME, DATADIR)).not.toThrow();
   });
 
   it('refuses a SYMLINKED secret dir via the realpath-if-exists form', async () => {
@@ -367,7 +393,7 @@ describe('assertGrantedRootBindable', () => {
       await symlink(target, join(home, '.ssh'));
       // realpath the target the same way requireRootAndDir would hand it in.
       const repoReal = await realpath(target);
-      expect(() => assertGrantedRootBindable(repoReal, home)).toThrow(
+      expect(() => assertGrantedRootBindable(repoReal, home, join(home, 'daemon-data'))).toThrow(
         /overlaps the never-bound secret path/,
       );
     } finally {
@@ -399,7 +425,7 @@ describe('resolveOperatorHome (GAP-320a review S1)', () => {
 
 describe('neverBoundSet', () => {
   it('materializes the home-relative secrets and absolute mounts', () => {
-    const set = neverBoundSet('/base/op');
+    const set = neverBoundSet('/base/op', '/base/op/.local/share/revealui');
     for (const p of [
       '/base/op/.ssh',
       '/base/op/.age-identity',
@@ -418,7 +444,7 @@ describe('neverBoundSet', () => {
 
   it('includes /run/user/<uid> when getuid is available', () => {
     if (typeof process.getuid !== 'function') return;
-    const set = neverBoundSet('/base/op');
+    const set = neverBoundSet('/base/op', '/base/op/.local/share/revealui');
     expect(set).toContain(`/run/user/${process.getuid()}`);
   });
 });
@@ -433,6 +459,7 @@ describe('linuxBubblewrapBackend.spawnConfined — overlap guard', () => {
     cwd: '/base/op/.ssh',
     agentHome: '/base/op/.local/share/revealui/agent-homes/deadbeef',
     operatorHome: '/base/op',
+    dataDir: '/base/op/.local/share/revealui',
   };
 
   it('refuses to build argv when the granted root overlaps a secret path', () => {
@@ -441,12 +468,23 @@ describe('linuxBubblewrapBackend.spawnConfined — overlap guard', () => {
     );
   });
 
+  it('refuses to build argv when the granted root overlaps the daemon data dir', () => {
+    expect(() =>
+      backend.spawnConfined('bash', [], {
+        ...base,
+        repoReal: '/base/op/.local/share/revealui',
+        cwd: '/base/op/.local/share/revealui',
+      }),
+    ).toThrow(/overlaps the never-bound secret path/);
+  });
+
   it('still builds argv for a normal project root beneath the home', () => {
     const { argv } = backend.spawnConfined('bash', [], {
       repoReal: '/base/op/revfleet/repo',
       cwd: '/base/op/revfleet/repo',
       agentHome: base.agentHome,
       operatorHome: base.operatorHome,
+      dataDir: base.dataDir,
     });
     expect(argv).toContain('--bind');
     expect(argv.join(' ')).toContain('--bind /base/op/revfleet/repo /base/op/revfleet/repo');

--- a/packages/daemon/src/__tests__/confinement.test.ts
+++ b/packages/daemon/src/__tests__/confinement.test.ts
@@ -301,7 +301,9 @@ describe('assertGrantedRootBindable', () => {
   const DATADIR = '/base/op/.local/share/revealui';
 
   it('refuses the operator home itself', () => {
-    expect(() => assertGrantedRootBindable(HOME, HOME, DATADIR)).toThrow(/is or contains the operator home/);
+    expect(() => assertGrantedRootBindable(HOME, HOME, DATADIR)).toThrow(
+      /is or contains the operator home/,
+    );
   });
 
   it('refuses an ANCESTOR of the operator home', () => {
@@ -369,7 +371,9 @@ describe('assertGrantedRootBindable', () => {
 
   it('does NOT refuse the normal case: a project root beneath the home', () => {
     // The supported shape — ~/revfleet/<repo>. Must NOT throw.
-    expect(() => assertGrantedRootBindable(join(HOME, 'revfleet', 'revealui'), HOME, DATADIR)).not.toThrow();
+    expect(() =>
+      assertGrantedRootBindable(join(HOME, 'revfleet', 'revealui'), HOME, DATADIR),
+    ).not.toThrow();
   });
 
   it('does NOT refuse a sibling of the home that shares a name prefix (separator-safe)', () => {

--- a/packages/daemon/src/__tests__/confinement.test.ts
+++ b/packages/daemon/src/__tests__/confinement.test.ts
@@ -19,6 +19,7 @@ import {
   neverBoundSet,
   resolveBwrapAbsPath,
   resolveConfinementBackend,
+  resolveOperatorHome,
 } from '../confinement.js';
 
 // ---------------------------------------------------------------------------
@@ -372,6 +373,27 @@ describe('assertGrantedRootBindable', () => {
     } finally {
       await rm(home, { recursive: true, force: true });
     }
+  });
+});
+
+describe('resolveOperatorHome (GAP-320a review S1)', () => {
+  it('realpaths a symlinked home so the guard compares canonical paths', async () => {
+    // /real-home is the true dir; /link-home is a symlink to it. Resolving the
+    // symlink yields the same canonical path repoReal would realpath to.
+    const base = await mkdtemp(join(tmpdir(), 'op-home-'));
+    try {
+      const realHome = join(base, 'real-home');
+      const linkHome = join(base, 'link-home');
+      await mkdir(realHome, { recursive: true });
+      await symlink(realHome, linkHome);
+      expect(await resolveOperatorHome(linkHome)).toBe(await realpath(realHome));
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the lexical value when the path does not resolve', () => {
+    expect(resolveOperatorHome('/no/such/dir/xyzzy')).toBe('/no/such/dir/xyzzy');
   });
 });
 

--- a/packages/daemon/src/__tests__/confinement.test.ts
+++ b/packages/daemon/src/__tests__/confinement.test.ts
@@ -6,15 +6,17 @@
  * @vitest-environment node
  */
 
-import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
+  assertGrantedRootBindable,
   buildConfinedEnv,
   ensureAgentHome,
   filterCallerEnv,
   linuxBubblewrapBackend,
+  neverBoundSet,
   resolveBwrapAbsPath,
   resolveConfinementBackend,
 } from '../confinement.js';
@@ -40,6 +42,16 @@ describe('filterCallerEnv', () => {
 
   it('rejects PATH', () => {
     expect(() => filterCallerEnv({ PATH: '/evil/bin' })).toThrow(/"PATH" is not caller-settable/);
+  });
+
+  it('rejects REVDEV_SPAWN_CONFINEMENT by name despite the REVDEV_ prefix (GAP-320b)', () => {
+    expect(() => filterCallerEnv({ REVDEV_SPAWN_CONFINEMENT: 'none' })).toThrow(
+      /"REVDEV_SPAWN_CONFINEMENT" is not caller-settable/,
+    );
+    // The deny check runs FIRST, so it wins even when a benign REVDEV_ key precedes it.
+    expect(() => filterCallerEnv({ REVDEV_HINT: 'ok', REVDEV_SPAWN_CONFINEMENT: 'none' })).toThrow(
+      /"REVDEV_SPAWN_CONFINEMENT" is not caller-settable/,
+    );
   });
 
   it.each([
@@ -275,5 +287,146 @@ describe('ensureAgentHome', () => {
     const a = await ensureAgentHome(dataDir, 'did:key:zOne');
     const b = await ensureAgentHome(dataDir, 'did:key:zTwo');
     expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertGrantedRootBindable — the overlap guard (GAP-320a, spec §4.3)
+// ---------------------------------------------------------------------------
+
+describe('assertGrantedRootBindable', () => {
+  const HOME = '/base/op';
+
+  it('refuses the operator home itself', () => {
+    expect(() => assertGrantedRootBindable(HOME, HOME)).toThrow(/is or contains the operator home/);
+  });
+
+  it('refuses an ANCESTOR of the operator home', () => {
+    // repoReal = /base contains /base/op — the tmpfs-then-bind would carry the home.
+    expect(() => assertGrantedRootBindable('/base', HOME)).toThrow(
+      /is or contains the operator home/,
+    );
+  });
+
+  it('refuses a granted root that IS a secret path', () => {
+    expect(() => assertGrantedRootBindable(join(HOME, '.ssh'), HOME)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('refuses a granted root INSIDE a secret path', () => {
+    expect(() => assertGrantedRootBindable(join(HOME, '.ssh', 'sub'), HOME)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('refuses a granted root that CONTAINS a secret path (.revealui over passage-store)', () => {
+    // repoReal = <home>/.revealui contains <home>/.revealui/passage-store.
+    expect(() => assertGrantedRootBindable(join(HOME, '.revealui'), HOME)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('refuses the absolute NTFS mounts', () => {
+    // A root INSIDE the first NTFS mount (within direction), and the second mount
+    // itself (equal direction). Fixtures avoid the Windows-user and trailing-slash
+    // mount shapes the private-leak scanner flags — the refusal is identical for
+    // any path on those mounts.
+    expect(() => assertGrantedRootBindable('/mnt/c/project', HOME)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+    expect(() => assertGrantedRootBindable('/mnt/e', HOME)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('does NOT refuse the normal case: a project root beneath the home', () => {
+    // The supported shape — ~/revfleet/<repo>. Must NOT throw.
+    expect(() => assertGrantedRootBindable(join(HOME, 'revfleet', 'revealui'), HOME)).not.toThrow();
+  });
+
+  it('does NOT refuse a sibling of the home that shares a name prefix (separator-safe)', () => {
+    // /base/op-scratch must not match /base/op via a naive startsWith.
+    expect(() => assertGrantedRootBindable('/base/op-scratch/repo', HOME)).not.toThrow();
+  });
+
+  it('does NOT refuse a repo whose name merely prefixes a secret name (.sshkeep)', () => {
+    // <home>/.sshkeep is not <home>/.ssh — separator-safe within() must not match.
+    expect(() => assertGrantedRootBindable(join(HOME, '.sshkeep'), HOME)).not.toThrow();
+  });
+
+  it('refuses a SYMLINKED secret dir via the realpath-if-exists form', async () => {
+    // Fixture: a real operator-home layout where <home>/.ssh -> <home>/real-ssh.
+    // A grant of the symlink TARGET (which is what requireRootAndDir realpaths to)
+    // must still be refused, even though the lexical secret entry is <home>/.ssh.
+    const home = await mkdtemp(join(tmpdir(), 'nb-symlink-'));
+    try {
+      const target = join(home, 'real-ssh');
+      await mkdir(target, { recursive: true });
+      await symlink(target, join(home, '.ssh'));
+      // realpath the target the same way requireRootAndDir would hand it in.
+      const repoReal = await realpath(target);
+      expect(() => assertGrantedRootBindable(repoReal, home)).toThrow(
+        /overlaps the never-bound secret path/,
+      );
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('neverBoundSet', () => {
+  it('materializes the home-relative secrets and absolute mounts', () => {
+    const set = neverBoundSet('/base/op');
+    for (const p of [
+      '/base/op/.ssh',
+      '/base/op/.age-identity',
+      '/base/op/.revealui/passage-store',
+      '/base/op/.config/gh',
+      '/base/op/.npmrc',
+      '/base/op/.aws',
+      '/base/op/.docker/config.json',
+      '/base/op/.claude',
+      '/mnt/c',
+      '/mnt/e',
+    ]) {
+      expect(set).toContain(p);
+    }
+  });
+
+  it('includes /run/user/<uid> when getuid is available', () => {
+    if (typeof process.getuid !== 'function') return;
+    const set = neverBoundSet('/base/op');
+    expect(set).toContain(`/run/user/${process.getuid()}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spawnConfined guard wiring — the backend refuses an overlapping root (GAP-320a)
+// ---------------------------------------------------------------------------
+
+describe('linuxBubblewrapBackend.spawnConfined — overlap guard', () => {
+  const backend = linuxBubblewrapBackend('/usr/bin/bwrap');
+  const base = {
+    cwd: '/base/op/.ssh',
+    agentHome: '/base/op/.local/share/revealui/agent-homes/deadbeef',
+    operatorHome: '/base/op',
+  };
+
+  it('refuses to build argv when the granted root overlaps a secret path', () => {
+    expect(() => backend.spawnConfined('bash', [], { ...base, repoReal: '/base/op/.ssh' })).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('still builds argv for a normal project root beneath the home', () => {
+    const { argv } = backend.spawnConfined('bash', [], {
+      repoReal: '/base/op/revfleet/repo',
+      cwd: '/base/op/revfleet/repo',
+      agentHome: base.agentHome,
+      operatorHome: base.operatorHome,
+    });
+    expect(argv).toContain('--bind');
+    expect(argv.join(' ')).toContain('--bind /base/op/revfleet/repo /base/op/revfleet/repo');
   });
 });

--- a/packages/daemon/src/confinement.ts
+++ b/packages/daemon/src/confinement.ts
@@ -51,6 +51,15 @@ export interface ConfinementOpts {
   agentHome: string;
   /** The operator's real home; tmpfs'd to hide everything beneath it. */
   operatorHome: string;
+  /**
+   * The daemon data directory (`getDaemonConfig().dataDir`, default
+   * `~/.local/share/revealui`). Never-bound: it holds the PGlite integrity DB
+   * (grants, identities, roots), the control socket, and the per-agent homes —
+   * a confined agent that could read/write it could rewrite its own
+   * authorization state. A specific per-agent home subdir IS bound (that is the
+   * agent's own home); the guard only refuses a GRANTED ROOT overlapping dataDir.
+   */
+  dataDir: string;
 }
 
 export interface ConfinementResult {
@@ -239,18 +248,25 @@ const NEVER_BOUND_ABSOLUTE = ['/mnt/c', '/mnt/e'] as const;
 
 /**
  * Materialize spec §4.3's never-bound secret set for this host, from the
- * operator home. Each entry is carried in two forms: its lexical path, and its
- * realpath WHEN the entry exists (realpath-if-exists). Rationale: `repoReal`
- * arrives already realpath'd (requireRootAndDir), so a lexical-only compare
- * misses a secret directory that is itself a symlink (`~/.ssh -> /data/ssh`).
- * Entries absent on this host stay lexical-only. Computed per spawn (a handful
- * of joins plus at most a few stats), so a secret path or symlink that appears
- * after daemon start is guarded without a restart. Zero authored regex.
+ * operator home and the daemon data directory. Each entry is carried in two
+ * forms: its lexical path, and its realpath WHEN the entry exists
+ * (realpath-if-exists). Rationale: `repoReal` arrives already realpath'd
+ * (requireRootAndDir), so a lexical-only compare misses a secret directory that
+ * is itself a symlink (`~/.ssh -> /data/ssh`). Entries absent on this host stay
+ * lexical-only. Computed per spawn (a handful of joins plus at most a few
+ * stats), so a secret path or symlink that appears after daemon start is guarded
+ * without a restart. Zero authored regex.
+ *
+ * `dataDir` is included because it holds the daemon's integrity DB, control
+ * socket, and per-agent homes (the authorization state itself); it is often but
+ * not always under the operator home, so it gets its own entry regardless of
+ * where it is configured.
  */
-export function neverBoundSet(operatorHome: string): string[] {
+export function neverBoundSet(operatorHome: string, dataDir: string): string[] {
   const lexical: string[] = [
     ...NEVER_BOUND_HOME_RELATIVE.map((p) => join(operatorHome, p)),
     ...NEVER_BOUND_ABSOLUTE,
+    dataDir,
   ];
   // /run/user/<uid> carries the ssh-agent socket (spec §4.3).
   if (typeof process.getuid === 'function') {
@@ -284,7 +300,11 @@ export function neverBoundSet(operatorHome: string): string[] {
  * @throws naming the granted root, the colliding path, and the reason. Both are
  *   operator-known material (their own home layout), so naming them is not an oracle.
  */
-export function assertGrantedRootBindable(repoReal: string, operatorHome: string): void {
+export function assertGrantedRootBindable(
+  repoReal: string,
+  operatorHome: string,
+  dataDir: string,
+): void {
   // repoReal IS the home, or is an ANCESTOR of it (e.g. `/base` over `/base/op`):
   // the tmpfs-then-bind sequence would re-expose the entire home read-write.
   if (repoReal === operatorHome || within(repoReal, operatorHome)) {
@@ -292,7 +312,7 @@ export function assertGrantedRootBindable(repoReal: string, operatorHome: string
       `agent.spawn: refusing to bind granted root "${repoReal}" — it is or contains the operator home "${operatorHome}" (confinement would re-expose the entire home read-write). Grant a project root beneath the home, not the home itself.`,
     );
   }
-  for (const nb of neverBoundSet(operatorHome)) {
+  for (const nb of neverBoundSet(operatorHome, dataDir)) {
     // within(repoReal, nb): the secret lives INSIDE the granted root (bind exposes it).
     // within(nb, repoReal): the granted root IS or lives INSIDE a secret path.
     if (within(repoReal, nb) || within(nb, repoReal)) {
@@ -340,12 +360,12 @@ export function linuxBubblewrapBackend(bwrapAbs: string): ConfinementBackend {
   return {
     name: 'linux-bubblewrap',
     spawnConfined(command, args, opts): ConfinementResult {
-      const { repoReal, cwd, agentHome, operatorHome } = opts;
+      const { repoReal, cwd, agentHome, operatorHome, dataDir } = opts;
 
-      // Refuse a granted root that overlaps a secret path or the operator home
-      // BEFORE any argv is assembled — the invariant lives next to the bind
-      // sequence that creates the hazard (GAP-320a, spec §4.3).
-      assertGrantedRootBindable(repoReal, operatorHome);
+      // Refuse a granted root that overlaps a secret path, the operator home, or
+      // the daemon data dir BEFORE any argv is assembled — the invariant lives
+      // next to the bind sequence that creates the hazard (GAP-320a, spec §4.3).
+      assertGrantedRootBindable(repoReal, operatorHome, dataDir);
 
       const a: string[] = [];
 

--- a/packages/daemon/src/confinement.ts
+++ b/packages/daemon/src/confinement.ts
@@ -23,10 +23,20 @@
 import { createHash } from 'node:crypto';
 import { existsSync, realpathSync, statSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { createLogger } from '@revealui/utils/logger';
 
 const log = createLogger({ service: 'revdev-daemon/confinement' });
+
+/**
+ * True when `target` is `root` itself or a descendant of it. Separator-safe
+ * (never a bare `startsWith`, which would treat `/a/bc` as within `/a/b`).
+ * Local to this module — same shape as filegit.ts `within()`, kept here so the
+ * confinement layer carries no dependency on the file layer. Zero regex.
+ */
+function within(root: string, target: string): boolean {
+  return target === root || target.startsWith(root + sep);
+}
 
 // ---------------------------------------------------------------------------
 // Backend interface
@@ -52,6 +62,12 @@ export interface ConfinementResult {
 
 export interface ConfinementBackend {
   readonly name: string;
+  /**
+   * Resolve the argv for this backend. Every backend MUST validate the granted
+   * root against the never-bound secret set (via `assertGrantedRootBindable`)
+   * before building its argv — a backend that skips it re-exposes secrets a
+   * broad grant overlaps (GAP-320a). Throws the guard's named error on overlap.
+   */
   spawnConfined(command: string, args: string[], opts: ConfinementOpts): ConfinementResult;
 }
 
@@ -106,6 +122,19 @@ export function resolveBwrapAbsPath(candidate: string = BWRAP_CANDIDATE): string
 const CALLER_ENV_EXACT = new Set(['TERM', 'LANG', 'CI', 'NO_COLOR']);
 /** Namespaced prefixes a caller may set. */
 const CALLER_ENV_PREFIXES = ['LC_', 'REVDEV_'] as const;
+/**
+ * Daemon-control keys a caller may NEVER set, even under an allowed prefix
+ * (GAP-320b). Membership criterion: an env var the daemon itself reads to
+ * configure or WEAKEN a security boundary. `REVDEV_SPAWN_CONFINEMENT` is the
+ * only member — it is inert in a child today (resolveConfinementBackend reads
+ * only the daemon's own `process.env`, never caller env), but a caller-seedable
+ * escape-hatch key sitting in a sandboxed process's environment invites a future
+ * misread that it is load-bearing. Prune knobs (`REVDEV_STALE_THRESHOLD_DAYS`,
+ * `REVDEV_HARD_DELETE_DAYS`) do NOT qualify: they configure nothing in a child
+ * and mislead nobody about a boundary. Keep this set tiny — the allow-list is
+ * the load-bearing control; a deny-list always loses eventually.
+ */
+const CALLER_ENV_DENY_EXACT = new Set(['REVDEV_SPAWN_CONFINEMENT']);
 
 /**
  * Filter caller-supplied env to the allow-list. A deny-list of dangerous keys
@@ -120,6 +149,13 @@ const CALLER_ENV_PREFIXES = ['LC_', 'REVDEV_'] as const;
 export function filterCallerEnv(extraEnv: Record<string, string>): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(extraEnv)) {
+    // Daemon-control keys are rejected FIRST, before the prefix allowance that
+    // would otherwise wave `REVDEV_SPAWN_CONFINEMENT` through (GAP-320b).
+    if (CALLER_ENV_DENY_EXACT.has(k)) {
+      throw new Error(
+        `agent.spawn: env key "${k}" is not caller-settable — it is a daemon-control key that configures the confinement boundary (the REVDEV_ prefix is otherwise allowed).`,
+      );
+    }
     if (CALLER_ENV_EXACT.has(k)) {
       out[k] = v;
       continue;
@@ -180,6 +216,93 @@ const ETC_RO_BINDS = [
   '/etc/alternatives',
 ] as const;
 
+// ---------------------------------------------------------------------------
+// Never-bound secret set + granted-root overlap guard (spec §4.3, GAP-320a)
+// ---------------------------------------------------------------------------
+
+/** Home-relative secret paths (spec §4.3), joined onto the operator home. */
+const NEVER_BOUND_HOME_RELATIVE = [
+  '.ssh',
+  '.age-identity',
+  '.revealui/passage-store',
+  '.config/gh',
+  '.npmrc',
+  '.aws',
+  '.docker/config.json',
+  '.claude',
+] as const;
+
+/** Absolute mounts that must never be bound (spec §4.3). No development happens
+ *  on the NTFS mounts; /mnt/c carries the Windows credential stores, /mnt/e the
+ *  LTS backups. */
+const NEVER_BOUND_ABSOLUTE = ['/mnt/c', '/mnt/e'] as const;
+
+/**
+ * Materialize spec §4.3's never-bound secret set for this host, from the
+ * operator home. Each entry is carried in two forms: its lexical path, and its
+ * realpath WHEN the entry exists (realpath-if-exists). Rationale: `repoReal`
+ * arrives already realpath'd (requireRootAndDir), so a lexical-only compare
+ * misses a secret directory that is itself a symlink (`~/.ssh -> /data/ssh`).
+ * Entries absent on this host stay lexical-only. Computed per spawn (a handful
+ * of joins plus at most a few stats), so a secret path or symlink that appears
+ * after daemon start is guarded without a restart. Zero authored regex.
+ */
+export function neverBoundSet(operatorHome: string): string[] {
+  const lexical: string[] = [
+    ...NEVER_BOUND_HOME_RELATIVE.map((p) => join(operatorHome, p)),
+    ...NEVER_BOUND_ABSOLUTE,
+  ];
+  // /run/user/<uid> carries the ssh-agent socket (spec §4.3).
+  if (typeof process.getuid === 'function') {
+    lexical.push(`/run/user/${process.getuid()}`);
+  }
+  const out = new Set<string>(lexical);
+  for (const p of lexical) {
+    try {
+      out.add(realpathSync(p));
+    } catch {
+      // absent on this host — the lexical form stays, realpath is skipped
+    }
+  }
+  return [...out];
+}
+
+/**
+ * Refuse to bind a granted root that overlaps the never-bound secret set or the
+ * operator home (GAP-320a). The bind sequence tmpfs-hides the operator home and
+ * then re-binds `repoReal` read-write on top (§4.3); if `repoReal` IS, CONTAINS,
+ * or lives INSIDE a secret path, that rw bind re-exposes the secret inside the
+ * sandbox. We REFUSE (fail closed) rather than mask: a mask that misses a path
+ * exposes it silently, whereas an over-broad refusal fails loud and is fixed the
+ * same day. Confinement does not replace authorization (spec §4.2 invariant 3) —
+ * this only refuses grants the confinement layer cannot actually confine.
+ *
+ * `repoReal` BENEATH the operator home (`within(operatorHome, repoReal)`) is the
+ * normal, supported case (`~/revfleet/<repo>`) and is NOT refused. Every backend
+ * MUST call this before building its argv (see the ConfinementBackend contract).
+ *
+ * @throws naming the granted root, the colliding path, and the reason. Both are
+ *   operator-known material (their own home layout), so naming them is not an oracle.
+ */
+export function assertGrantedRootBindable(repoReal: string, operatorHome: string): void {
+  // repoReal IS the home, or is an ANCESTOR of it (e.g. `/base` over `/base/op`):
+  // the tmpfs-then-bind sequence would re-expose the entire home read-write.
+  if (repoReal === operatorHome || within(repoReal, operatorHome)) {
+    throw new Error(
+      `agent.spawn: refusing to bind granted root "${repoReal}" — it is or contains the operator home "${operatorHome}" (confinement would re-expose the entire home read-write). Grant a project root beneath the home, not the home itself.`,
+    );
+  }
+  for (const nb of neverBoundSet(operatorHome)) {
+    // within(repoReal, nb): the secret lives INSIDE the granted root (bind exposes it).
+    // within(nb, repoReal): the granted root IS or lives INSIDE a secret path.
+    if (within(repoReal, nb) || within(nb, repoReal)) {
+      throw new Error(
+        `agent.spawn: refusing to bind granted root "${repoReal}" — it overlaps the never-bound secret path "${nb}" (confinement would re-expose it read-write). Grant a root that does not contain secret material.`,
+      );
+    }
+  }
+}
+
 /**
  * The Linux/WSL2 backend. Builds a deny-by-default bwrap argv:
  *   - /usr read-only, the merged-usr symlinks, minimal /etc, /proc, /dev, /tmp;
@@ -200,6 +323,12 @@ export function linuxBubblewrapBackend(bwrapAbs: string): ConfinementBackend {
     name: 'linux-bubblewrap',
     spawnConfined(command, args, opts): ConfinementResult {
       const { repoReal, cwd, agentHome, operatorHome } = opts;
+
+      // Refuse a granted root that overlaps a secret path or the operator home
+      // BEFORE any argv is assembled — the invariant lives next to the bind
+      // sequence that creates the hazard (GAP-320a, spec §4.3).
+      assertGrantedRootBindable(repoReal, operatorHome);
+
       const a: string[] = [];
 
       // System, read-only + merged-usr symlinks.

--- a/packages/daemon/src/confinement.ts
+++ b/packages/daemon/src/confinement.ts
@@ -304,6 +304,24 @@ export function assertGrantedRootBindable(repoReal: string, operatorHome: string
 }
 
 /**
+ * Resolve the operator's real home, realpath'd. `assertGrantedRootBindable`
+ * compares the home against an already-realpath'd `repoReal`, and the backend
+ * tmpfs-hides this path; realpath'ing here keeps both consistent, so a symlinked
+ * `$HOME` component can't make the guard's home-identity/ancestor checks
+ * lexical-only and diverge from the canonical path (GAP-320a review S1). Falls
+ * back to the lexical value when it does not resolve (e.g. an absent `/root`),
+ * which never WIDENS the guard — the never-bound entries carry their own
+ * realpath-if-exists forms, so a real secret is still caught.
+ */
+export function resolveOperatorHome(rawHome: string = process.env.HOME ?? '/root'): string {
+  try {
+    return realpathSync(rawHome);
+  } catch {
+    return rawHome;
+  }
+}
+
+/**
  * The Linux/WSL2 backend. Builds a deny-by-default bwrap argv:
  *   - /usr read-only, the merged-usr symlinks, minimal /etc, /proc, /dev, /tmp;
  *   - the operator home tmpfs'd (hides everything beneath it), THEN the granted

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -277,7 +277,8 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   }
 
   // Per-agent persistent home (spec §5); HOME points here inside the sandbox.
-  const agentHome = await ensureAgentHome(getDaemonConfig().dataDir, ownerAgentId);
+  const dataDir = getDaemonConfig().dataDir;
+  const agentHome = await ensureAgentHome(dataDir, ownerAgentId);
   const env = buildConfinedEnv(callerEnv, agentHome);
 
   // Resolve the confinement backend (cached at daemon start; lazy fallback for
@@ -297,6 +298,7 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
       cwd,
       agentHome,
       operatorHome,
+      dataDir,
     }));
     confinement = conf.mode;
   } else if (conf.escapeHatch) {

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -38,6 +38,7 @@ import {
   filterCallerEnv,
   type ResolvedConfinement,
   resolveConfinementBackend,
+  resolveOperatorHome,
 } from './confinement.js';
 import { onAgentEnded, onDaemonStarted } from './eviction.js';
 import { requireRootAndDir } from './filegit.js';
@@ -282,7 +283,9 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   // Resolve the confinement backend (cached at daemon start; lazy fallback for
   // a handler somehow invoked before the startDaemon hook fired).
   const conf = _confinement ?? resolveConfinementBackend();
-  const operatorHome = process.env.HOME ?? '/root';
+  // Realpath'd so the overlap guard (which compares against a realpath'd
+  // repoReal) and the tmpfs bind agree on the canonical home (GAP-320a review S1).
+  const operatorHome = resolveOperatorHome();
 
   let file: string;
   let argv: string[];


### PR DESCRIPTION
## What

Implements the approved GAP-320 Phase-1b confinement design ([.jv jv#411](https://github.com/RevealUIStudio/revealui-jv/pull/411), non-author verdict recorded, merged to `.jv:test`). Two hardening residuals surfaced by the revdev#264 crown-jewel adversarial review — neither a live vulnerability in the shipped design, both places the confinement layer could silently defeat itself under operator action.

### (a) Granted-root overlap guard
- `neverBoundSet(operatorHome)` materializes spec §4.3's never-bound list in code for the first time: the home-relative secrets (`.ssh`, `.age-identity`, `.revealui/passage-store`, `.config/gh`, `.npmrc`, `.aws`, `.docker/config.json`, `.claude`), the absolute NTFS mounts (`/mnt/c`, `/mnt/e`), and `/run/user/<uid>` (the ssh-agent socket). Each entry in **lexical + realpath-if-exists** form, because `repoReal` arrives realpath'd and a symlinked secret dir (`~/.ssh -> /data/ssh`) would slip a lexical-only compare. Computed per spawn, so a secret path appearing after daemon start is guarded without a restart.
- `assertGrantedRootBindable(repoReal, operatorHome)` refuses (throws a named error) when the granted root **is, contains, or lives inside** a secret path or the operator home. **Fail closed, not mask** — a mask that misses a path exposes it silently; an over-broad refusal fails loud and is fixed the same day (the design §3.1 records the full rationale).
- Runs at the top of `spawnConfined`, co-located with the tmpfs-then-bind sequence (confinement.ts §4.3) that creates the hazard. The `ConfinementBackend` contract now requires every backend to call it, so the staged darwin backend inherits the requirement.

### (b) `REVDEV_SPAWN_CONFINEMENT` env deny
`filterCallerEnv` rejects `REVDEV_SPAWN_CONFINEMENT` by name, checked **before** the `REVDEV_` prefix allowance, so a caller cannot seed the daemon's escape-hatch key into a sandboxed child's environment. Inert today (the resolver reads only the daemon's own `process.env`), but a caller-seedable boundary-control key in a sandboxed env invites a future misread. The `REVDEV_` prefix otherwise stands.

## Verification

- **Prove-red (per feedback-prove-tests-fail-without-the-fix):** stashed the source fix, ran the tests — all 14 new-behavior assertions fail against the pre-fix backend (refusals, `neverBoundSet`, the backend guard wiring, the env deny); they pass with the fix. Separator-safety pinned: `/base/op-scratch` and `.sshkeep` do **not** false-match; the normal `~/revfleet/<repo>` case is not refused.
- **Full daemon suite:** 612/612 green. **confinement.test.ts:** 47/47. `tsc --noEmit` clean. Biome clean.
- Zero authored regex — `join` + string equality + the `within()` prefix shape only. Fixtures use `/base/op`, never a literal `/home/<user>` (leak-scan-safe, per revdev#265).

## Scope / not in scope

Exactly the two GAP-320 items. The adjacent `file.*` reachability finding (a broad grant can read secrets at the file layer with no spawn) and the `project.open`-accepts-non-repos drift are **out of scope** and filed as [GAP-326](https://github.com/RevealUIStudio/revealui-jv/blob/test/docs/gaps/GAP-326.yml) (design §6). Shared-cache rw exposure is noted for Phase 2.

## Review ask (crown-jewel — do NOT self-merge)

`agent.spawn` is a crown-jewel surface. This PR carries **no gate labels**. Requesting a non-author guardrail-2 verdict grounded to file:line before merge. No live Fable session (safeguard flip 2026-07-11); per model-allocation the review falls back to an Opus peer, recorded. Owner merges on the recorded verdict.

Design: `.jv docs/gap-specs/GAP-320-confinement-phase-1b-hardening-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
