### PR TITLE
docs(api-reference): reconcile daemon RPC docs with the handler registry

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -10,7 +10,11 @@ The RevDev Harness Daemon exposes a JSON-RPC 2.0 API over Unix socket at `~/.loc
 
 ## Authentication
 
-Local socket access is trust-based (mode 0600, owner-only). Identity is established by calling `session.register` once, then passing the returned `sessionId` as `actorAgentId` on subsequent calls.
+Local socket access is trust-based (mode 0600, owner-only). Identity is established by calling `session.register` once, then passing the returned `sessionId` as `actorAgentId` on subsequent calls (or keeping the socket open, which stays bound to that identity for its lifetime).
+
+### Signing
+
+Every mutation and every content-returning read additionally requires a verified Ed25519 request signature (the `x-revdev-signature` field on the JSON-RPC frame), not just a registered session. These methods reject an unsigned or `actorAgentId`-only caller with `-32003` before the handler ever runs, even after a successful `session.register`. They are marked **Signature: required** below. Most coordination methods (mail, tasks, memory, file reservations) accept either a verified signature or a daemon-minted bound identity instead. See `docs/SPEC.md` and `docs/KEY_GENERATION.md` for the full client-identity model.
 
 ## License Gating
 
@@ -25,22 +29,17 @@ Methods marked with a tier require that tier or higher. Free tier methods are al
 
 Returns a pong response to verify daemon connectivity.
 
-**Params**: none  
+**Params**: none
 **Response**: `{ pong: true, ts: number }`
 
 ---
 
 ### `harness.health`
-**Tier**: Free
+**Tier**: Pro
 
-Returns daemon health status, active session count, and optionally detailed checks and Prometheus metrics.
+Returns daemon health status, active session/task counts, prune state, and client-identity anchor consistency. Takes no params (any passed are ignored).
 
-**Params**:
-| Field | Type | Description |
-|-------|------|-------------|
-| `detailed` | boolean? | Include health check results |
-| `metrics` | boolean? | Include Prometheus metrics string |
-
+**Params**: none
 **Response**:
 ```json
 {
@@ -48,11 +47,28 @@ Returns daemon health status, active session count, and optionally detailed chec
   "activeSessions": 3,
   "openTasks": 5,
   "uptime": 86400,
-  "memoryUsage": 52428800,
-  "checks": { ... },
-  "metrics": "# HELP revdev_daemon_rpc_calls_total..."
+  "prune": { "lastRunAt": "2026-07-10T00:00:00.000Z", "lastAgedCount": 0, "lastDeletedCount": 0 },
+  "neonSyncActive": false,
+  "identitySignatureMode": "accept-if-present",
+  "anchorInconsistencies": []
 }
 ```
+
+---
+
+### `harness.prune`
+**Tier**: Pro
+**Signature**: required
+
+Run a stale-session reap pass on demand: marks sessions older than `staleDays` as ended, hard-deletes sessions ended longer than `hardDeleteDays` ago, and evicts filesystem roots for every reaped session. Also runs automatically on a periodic internal timer.
+
+**Params**:
+| Field | Type | Description |
+|-------|------|-------------|
+| `staleDays` | number? | Floored at 1 (default from daemon config) |
+| `hardDeleteDays` | number? | Floored at 1 (default from daemon config) |
+
+**Response**: `{ aged: number, deleted: number, runAt: string | null, staleDays: number, hardDeleteDays: number }`
 
 ---
 
@@ -61,17 +77,19 @@ Returns daemon health status, active session count, and optionally detailed chec
 ### `session.register`
 **Tier**: Free
 
-Register a new agent session. Returns a sessionId to use as identity.
+Register a new agent session. Returns a sessionId to use as identity. Two ownership models: pass `publicKeyPem` for a client-owned (Studio) identity, or omit it for a daemon-minted identity (headless hooks).
 
 **Params**:
 | Field | Type | Description |
 |-------|------|-------------|
 | `agentId` | string? | Stable ID (upserts if exists). Omit for ephemeral UUID. |
 | `agentName` | string? | Human-readable name (e.g., "agent-main") |
-| `workDir` | string? | Agent's working directory |
-| `backend` | string? | Agent backend type (e.g., "studio", "mcp-agent") |
+| `workDir` | string? | Agent's working directory (alias: `task`) |
+| `backend` | string? | Agent backend type, e.g. "studio", "mcp-agent" (alias: `env`) |
+| `pid` | number? | Caller process ID |
+| `publicKeyPem` | string? | Client-owned Ed25519 SPKI PEM public key (Studio zero-9P model); the fingerprint must be in the daemon's trust anchor or registration fails with -32004 |
 
-**Response**: `{ sessionId: string }`
+**Response**: `{ sessionId: string, agentId: string, agentName: string, backend: string, did: string, publicKeyPem: string, session: { id, env, task } }`
 
 ---
 
@@ -80,7 +98,7 @@ Register a new agent session. Returns a sessionId to use as identity.
 
 Attach to an existing session by ID. Binds the socket to that identity.
 
-**Params**: `{ sessionId: string }`  
+**Params**: `{ sessionId?: string, agentId?: string }` (one of the two is required; `agentId` is an alias for `sessionId`)
 **Response**: `{ attached: true }`
 
 ---
@@ -88,9 +106,9 @@ Attach to an existing session by ID. Binds the socket to that identity.
 ### `session.list`
 **Tier**: Free
 
-List all active sessions.
+List active sessions.
 
-**Params**: none  
+**Params**: `{ scope?: 'local' | 'fleet' }` (`local` queries the daemon's own PGlite store; `fleet` queries the Neon-backed cross-machine view)
 **Response**: Array of session objects.
 
 ---
@@ -98,20 +116,34 @@ List all active sessions.
 ### `session.update`
 **Tier**: Free
 
-Update the current session's task/files description.
+Update the current session's task/files description, or self-scoped activity state.
 
-**Params**: `{ task?: string, files?: string }`  
-**Response**: `{ updated: true }`
+**Params**: `{ task?: string, files?: string, state?: 'active' | 'blocked' | 'idle', blockedReason?: string }` (`state` always applies to the caller's own bound session, never to a targeted `sessionId`/`agentId`)
+**Response**: `{ updated: string }` (adds `stateScopedTo` when `state` was set)
 
 ---
 
 ### `session.end`
 **Tier**: Free
+**Signature**: required
 
-End the current session. Optionally record an exit summary.
+End the current session. Optionally record an exit summary. Self-scoped to the verified signer; a caller-supplied session/agent override is not honored.
 
-**Params**: `{ exitSummary?: string }`  
-**Response**: `{ ended: true }`
+**Params**: `{ exitSummary?: string }`
+**Response**: `{ ended: string }`
+
+---
+
+## Identity
+
+### `identity.rotate`
+**Tier**: Pro
+**Signature**: required (proof-of-possession from the CURRENT key)
+
+Rotate a client-owned identity's Ed25519 key. The new key's fingerprint must already be present in the daemon's trust anchor.
+
+**Params**: `{ newPublicKeyPem: string }`
+**Response**: identity result including the new DID and public key.
 
 ---
 
@@ -125,7 +157,7 @@ Send a message to another agent.
 **Params**:
 | Field | Type | Description |
 |-------|------|-------------|
-| `to` | string | Recipient agent ID |
+| `to` | string | Recipient agent ID (alias: `toAgent`) |
 | `subject` | string | Message subject (max 500 chars) |
 | `body` | string | Message body (max 50KB) |
 
@@ -136,12 +168,11 @@ Send a message to another agent.
 ### `mail.inbox`
 **Tier**: Pro
 
-Get messages for an agent.
+Get messages for the calling agent.
 
 **Params**:
 | Field | Type | Description |
 |-------|------|-------------|
-| `agentId` | string? | Target agent (defaults to caller) |
 | `unreadOnly` | boolean? | Only unread messages (default: true) |
 
 **Response**: `{ messages: Message[] }`
@@ -153,8 +184,8 @@ Get messages for an agent.
 
 Send a message to all active agents (except sender).
 
-**Params**: `{ subject: string, body: string }`  
-**Response**: `{ broadcast: true, sent: number }`
+**Params**: `{ subject: string, body: string }`
+**Response**: `{ broadcast: true, sent: number, recipients: number }`
 
 ---
 
@@ -163,7 +194,7 @@ Send a message to all active agents (except sender).
 
 Mark messages as read by ID.
 
-**Params**: `{ messageIds: number[] }`  
+**Params**: `{ messageIds: number[] }`
 **Response**: `{ marked: number }`
 
 ---
@@ -180,29 +211,29 @@ Reserve files for exclusive editing. Prevents other agents from modifying.
 |-------|------|-------------|
 | `filePath` | string? | Single file path |
 | `paths` | string[]? | Multiple file paths |
-| `ttlSeconds` | number? | Reservation TTL (default: 600, max: 86400) |
+| `ttlSeconds` | number? | Reservation TTL (default: 1800, max: 86400) |
 | `reason` | string? | Why the file is reserved |
 
-**Response**: `{ reserved: string[], conflicts: { path, holder }[] }`
+**Response**: `{ success: boolean, reserved: string[], conflicts: { path, holder }[] }`
 
 ---
 
 ### `files.check`
 **Tier**: Pro
 
-Check who holds a file reservation.
+Check reservation status. Only the caller's own reservations are returned in full; a path held by another agent collapses to a boolean so callers cannot learn who holds it.
 
-**Params**: `{ filePath?: string, paths?: string[] }`  
-**Response**: Array of reservations or null if unreserved.
+**Params**: `{ filePath?: string, paths?: string[] }`
+**Response**: `{ reservations: Reservation[], reservedByOther: boolean }`
 
 ---
 
 ### `files.release`
 **Tier**: Pro
 
-Release file reservations.
+Release file reservations. Omitting `filePath`/`paths` releases all of the caller's reservations.
 
-**Params**: `{ filePath?: string, paths?: string[] }`  
+**Params**: `{ filePath?: string, paths?: string[] }`
 **Response**: `{ released: number }`
 
 ---
@@ -210,10 +241,219 @@ Release file reservations.
 ### `files.list`
 **Tier**: Pro
 
-List all active file reservations.
+List the calling agent's active file reservations.
 
-**Params**: `{ agentId?: string }` (use `"__all__"` for all agents)  
-**Response**: Array of reservation objects.
+**Params**: none
+**Response**: `{ reservations: Reservation[] }`
+
+---
+
+## Projects and File I/O
+
+Single-repo file and git access is **Free** — RevDev is meant to be usable as a daily driver without a license. Multi-agent coordination (mail, tasks, files.\* reservations, memory, agent.\*, merge.\*) stays Pro/Max. Every method below is also **Signature: required**.
+
+### `project.open`
+**Tier**: Free
+**Signature**: required
+
+Register a git repository root the caller owns, so `file.*`/`git.*`/`agent.spawn` can operate inside it. Refuses non-existent paths and repos whose git config carries an exec-bearing key (`filter.*`/`diff.external` etc.).
+
+**Params**: `{ repoPath: string }`
+**Response**: `{ success: true, root: string, isGitRepo: boolean }`
+
+---
+
+### `project.grant`
+**Tier**: Pro
+**Signature**: required
+
+Grant another agent access to a root the caller owns. Only the owner may call this.
+
+**Params**: `{ repoPath: string, granteeAgentId: string }`
+**Response**: `{ granted: string, root: string }`
+
+---
+
+### `project.revoke`
+**Tier**: Pro
+**Signature**: required
+
+Revoke a grantee's access to a root. Blocks future operations (including `agent.spawn`) but does not kill PTY processes the grantee already spawned.
+
+**Params**: `{ repoPath: string, granteeAgentId: string }`
+**Response**: `{ revoked: string, root: string }`
+
+---
+
+### `file.read`
+**Tier**: Free
+**Signature**: required
+
+Read a file inside a registered project root.
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ content: string, bytes: number }`, or `{ tooLarge: true, bytes: number }` when the file exceeds the daemon's inline-read cap.
+
+---
+
+### `file.write`
+**Tier**: Free
+**Signature**: required
+
+Write (create/overwrite) a file inside a registered project root. Refuses `.git/` internals.
+
+**Params**: `{ repoPath: string, filePath: string, content: string }` (content capped at 768 KiB)
+**Response**: `{ success: true, bytes: number }`
+
+---
+
+### `file.delete`
+**Tier**: Free
+**Signature**: required
+
+Delete a file inside a registered project root. Refuses `.git/` internals.
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ success: true }`
+
+---
+
+### `file.stat`
+**Tier**: Free
+**Signature**: required
+
+Stat a path inside a registered project root.
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ exists: true, isFile: boolean, isDirectory: boolean, size: number, mtimeMs: number }`, or `{ exists: false }`
+
+---
+
+## Git
+
+All `git.*` methods operate inside a `project.open`'d root and are **Free** tier, **Signature: required**.
+
+### `git.status`
+
+Porcelain status plus current branch.
+
+**Params**: `{ repoPath: string }`
+**Response**: `{ success: true, branch: string | null, files: { status, path }[], clean: boolean }`
+
+---
+
+### `git.diffFile`
+
+Diff a single file (working tree vs. index, or index vs. HEAD when `staged`).
+
+**Params**: `{ repoPath: string, filePath: string, staged?: boolean }`
+**Response**: `{ success: true, diff: string }`
+
+---
+
+### `git.diffContent`
+
+The current working-tree content of a file, read directly off disk (for a diff view's "after" pane).
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ success: true, content: string, bytes: number }` or `{ success: true, tooLarge: true, bytes: number }`
+
+---
+
+### `git.readBlobAtHead`
+
+The committed (HEAD) content of a file.
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ success: true, content: string, bytes: number }` (or `success: false` on error)
+
+---
+
+### `git.readBlobAtIndex`
+
+The staged (index) content of a file.
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ success: true, content: string, bytes: number }` (or `success: false` on error)
+
+---
+
+### `git.listBranches`
+
+**Params**: `{ repoPath: string }`
+**Response**: `{ success: true, branches: string[], current: string | null }`
+
+---
+
+### `git.log`
+
+**Params**: `{ repoPath: string, limit?: number }` (default 50)
+**Response**: `{ success: true, commits: { hash, author, date, timestamp, subject }[] }`
+
+---
+
+### `git.stageFile`
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ success: true, stdout: string }` or `{ success: false, error: string, code: number }`
+
+---
+
+### `git.unstageFile`
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: same shape as `git.stageFile`
+
+---
+
+### `git.discardFile`
+
+Discard unstaged working-tree edits to a file.
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: same shape as `git.stageFile`
+
+---
+
+### `git.createBranch`
+
+**Params**: `{ repoPath: string, name: string, baseBranch?: string }`
+**Response**: same shape as `git.stageFile`
+
+---
+
+### `git.switchBranch`
+
+**Params**: `{ repoPath: string, name: string }`
+**Response**: same shape as `git.stageFile`
+
+---
+
+### `git.deleteBranch`
+
+**Params**: `{ repoPath: string, name: string, force?: boolean }`
+**Response**: same shape as `git.stageFile`
+
+---
+
+### `git.commit`
+
+**Params**: `{ repoPath: string, message: string }`
+**Response**: `{ success: true, sha: string, shortSha: string, stdout: string }` or `{ success: false, error: string }`
+
+---
+
+### `git.push`
+
+**Params**: `{ repoPath: string, remote?: string, branch?: string }`
+**Response**: same shape as `git.stageFile`
+
+---
+
+### `git.pull`
+
+**Params**: `{ repoPath: string, remote?: string, branch?: string }`
+**Response**: same shape as `git.stageFile`
 
 ---
 
@@ -230,6 +470,7 @@ Create a coordination task.
 | `taskId` | string? | Custom ID (auto-generated if omitted) |
 | `title` | string? | Short title (max 500 chars) |
 | `description` | string? | Full description (max 50KB) |
+| `priority` | 'low' \| 'medium' \| 'high' \| 'critical' ? | Task priority |
 
 **Response**: `{ taskId: string, id: string }`
 
@@ -238,9 +479,9 @@ Create a coordination task.
 ### `tasks.list`
 **Tier**: Pro
 
-List tasks with optional filters.
+List tasks with optional filters. Filtering by a specific `owner` requires the caller to BE that owner (verified identity); otherwise only the unfiltered/open pool is visible.
 
-**Params**: `{ status?: string, owner?: string }`  
+**Params**: `{ status?: string, owner?: string }`
 **Response**: `{ tasks: Task[] }`
 
 ---
@@ -250,8 +491,8 @@ List tasks with optional filters.
 
 Claim an open task. Only one agent can own a task.
 
-**Params**: `{ taskId: string }`  
-**Response**: `{ success: boolean, owner: string }`
+**Params**: `{ taskId: string }`
+**Response**: `{ success: true, claimed: string, owner: string }` on success, or `{ success: false, claimed: false, owner: string | null, status: string }` if already claimed by someone else.
 
 ---
 
@@ -260,8 +501,8 @@ Claim an open task. Only one agent can own a task.
 
 Complete a claimed task. Only the owner can complete it.
 
-**Params**: `{ taskId: string }`  
-**Response**: `{ completed: true }`
+**Params**: `{ taskId: string, summary?: string }`
+**Response**: `{ ok: boolean, completed: string | null }` (`completed` is the taskId on success, `null` if the caller doesn't own the task)
 
 ---
 
@@ -270,8 +511,8 @@ Complete a claimed task. Only the owner can complete it.
 
 Release a claimed task back to open status.
 
-**Params**: `{ taskId: string }`  
-**Response**: `{ released: true }`
+**Params**: `{ taskId: string }`
+**Response**: `{ ok: boolean, released: string | null }` (`released` is the taskId on success, `null` if the caller doesn't own the task)
 
 ---
 
@@ -286,7 +527,7 @@ Log a structured event.
 | Field | Type | Description |
 |-------|------|-------------|
 | `eventType` | string | Event type (max 128 chars) |
-| `payload` | object? | JSON payload (max 100KB) |
+| `payload` | object? | JSON-serializable payload (max 100KB) |
 
 **Response**: `{ logged: true }`
 
@@ -297,7 +538,7 @@ Log a structured event.
 
 Query recent events.
 
-**Params**: `{ limit?: number, since?: string }`  
+**Params**: `{ limit?: number, since?: string }`
 **Response**: `{ events: Event[] }`
 
 ---
@@ -316,7 +557,7 @@ Store long-term agent memory.
 | `content` | string | Memory content (max 500KB) |
 | `metadata` | object? | Structured metadata |
 
-**Response**: `{ stored: true, id: number }`
+**Response**: `{ stored: string }` (the stored `memoryType`)
 
 ---
 
@@ -325,59 +566,130 @@ Store long-term agent memory.
 
 Query stored memories.
 
-**Params**: `{ memoryType?: string, limit?: number }`  
+**Params**: `{ memoryType?: string, query?: string, tags?: string[], limit?: number }`
 **Response**: `{ memories: Memory[] }`
 
 ---
 
 ## Inference
 
+Interacting with an already-running local model (`inference.status`/`chat`/`generate`) is a **Free** run surface. Model *management* (`pull`/`start`/`stop`) is **Max**. All `inference.*` methods are identity-exempt (no `session.register` required).
+
 ### `inference.status`
-**Tier**: Max (identity-exempt)
+**Tier**: Free (identity-exempt)
 
-Check Ollama inference status and loaded models.
+Check Ollama connectivity and loaded models.
 
-**Params**: none  
-**Response**: `{ available: boolean, models: Model[] }`
+**Params**: none
+**Response**: `{ running: boolean, url: string, version?: string, models?: { name, sizeMb, modified }[], error?: string }`
 
 ---
 
 ### `inference.pull`
-**Tier**: Max
+**Tier**: Max (identity-exempt)
 
 Download a model via Ollama.
 
-**Params**: `{ model: string }`  
-**Response**: `{ pulled: true }`
+**Params**: `{ model: string }`
+**Response**: `{ success: true, model: string, status: string }` or `{ success: false, error: string }`
 
 ---
 
 ### `inference.start` / `inference.stop`
-**Tier**: Max
+**Tier**: Max (identity-exempt)
 
 Warm up or unload a model.
 
 **Params**: `{ model: string }`
+**Response**: `{ loaded: boolean, model?: string, error?: string }` / `{ unloaded: boolean, model?: string, error?: string }`
 
 ---
 
 ### `inference.chat`
-**Tier**: Max
+**Tier**: Free (identity-exempt)
 
 Chat completion via Ollama.
 
-**Params**: `{ model: string, messages: { role, content }[] }`  
-**Response**: `{ message: { role, content } }`
+**Params**: `{ model: string, messages: { role: 'system' | 'user' | 'assistant', content: string }[], temperature?: number, maxTokens?: number }`
+**Response**: `{ message: { role, content }, stats: { totalMs, tokens, tokensPerSecond } }` or `{ error: string }`
 
 ---
 
 ### `inference.generate`
-**Tier**: Max
+**Tier**: Free (identity-exempt)
 
 Text generation via Ollama.
 
-**Params**: `{ model: string, prompt: string }`  
-**Response**: `{ response: string }`
+**Params**: `{ model: string, prompt: string, system?: string, temperature?: number, maxTokens?: number }`
+**Response**: `{ response: string, stats: { totalMs, tokens, tokensPerSecond } }` or `{ error: string }`
+
+---
+
+## Agent Processes
+
+PTY-backed process spawning under the daemon's sandbox. All five methods are **Pro** tier and **Signature: required**; `agent.spawn` additionally requires a `project.open`'d `repoPath` the caller owns or was granted via `project.grant`.
+
+### `agent.spawn`
+**Tier**: Pro
+**Signature**: required
+
+Spawn a command as a PTY process inside a granted project root, with an allow-listed environment (`TERM`, `LANG`, `LC_*`, `CI`, `NO_COLOR`, `REVDEV_*` only).
+
+**Params**:
+| Field | Type | Description |
+|-------|------|-------------|
+| `command` | string | Binary to run (not allow-listed itself) |
+| `args` | string[]? | Command arguments |
+| `repoPath` | string | A root the caller owns/was granted (via `project.open`/`project.grant`) |
+| `cwd` | string? | Working directory, must resolve inside `repoPath` |
+| `cols` / `rows` | number? | PTY size (default 80×24) |
+| `env` | object? | Caller env overrides, filtered by the allow-list |
+
+**Response**: `{ processId: string, pid: number }`
+
+---
+
+### `agent.stop`
+**Tier**: Pro
+**Signature**: required
+
+Send SIGTERM to a live PTY process. Only the owning agent may stop it.
+
+**Params**: `{ processId: string }`
+**Response**: `{ stopped: string, status: string }`
+
+---
+
+### `agent.input`
+**Tier**: Pro
+**Signature**: required
+
+Write bytes to a live PTY's stdin.
+
+**Params**: `{ processId: string, data: string }`
+**Response**: `{ written: true }`
+
+---
+
+### `agent.resize`
+**Tier**: Pro
+**Signature**: required
+
+Resize a live PTY window.
+
+**Params**: `{ processId: string, cols: number, rows: number }`
+**Response**: `{ resized: true, cols: number, rows: number }`
+
+---
+
+### `agent.output`
+**Tier**: Pro
+**Signature**: required
+
+Poll-based output retrieval. There is no server push over this transport; pass the returned cursor back on the next poll.
+
+**Params**: `{ processId: string, cursor?: string, limit?: number }` (limit default 100, max 1000)
+**Response**: buffered output chunks since `cursor`, plus process `status`.
 
 ---
 
@@ -385,29 +697,33 @@ Text generation via Ollama.
 
 ### `worktree.create`
 **Tier**: Pro
+**Signature**: required
 
-Create a git worktree for isolated branch work.
+Create a git worktree for isolated branch work. The worktree path is daemon-derived (a sibling of the registered root); a caller-supplied path is not honored.
 
-**Params**: `{ branch: string, baseBranch?: string }`  
-**Response**: `{ created: true, path: string }`
+**Params**: `{ repoPath: string, branch: string, baseBranch?: string }` (`baseBranch` defaults to `main`)
+**Response**: `{ success: true, branch: string, worktreePath: string, baseBranch: string }` or `{ success: false, error: string }`
 
 ---
 
 ### `worktree.list`
 **Tier**: Pro
 
-List active worktrees.
+List worktrees. Without `agentId`, returns all active worktrees; with it, all worktrees (any status) owned by that agent.
 
+**Params**: `{ agentId?: string }`
 **Response**: `{ worktrees: Worktree[] }`
 
 ---
 
 ### `worktree.remove`
 **Tier**: Pro
+**Signature**: required
 
-Remove a worktree.
+Remove a worktree previously created by the caller for the given `repoPath` + `branch`.
 
-**Response**: `{ removed: true }`
+**Params**: `{ repoPath: string, branch: string }`
+**Response**: `{ success: true, branch: string, worktreePath: string }` or `{ success: false, error: string }`
 
 ---
 
@@ -418,8 +734,8 @@ Remove a worktree.
 
 Create a merge request (tracked in daemon; PR creation is client-side).
 
-**Params**: `{ sourceBranch: string, baseBranch?: string, taskId?: string }`  
-**Response**: `{ mergeId: string }`
+**Params**: `{ sourceBranch: string, baseBranch?: string, taskId?: string, description?: string }` (`sourceBranch` alias: `branch`; `baseBranch` alias: `targetBranch`, defaults to `main`)
+**Response**: `{ success: true, mergeId: string, sourceBranch: string, baseBranch: string, status: 'pending' }`
 
 ---
 
@@ -428,8 +744,8 @@ Create a merge request (tracked in daemon; PR creation is client-side).
 
 Get merge request status.
 
-**Params**: `{ mergeId: string }`  
-**Response**: Merge request object.
+**Params**: `{ mergeId: string }`
+**Response**: `{ found: true, ...MergeRequest }` or `{ found: false }`
 
 ---
 
@@ -438,8 +754,8 @@ Get merge request status.
 
 List merge requests.
 
-**Params**: `{ status?: string }`  
-**Response**: Array of merge requests.
+**Params**: `{ status?: string, agentId?: string }`
+**Response**: `{ mergeRequests: MergeRequest[] }`
 
 ---
 
@@ -448,7 +764,7 @@ List merge requests.
 
 Update merge request status (e.g., after PR creation or CI result).
 
-**Params**: `{ mergeId: string, status?: string, prNumber?: number, prUrl?: string, errorMessage?: string }`  
+**Params**: `{ mergeId: string, status?: string, prNumber?: number, prUrl?: string, errorMessage?: string, ciOutput?: string }`
 **Response**: `{ updated: true }`
 
 ---
@@ -457,11 +773,14 @@ Update merge request status (e.g., after PR creation or CI result).
 
 | Code | Meaning |
 |------|---------|
-| -32700 | Parse error (malformed JSON) |
+| -32700 | Parse error (malformed JSON, or frame exceeded the max line size) |
 | -32601 | Method not found |
 | -32602 | Invalid params (Zod validation failed) |
 | -32001 | License required (tier too low) |
-| -32002 | Identity required (call session.register first) |
+| -32002 | Identity required (call session.register or session.attach first) |
+| -32003 | Signature required (missing or invalid Ed25519 signature on a Signature-required method) |
+| -32004 | Untrusted client key (identity enrollment/rotation rejected; fingerprint not in the trust anchor) |
+| -32099 | Server is shutting down |
 | -32000 | Internal error (handler threw) |
 
 ---
@@ -476,6 +795,7 @@ All params are validated with Zod schemas. Key limits:
 | Subject | 500 chars |
 | Body/description | 50 KB |
 | File path | 4,096 chars |
+| File write content | 768 KiB (786,432 bytes) |
 | Event payload | 100 KB |
 | Memory content | 500 KB |
 | Batch operations | 100-200 items |
@@ -483,3 +803,5 @@ All params are validated with Zod schemas. Key limits:
 | File TTL | 86,400 seconds (24h) |
 
 Path traversal (`../`) and system paths (`/etc/`, `/proc/`, `/sys/`) are blocked.
+
+`ping`, `identity.rotate`, `project.grant`, and `project.revoke` have no dedicated Zod schema — their params are checked only inside the handler, so malformed extra fields don't produce a -32602; a missing required field surfaces as a generic -32000 handler error instead.


### PR DESCRIPTION
## Summary

Method-level verification of `docs/API_REFERENCE.md` against the daemon's real handler registry (`packages/daemon/src/{server,inference,spawn,vcs,filegit}.ts`). The doc previously documented 37 of the daemon's 67 live JSON-RPC methods; the other 30 (all of `agent.*`, `project.*`, `file.*`, every `git.*` method, `identity.rotate`, `harness.prune`) were undocumented, and four of the 37 documented methods had inverted license-tier claims.

Ground truth for the method surface: 26 `registerHandler(...)` calls in `server.ts`, 6 in `inference.ts`, 5 in `spawn.ts` (the real PTY-backed `agent.*` implementations; the 4 stubs in `agent.ts` are always overwritten by the `spawn.js` import that follows `agent.js` in `index.ts`), 5 in `vcs.ts`, 25 in `filegit.ts` = 67 unique methods. Tier gating cross-checked against `EXEMPT_METHODS` / `METHOD_MIN_TIER` in `packages/daemon/src/license.ts`, params against `packages/daemon/src/validation/schemas.ts`.

## Method diff table

**Legend**: EXISTS = doc already matched code, no change needed · FIXED = doc changed to match code · ADDED = method was entirely missing from the doc.

### Existing entries verified/fixed

| Method | Verdict | Detail |
|---|---|---|
| `ping` | EXISTS | [license.ts:52](packages/daemon/src/license.ts#L52) exempt, matches doc |
| `harness.health` | **FIXED (tier)** | Doc said Free; not in `EXEMPT_METHODS` or `METHOD_MIN_TIER` → actually **Pro** by default ([license.ts:171-172](packages/daemon/src/license.ts#L171)). Also fixed params (handler ignores all params — the doc's `detailed`/`metrics` params don't exist) and response shape ([server.ts:1559-1614](packages/daemon/src/server.ts#L1559)) |
| `session.register` | **FIXED (params)** | Added `pid`, `publicKeyPem` (client-owned Studio zero-9P identity) — [server.ts:694-766](packages/daemon/src/server.ts#L694) |
| `session.attach` | **FIXED (params)** | `agentId` alias for `sessionId` — [schemas.ts:112-124](packages/daemon/src/validation/schemas.ts#L112) |
| `session.list`, `session.update`, `session.end` | EXISTS / minor param additions | tier and core shape matched |
| `mail.send/inbox/broadcast/markRead` | EXISTS (broadcast: added `recipients` field) | |
| `files.reserve/release` | EXISTS | |
| `files.check` | **FIXED (response)** | Doc said "array or null"; actual is `{ reservations, reservedByOther }` — other agents' holds collapse to a boolean by design ([server.ts:1345-1360](packages/daemon/src/server.ts#L1345)) |
| `files.list` | **FIXED (response)** | Doc said "array"; actual is `{ reservations: [...] }` — [server.ts:1384-1394](packages/daemon/src/server.ts#L1384) |
| `tasks.create/list/claim` | EXISTS / expanded | |
| `tasks.complete` | **FIXED (response)** | Doc said `{ completed: true }`; actual is `{ ok: boolean, completed: string \| null }` ([server.ts:1485-1511](packages/daemon/src/server.ts#L1485)) |
| `tasks.release` | **FIXED (response)** | Same pattern: `{ ok, released: string \| null }` ([server.ts:1513-1529](packages/daemon/src/server.ts#L1513)) |
| `events.log/query` | EXISTS | |
| `memory.store` | **FIXED (response)** | Doc said `{ stored: true, id: number }`; handler never returns an `id` — actual is `{ stored: string }` ([server.ts:1645-1659](packages/daemon/src/server.ts#L1645)) |
| `memory.query` | EXISTS | |
| `inference.status` | **FIXED (tier)** | Doc said Max; `EXEMPT_METHODS` marks it **Free** (the "already-running model" run surface) — [license.ts:121](packages/daemon/src/license.ts#L121) |
| `inference.chat` | **FIXED (tier + params)** | Doc said Max; actually **Free** (same exemption). Added undocumented `temperature`/`maxTokens` — [inference.ts:192-243](packages/daemon/src/inference.ts#L192) |
| `inference.generate` | **FIXED (tier + params)** | Doc said Max; actually **Free**. Added undocumented `system`/`temperature`/`maxTokens` — [inference.ts:249-302](packages/daemon/src/inference.ts#L249) |
| `inference.pull/start/stop` | EXISTS | correctly Max per `METHOD_MIN_TIER` |
| `worktree.create` | **FIXED (params + response)** | Doc omitted the *required* `repoPath` param and the caller-supplied `path` field the doc implied is honored is actually dead (path is daemon-derived); response is `{ success, branch, worktreePath, baseBranch }`, not `{ created: true, path }` — [filegit.ts:932-966](packages/daemon/src/filegit.ts#L932) |
| `worktree.remove` | **FIXED (params + response)** | Doc had no params documented at all; `repoPath` + `branch` are both required — [filegit.ts:967-991](packages/daemon/src/filegit.ts#L967) |
| `worktree.list` | **FIXED (params)** | Added the undocumented `agentId` filter — [vcs.ts:244-251](packages/daemon/src/vcs.ts#L244) |
| `merge.request` | **FIXED (params)** | Added undocumented `description` — [vcs.ts:257-278](packages/daemon/src/vcs.ts#L257) |
| `merge.status` | EXISTS | |
| `merge.list` | **FIXED (response)** | Doc said "array"; actual is `{ mergeRequests: [...] }` — [vcs.ts:293-314](packages/daemon/src/vcs.ts#L293) |
| `merge.update` | **FIXED (params)** | Added undocumented `ciOutput` — [vcs.ts:316-...](packages/daemon/src/vcs.ts#L316) |

No documented method was a phantom (DOES-NOT-EXIST) — all 37 previously-documented methods exist in code.

### Added (previously undocumented) — 30 methods

| Group | Methods | Tier / gating |
|---|---|---|
| System | `harness.prune` | Pro, Signature-required |
| Identity | `identity.rotate` | Pro, Signature-required (proof-of-possession) |
| Projects | `project.open`, `project.grant`, `project.revoke` | Free / Pro / Pro, all Signature-required |
| File I/O | `file.read`, `file.write`, `file.delete`, `file.stat` | Free, Signature-required |
| Git | `git.status`, `git.diffFile`, `git.diffContent`, `git.readBlobAtHead`, `git.readBlobAtIndex`, `git.listBranches`, `git.log`, `git.stageFile`, `git.unstageFile`, `git.discardFile`, `git.createBranch`, `git.switchBranch`, `git.deleteBranch`, `git.commit`, `git.push`, `git.pull` | Free, Signature-required |
| Agent processes | `agent.spawn`, `agent.stop`, `agent.input`, `agent.resize`, `agent.output` | Pro, Signature-required |

All 30 are Free/Pro-tier single-repo daily-driver or coordination surface — deliberately kept out of Max. See `packages/daemon/src/license.ts` `EXEMPT_METHODS` for the "single-repo file/git I/O is Free" design intent.

## Framing verifications

- **Socket path**: `~/.local/share/revealui/harness.sock` — matches `DAEMON_DEFAULTS.socketPath` exactly ([config.ts:152](packages/daemon/src/config.ts#L152)). Confirmed.
- **Newline-delimited JSON-RPC 2.0**: confirmed against the line-buffered socket reader + `JSON.parse(line)` in `server.ts`.
- **`session.register` → `sessionId` auth flow**: confirmed — `session.register` binds `ctx.agentId` on the socket directly ([server.ts:733-735](packages/daemon/src/server.ts#L733)); a fresh-socket-per-call client instead passes the returned id as `actorAgentId`, which the dispatch identity gate accepts as a fallback ([server.ts:1994-1997](packages/daemon/src/server.ts#L1994)).
- **New finding, not previously documented anywhere in API_REFERENCE.md**: every mutation and every content-returning read additionally requires a verified Ed25519 request signature (`MUTATING_OR_CONTENT_METHODS` in [server.ts:153-236](packages/daemon/src/server.ts#L153)) — a registered session alone is not sufficient for these 30 methods, and an unsigned call gets `-32003` even after a successful `session.register`. Added a "Signing" subsection under Authentication plus a **Signature: required** tag on every affected entry. This was already documented at a design level in `docs/SPEC.md`/`docs/KEY_GENERATION.md`, just missing from the RPC reference agents actually consult per-method.
- **`docs/MASTER_SPEC.md` cross-check**: it is a 29-line pointer stub with no method-level content (it just links to `SPEC.md` and `API_REFERENCE.md`) — nothing to reconcile there.
- **Retired-term pass**: no retired terminology (`RVUI.v2`, `RVUI-*`, etc.) found in `API_REFERENCE.md`.

## Also fixed

- **Error Codes table**: was missing `-32003` (signature required), `-32004` (untrusted client key), `-32099` (server shutting down) — all real codes emitted by `server.ts`/`filegit.ts`/`guard.ts`.
- **Input Limits table**: added the `file.write` content cap (768 KiB / `MAX_FILE_WRITE_BYTES`), the one limit constant not already reflected.
- Noted (not fixed, out of scope for a docs-only sweep) that `ping`, `identity.rotate`, `project.grant`, `project.revoke` have no Zod schema in `validation/schemas.ts` — their params are handler-checked only.

## Build

```
pnpm --filter @revdev/protocol build && pnpm --filter @revdev/daemon build
```
Both succeed clean (tsc + tsup, no errors). Full test suite was not run per the task scope (docs-only change, no source touched).

## Test plan

- [ ] Skim the new Agent Processes / Projects / Git sections against `packages/daemon/src/{spawn,filegit}.ts` for anything I mis-summarized
- [ ] Confirm the four tier-drift fixes (`harness.health`, `inference.status/chat/generate`) match the intended product behavior — these are corrections to the DOC, not the code; if the code's gating is itself wrong (e.g. `harness.health` requiring Pro seems like an odd choice for a monitoring endpoint) that's a separate follow-up decision, not something this PR changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
