### PR TITLE
docs(license): correct activation-key accuracy (B4)

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -175,7 +175,7 @@ This gives the tool access to agent coordination, file reservations, and task ma
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `REVEALUI_LICENSE_KEY` | (none) | License key for Pro+ features — an `eyJ`-prefixed Ed25519 JWT |
-| `REVDEV_LICENSE_PUBLIC_KEY` | (none) | PEM Ed25519 public key the daemon verifies the license against. Required for activation — without it the daemon stays in Free mode |
+| `REVDEV_LICENSE_PUBLIC_KEY` | (none) | PEM Ed25519 public key the daemon verifies the license against. Optional; overrides the baked-in vendor key (needed only after a signing-key rotation or when testing your own keypair) |
 | `REVDEV_DAEMON_SOCKET` | `~/.local/share/revealui/harness.sock` | Socket path |
 | `REVDEV_DAEMON_DATA` | `~/.local/share/revealui` | Database directory |
 | `REVDEV_DAEMON_PID` | `~/.local/share/revealui/harness.pid` | PID file path |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -91,15 +91,14 @@ You're on the Free tier. Set `REVEALUI_LICENSE_KEY` and restart the daemon. See 
 
 ### "running in FREE (degraded) mode"
 
-No valid license key detected. Set `REVEALUI_LICENSE_KEY` (and `REVDEV_LICENSE_PUBLIC_KEY`) in your environment:
+No valid license key detected. Set `REVEALUI_LICENSE_KEY` in your environment:
 
 ```bash
 export REVEALUI_LICENSE_KEY="eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9..."
-export REVDEV_LICENSE_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEA...
------END PUBLIC KEY-----"
 systemctl --user restart revdev-daemon
 ```
+
+The daemon ships with the vendor public key baked in, so this is normally all you need. `REVDEV_LICENSE_PUBLIC_KEY` is only for key rotation or testing your own keypair; see "License key doesn't activate" below if the key is valid but still shows Free.
 
 <!-- doclint:allow-legacy-format:start — this section documents the REJECTED formats on purpose -->
 ### Old-format key (`RVUI-*` or `RVUI.v2.*`) rejected

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -77,7 +77,7 @@ Environment variables (all optional):
 
 | Var | Default | Purpose |
 |---|---|---|
-| `REVEALUI_LICENSE_KEY` | (none → FREE tier) | v2 Ed25519-signed license. Pro+ unlocks coordination RPCs |
+| `REVEALUI_LICENSE_KEY` | (none → FREE tier) | Ed25519-signed license. Pro+ unlocks coordination RPCs |
 | `REVDEV_LICENSE_PUBLIC_KEY` | (none) | Public key matching the license signature |
 | `REVDEV_DAEMON_SOCKET` | `~/.local/share/revealui/harness.sock` | Unix socket bind path |
 | `REVDEV_DAEMON_DATA` | `~/.local/share/revealui` | PGlite data directory |

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -97,7 +97,7 @@ Environment variables (all optional):
 ## Smoke test
 
 For local dev / smoke testing without a real license key, use the
-Ed25519 v2 test-license generator at
+Ed25519 test-license generator at
 [`src/__tests__/test-license-helper.ts`](src/__tests__/test-license-helper.ts).
 It produces a self-signed keypair on the fly and returns a license + public
 key suitable for the `enterprise` tier. The integration test suite at


### PR DESCRIPTION
## Summary

Documentation-accuracy fixes for revdev license activation docs (Part B item B4), so they match what the daemon license code actually accepts (verified against `packages/daemon/src/license.ts` and `packages/daemon/src/license-crypto.ts`).

- `docs/GETTING_STARTED.md` (env-var table): `REVDEV_LICENSE_PUBLIC_KEY` was documented as required for activation, without it the daemon stays in Free mode. That contradicts the same file's own line 106 ("baked in ... no further configuration") and the code, where `getVendorPublicKey()` falls back to a baked-in `DEFAULT_VENDOR_PUBLIC_KEY`. Now documented as optional, only needed after a signing-key rotation or when testing your own keypair.
- `docs/TROUBLESHOOTING.md` ("running in FREE (degraded) mode" fix): previously told the reader to set both `REVEALUI_LICENSE_KEY` and `REVDEV_LICENSE_PUBLIC_KEY` as the first step. Now the public key is presented only as the fallback for "still shows Free after setting the key," which is what the code actually requires and matches the correct guidance already present later in the same file.
- `packages/daemon/README.md` (smoke test section): dropped the stale "v2" label from "Ed25519 v2 test-license generator." The code rejects the legacy `RVUI.v2.*` format outright; the helper generates a current Ed25519 JWT, so "v2" was leftover nomenclature from the retired scheme.

## Test plan

- [x] `node scripts/doc-lint-license-format.mjs` passes
- [x] Verified `REVEALUI_LICENSE_KEY` / `_FILE` and `eyJ`-prefixed Ed25519 JWT format against `packages/daemon/src/license.ts`
- [x] Verified `REVDEV_LICENSE_PUBLIC_KEY` is optional (baked-in `DEFAULT_VENDOR_PUBLIC_KEY` fallback) against `packages/daemon/src/license-crypto.ts:46-49`
- [x] Docs-only change, no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)