### PR TITLE
fix(studio): use dot access for errors.__all__ (biome useLiteralKeys)

### DIFF
--- a/apps/studio/src/hooks/use-sync.ts
+++ b/apps/studio/src/hooks/use-sync.ts
@@ -79,7 +79,7 @@ export function useSync() {
   return {
     syncingRepos: state.syncingRepos,
     anySyncing,
-    globalError: (state.errors['__all__'] ?? null) as string | null,
+    globalError: (state.errors.__all__ ?? null) as string | null,
     errors: state.errors,
     results: state.results,
     log: state.log,


### PR DESCRIPTION
Fixes a pre-existing biome `useLiteralKeys` lint at `apps/studio/src/hooks/use-sync.ts:82` that is red on `test` and red-gates the Quality check on every PR branch. Surfaced during the revdev#270 (GAP-320) review as the only thing blocking that crown-jewel PR's CI.

`state.errors['__all__']` → `state.errors.__all__` — semantically identical for the `Record<string,string>` key; biome's own suggested fix. `biome check` clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)