### PR TITLE
fix(studio): clear the repo-wide biome error blocking CI (useLiteralKeys on __all__)

### DIFF
--- a/apps/studio/src/hooks/use-sync.ts
+++ b/apps/studio/src/hooks/use-sync.ts
@@ -79,7 +79,7 @@ export function useSync() {
   return {
     syncingRepos: state.syncingRepos,
     anySyncing,
-    globalError: (state.errors['__all__'] ?? null) as string | null,
+    globalError: (state.errors.__all__ ?? null) as string | null,
     errors: state.errors,
     results: state.results,
     log: state.log,


### PR DESCRIPTION
## What
One-line fix: `state.errors['__all__']` → `state.errors.__all__` in `apps/studio/src/hooks/use-sync.ts`.

## Why
`origin/test` is currently **red on the Quality gate** (`biome check .`): biome 2.5.2's `lint/complexity/useLiteralKeys` rule flags the bracket access on `__all__` (a valid identifier, so it's unnecessary). This single error fails the gate on **every** PR that touches the repo — it surfaced while landing the GAP-320 confinement work ([revdev#270](https://github.com/RevealUIStudio/revdev/pull/270)), whose own files are lint-clean. Pre-existing, unrelated to that PR; splitting it out here keeps #270 scoped to confinement.

## Verification
Pure equivalent rewrite (dot access ≡ bracket access for a valid identifier key; the `as string | null` cast is unchanged). `pnpm biome check .` now passes — 280 files, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)