### PR TITLE
fix(console): align offline tier fallback with canonical 2026-06 ladder

### DIFF
--- a/apps/console/tui/model.go
+++ b/apps/console/tui/model.go
@@ -104,13 +104,13 @@ func fallbackTiers() []Tier {
 			Highlighted: true,
 		},
 		{
-			ID: "max", Name: "Max", Price: "$149", Period: "/mo",
-			Description: "AI memory, multi-provider, compliance tooling.",
+			ID: "max", Name: "Max", Price: "$299", Period: "/mo",
+			Description: "AI memory, advanced inference, and compliance tooling.",
 			Features:    []string{"15 sites", "100 users", "AI memory", "BYOK server-side", "50K tasks/mo"},
 		},
 		{
-			ID: "enterprise", Name: "Forge", Price: "$299", Period: "/mo",
-			Description: "Advanced scale and compliance requirements.",
+			ID: "enterprise", Name: "Enterprise", Price: "$1,499", Period: "/mo",
+			Description: "Scale, compliance, and agent payments.",
 			Features:    []string{"Unlimited sites", "Unlimited users", "SSO/SAML", "White-label", "Unlimited tasks"},
 		},
 	}

--- a/apps/console/tui/model.go
+++ b/apps/console/tui/model.go
@@ -95,23 +95,23 @@ func fallbackTiers() []Tier {
 		{
 			ID: "free", Name: "Free (OSS)", Price: "$0",
 			Description: "Perfect for trying out RevealUI and small projects.",
-			Features:    []string{"1 site", "3 users", "Basic sync", "Community support"},
+			Features:    []string{"1 site", "3 users", "Local AI inference", "Community support", "Full source access"},
 		},
 		{
 			ID: "pro", Name: "Pro", Price: "$49", Period: "/mo",
 			Description: "For software companies building production products.",
-			Features:    []string{"5 sites", "25 users", "AI agents", "Stripe payments", "10K tasks/mo"},
+			Features:    []string{"5 sites", "25 users", "AI agents", "Stripe payments", "10K tasks/mo", "RevVault desktop + rotation", "Email support (48h)"},
 			Highlighted: true,
 		},
 		{
 			ID: "max", Name: "Max", Price: "$299", Period: "/mo",
 			Description: "AI memory, advanced inference, and compliance tooling.",
-			Features:    []string{"15 sites", "100 users", "AI memory", "BYOK server-side", "50K tasks/mo"},
+			Features:    []string{"15 sites", "100 users", "Full AI memory", "Audit logging", "50K tasks/mo", "Email support (24h)"},
 		},
 		{
 			ID: "enterprise", Name: "Enterprise", Price: "$1,499", Period: "/mo",
 			Description: "Scale, compliance, and agent payments.",
-			Features:    []string{"Unlimited sites", "Unlimited users", "SSO/SAML", "White-label", "Unlimited tasks"},
+			Features:    []string{"Unlimited sites", "Unlimited users", "OAuth", "x402 agent payments (soon)", "Unlimited tasks", "Slack support (4h SLA)"},
 		},
 	}
 }

--- a/apps/console/tui/model_test.go
+++ b/apps/console/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/RevealUIStudio/revdev/apps/console/api"
@@ -108,6 +109,30 @@ func TestFallbackTiers_Prices(t *testing.T) {
 		}
 		if tier.Period != want.period {
 			t.Errorf("tier %q Period = %q, want %q", tier.ID, tier.Period, want.period)
+		}
+	}
+}
+
+// TestFallbackTiers_Features pins the offline fallback ladder's feature
+// bullets to the canonical inclusions in @revealui/contracts pricing.ts
+// (SUBSCRIPTION_TIERS[].features, realignment ADR 2026-06-07), TUI-shortened.
+// Guards against stale claims (e.g. the retired "BYOK server-side",
+// "SSO/SAML", "White-label" bullets) silently surviving a price/name fix.
+func TestFallbackTiers_Features(t *testing.T) {
+	tiers := fallbackTiers()
+	expected := map[string][]string{
+		"free":       {"1 site", "3 users", "Local AI inference", "Community support", "Full source access"},
+		"pro":        {"5 sites", "25 users", "AI agents", "Stripe payments", "10K tasks/mo", "RevVault desktop + rotation", "Email support (48h)"},
+		"max":        {"15 sites", "100 users", "Full AI memory", "Audit logging", "50K tasks/mo", "Email support (24h)"},
+		"enterprise": {"Unlimited sites", "Unlimited users", "OAuth", "x402 agent payments (soon)", "Unlimited tasks", "Slack support (4h SLA)"},
+	}
+	for _, tier := range tiers {
+		want, ok := expected[tier.ID]
+		if !ok {
+			t.Fatalf("unexpected tier ID %q", tier.ID)
+		}
+		if !slices.Equal(tier.Features, want) {
+			t.Errorf("tier %q Features = %v, want %v", tier.ID, tier.Features, want)
 		}
 	}
 }

--- a/apps/console/tui/model_test.go
+++ b/apps/console/tui/model_test.go
@@ -79,10 +79,35 @@ func TestFallbackTiers_PaidTiersHavePeriod(t *testing.T) {
 
 func TestFallbackTiers_Names(t *testing.T) {
 	tiers := fallbackTiers()
-	expected := []string{"Free (OSS)", "Pro", "Max", "Forge"}
+	expected := []string{"Free (OSS)", "Pro", "Max", "Enterprise"}
 	for i, want := range expected {
 		if tiers[i].Name != want {
 			t.Errorf("tiers[%d].Name = %q, want %q", i, tiers[i].Name, want)
+		}
+	}
+}
+
+// TestFallbackTiers_Prices pins the offline fallback ladder to the canonical
+// prices in @revealui/contracts pricing.ts (realignment ADR 2026-06-07), so a
+// future edit can't silently reintroduce a superseded price.
+func TestFallbackTiers_Prices(t *testing.T) {
+	tiers := fallbackTiers()
+	expected := map[string]struct{ price, period string }{
+		"free":       {"$0", ""},
+		"pro":        {"$49", "/mo"},
+		"max":        {"$299", "/mo"},
+		"enterprise": {"$1,499", "/mo"},
+	}
+	for _, tier := range tiers {
+		want, ok := expected[tier.ID]
+		if !ok {
+			t.Fatalf("unexpected tier ID %q", tier.ID)
+		}
+		if tier.Price != want.price {
+			t.Errorf("tier %q Price = %q, want %q", tier.ID, tier.Price, want.price)
+		}
+		if tier.Period != want.period {
+			t.Errorf("tier %q Period = %q, want %q", tier.ID, tier.Period, want.period)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `fallbackTiers()` in `apps/console/tui/model.go` showed a superseded price ladder when the console's live `/api/pricing` fetch fails: Free $0, Pro $49/mo, Max **$149**/mo, **Forge** $299/mo. This would misquote prices to a buyer on the offline path.
- Realigns to the canonical ladder in `@revealui/contracts` (`packages/contracts/src/pricing.ts`, realignment ADR 2026-06-07): Free (OSS) $0, Pro $49/mo, Max **$299**/mo, **Enterprise** **$1,499**/mo. There is no "Forge" pricing tier; that name is retired from the ladder (the Fleet-kit stamping tool is a separate "RevForge" product and is untouched here).
- Tier descriptions realigned to the canonical short feature summaries (`apps/marketing/app/lib/pricing-fallbacks.ts` / `apps/marketing/app/content/pricing-teaser.ts` wording), kept TUI-short.
- Repo-wide grep for other stale-ladder occurrences (`$149`, `Forge` as a tier name) found only `apps/console/tui/model.go` and its test — no other hardcoded ladder in the console API client or docs. `docs/SPEC.md`'s one "RevForge" hit is the stamping tool, out of scope per task.

## Test plan

- [x] Added `TestFallbackTiers_Prices`, pinning all four fallback tier IDs to their canonical price/period, and updated `TestFallbackTiers_Names` to expect `"Enterprise"` instead of `"Forge"`.
- [x] Proved red: ran the new/updated tests against the pre-fix code first — `TestFallbackTiers_Names` and `TestFallbackTiers_Prices` failed with the exact stale values (`"Forge"`, Max `$149`, enterprise `$299`).
- [x] Applied the fix, reran — all `TestFallbackTiers_*` tests pass.
- [x] `cd apps/console && go test ./...` — all packages pass (matches `.github/workflows/ci.yml`'s console job).
- [x] `cd apps/console && go build -o /dev/null .` — builds clean (matches CI).
- [x] `go vet ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)