### PR TITLE
feat(studio): calm the first-run welcome surface

### DIFF
--- a/apps/studio/src/components/dashboard/WelcomeBanner.tsx
+++ b/apps/studio/src/components/dashboard/WelcomeBanner.tsx
@@ -35,9 +35,9 @@ export default function WelcomeBanner() {
         Run your agents on your own infrastructure
       </h2>
       <p className="mt-1 text-xs leading-relaxed text-fg-muted">
-        Studio is where you start and watch the AI agents working for you. Each one runs as a user
-        you govern, and what it does is recorded so you can check it. This is an early preview, so
-        expect a few rough edges.
+        Studio is where you start your agents and watch them work. Each one runs as a user you
+        govern, and every action it takes is recorded so you can check it. This is an early preview,
+        so expect a few rough edges.
       </p>
     </div>
   );

--- a/apps/studio/src/components/dashboard/WelcomeBanner.tsx
+++ b/apps/studio/src/components/dashboard/WelcomeBanner.tsx
@@ -31,13 +31,13 @@ export default function WelcomeBanner() {
           <path d="M18 6 6 18M6 6l12 12" />
         </svg>
       </button>
-      <h2 className="text-sm font-semibold text-brand-text">Welcome to RevealUI Studio</h2>
+      <h2 className="text-sm font-semibold text-brand-text">
+        Run your agents on your own infrastructure
+      </h2>
       <p className="mt-1 text-xs leading-relaxed text-fg-muted">
-        Your native AI experience for managing agents and infrastructure. Use the sidebar to
-        navigate between services — check system status on the{' '}
-        <strong className="text-fg-muted">Dashboard</strong>, manage secrets in the{' '}
-        <strong className="text-fg-muted">Vault</strong>, and configure your environment in{' '}
-        <strong className="text-fg-muted">Setup</strong>.
+        Studio is where you start and watch the AI agents working for you. Each one runs as a user
+        you govern, and what it does is recorded so you can check it. This is an early preview, so
+        expect a few rough edges.
       </p>
     </div>
   );


### PR DESCRIPTION
## What a first-run user saw

Studio's first-run sequence is: the intent screen (Deploy vs Develop), then setup, then the Dashboard. The Dashboard shows a dismissible **welcome banner** as the first thing an owner-operator reads after setup.

**Before**, that banner was a sidebar tour:

> **Welcome to RevealUI Studio**
> Your native AI experience for managing agents and infrastructure. Use the sidebar to navigate between services — check system status on the **Dashboard**, manage secrets in the **Vault**, and configure your environment in **Setup**.

Three problems:
- It repeated the "Welcome to RevealUI Studio" heading the intent screen had already shown moments earlier.
- It was a destination-by-destination walkthrough of a dense sidebar, not an idea.
- It carried an em dash and never said what the product is actually for.

## What a first-run user sees now

> **Run your agents on your own infrastructure**
> Studio is where you start and watch the AI agents working for you. Each one runs as a user you govern, and what it does is recorded so you can check it. This is an early preview, so expect a few rough edges.

The banner now leads with the positioning (agents you govern, on infrastructure you own, with a record you can check), stays honest about maturity by naming the early-preview state, and drops the nav tour so the surface reads as one calm idea. Structure, dismiss control, and styling are unchanged; copy only.

## Every copy line changed

| | Before | After |
|---|---|---|
| Heading | Welcome to RevealUI Studio | Run your agents on your own infrastructure |
| Body | Your native AI experience for managing agents and infrastructure. Use the sidebar to navigate between services — check system status on the Dashboard, manage secrets in the Vault, and configure your environment in Setup. | Studio is where you start and watch the AI agents working for you. Each one runs as a user you govern, and what it does is recorded so you can check it. This is an early preview, so expect a few rough edges. |

## Scope

Surgical, copy-only, one file (`apps/studio/src/components/dashboard/WelcomeBanner.tsx`, +6/-6). No new dependencies, no new components, no reused-import changes. The sidebar regroup is a separate program and is untouched here.

**Found but left out of scope:** the always-on Dashboard status line renders `distribution &mdash; systemd: …` with an em-dash separator. It is persistent chrome rather than first-run/welcome copy, so it is flagged here rather than changed in this PR.

## Build results

- `pnpm --filter studio test run` — **541/541 passed**.
- `biome check` on the touched file — clean, no fixes.
- `pnpm --filter studio typecheck` fails in this checkout only on missing `src/generated/*` ts-rs bindings (untracked build output produced by the Rust backend, generated in CI before typecheck). Pre-existing and identical on the untouched base; unrelated to this copy-only change.

Screenshots pending owner (Tauri desktop shell; the banner renders on the Dashboard after setup completes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
