### PR TITLE
fix(daemon): close file-layer never-bound reachability at project.open + resolution (GAP-326)

### DIFF
--- a/packages/daemon/src/__tests__/filegit-enrollment.test.ts
+++ b/packages/daemon/src/__tests__/filegit-enrollment.test.ts
@@ -14,6 +14,7 @@
  * pointed at a fixture (production writes it root-owned at install).
  */
 
+import { execFileSync } from 'node:child_process';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
@@ -119,6 +120,9 @@ describe('daemon enrollment gate + per-agent root scoping', () => {
     dataDir = await mkdtemp(join(tmpdir(), 'revdev-enroll-'));
     repoA = await mkdtemp(join(tmpdir(), 'revdev-enroll-repoA-'));
     repoB = await mkdtemp(join(tmpdir(), 'revdev-enroll-repoB-'));
+    // project.open now rejects a non-repo root (GAP-326 D1); make the fixtures repos.
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repoA });
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repoB });
     socketPath = join(dataDir, 'harness.sock');
     const anchor = join(dataDir, 'trusted-client-fingerprint');
     // Anchor trusts the (agentId, fingerprint) PAIRS of A and B but NOT evil.

--- a/packages/daemon/src/__tests__/filegit-neverbound-unit.test.ts
+++ b/packages/daemon/src/__tests__/filegit-neverbound-unit.test.ts
@@ -1,0 +1,227 @@
+/**
+ * GAP-326 — file-layer never-bound guards, UNIT coverage via the @internal
+ * seams (no socket): the D1/D3 registration-refusal matrix, the D2 resolution
+ * belt in isolation (a pre-fix persisted overlapping root seeded directly), and
+ * the D3 startup eviction of a persisted overlapping row.
+ *
+ * The end-to-end attack + regression live in filegit-neverbound.test.ts (real
+ * socket, no seams). This file drives the individual guards where a seam is the
+ * cheapest faithful surface.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, realpath, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGlite } from '@electric-sql/pglite';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture the eviction log line (D3) without a real logger. Only createLogger is
+// stubbed; every other logger export keeps its real implementation.
+const { warnCalls } = vi.hoisted(() => ({
+  warnCalls: [] as Array<{ msg: string; meta: unknown }>,
+}));
+vi.mock('@revealui/utils/logger', async (importActual) => {
+  const actual = await importActual<typeof import('@revealui/utils/logger')>();
+  const stub = (): Record<string, unknown> => ({
+    debug() {},
+    info() {},
+    error() {},
+    fatal() {},
+    warn(msg: string, meta?: unknown) {
+      warnCalls.push({ msg, meta });
+    },
+    child() {
+      return stub();
+    },
+  });
+  return { ...actual, createLogger: () => stub() };
+});
+
+import {
+  _addRootForTest,
+  _assertRootAvoidsNeverBoundForTest,
+  _clearRegisteredRootsForTest,
+  _resetNeverBoundForTest,
+  _resolveInRootForTest,
+  _setNeverBoundForTest,
+  restoreProjectRoots,
+} from '../filegit.js';
+import { MIGRATIONS } from '../migrations/index.js';
+import { migrate } from '../storage/migrate.js';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+// ---------------------------------------------------------------------------
+// D1/D3 registration-refusal matrix (pure — lexical fixtures, no fs)
+// ---------------------------------------------------------------------------
+
+describe('D1/D3 never-bound root gate — registration refusal matrix', () => {
+  const HOME = '/base/op';
+  const DATADIR = '/base/op/.local/share/revealui';
+
+  afterEach(() => _resetNeverBoundForTest());
+
+  it('refuses the operator home itself', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest(HOME)).toThrow(/operator home/);
+  });
+
+  it('refuses an ancestor of the operator home', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest('/base')).toThrow(/operator home/);
+  });
+
+  it('refuses a root that IS a secret path', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest(join(HOME, '.ssh'))).toThrow(
+      /never-bound secret path/,
+    );
+  });
+
+  it('refuses a root INSIDE a secret path', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest(join(HOME, '.ssh', 'sub'))).toThrow(
+      /never-bound secret path/,
+    );
+  });
+
+  it('refuses a root that CONTAINS a never-bound path (not the home itself)', () => {
+    // Home elsewhere so this isolates "never-bound inside root" from the home check:
+    // the root /base/proj contains the daemon data dir /base/proj/data.
+    _setNeverBoundForTest('/other/home', '/base/proj/data');
+    expect(() => _assertRootAvoidsNeverBoundForTest('/base/proj')).toThrow(
+      /never-bound secret path/,
+    );
+  });
+
+  it('names the CLASS, never the full secret path (no oracle back to a hostile caller)', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest(join(HOME, '.ssh'))).toThrow(/ssh keys/);
+    expect(() => _assertRootAvoidsNeverBoundForTest(join(HOME, '.ssh'))).not.toThrow(
+      /\/base\/op\/\.ssh/,
+    );
+  });
+
+  it('does NOT refuse a normal project root beneath the home', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest(join(HOME, 'revfleet', 'repo'))).not.toThrow();
+  });
+
+  it('is separator-safe: a sibling sharing a name prefix is not refused', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest('/base/op-scratch/repo')).not.toThrow();
+    expect(() => _assertRootAvoidsNeverBoundForTest(join(HOME, '.sshkeep'))).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D2 resolution belt in isolation — a pre-fix overlapping root cannot resolve
+// a target onto the never-bound set (seed the root directly, bypassing D1).
+// ---------------------------------------------------------------------------
+
+describe('D2 resolution belt (isolation)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    _clearRegisteredRootsForTest();
+    root = await realpath(await mkdtemp(join(tmpdir(), 'revdev-nb-belt-')));
+    await mkdir(join(root, 'secrets'));
+    await writeFile(join(root, 'secrets', 'key.txt'), 'PRIVATE\n');
+    await writeFile(join(root, 'ok.txt'), 'fine\n');
+    // Simulate a pre-fix persisted row: register the overlapping root directly,
+    // bypassing project.open's D1 gate.
+    await _addRootForTest(root);
+    // Pin never-bound so <root>/secrets is a secret path (the daemon dataDir entry).
+    _setNeverBoundForTest('/no/such/home', join(root, 'secrets'));
+  });
+
+  afterEach(async () => {
+    _resetNeverBoundForTest();
+    _clearRegisteredRootsForTest();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('refuses a read target inside the never-bound set (mustExist=true)', async () => {
+    await expect(_resolveInRootForTest(root, 'secrets/key.txt', true)).rejects.toThrow(
+      /never-bound secret path/,
+    );
+  });
+
+  it('refuses a write target inside the never-bound set (mustExist=false)', async () => {
+    await expect(_resolveInRootForTest(root, 'secrets/new.txt', false)).rejects.toThrow(
+      /never-bound secret path/,
+    );
+  });
+
+  it('still resolves a legit target that does not overlap', async () => {
+    await expect(_resolveInRootForTest(root, 'ok.txt', true)).resolves.toBe(join(root, 'ok.txt'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D3 startup eviction — restoreProjectRoots evicts a persisted overlapping (or
+// non-repo) row, keeps the clean one, and logs each eviction.
+// ---------------------------------------------------------------------------
+
+describe('D3 startup re-validation (restoreProjectRoots eviction)', () => {
+  let db: PGlite;
+  let scratchDataDir: string;
+  let overlapRepo: string;
+  let cleanRepo: string;
+  let nonRepoRow: string;
+
+  beforeEach(async () => {
+    warnCalls.length = 0;
+    _clearRegisteredRootsForTest();
+    db = new PGlite();
+    await migrate(db, MIGRATIONS);
+
+    scratchDataDir = await realpath(await mkdtemp(join(tmpdir(), 'revdev-nb-evict-')));
+    // An active (not-ended) session so the rows are not treated as orphans.
+    await db.query(`INSERT INTO agent_sessions (id) VALUES ($1)`, ['evict-agent']);
+
+    overlapRepo = join(scratchDataDir, 'overlap-repo');
+    execFileSync('mkdir', ['-p', overlapRepo]);
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: overlapRepo });
+
+    cleanRepo = await realpath(await mkdtemp(join(tmpdir(), 'revdev-nb-clean-')));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: cleanRepo });
+
+    nonRepoRow = await realpath(await mkdtemp(join(tmpdir(), 'revdev-nb-nonrepo-')));
+
+    for (const p of [overlapRepo, cleanRepo, nonRepoRow]) {
+      const s = await stat(p);
+      await db.query(
+        `INSERT INTO project_roots (dev, ino, real_path, agent_id) VALUES ($1, $2, $3, $4)`,
+        [BigInt(s.dev), BigInt(s.ino), p, 'evict-agent'],
+      );
+    }
+
+    // Pin never-bound: <scratchDataDir> is the daemon data dir (never-bound), so
+    // overlapRepo (inside it) overlaps; cleanRepo / nonRepoRow do not.
+    _setNeverBoundForTest('/no/such/home', scratchDataDir);
+  });
+
+  afterEach(async () => {
+    _resetNeverBoundForTest();
+    _clearRegisteredRootsForTest();
+    await db.close().catch(() => {});
+    for (const p of [scratchDataDir, cleanRepo, nonRepoRow]) {
+      await rm(p, { recursive: true, force: true });
+    }
+  });
+
+  it('evicts the overlapping + non-repo rows, keeps the clean one, and logs each eviction', async () => {
+    await restoreProjectRoots(db);
+
+    const rows = await db.query<{ real_path: string }>(`SELECT real_path FROM project_roots`);
+    const survivors = rows.rows.map((r) => r.real_path);
+    expect(survivors).toContain(cleanRepo);
+    expect(survivors).not.toContain(overlapRepo);
+    expect(survivors).not.toContain(nonRepoRow);
+
+    const evictions = warnCalls.filter((c) => c.msg.includes('evicting persisted project root'));
+    expect(evictions.length).toBe(2);
+  });
+});

--- a/packages/daemon/src/__tests__/filegit-neverbound.test.ts
+++ b/packages/daemon/src/__tests__/filegit-neverbound.test.ts
@@ -1,0 +1,200 @@
+/**
+ * GAP-326 — file.* never-bound reachability, END-TO-END over a real signed
+ * socket (the prove-red attack + the registration/resolution refusals it must
+ * produce, plus a legit-repo regression control).
+ *
+ * The attack (gap description): a client-owned, verified signer project.open's a
+ * secret-bearing tree, then file.read's a secret inside it — no spawn, so the
+ * confinement never-bound guard never runs. This suite drives that attack
+ * through the daemon and proves it is refused at project.open (D1). The daemon
+ * data directory is itself a never-bound entry (it holds the integrity DB, the
+ * socket, the per-agent homes), so a git repo placed INSIDE dataDir is a
+ * self-contained secret-bearing tree that needs no real operator secret to
+ * exercise the guard. Reverting the source (confinement.ts + filegit.ts) makes
+ * both refusals disappear (project.open succeeds, the secret reads back) — that
+ * is the red-first proof this file carries. It uses ONLY the real RPC handlers,
+ * no @internal seams, so it runs unchanged against the pre-fix daemon.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { formatDid } from '@revdev/protocol/did';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  generateNonce,
+  hashParams,
+  serializeEnvelope,
+  signEnvelope,
+} from '../agent-identity-crypto.js';
+import { startDaemon } from '../server.js';
+// Side-effect import: registers project.open / file.* / git.* handlers.
+import '../filegit.js';
+
+// PGlite cold-init can exceed the 10s default hook budget under load.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+interface RpcResult {
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+function rpcFrame(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown>,
+  signature?: string,
+): Promise<RpcResult> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req: Record<string, unknown> = { jsonrpc: '2.0', id: 1, method, params };
+    if (signature) req['x-revdev-signature'] = signature;
+    sock.on('connect', () => sock.write(`${JSON.stringify(req)}\n`));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      sock.end();
+      try {
+        resolve(JSON.parse(buf.slice(0, nl)) as RpcResult);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error(`rpc timeout: ${method}`));
+    });
+  });
+}
+
+describe('GAP-326 file-layer never-bound reachability (end-to-end)', () => {
+  let daemon: { close: () => Promise<void> };
+  let socketPath: string;
+  let dataDir: string;
+  const agentId = 'gap326-e2e';
+
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid(agentId, fingerprint);
+
+  function sign(method: string, params: Record<string, unknown>): string {
+    const payload = {
+      did,
+      kid: fingerprint,
+      nonce: generateNonce(),
+      ts: Math.floor(Date.now() / 1000),
+      method,
+      paramsHash: hashParams(method, params),
+    };
+    return serializeEnvelope(signEnvelope(payload, kp.privateKeyPem));
+  }
+
+  function signedRpc(method: string, params: Record<string, unknown>): Promise<RpcResult> {
+    return rpcFrame(socketPath, method, params, sign(method, params));
+  }
+
+  /** git-init a directory so it passes the D1 non-repo check. */
+  function gitInit(dir: string): void {
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 'test@revdev.local'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'RevDev Test'], { cwd: dir });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+  }
+
+  beforeAll(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-gap326-'));
+    socketPath = join(dataDir, 'harness.sock');
+    const anchor = join(dataDir, 'trusted-client-fingerprint');
+    await writeFile(anchor, `${agentId}:${fingerprint}\n`);
+    daemon = await startDaemon({
+      socketPath,
+      dataDir,
+      trustedClientFingerprintPath: anchor,
+      trustedAnchorRequireRootOwned: false,
+    });
+    const reg = await rpcFrame(socketPath, 'session.register', {
+      agentId,
+      agentName: 'studio-ui',
+      backend: 'studio',
+      publicKeyPem: kp.publicKeyPem,
+    });
+    expect((reg.result as { did: string }).did).toBe(did);
+  });
+
+  afterAll(async () => {
+    await daemon.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it('REFUSES the never-bound attack: project.open a secret-bearing tree, then read a secret inside (prove-red)', async () => {
+    // The daemon data dir is a never-bound entry. A git repo placed inside it is
+    // a secret-bearing tree with no real operator secret involved.
+    const secretRepo = join(dataDir, 'secret-repo');
+    execFileSync('mkdir', ['-p', secretRepo]);
+    gitInit(secretRepo);
+    // A stand-in for ~/.ssh/id_ed25519 — the thing the attack wants to read.
+    await writeFile(join(secretRepo, 'id_ed25519'), 'PRIVATE-KEY-MATERIAL\n');
+
+    // D1: project.open must refuse a root that overlaps the never-bound set.
+    // (pre-fix: this SUCCEEDS — the attack's first step works.)
+    const open = await signedRpc('project.open', { repoPath: secretRepo });
+    expect(open.error).toBeDefined();
+    expect(open.error?.message ?? '').toContain('never-bound secret path');
+    // The class is named, the full secret path is NOT echoed back to the caller.
+    expect(open.error?.message ?? '').not.toContain('id_ed25519');
+
+    // The secret is therefore unreadable: the root was never registered.
+    // (pre-fix: project.open registered it and this returns the key material.)
+    const read = await signedRpc('file.read', { repoPath: secretRepo, filePath: 'id_ed25519' });
+    expect((read.result as { content?: string })?.content).toBeUndefined();
+    expect(read.error?.message ?? '').toContain('not registered');
+  });
+
+  it('REFUSES a non-repo root at project.open (makes the drifted comment true)', async () => {
+    // (pre-fix: registering a bare directory SUCCEEDED — file.* over an arbitrary
+    // tree.)
+    const bare = await mkdtemp(join(tmpdir(), 'revdev-gap326-bare-'));
+    try {
+      const open = await signedRpc('project.open', { repoPath: bare });
+      expect(open.error).toBeDefined();
+      expect(open.error?.message ?? '').toContain('not a git repository');
+    } finally {
+      await rm(bare, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves a legit repo root unaffected: open + file.write/read + git.status all succeed (regression)', async () => {
+    // A normal project root (a sibling of dataDir under /tmp, not overlapping any
+    // never-bound entry) must behave exactly as before.
+    const legit = await mkdtemp(join(tmpdir(), 'revdev-gap326-legit-'));
+    try {
+      gitInit(legit);
+      const open = await signedRpc('project.open', { repoPath: legit });
+      expect((open.result as { success: boolean }).success).toBe(true);
+
+      const w = await signedRpc('file.write', {
+        repoPath: legit,
+        filePath: 'note.txt',
+        content: 'hello',
+      });
+      expect((w.result as { success: boolean }).success).toBe(true);
+
+      const r = await signedRpc('file.read', { repoPath: legit, filePath: 'note.txt' });
+      expect((r.result as { content: string }).content).toBe('hello');
+      // And it actually hit ext4.
+      expect(await readFile(join(legit, 'note.txt'), 'utf8')).toBe('hello');
+
+      const st = await signedRpc('git.status', { repoPath: legit });
+      expect((st.result as { success: boolean }).success).toBe(true);
+    } finally {
+      await rm(legit, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/daemon/src/__tests__/filegit-signed.test.ts
+++ b/packages/daemon/src/__tests__/filegit-signed.test.ts
@@ -13,6 +13,7 @@
  * side): produce envelopes byte-compatible with what this test sends.
  */
 
+import { execFileSync } from 'node:child_process';
 import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
@@ -105,6 +106,8 @@ describe('Studio client-key signing (zero-9P P1)', () => {
   beforeAll(async () => {
     dataDir = await mkdtemp(join(tmpdir(), 'revdev-signed-'));
     repo = await mkdtemp(join(tmpdir(), 'revdev-signed-repo-'));
+    // project.open now rejects a non-repo root (GAP-326 D1); make the fixture a repo.
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo });
     socketPath = join(dataDir, 'harness.sock');
     // Trust anchor: provision THIS client's fingerprint so enrollment is
     // allowed (the production install writes this root-owned; the test points

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -74,6 +74,7 @@ vi.mock('node-pty', () => ({
 // Imports (after mock declarations)
 // ---------------------------------------------------------------------------
 
+import { execFileSync } from 'node:child_process';
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
@@ -235,6 +236,9 @@ beforeAll(async () => {
   // signer cannot spawn into a root it neither owns nor was granted.
   repoRoot = await mkdtemp(join(tmpdir(), 'revdev-spawn-root-'));
   otherRoot = await mkdtemp(join(tmpdir(), 'revdev-spawn-otherroot-'));
+  // project.open now rejects a non-repo root (GAP-326 D1); make the fixtures repos.
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: otherRoot });
   await signedRpc(owner, 'project.open', { repoPath: repoRoot });
   await signedRpc(other, 'project.open', { repoPath: otherRoot });
 });

--- a/packages/daemon/src/confinement.ts
+++ b/packages/daemon/src/confinement.ts
@@ -284,6 +284,27 @@ export function neverBoundSet(operatorHome: string, dataDir: string): string[] {
 }
 
 /**
+ * Return the first never-bound entry that overlaps `real` in either direction,
+ * or `null` when none does. Pure, zero I/O (the caller passes a precomputed
+ * `neverBound` list) and zero regex — the shared overlap predicate.
+ *
+ *   - `within(real, nb)`: the secret lives INSIDE `real` (a bind/read exposes it).
+ *   - `within(nb, real)`: `real` IS or lives INSIDE a secret path.
+ *
+ * Consumed by BOTH the spawn side (`assertGrantedRootBindable`, which formats a
+ * full-path error because a granted root is operator-known material) and the
+ * file side (`filegit.ts` D1/D2/D3, which formats a CLASS-only error because a
+ * `project.open` caller may be hostile). One never-bound set (`neverBoundSet`),
+ * one predicate, no copied logic (extend-before-create, GAP-326).
+ */
+export function findNeverBoundOverlap(real: string, neverBound: readonly string[]): string | null {
+  for (const nb of neverBound) {
+    if (within(real, nb) || within(nb, real)) return nb;
+  }
+  return null;
+}
+
+/**
  * Refuse to bind a granted root that overlaps the never-bound secret set or the
  * operator home (GAP-320a). The bind sequence tmpfs-hides the operator home and
  * then re-binds `repoReal` read-write on top (§4.3); if `repoReal` IS, CONTAINS,
@@ -312,14 +333,13 @@ export function assertGrantedRootBindable(
       `agent.spawn: refusing to bind granted root "${repoReal}" — it is or contains the operator home "${operatorHome}" (confinement would re-expose the entire home read-write). Grant a project root beneath the home, not the home itself.`,
     );
   }
-  for (const nb of neverBoundSet(operatorHome, dataDir)) {
-    // within(repoReal, nb): the secret lives INSIDE the granted root (bind exposes it).
-    // within(nb, repoReal): the granted root IS or lives INSIDE a secret path.
-    if (within(repoReal, nb) || within(nb, repoReal)) {
-      throw new Error(
-        `agent.spawn: refusing to bind granted root "${repoReal}" — it overlaps the never-bound secret path "${nb}" (confinement would re-expose it read-write). Grant a root that does not contain secret material.`,
-      );
-    }
+  // within(repoReal, nb): the secret lives INSIDE the granted root (bind exposes it).
+  // within(nb, repoReal): the granted root IS or lives INSIDE a secret path.
+  const nb = findNeverBoundOverlap(repoReal, neverBoundSet(operatorHome, dataDir));
+  if (nb !== null) {
+    throw new Error(
+      `agent.spawn: refusing to bind granted root "${repoReal}" — it overlaps the never-bound secret path "${nb}" (confinement would re-expose it read-write). Grant a root that does not contain secret material.`,
+    );
   }
 }
 

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -29,9 +29,13 @@ import { open, readFile, realpath, stat, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
+import { createLogger } from '@revealui/utils/logger';
+import { findNeverBoundOverlap, neverBoundSet, resolveOperatorHome } from './confinement.js';
 import { onAgentEnded, onDaemonStarted } from './eviction.js';
 import { getDaemonConfig, registerHandler } from './server.js';
 import { runGit, type ShellResult } from './vcs.js';
+
+const log = createLogger({ service: 'revdev-daemon/filegit' });
 
 // ---------------------------------------------------------------------------
 // Registered project roots
@@ -140,9 +144,41 @@ export async function restoreProjectRoots(db: PGlite): Promise<void> {
      FROM project_roots pr
      INNER JOIN agent_sessions s ON s.id = pr.agent_id AND s.ended_at IS NULL`,
   );
+  // D3 (GAP-326): re-validation below uses neverBoundContext(), which lazily
+  // computes from this started daemon's config (getDaemonConfig() is set before
+  // this hook fires) — so a restart under a new dataDir is reflected without an
+  // explicit reset. Tests pin the context via _setNeverBoundForTest first.
   for (const row of rows.rows) {
     const dev = BigInt(row.dev);
     const ino = BigInt(row.ino);
+    // D3 (GAP-326): re-validate every persisted root against D1's checks. A row
+    // written before this gate existed — or before the never-bound set grew —
+    // may now be a non-repo or overlap a secret path; such a row is EVICTED
+    // (deleted + logged), never restored into the serving map, so set growth
+    // becomes retroactively protective. The path is the operator's own material
+    // and this is the operator's own daemon log, so naming it is not an oracle.
+    let evictReason: string | null = null;
+    const isRepo = await stat(join(row.real_path, '.git')).then(
+      () => true,
+      () => false,
+    );
+    if (!isRepo) {
+      evictReason = 'not a git repository';
+    } else {
+      try {
+        assertRootAvoidsNeverBound(row.real_path);
+      } catch (e) {
+        evictReason = e instanceof Error ? e.message : String(e);
+      }
+    }
+    if (evictReason !== null) {
+      log.warn('evicting persisted project root that fails never-bound re-validation', {
+        root: row.real_path,
+        reason: evictReason,
+      });
+      await db.query(`DELETE FROM project_roots WHERE dev = $1 AND ino = $2`, [row.dev, row.ino]);
+      continue;
+    }
     registeredRoots.set(inodeKey(dev, ino), {
       real: row.real_path,
       agentId: row.agent_id,
@@ -200,6 +236,117 @@ function expandTilde(p: string): string {
 /** True when `target` is `root` itself or a descendant of it. */
 function within(root: string, target: string): boolean {
   return target === root || target.startsWith(root + sep);
+}
+
+// ---------------------------------------------------------------------------
+// Never-bound secret set at the file layer (GAP-326)
+//
+// The confinement layer (agent.spawn) refuses to BIND a granted root that
+// overlaps the operator's secret set. The SAME set must gate the file.*/git.*
+// surface, or a client-owned verified signer can project.open a secret-bearing
+// tree — the operator home, ~/.ssh, the passage store — and read it straight
+// through file.read with no spawn involved (so confinement never runs). One
+// never-bound set (confinement.ts's `neverBoundSet`), imported here and shared
+// via `findNeverBoundOverlap` — never a second literal list.
+// ---------------------------------------------------------------------------
+
+/**
+ * Memoized (operatorHome, never-bound list) for this daemon. Computed lazily on
+ * first use — in a running daemon that is during restoreProjectRoots or the
+ * first file op, both after getDaemonConfig() is set, so it reflects the active
+ * dataDir/home without an explicit reset. Precomputed once thereafter so the D2
+ * resolution belt adds no per-call I/O. Tests override it via _setNeverBoundForTest.
+ */
+let neverBoundCache: { operatorHome: string; list: string[] } | null = null;
+
+function neverBoundContext(): { operatorHome: string; list: string[] } {
+  if (neverBoundCache === null) {
+    const operatorHome = resolveOperatorHome();
+    neverBoundCache = {
+      operatorHome,
+      list: neverBoundSet(operatorHome, getDaemonConfig().dataDir),
+    };
+  }
+  return neverBoundCache;
+}
+
+/**
+ * @internal — test seam: pin the never-bound context to a scratch home/dataDir
+ * so a test can register an overlapping "secret" tree without touching the real
+ * operator home.
+ */
+export function _setNeverBoundForTest(operatorHome: string, dataDir: string): void {
+  const home = resolveOperatorHome(operatorHome);
+  neverBoundCache = { operatorHome: home, list: neverBoundSet(home, dataDir) };
+}
+
+/** @internal — test seam: drop the pinned/memoized never-bound context. */
+export function _resetNeverBoundForTest(): void {
+  neverBoundCache = null;
+}
+
+/**
+ * Coarse CLASS of a never-bound entry, for an error handed back to a possibly
+ * hostile project.open/file.* caller. We name the CLASS ("ssh keys"), never the
+ * full path — echoing the operator's home layout back would be an oracle. The
+ * secret CATEGORIES are public knowledge; a specific home path is not. Zero
+ * regex (substring membership only).
+ */
+function neverBoundClass(entry: string): string {
+  if (entry.includes('/.ssh')) return 'ssh keys';
+  if (entry.includes('.age-identity')) return 'the age identity';
+  if (entry.includes('passage-store')) return 'the credential store';
+  if (entry.includes('/.config/gh')) return 'github credentials';
+  if (entry.includes('.npmrc')) return 'npm credentials';
+  if (entry.includes('/.aws')) return 'aws credentials';
+  if (entry.includes('.docker')) return 'docker credentials';
+  if (entry.includes('/.claude')) return 'agent credentials';
+  if (entry.includes('/mnt/c') || entry.includes('/mnt/e')) return 'a mounted credential volume';
+  if (entry.includes('/run/user')) return 'the runtime socket directory';
+  return 'daemon secret state';
+}
+
+/**
+ * D1/D3 root gate (GAP-326): refuse a project root that IS or CONTAINS the
+ * operator home, or that overlaps the never-bound secret set in either
+ * direction. Same semantics as confinement's `assertGrantedRootBindable`,
+ * sharing `findNeverBoundOverlap` + `neverBoundSet`; class-only errors (a root
+ * beneath the home, the normal `~/revfleet/<repo>` shape, is NOT refused).
+ */
+function assertRootAvoidsNeverBound(real: string): void {
+  const { operatorHome, list } = neverBoundContext();
+  if (real === operatorHome || within(real, operatorHome)) {
+    throw new Error(
+      'project root is or contains the operator home (it would expose the entire home through file.*)',
+    );
+  }
+  const nb = findNeverBoundOverlap(real, list);
+  if (nb !== null) {
+    throw new Error(`project root overlaps a never-bound secret path (${neverBoundClass(nb)})`);
+  }
+}
+
+/**
+ * D2 resolution belt (GAP-326): refuse a resolved target that lands on the
+ * never-bound set. Defense-in-depth behind D1 — the invariant holds even for a
+ * root that came to be registered before this gate existed (a pre-fix persisted
+ * row D3 eviction has not reached, or a never-bound entry that grew). One
+ * precomputed prefix scan, no added I/O (the caller already realpath'd).
+ */
+function assertTargetAvoidsNeverBound(target: string): void {
+  const nb = findNeverBoundOverlap(target, neverBoundContext().list);
+  if (nb !== null) {
+    throw new Error(`path resolves onto a never-bound secret path (${neverBoundClass(nb)})`);
+  }
+}
+
+/**
+ * @internal — test seam: exercise the D1/D3 never-bound root gate on an
+ * already-realpath'd root (the same check project.open and restoreProjectRoots
+ * run). Throws the class-only refusal; returns void on a clean root.
+ */
+export function _assertRootAvoidsNeverBoundForTest(real: string): void {
+  assertRootAvoidsNeverBound(real);
 }
 
 /**
@@ -265,6 +412,7 @@ async function resolveInRoot(
       throw new Error(`file not found: ${filePathRaw}`);
     }
     if (!within(repoReal, real)) throw new Error(`path escapes project root: ${filePathRaw}`);
+    assertTargetAvoidsNeverBound(real);
     return real;
   }
 
@@ -276,7 +424,9 @@ async function resolveInRoot(
     throw new Error(`parent directory does not exist: ${filePathRaw}`);
   }
   if (!within(repoReal, parentReal)) throw new Error(`path escapes project root: ${filePathRaw}`);
-  return join(parentReal, basename(abs));
+  const target = join(parentReal, basename(abs));
+  assertTargetAvoidsNeverBound(target);
+  return target;
 }
 
 /**
@@ -506,12 +656,26 @@ registerHandler('project.open', async (params, db, ctx) => {
   } catch {
     throw new Error(`project root does not exist: ${repoPathRaw}`);
   }
-  // Confirm it is actually a git repository — registering a non-repo root
-  // would let file.* operate on an arbitrary directory tree.
+  // D1 (GAP-326): confirm it is actually a git repository. Registering a non-repo
+  // root would let file.* operate on an arbitrary directory tree — the comment
+  // here has claimed this policy since the surface shipped; the code now enforces
+  // it. A non-repo root also skips assertNoExecConfig below, so rejecting it
+  // closes both gaps at once. A future non-repo need arrives as a new,
+  // separately-reviewed method — never by silently widening project.open.
   const isRepo = await stat(join(real, '.git')).then(
     () => true,
     () => false,
   );
+  if (!isRepo) {
+    throw new Error(`project root is not a git repository: ${repoPathRaw}`);
+  }
+  // D1 (GAP-326): refuse a root that overlaps the never-bound secret set (in
+  // either direction) or the operator home, BEFORE any registration side effect.
+  // Without this a client-owned verified signer could project.open("~") or
+  // project.open("~/.ssh") and read secrets straight through file.read — no spawn,
+  // so the confinement layer never runs. Same never-bound set the spawn side
+  // enforces (confinement.ts), imported — never a second copy.
+  assertRootAvoidsNeverBound(real);
   if (ctx.agentId === null) {
     // Unreachable in practice: project.open is in MUTATING_OR_CONTENT_METHODS,
     // so the dispatch signature gate binds ctx.agentId to the verified signer
@@ -535,8 +699,9 @@ registerHandler('project.open', async (params, db, ctx) => {
   // project.open is the trust boundary for a third-party repo: without this a
   // routine `git.diffFile`/`git.stageFile`/checkout would run attacker code as
   // the daemon UID (e.g. exfil ~/.age-identity/keys.txt). Done BEFORE adding to
-  // registeredRoots so a refused repo is never usable by file.*/git.*.
-  if (isRepo) await assertNoExecConfig(real);
+  // registeredRoots so a refused repo is never usable by file.*/git.*. isRepo is
+  // guaranteed true here (non-repo roots are rejected by D1 above).
+  await assertNoExecConfig(real);
   // Stat to get the canonical inode key.
   const s = await stat(real);
   const dev = BigInt(s.dev);


### PR DESCRIPTION
## What

Closes the file-layer never-bound reachability gap (GAP-326, design in the private
tracker `docs/gap-specs/GAP-326-file-layer-never-bound-reachability-design.md`).
A client-owned verified signer could `project.open` a secret-bearing tree and read
secrets straight through `file.read` with no `agent.spawn` involved, so the
confinement never-bound guard never ran. This lands all four parts as one
invariant (splitting reopens the fail-open windows between them):

- **D1 registration gate** (`project.open`): rejects a non-repo root (making the
  long-standing comment true) and refuses a root overlapping the never-bound set
  in either direction, or the operator home, before any registration side effect.
- **D2 resolution belt** (shared target resolver): refuses a resolved target that
  lands on the never-bound set. One precomputed prefix scan, no added I/O.
- **D3 startup re-validation** (`restoreProjectRoots`): re-checks every persisted
  row and evicts (deletes the row + logs a loud line) any that now fails, so
  never-bound-set growth is retroactively protective.
- **One list, imported**: `confinement.ts`'s `neverBoundSet` plus a new shared
  `findNeverBoundOverlap` predicate are consumed by both the spawn side and the
  file side. No second literal list. The file side names the offending entry by
  CLASS ("ssh keys"), never the full secret path, so the error is not an oracle
  back to a possibly hostile caller.

Registration-fixture scratch dirs that call `project.open` now carry a `git init`
line, per the design's audit item (the non-repo rejection would otherwise break
them).

## Never-bound set is imported, not copied

`filegit.ts` imports `neverBoundSet`, `findNeverBoundOverlap`, and
`resolveOperatorHome` from `confinement.ts`. `assertGrantedRootBindable` (spawn
side) was refactored to consume the same `findNeverBoundOverlap` predicate. A grep
for a second never-bound literal list finds none.

## Prove-red evidence (stashed-fix red run)

Stashed only the two source files (`confinement.ts` + `filegit.ts`), leaving the
tests, and ran the seam-free end-to-end attack file against the pre-fix daemon:

```
BEFORE (source stashed to base):
  × REFUSES the never-bound attack ... (project.open of a secret-bearing tree)
      AssertionError: expected undefined to be defined   <- open.error is undefined
                                                            = project.open SUCCEEDED
                                                              = the attack works
  × REFUSES a non-repo root at project.open
      AssertionError: expected undefined to be defined   <- bare dir registered
  ✓ leaves a legit repo root unaffected (regression control stays green)
  Tests  2 failed | 1 passed (3)

AFTER (fix restored):
  Tests  3 passed (3)
```

The CI prove-red gate agrees: reverting the source to base, 2 changed TypeScript
test units are red against base ("all active languages carry failing-first
evidence").

## Tests

- New `filegit-neverbound.test.ts` (real signed socket, no seams): the prove-red
  attack + non-repo refusal + a legit-repo regression control.
- New `filegit-neverbound-unit.test.ts`: the D1/D3 refusal matrix (operator home,
  root == / inside / containing a secret, separator-safe negatives, class-only
  error), the D2 belt in isolation (a pre-fix overlapping root seeded directly),
  and D3 eviction (`restoreProjectRoots` evicts overlapping + non-repo rows, keeps
  the clean one, logs each).
- Full daemon suite green: 31 files, 634 tests (was 619). Adversarial-isolation
  (25 cases), `spawn.test.ts`, and the confinement suites stay green. Typecheck,
  Biome, private-leak scan, and the zero-9P fence all pass.

## Review

This is a crown-jewel-adjacent security surface. Per the review-before-merge
convention, a **guardrail-2 non-author verdict is required before merge**; the
author does not self-approve and does not merge. Owner disposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
