### PR TITLE
fix(console): align user-facing copy with the voice rules

### DIFF
--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -1,9 +1,9 @@
 # RevealUI Console
 
-> **Status: Experimental** — Not production-deployed. Functional prototype.
+> **Status: Experimental.** Not production-deployed. A functional prototype.
 
 SSH-delivered TUI for RevealUI account management and licensing. Runs anywhere
-there's SSH — phone, borrowed laptop, server — and is explicitly **not** for
+there's SSH (phone, borrowed laptop, server) and is explicitly **not** for
 editing code (that's Studio's job).
 
 The TUI walks users through: browsing subscription tiers, initiating checkout
@@ -13,16 +13,16 @@ API (pass `agents` as the SSH command, or set `TERMINAL_MODE=agents`).
 
 Built with the [Charm](https://charm.sh/) ecosystem:
 
-- **Wish** — SSH server
-- **Bubble Tea** — TUI framework
-- **Lip Gloss** — Terminal styling
+- **Wish** runs the SSH server
+- **Bubble Tea** drives the TUI
+- **Lip Gloss** handles the terminal styling
 
 ## Usage
 
-The intended entry point — once hosted deployment ships — is a single SSH command:
+Once hosted deployment ships, the intended entry point is a single SSH command:
 
 ```bash
-ssh terminal.revealui.com           # planned — hosted endpoint not yet live
+ssh terminal.revealui.com           # planned, hosted endpoint not yet live
 ssh terminal.revealui.com -t agents # agent proxy mode
 ```
 

--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -132,7 +132,7 @@ func (p *Proxy) spawnSession(name string) (string, error) {
 
 // pickSession shows a text-based session selector.
 func (p *Proxy) pickSession(s ssh.Session, sessions []SessionInfo) (string, error) {
-	fmt.Fprintf(s, "\033[1;33mRevealUI Terminal — Agent Sessions\033[0m\r\n\r\n")
+	fmt.Fprintf(s, "\033[1;33mRevealUI Agent Sessions\033[0m\r\n\r\n")
 
 	// Partition PTY sessions: running ones are selectable; non-running ones are
 	// still listed (dimmed, with an explicit status word) instead of being

--- a/apps/console/tui/model.go
+++ b/apps/console/tui/model.go
@@ -501,11 +501,11 @@ func (m Model) viewLoading() string {
 // -- Tier selection ----------------------------------------------------------
 
 func (m Model) viewTiers() string {
-	s := titleStyle.Render("RevealUI — Choose Your Plan") + "\n"
+	s := titleStyle.Render("Choose your RevealUI plan") + "\n"
 
 	// Warn when the displayed prices are stale fallback data, not live pricing.
 	if m.pricingOffline {
-		s += errorStyle.Render("  ⚠ Offline pricing — may be out of date") + "\n"
+		s += errorStyle.Render("  ⚠ Offline pricing may be out of date") + "\n"
 	}
 
 	// Show current user info if known
@@ -531,7 +531,7 @@ func (m Model) viewTiers() string {
 			price = "—"
 		}
 
-		line := fmt.Sprintf("%s%s %s%s — %s",
+		line := fmt.Sprintf("%s%s %s%s • %s",
 			cursor, tier.Name, price, tier.Period, tier.Description)
 
 		// Mark current tier
@@ -571,7 +571,7 @@ func (m Model) viewCheckout() string {
 		return "No tier selected"
 	}
 
-	s := titleStyle.Render(fmt.Sprintf("Upgrade to %s — %s%s",
+	s := titleStyle.Render(fmt.Sprintf("Upgrade to %s for %s%s",
 		m.selected.Name, m.selected.Price, m.selected.Period)) + "\n\n"
 
 	for _, f := range m.selected.Features {


### PR DESCRIPTION
## What

A copy-only pass over the Console (`apps/console`) user-facing strings to align them with the house voice: full clauses where space allows, natural human phrasing, and zero em dashes. No TUI layout, flow, or behavior changed.

## Strings changed (before → after)

**`apps/console/tui/model.go`**

| Surface | Before | After |
|---|---|---|
| Tier-screen heading | `RevealUI — Choose Your Plan` | `Choose your RevealUI plan` |
| Offline-pricing warning | `⚠ Offline pricing — may be out of date` | `⚠ Offline pricing may be out of date` |
| Tier list row separator | `Name Price/Period — Description` (em dash) | `Name Price/Period • Description` (middle dot, matching the key-hint separator already used elsewhere in the TUI) |
| Checkout heading | `Upgrade to <Tier> — <Price>` | `Upgrade to <Tier> for <Price>` |

**`apps/console/proxy/proxy.go`**

| Surface | Before | After |
|---|---|---|
| Agent-session picker heading | `RevealUI Terminal — Agent Sessions` | `RevealUI Agent Sessions` |

**`apps/console/README.md`** (public docs prose)

| Before | After |
|---|---|
| `> **Status: Experimental** — Not production-deployed. Functional prototype.` | `> **Status: Experimental.** Not production-deployed. A functional prototype.` |
| `Runs anywhere there's SSH — phone, borrowed laptop, server — and is explicitly not for editing code` | `Runs anywhere there's SSH (phone, borrowed laptop, server) and is explicitly not for editing code` |
| `- **Wish** — SSH server` | `- **Wish** runs the SSH server` |
| `- **Bubble Tea** — TUI framework` | `- **Bubble Tea** drives the TUI` |
| `- **Lip Gloss** — Terminal styling` | `- **Lip Gloss** handles the terminal styling` |
| `The intended entry point — once hosted deployment ships — is a single SSH command:` | `Once hosted deployment ships, the intended entry point is a single SSH command:` |
| `# planned — hosted endpoint not yet live` | `# planned, hosted endpoint not yet live` |

## Deliberately left alone

- **Pricing strings and tier names.** No price, tier ID, or tier name was touched. The displayed tiers come from a hardcoded fallback table (`fallbackTiers()`) used only when the pricing API is unreachable; on a successful fetch the live API response replaces it at runtime (`pricingMsg`), and an "offline pricing" warning is shown while the fallback is on screen. Any staleness in the fallback values is a separate, non-copy concern and is out of scope here.
- **Key-hint / menu labels** (`q quit`, `esc back`, `enter submit`, `n) New agent session`, etc.). Terse keybind and menu labels are the correct TUI convention and were left as-is rather than padded into full clauses.
- **Two data-absence placeholders kept as `—`:** the empty-price cell in the tier row and the "no default" cell in the README env-var table. These are null-value indicators, not prose, so the dash convention stays.
- **Code comments.** Internal Go doc/inline comments still contain em dashes; those are not user-facing and are outside a copy pass.
- **Product naming.** The TUI calls itself "RevealUI Terminal" / "RevealUI"; renaming is a design decision, not a copy fix, so it was left untouched.

## Build / test

Run from `apps/console` (Go 1.25.9):

- `go build ./...` — OK
- `go vet ./...` — OK
- `go test ./...` — all packages pass (`console`, `api`, `proxy`, `qr`, `tui`)

No test asserts on any of the changed strings, so no test updates were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
