### PR TITLE
release: promote test to main (post-crash-recovery)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - run: pnpm test
 
   prove-red:
-    name: Prove-Red (changed tests must fail against base)
+    name: Prove-Red (TypeScript changed tests must fail against base)
     runs-on: ubuntu-latest
     needs: quality
     # PR-only: a merge-base is meaningless on a direct push to test/main.
@@ -130,9 +130,42 @@ jobs:
       # per-file vitest runs fail to resolve imports rather than on assertions.
       - run: pnpm --filter @revdev/protocol build
       - run: pnpm --filter @revdev/daemon build
-      - name: Prove changed tests are red against base
+      # Scoped to TypeScript: this runner installs only Node/pnpm. The Rust and
+      # Go languages the gate also covers run in their own jobs (prove-red-go
+      # here; prove-red-rust in studio-rust-tests.yml) so each installs only its
+      # own toolchain. Default (no PROVE_RED_LANGS) is all three, for local runs.
+      - name: Prove changed TypeScript tests are red against base
         env:
           BASE_REF: ${{ github.event.pull_request.base.sha }}
+          PROVE_RED_LANGS: typescript
+        run: node scripts/ci/prove-red.mjs
+
+  prove-red-go:
+    name: Prove-Red (Go changed tests must fail against base)
+    runs-on: ubuntu-latest
+    needs: quality
+    # PR-only: a merge-base is meaningless on a direct push to test/main.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: apps/console/go.mod
+          cache-dependency-path: apps/console/go.sum
+      # Node runs the gate script itself (Node stdlib only, no pnpm needed here).
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+      # Reverts the changed Go source to base, then runs each changed test's
+      # package (`go test ./pkg/`) and requires >=1 red. Package granularity is
+      # inherent to `go test`; see scripts/ci/prove-red.mjs header.
+      - name: Prove changed Go tests are red against base
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+          PROVE_RED_LANGS: go
         run: node scripts/ci/prove-red.mjs
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,36 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
+  prove-red:
+    name: Prove-Red (changed tests must fail against base)
+    runs-on: ubuntu-latest
+    needs: quality
+    # PR-only: a merge-base is meaningless on a direct push to test/main.
+    if: github.event_name == 'pull_request'
+    steps:
+      # Check out the PR head (not the synthetic merge commit) with full history
+      # so scripts/ci/prove-red.mjs can compute the merge base and revert the
+      # source diff. See docs (verification-enforcement lane) for the mechanism.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Changed daemon tests import @revdev/protocol and @revdev/daemon; build
+      # them from source first, exactly as the root `test` script does, or the
+      # per-file vitest runs fail to resolve imports rather than on assertions.
+      - run: pnpm --filter @revdev/protocol build
+      - run: pnpm --filter @revdev/daemon build
+      - name: Prove changed tests are red against base
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/ci/prove-red.mjs
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,29 @@ jobs:
     needs: quality
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Install bubblewrap (agent.spawn confinement integration tests)
-        # The real-bwrap adversarial-read tests (confinement-integration.test.ts)
-        # need bwrap present AND able to create unprivileged namespaces. When it
-        # cannot, the suite self-skips via its bwrapUsable() probe — the install
-        # is what lets the boundary be proven for real on CI rather than skipped.
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+      - name: Install bubblewrap + enable unprivileged user namespaces (agent.spawn confinement tests)
+        # confinement-integration.test.ts runs REAL bwrap adversarial reads proving
+        # ~/.ssh, ~/.age-identity, and the revvault store are denied inside the
+        # sandbox. They need bwrap present AND able to create unprivileged user
+        # namespaces. ubuntu-24.04 ships kernel.apparmor_restrict_unprivileged_userns=1,
+        # which blocks that — so without lowering it, bwrapUsable() fails and the
+        # whole suite self-skips and the boundary is never proven on CI (GAP-319).
+        run: |
+          sudo apt-get update && sudo apt-get install -y bubblewrap
+          # `|| true`: if a future runner kernel lacks this knob, the guard step
+          # below is the real gate — do not fail here on a missing sysctl.
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+      - name: Guard — unprivileged user namespaces must work (no silent confinement skip)
+        # Turn a SILENT all-skip of the confinement suite into a LOUD failure. This
+        # probe mirrors bwrapUsable() in confinement-integration.test.ts; if it cannot
+        # build a userns sandbox, the 7 real-bwrap tests would skip and a bwrap-argv
+        # regression would pass CI unnoticed (GAP-319 acceptance).
+        run: |
+          bwrap --unshare-user --unshare-pid \
+            --ro-bind /usr /usr \
+            --symlink usr/bin /bin --symlink usr/lib /lib --symlink usr/lib64 /lib64 \
+            --proc /proc --dev /dev -- /bin/true
+          echo "OK: unprivileged user namespaces work — the confinement integration suite will run for real"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,12 @@ jobs:
     needs: quality
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install bubblewrap (agent.spawn confinement integration tests)
+        # The real-bwrap adversarial-read tests (confinement-integration.test.ts)
+        # need bwrap present AND able to create unprivileged namespaces. When it
+        # cannot, the suite self-skips via its bwrapUsable() probe — the install
+        # is what lets the boundary be proven for real on CI rather than skipped.
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/studio-rust-tests.yml
+++ b/.github/workflows/studio-rust-tests.yml
@@ -88,6 +88,7 @@ jobs:
             --manifest-path apps/studio/src-tauri/Cargo.toml \
             --test harness_integration \
             --test daemon_ctl_integration \
+            --test ssh_output_pump \
             -- --test-threads=1
 
   relay:

--- a/.github/workflows/studio-rust-tests.yml
+++ b/.github/workflows/studio-rust-tests.yml
@@ -110,3 +110,67 @@ jobs:
       # tests drive the real built binary against a mock socket.
       - name: Build + test the WSL relay
         run: cargo test --manifest-path apps/studio/relay/Cargo.toml --release
+
+  # Prove-red for the Rust surface (verification-enforcement lane item 1d). Lives
+  # here rather than in ci.yml because it reuses this workflow's heavy Rust/tauri
+  # toolchain + path filter: it only runs when the Rust surface (or the daemon it
+  # talks to) changes, and it self-skips inside the script unless the PR touches
+  # BOTH Rust source and a Rust integration test. Like the ci.yml prove-red jobs
+  # it is a NON-required check (the required-check flip is lane item 1c, owner-gated).
+  prove-red-rust:
+    name: Prove-Red (Rust changed tests must fail against base)
+    runs-on: ubuntu-latest
+    # PR-only: a merge-base is meaningless on a direct push to test/main.
+    if: github.event_name == 'pull_request'
+    steps:
+      # PR head + full history so prove-red.mjs can compute the merge base.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: apps/studio/src-tauri -> target
+
+      - run: pnpm install --frozen-lockfile
+
+      # A changed test that legitimately compiles + runs green against base needs
+      # the daemon it spawns; build it so green-detection is faithful (a failing
+      # test still reds at compile/assert without it).
+      - name: Build daemon (integration tests spawn packages/daemon/dist/cli.js)
+        run: |
+          pnpm --filter @revdev/protocol build
+          pnpm --filter @revdev/daemon build
+
+      # tauri-build's codegen requires the configured frontendDist path to exist.
+      - name: Satisfy tauri-build frontendDist
+        run: mkdir -p apps/studio/dist
+
+      # Reverts the changed Rust source to base, then runs each changed
+      # integration test (`cargo test --test <name>`) and requires >=1 red.
+      - name: Prove changed Rust tests are red against base
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+          PROVE_RED_LANGS: rust
+        run: node scripts/ci/prove-red.mjs

--- a/.leakignore
+++ b/.leakignore
@@ -12,12 +12,6 @@
 apps/studio/src/__tests__/hooks/use-local-shell.test.ts   abs-home-path
 apps/studio/src/__tests__/hooks/use-ssh.test.ts           abs-home-path
 
-# Phase-1 agent.spawn confinement test fixtures use a synthetic operator
-# username (/home/<op>) — same placeholder case as the two entries above;
-# not a real developer path.
-packages/daemon/src/__tests__/confinement.test.ts         abs-home-path
-packages/daemon/src/__tests__/spawn.test.ts               abs-home-path
-
 # Test fixture: the license-key shape matches the regex but the body is a
 # repeating hex pattern (abcdef-0123456789 doubled). Not a real key.
 packages/daemon/src/__tests__/flows.test.ts               license-key

--- a/.leakignore
+++ b/.leakignore
@@ -12,6 +12,12 @@
 apps/studio/src/__tests__/hooks/use-local-shell.test.ts   abs-home-path
 apps/studio/src/__tests__/hooks/use-ssh.test.ts           abs-home-path
 
+# Phase-1 agent.spawn confinement test fixtures use a synthetic operator
+# username (/home/<op>) — same placeholder case as the two entries above;
+# not a real developer path.
+packages/daemon/src/__tests__/confinement.test.ts         abs-home-path
+packages/daemon/src/__tests__/spawn.test.ts               abs-home-path
+
 # Test fixture: the license-key shape matches the regex but the body is a
 # repeating hex pattern (abcdef-0123456789 doubled). Not a real key.
 packages/daemon/src/__tests__/flows.test.ts               license-key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,9 @@ RevDev **consumes** RevealUI packages — it does not contain them:
 The harness daemon is the brain; Studio is its UI. Console is a separate SSH surface talking to the RevealUI API, not the daemon.
 
 ## Git Identity
-RevealUI Studio <founder@revealui.com>
+Commit as the fleet's verified GitHub noreply identity, configured once in the global `~/.gitconfig` (never override it per-repo; the literal address lives there, not in docs, and this repo's leak scanner enforces that).
+
+> Amended 2026-07-10. The prior founder@revealui.com address is retired: commits carrying it render Unverified under required signatures. Do not restore it, and do not re-add local user.email overrides.
 
 ## Stack
 - **Studio**: Rust (Tauri 2 backend) + TypeScript/React 19 (frontend)

--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -1,9 +1,9 @@
 # RevealUI Console
 
-> **Status: Experimental** — Not production-deployed. Functional prototype.
+> **Status: Experimental.** Not production-deployed. A functional prototype.
 
 SSH-delivered TUI for RevealUI account management and licensing. Runs anywhere
-there's SSH — phone, borrowed laptop, server — and is explicitly **not** for
+there's SSH (phone, borrowed laptop, server) and is explicitly **not** for
 editing code (that's Studio's job).
 
 The TUI walks users through: browsing subscription tiers, initiating checkout
@@ -13,16 +13,16 @@ API (pass `agents` as the SSH command, or set `TERMINAL_MODE=agents`).
 
 Built with the [Charm](https://charm.sh/) ecosystem:
 
-- **Wish** — SSH server
-- **Bubble Tea** — TUI framework
-- **Lip Gloss** — Terminal styling
+- **Wish** runs the SSH server
+- **Bubble Tea** drives the TUI
+- **Lip Gloss** handles the terminal styling
 
 ## Usage
 
-The intended entry point — once hosted deployment ships — is a single SSH command:
+Once hosted deployment ships, the intended entry point is a single SSH command:
 
 ```bash
-ssh terminal.revealui.com           # planned — hosted endpoint not yet live
+ssh terminal.revealui.com           # planned, hosted endpoint not yet live
 ssh terminal.revealui.com -t agents # agent proxy mode
 ```
 

--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -132,7 +132,7 @@ func (p *Proxy) spawnSession(name string) (string, error) {
 
 // pickSession shows a text-based session selector.
 func (p *Proxy) pickSession(s ssh.Session, sessions []SessionInfo) (string, error) {
-	fmt.Fprintf(s, "\033[1;33mRevealUI Terminal — Agent Sessions\033[0m\r\n\r\n")
+	fmt.Fprintf(s, "\033[1;33mRevealUI Agent Sessions\033[0m\r\n\r\n")
 
 	// Partition PTY sessions: running ones are selectable; non-running ones are
 	// still listed (dimmed, with an explicit status word) instead of being

--- a/apps/console/tui/model.go
+++ b/apps/console/tui/model.go
@@ -95,23 +95,23 @@ func fallbackTiers() []Tier {
 		{
 			ID: "free", Name: "Free (OSS)", Price: "$0",
 			Description: "Perfect for trying out RevealUI and small projects.",
-			Features:    []string{"1 site", "3 users", "Basic sync", "Community support"},
+			Features:    []string{"1 site", "3 users", "Local AI inference", "Community support", "Full source access"},
 		},
 		{
 			ID: "pro", Name: "Pro", Price: "$49", Period: "/mo",
 			Description: "For software companies building production products.",
-			Features:    []string{"5 sites", "25 users", "AI agents", "Stripe payments", "10K tasks/mo"},
+			Features:    []string{"5 sites", "25 users", "AI agents", "Stripe payments", "10K tasks/mo", "RevVault desktop + rotation", "Email support (48h)"},
 			Highlighted: true,
 		},
 		{
-			ID: "max", Name: "Max", Price: "$149", Period: "/mo",
-			Description: "AI memory, multi-provider, compliance tooling.",
-			Features:    []string{"15 sites", "100 users", "AI memory", "BYOK server-side", "50K tasks/mo"},
+			ID: "max", Name: "Max", Price: "$299", Period: "/mo",
+			Description: "AI memory, advanced inference, and compliance tooling.",
+			Features:    []string{"15 sites", "100 users", "Full AI memory", "Audit logging", "50K tasks/mo", "Email support (24h)"},
 		},
 		{
-			ID: "enterprise", Name: "Forge", Price: "$299", Period: "/mo",
-			Description: "Advanced scale and compliance requirements.",
-			Features:    []string{"Unlimited sites", "Unlimited users", "SSO/SAML", "White-label", "Unlimited tasks"},
+			ID: "enterprise", Name: "Enterprise", Price: "$1,499", Period: "/mo",
+			Description: "Scale, compliance, and agent payments.",
+			Features:    []string{"Unlimited sites", "Unlimited users", "OAuth", "x402 agent payments (soon)", "Unlimited tasks", "Slack support (4h SLA)"},
 		},
 	}
 }

--- a/apps/console/tui/model.go
+++ b/apps/console/tui/model.go
@@ -109,7 +109,7 @@ func fallbackTiers() []Tier {
 			Features:    []string{"15 sites", "100 users", "Full AI memory", "Audit logging", "50K tasks/mo", "Email support (24h)"},
 		},
 		{
-			ID: "enterprise", Name: "Enterprise", Price: "$1,499", Period: "/mo",
+			ID: "enterprise", Name: "Enterprise", Price: "$1499", Period: "/mo",
 			Description: "Scale, compliance, and agent payments.",
 			Features:    []string{"Unlimited sites", "Unlimited users", "OAuth", "x402 agent payments (soon)", "Unlimited tasks", "Slack support (4h SLA)"},
 		},

--- a/apps/console/tui/model.go
+++ b/apps/console/tui/model.go
@@ -501,11 +501,11 @@ func (m Model) viewLoading() string {
 // -- Tier selection ----------------------------------------------------------
 
 func (m Model) viewTiers() string {
-	s := titleStyle.Render("RevealUI — Choose Your Plan") + "\n"
+	s := titleStyle.Render("Choose your RevealUI plan") + "\n"
 
 	// Warn when the displayed prices are stale fallback data, not live pricing.
 	if m.pricingOffline {
-		s += errorStyle.Render("  ⚠ Offline pricing — may be out of date") + "\n"
+		s += errorStyle.Render("  ⚠ Offline pricing may be out of date") + "\n"
 	}
 
 	// Show current user info if known
@@ -531,7 +531,7 @@ func (m Model) viewTiers() string {
 			price = "—"
 		}
 
-		line := fmt.Sprintf("%s%s %s%s — %s",
+		line := fmt.Sprintf("%s%s %s%s • %s",
 			cursor, tier.Name, price, tier.Period, tier.Description)
 
 		// Mark current tier
@@ -571,7 +571,7 @@ func (m Model) viewCheckout() string {
 		return "No tier selected"
 	}
 
-	s := titleStyle.Render(fmt.Sprintf("Upgrade to %s — %s%s",
+	s := titleStyle.Render(fmt.Sprintf("Upgrade to %s for %s%s",
 		m.selected.Name, m.selected.Price, m.selected.Period)) + "\n\n"
 
 	for _, f := range m.selected.Features {

--- a/apps/console/tui/model_test.go
+++ b/apps/console/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/RevealUIStudio/revdev/apps/console/api"
@@ -79,10 +80,59 @@ func TestFallbackTiers_PaidTiersHavePeriod(t *testing.T) {
 
 func TestFallbackTiers_Names(t *testing.T) {
 	tiers := fallbackTiers()
-	expected := []string{"Free (OSS)", "Pro", "Max", "Forge"}
+	expected := []string{"Free (OSS)", "Pro", "Max", "Enterprise"}
 	for i, want := range expected {
 		if tiers[i].Name != want {
 			t.Errorf("tiers[%d].Name = %q, want %q", i, tiers[i].Name, want)
+		}
+	}
+}
+
+// TestFallbackTiers_Prices pins the offline fallback ladder to the canonical
+// prices in @revealui/contracts pricing.ts (realignment ADR 2026-06-07), so a
+// future edit can't silently reintroduce a superseded price.
+func TestFallbackTiers_Prices(t *testing.T) {
+	tiers := fallbackTiers()
+	expected := map[string]struct{ price, period string }{
+		"free":       {"$0", ""},
+		"pro":        {"$49", "/mo"},
+		"max":        {"$299", "/mo"},
+		"enterprise": {"$1,499", "/mo"},
+	}
+	for _, tier := range tiers {
+		want, ok := expected[tier.ID]
+		if !ok {
+			t.Fatalf("unexpected tier ID %q", tier.ID)
+		}
+		if tier.Price != want.price {
+			t.Errorf("tier %q Price = %q, want %q", tier.ID, tier.Price, want.price)
+		}
+		if tier.Period != want.period {
+			t.Errorf("tier %q Period = %q, want %q", tier.ID, tier.Period, want.period)
+		}
+	}
+}
+
+// TestFallbackTiers_Features pins the offline fallback ladder's feature
+// bullets to the canonical inclusions in @revealui/contracts pricing.ts
+// (SUBSCRIPTION_TIERS[].features, realignment ADR 2026-06-07), TUI-shortened.
+// Guards against stale claims (e.g. the retired "BYOK server-side",
+// "SSO/SAML", "White-label" bullets) silently surviving a price/name fix.
+func TestFallbackTiers_Features(t *testing.T) {
+	tiers := fallbackTiers()
+	expected := map[string][]string{
+		"free":       {"1 site", "3 users", "Local AI inference", "Community support", "Full source access"},
+		"pro":        {"5 sites", "25 users", "AI agents", "Stripe payments", "10K tasks/mo", "RevVault desktop + rotation", "Email support (48h)"},
+		"max":        {"15 sites", "100 users", "Full AI memory", "Audit logging", "50K tasks/mo", "Email support (24h)"},
+		"enterprise": {"Unlimited sites", "Unlimited users", "OAuth", "x402 agent payments (soon)", "Unlimited tasks", "Slack support (4h SLA)"},
+	}
+	for _, tier := range tiers {
+		want, ok := expected[tier.ID]
+		if !ok {
+			t.Fatalf("unexpected tier ID %q", tier.ID)
+		}
+		if !slices.Equal(tier.Features, want) {
+			t.Errorf("tier %q Features = %v, want %v", tier.ID, tier.Features, want)
 		}
 	}
 }

--- a/apps/console/tui/model_test.go
+++ b/apps/console/tui/model_test.go
@@ -97,7 +97,7 @@ func TestFallbackTiers_Prices(t *testing.T) {
 		"free":       {"$0", ""},
 		"pro":        {"$49", "/mo"},
 		"max":        {"$299", "/mo"},
-		"enterprise": {"$1,499", "/mo"},
+		"enterprise": {"$1499", "/mo"},
 	}
 	for _, tier := range tiers {
 		want, ok := expected[tier.ID]
@@ -133,6 +133,37 @@ func TestFallbackTiers_Features(t *testing.T) {
 		}
 		if !slices.Equal(tier.Features, want) {
 			t.Errorf("tier %q Features = %v, want %v", tier.ID, tier.Features, want)
+		}
+	}
+}
+
+// TestFallbackTiers_CanonicalCatalogValues pins fallbackTiers() against the
+// canonical RevealUI Stripe catalog (revealui/scripts/setup/stripe-catalog.ts
+// CATALOG). These id/name/price triples MUST be updated in lockstep with the
+// catalog on any reprice or rename, or the console's offline fallback will
+// silently show stale numbers to a paying customer. See stripe-catalog.ts
+// header for the other surfaces (pricing.ts, pricing-fallbacks.ts) that must
+// move together.
+func TestFallbackTiers_CanonicalCatalogValues(t *testing.T) {
+	type want struct {
+		id, name, price string
+	}
+	expected := []want{
+		{id: "free", name: "Free (OSS)", price: "$0"},
+		{id: "pro", name: "Pro", price: "$49"},
+		{id: "max", name: "Max", price: "$299"},
+		{id: "enterprise", name: "Enterprise", price: "$1499"},
+	}
+
+	tiers := fallbackTiers()
+	if len(tiers) != len(expected) {
+		t.Fatalf("fallbackTiers() returned %d tiers, want %d", len(tiers), len(expected))
+	}
+	for i, w := range expected {
+		got := tiers[i]
+		if got.ID != w.id || got.Name != w.name || got.Price != w.price {
+			t.Errorf("tiers[%d] = {ID: %q, Name: %q, Price: %q}, want {ID: %q, Name: %q, Price: %q}",
+				i, got.ID, got.Name, got.Price, w.id, w.name, w.price)
 		}
 	}
 }

--- a/apps/studio/src-tauri/src/commands/ssh.rs
+++ b/apps/studio/src-tauri/src/commands/ssh.rs
@@ -58,15 +58,16 @@ pub async fn ssh_send(
         .decode(&data)
         .map_err(|e| StudioError::Other(format!("Invalid base64: {e}")))?;
 
-    let sessions = state.sessions.lock().await;
-    let session = sessions
-        .get(&session_id)
-        .ok_or_else(|| StudioError::Other(format!("No session with id {session_id}")))?;
-
-    let channel_guard = session.channel.lock().await;
-    let channel = channel_guard
-        .as_ref()
-        .ok_or_else(|| StudioError::Ssh("Channel closed".into()))?;
+    // Clone the write half and release the sessions map before awaiting, so a
+    // slow send on one session cannot stall every other session's commands.
+    let channel = {
+        let sessions = state.sessions.lock().await;
+        sessions
+            .get(&session_id)
+            .ok_or_else(|| StudioError::Other(format!("No session with id {session_id}")))?
+            .channel
+            .clone()
+    };
 
     channel
         .data(&bytes[..])
@@ -84,15 +85,14 @@ pub async fn ssh_resize(
     rows: u32,
     state: State<'_, SshState>,
 ) -> Result<(), StudioError> {
-    let sessions = state.sessions.lock().await;
-    let session = sessions
-        .get(&session_id)
-        .ok_or_else(|| StudioError::Other(format!("No session with id {session_id}")))?;
-
-    let channel_guard = session.channel.lock().await;
-    let channel = channel_guard
-        .as_ref()
-        .ok_or_else(|| StudioError::Ssh("Channel closed".into()))?;
+    let channel = {
+        let sessions = state.sessions.lock().await;
+        sessions
+            .get(&session_id)
+            .ok_or_else(|| StudioError::Other(format!("No session with id {session_id}")))?
+            .channel
+            .clone()
+    };
 
     channel
         .window_change(cols, rows, 0, 0)

--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -322,7 +322,22 @@ pub async fn daemon_stop() -> Result<(), String> {
         }
     }
 
-    Err(format!("Daemon PID {pid} did not exit within 10s"))
+    // Escalate. Without this, Stop reports an error while leaving a wedged
+    // daemon running, and the UI offers no way to recover short of a shell.
+    if unsafe { libc::kill(pid as i32, libc::SIGKILL) } != 0 {
+        return Err(format!(
+            "Daemon PID {pid} ignored SIGTERM and SIGKILL could not be sent"
+        ));
+    }
+
+    for _ in 0..20 {
+        sleep(Duration::from_millis(100)).await;
+        if !is_pid_alive(pid) {
+            return Ok(());
+        }
+    }
+
+    Err(format!("Daemon PID {pid} survived SIGTERM and SIGKILL"))
 }
 
 #[cfg(not(unix))]

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ mod local_shell;
 mod platform;
 pub mod signing;
 mod spawner;
-mod ssh;
+pub mod ssh;
 mod state;
 mod tray;
 mod updater;
@@ -177,6 +177,11 @@ pub fn run() {
             updater::check_for_update,
             updater::install_update,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running RevealUI Studio");
+        .build(tauri::generate_context!())
+        .expect("error while running RevealUI Studio")
+        .run(|app, event| {
+            if matches!(event, tauri::RunEvent::Exit) {
+                spawner::kill_all(app.state::<SpawnerState>().sessions.clone());
+            }
+        });
 }

--- a/apps/studio/src-tauri/src/platform/trait_defs.rs
+++ b/apps/studio/src-tauri/src/platform/trait_defs.rs
@@ -75,7 +75,6 @@ pub struct SyncResult {
 pub struct RepoEntry {
     pub name: String,
     pub c_path: String,
-    pub e_path: String,
     pub identity: String,
 }
 

--- a/apps/studio/src-tauri/src/platform/windows.rs
+++ b/apps/studio/src-tauri/src/platform/windows.rs
@@ -98,50 +98,6 @@ impl WindowsPlatform {
         }
     }
 
-    fn git_sync_e(&self, repo_path: &str) -> SyncResult {
-        let full_path = format!("E:\\repos\\{}", repo_path);
-        let branch = self.git_branch(&full_path);
-
-        let check = Command::new("git")
-            .args(["-C", &full_path, "rev-parse", "--git-dir"])
-            .output();
-
-        if check.is_err() || !check.unwrap().status.success() {
-            return SyncResult {
-                drive: "E:".to_string(),
-                repo: String::new(),
-                status: "skip".to_string(),
-                branch: "-".to_string(),
-            };
-        }
-
-        let _ = Command::new("git")
-            .args(["-C", &full_path, "fetch", "origin", "--quiet"])
-            .output();
-
-        let reset = Command::new("git")
-            .args([
-                "-C",
-                &full_path,
-                "reset",
-                "--hard",
-                &format!("origin/{branch}"),
-            ])
-            .output();
-
-        let status = match reset {
-            Ok(o) if o.status.success() => "ok",
-            _ => "reset_failed",
-        };
-
-        SyncResult {
-            drive: "E:".to_string(),
-            repo: String::new(),
-            status: status.to_string(),
-            branch,
-        }
-    }
-
     fn git_branch(&self, path: &str) -> String {
         Command::new("git")
             .args(["-C", path, "rev-parse", "--abbrev-ref", "HEAD"])
@@ -154,7 +110,6 @@ impl WindowsPlatform {
         vec![RepoEntry {
             name: "RevealUI".to_string(),
             c_path: "projects\\RevealUI".to_string(),
-            e_path: "repos\\RevealUI".to_string(),
             identity: "professional".to_string(),
         }]
     }
@@ -362,23 +317,17 @@ impl PlatformOps for WindowsPlatform {
         }
     }
 
+    // The E: mirror sync was removed: it ran `reset --hard` against `E:\repos`,
+    // a mirror retired in 2026, with no dirty check. The C: sync below stays
+    // because it refuses to touch a dirty tree and only fast-forwards.
     fn sync_all_repos(&self) -> Result<Vec<SyncResult>, String> {
         let registry = Self::repo_registry();
-        let e_available = std::path::Path::new("E:\\repos").exists();
         let mut results = Vec::new();
 
         for repo in &registry {
-            // C: drive sync
             let mut c_result = self.git_sync_c(&repo.c_path);
             c_result.repo = repo.name.clone();
             results.push(c_result);
-
-            // E: drive sync (if available)
-            if e_available {
-                let mut e_result = self.git_sync_e(&repo.e_path);
-                e_result.repo = repo.name.clone();
-                results.push(e_result);
-            }
         }
 
         Ok(results)

--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -84,6 +84,10 @@ pub fn requires_signature(method: &str) -> bool {
             | "agent.input"
             | "agent.resize"
             | "agent.output"
+            // session.end evicts the target's project roots and kills its PTYs.
+            // Signature-required so the daemon can self-scope it to the verified
+            // signer instead of a caller-supplied `sessionId`.
+            | "session.end"
     )
 }
 
@@ -516,6 +520,7 @@ mod tests {
         assert!(requires_signature("agent.input"));
         assert!(requires_signature("agent.resize"));
         assert!(requires_signature("agent.output"));
+        assert!(requires_signature("session.end"));
         assert!(!requires_signature("ping"));
         assert!(!requires_signature("session.list"));
     }

--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -88,6 +88,13 @@ pub fn requires_signature(method: &str) -> bool {
             // Signature-required so the daemon can self-scope it to the verified
             // signer instead of a caller-supplied `sessionId`.
             | "session.end"
+            // harness.prune reaches the SAME eviction primitive as session.end,
+            // but fans it across every matched session rather than one. It was
+            // identity-exempt and unsigned, so one frame from any same-UID
+            // socket peer ended the whole fleet's sessions and killed every PTY
+            // (`staleDays: 0` selects `started_at < NOW()`). GAP-312.
+            // MUST mirror server.ts MUTATING_OR_CONTENT_METHODS.
+            | "harness.prune"
     )
 }
 
@@ -521,7 +528,12 @@ mod tests {
         assert!(requires_signature("agent.resize"));
         assert!(requires_signature("agent.output"));
         assert!(requires_signature("session.end"));
+        // GAP-312: same eviction primitive as session.end, fleet-wide fan-out.
+        assert!(requires_signature("harness.prune"));
         assert!(!requires_signature("ping"));
         assert!(!requires_signature("session.list"));
+        // harness.health is a read; it stays unsigned. Guards against a
+        // copy-paste that gates the wrong half of the harness.* surface.
+        assert!(!requires_signature("harness.health"));
     }
 }

--- a/apps/studio/src-tauri/src/spawner.rs
+++ b/apps/studio/src-tauri/src/spawner.rs
@@ -324,6 +324,25 @@ pub fn list(
     Ok(list)
 }
 
+/// Kill every still-running agent child.
+///
+/// Tauri's exit path reaches `std::process::exit`, which does not run
+/// destructors, so a `Drop` impl would not fire and long-lived children such as
+/// `ollama run` would outlive the app. The kill is issued under the lock and we
+/// deliberately do not `wait()`, since the reaper thread polls for the same
+/// lock and the process is terminating anyway.
+pub fn kill_all(state: Arc<Mutex<HashMap<String, AgentProcess>>>) {
+    let Ok(mut sessions) = state.lock() else {
+        return;
+    };
+    for proc in sessions.values_mut() {
+        if proc.status == "running" {
+            let _ = proc.child.kill();
+            proc.status = "stopped".to_string();
+        }
+    }
+}
+
 /// Remove a stopped/errored session from the session map.
 pub fn remove(
     session_id: &str,

--- a/apps/studio/src-tauri/src/ssh.rs
+++ b/apps/studio/src-tauri/src/ssh.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use base64::Engine;
 use base64::engine::general_purpose::{STANDARD as BASE64, STANDARD_NO_PAD};
 use russh::keys::{PublicKey, PublicKeyBase64};
-use russh::{ChannelId, ChannelMsg, client};
+use russh::{ChannelId, ChannelMsg, ChannelReadHalf, ChannelWriteHalf, client};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::Emitter;
@@ -58,9 +58,13 @@ pub struct SshHostKeyEvent {
 }
 
 /// Holds a single SSH session's handle and channel.
+///
+/// Only the channel's write half is stored. The read half is owned exclusively
+/// by that session's output task, so a `wait()` parked on an idle prompt can
+/// never block a concurrent `data()` or `window_change()`.
 pub struct SshSession {
     pub handle: client::Handle<SshClientHandler>,
-    pub channel: Arc<Mutex<Option<russh::Channel<client::Msg>>>>,
+    pub channel: Arc<ChannelWriteHalf<client::Msg>>,
 }
 
 /// Managed Tauri state for SSH sessions.
@@ -261,6 +265,41 @@ impl client::Handler for SshClientHandler {
     }
 }
 
+// ── Output pump ──────────────────────────────────────────────────────────────
+
+/// A decoded message from a session's output stream.
+pub enum PumpEvent {
+    /// Base64-encoded bytes from the remote shell (stdout or stderr).
+    Output(String),
+    /// The remote side closed the channel.
+    Disconnected(String),
+}
+
+/// Drive a channel's read half to completion, handing each decoded message to
+/// `on_event`.
+///
+/// Takes the read half by value: nothing else can hold it, so a `wait()` parked
+/// on an idle prompt can never block a concurrent `data()` / `window_change()`
+/// on the write half. Keeping the two halves unshared is what makes the SSH
+/// terminal responsive while the remote shell is silent, so do not reintroduce
+/// a lock around either one.
+pub async fn pump_output<F: Fn(PumpEvent)>(mut read_half: ChannelReadHalf, on_event: F) {
+    loop {
+        match read_half.wait().await {
+            Some(ChannelMsg::Data { data }) | Some(ChannelMsg::ExtendedData { data, .. }) => {
+                on_event(PumpEvent::Output(BASE64.encode(&*data)));
+            }
+            Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
+                on_event(PumpEvent::Disconnected(
+                    "Connection closed by server".to_string(),
+                ));
+                break;
+            }
+            _ => {}
+        }
+    }
+}
+
 // ── Connect ──────────────────────────────────────────────────────────────────
 
 /// Connect to an SSH server, open a PTY and shell. Returns session ID.
@@ -336,58 +375,35 @@ pub async fn connect(
         .await
         .map_err(|e| format!("Shell request failed: {e}"))?;
 
-    let channel = Arc::new(Mutex::new(Some(channel)));
+    let (read_half, write_half) = channel.split();
+    let channel = Arc::new(write_half);
 
     // Spawn a task to poll channel output and emit events.
     let sid = session_id.clone();
     let ah = app_handle.clone();
     let state_clone = ssh_state.clone();
-    let channel_clone = channel.clone();
     tokio::spawn(async move {
-        loop {
-            // Lock briefly to call wait(), then release
-            let msg = {
-                let mut guard = channel_clone.lock().await;
-                match guard.as_mut() {
-                    Some(ch) => ch.wait().await,
-                    None => break,
-                }
-            };
-
-            match msg {
-                Some(ChannelMsg::Data { data }) => {
-                    let encoded = BASE64.encode(&*data);
-                    let _ = ah.emit(
-                        "ssh_output",
-                        SshOutputEvent {
-                            session_id: sid.clone(),
-                            data: encoded,
-                        },
-                    );
-                }
-                Some(ChannelMsg::ExtendedData { data, .. }) => {
-                    let encoded = BASE64.encode(&*data);
-                    let _ = ah.emit(
-                        "ssh_output",
-                        SshOutputEvent {
-                            session_id: sid.clone(),
-                            data: encoded,
-                        },
-                    );
-                }
-                Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
-                    let _ = ah.emit(
-                        "ssh_disconnect",
-                        SshDisconnectEvent {
-                            session_id: sid.clone(),
-                            reason: "Connection closed by server".to_string(),
-                        },
-                    );
-                    break;
-                }
-                _ => {}
+        pump_output(read_half, |event| match event {
+            PumpEvent::Output(data) => {
+                let _ = ah.emit(
+                    "ssh_output",
+                    SshOutputEvent {
+                        session_id: sid.clone(),
+                        data,
+                    },
+                );
             }
-        }
+            PumpEvent::Disconnected(reason) => {
+                let _ = ah.emit(
+                    "ssh_disconnect",
+                    SshDisconnectEvent {
+                        session_id: sid.clone(),
+                        reason,
+                    },
+                );
+            }
+        })
+        .await;
 
         // Clean up session from state
         let mut sessions = state_clone.lock().await;

--- a/apps/studio/src-tauri/src/tray.rs
+++ b/apps/studio/src-tauri/src/tray.rs
@@ -9,8 +9,15 @@ use crate::state::AppState;
 pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     let menu = build_menu(app)?;
 
+    // A build without a bundled window icon must not take the whole app down at
+    // startup; a tray without an icon is still usable.
+    let Some(icon) = app.default_window_icon().cloned() else {
+        eprintln!("warning: no bundled window icon; skipping tray icon setup");
+        return Ok(());
+    };
+
     TrayIconBuilder::new()
-        .icon(app.default_window_icon().unwrap().clone())
+        .icon(icon)
         .tooltip("RevealUI Studio")
         .menu(&menu)
         // Right-click opens menu; left-click focuses the window.

--- a/apps/studio/src-tauri/tests/ssh_output_pump.rs
+++ b/apps/studio/src-tauri/tests/ssh_output_pump.rs
@@ -1,0 +1,216 @@
+//! Regression test: a session parked at an idle prompt must not block writes.
+//!
+//! The SSH output task used to hold the channel mutex across `wait()`. A remote
+//! shell sitting silently at a prompt leaves `wait()` pending indefinitely, so
+//! the lock was never released and `ssh_send` / `ssh_resize` could not acquire
+//! it: the terminal silently ate every keystroke until the server spoke first.
+//!
+//! `ssh::pump_output` now takes the channel's read half by value, and the write
+//! half is shared separately, so no lock exists to contend on. This test pins
+//! that invariant against an in-process russh server that stays deliberately
+//! silent until it is written to.
+
+#![cfg(unix)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use russh::keys::PrivateKey;
+use russh::keys::ssh_key::private::Ed25519Keypair;
+use russh::server::{Auth, Msg, Server as _, Session};
+use russh::{Channel, ChannelId, client};
+use tokio::sync::mpsc;
+
+use studio_lib::ssh::{PumpEvent, pump_output};
+
+// ── A silent echo server ─────────────────────────────────────────────────────
+// Accepts any user, opens a session, and sends NOTHING until it receives data.
+// The silence is the point: it reproduces an idle shell prompt.
+
+#[derive(Clone)]
+struct SilentEchoServer;
+
+impl russh::server::Server for SilentEchoServer {
+    type Handler = SilentEchoHandler;
+    fn new_client(&mut self, _peer: Option<std::net::SocketAddr>) -> SilentEchoHandler {
+        SilentEchoHandler
+    }
+}
+
+struct SilentEchoHandler;
+
+impl russh::server::Handler for SilentEchoHandler {
+    type Error = russh::Error;
+
+    async fn auth_none(&mut self, _user: &str) -> Result<Auth, Self::Error> {
+        Ok(Auth::Accept)
+    }
+
+    async fn channel_open_session(
+        &mut self,
+        _channel: Channel<Msg>,
+        _session: &mut Session,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+
+    async fn data(
+        &mut self,
+        channel: ChannelId,
+        data: &[u8],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        session.data(channel, data.to_vec())?;
+        Ok(())
+    }
+}
+
+// ── A client that trusts the throwaway host key ──────────────────────────────
+
+struct AcceptAnyKey;
+
+impl client::Handler for AcceptAnyKey {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        _key: &russh::keys::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+async fn start_server() -> u16 {
+    // A fixed seed keeps the throwaway host key deterministic and avoids
+    // depending on which rand_core version russh's key crate was built against.
+    let key = PrivateKey::from(Ed25519Keypair::from_seed(&[7u8; 32]));
+    let config = Arc::new(russh::server::Config {
+        keys: vec![key],
+        ..Default::default()
+    });
+
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+
+    tokio::spawn(async move {
+        let mut server = SilentEchoServer;
+        let _ = server.run_on_socket(config, &listener).await;
+    });
+
+    port
+}
+
+/// With the reader parked in `wait()` against a silent server, a write must
+/// still complete promptly, and its echo must come back through the pump.
+#[tokio::test]
+async fn idle_prompt_does_not_block_writes() {
+    let port = start_server().await;
+
+    let handle = client::connect(
+        Arc::new(client::Config::default()),
+        ("127.0.0.1", port),
+        AcceptAnyKey,
+    )
+    .await
+    .expect("connect");
+
+    let mut handle = handle;
+    assert!(
+        handle.authenticate_none("tester").await.expect("auth").success(),
+        "server should accept auth_none"
+    );
+
+    let channel = handle.channel_open_session().await.expect("open session");
+    channel
+        .request_pty(false, "xterm-256color", 80, 24, 0, 0, &[])
+        .await
+        .expect("pty");
+    channel.request_shell(false).await.expect("shell");
+
+    let (read_half, write_half) = channel.split();
+    let write_half = Arc::new(write_half);
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        pump_output(read_half, move |event| {
+            let _ = tx.send(event);
+        })
+        .await;
+    });
+
+    // Let the pump reach `wait()` and park there. The server is silent, so this
+    // is exactly the idle-prompt state that used to wedge the old lock.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // The write must not wait on the reader.
+    let sent = tokio::time::timeout(Duration::from_secs(3), write_half.data(&b"ping\n"[..])).await;
+    assert!(
+        sent.is_ok(),
+        "write blocked while the reader was parked at an idle prompt"
+    );
+    sent.unwrap().expect("data sent");
+
+    // And the echo must arrive back through the pump.
+    let echoed = tokio::time::timeout(Duration::from_secs(5), async {
+        while let Some(event) = rx.recv().await {
+            if let PumpEvent::Output(b64) = event {
+                return Some(b64);
+            }
+        }
+        None
+    })
+    .await
+    .expect("timed out waiting for echo")
+    .expect("pump closed before echoing");
+
+    use base64::Engine;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(echoed)
+        .expect("pump emits base64");
+    assert_eq!(decoded, b"ping\n");
+}
+
+/// A resize also must not block against a parked reader.
+#[tokio::test]
+async fn idle_prompt_does_not_block_resize() {
+    let port = start_server().await;
+
+    let mut handle = client::connect(
+        Arc::new(client::Config::default()),
+        ("127.0.0.1", port),
+        AcceptAnyKey,
+    )
+    .await
+    .expect("connect");
+
+    assert!(
+        handle.authenticate_none("tester").await.expect("auth").success(),
+        "server should accept auth_none"
+    );
+
+    let channel = handle.channel_open_session().await.expect("open session");
+    channel
+        .request_pty(false, "xterm-256color", 80, 24, 0, 0, &[])
+        .await
+        .expect("pty");
+    channel.request_shell(false).await.expect("shell");
+
+    let (read_half, write_half) = channel.split();
+    let write_half = Arc::new(write_half);
+
+    tokio::spawn(async move {
+        pump_output(read_half, |_| {}).await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let resized =
+        tokio::time::timeout(Duration::from_secs(3), write_half.window_change(120, 40, 0, 0)).await;
+    assert!(
+        resized.is_ok(),
+        "resize blocked while the reader was parked at an idle prompt"
+    );
+    resized.unwrap().expect("window_change sent");
+}

--- a/apps/studio/src/__tests__/lib/deploy.test.ts
+++ b/apps/studio/src/__tests__/lib/deploy.test.ts
@@ -46,8 +46,8 @@ describe('deploy bridge (browser mocks)', () => {
     await expect(vercelSetEnv('t', 'p', 'k', 'v')).resolves.toBeUndefined();
   });
 
-  it('vercelDeploy returns mock ID', async () => {
-    expect(await vercelDeploy('t', 'p')).toBe('mock-deploy-id');
+  it('vercelDeploy returns an obviously-fake deploy id', async () => {
+    expect(await vercelDeploy('t', 'p')).toBe('MOCK_DEPLOY_ID_DO_NOT_USE');
   });
 
   it('vercelGetDeployment returns READY state with deployment ID', async () => {

--- a/apps/studio/src/components/agent/SpawnerPanel.tsx
+++ b/apps/studio/src/components/agent/SpawnerPanel.tsx
@@ -8,11 +8,29 @@
 import { useRef, useState } from 'react';
 import { useSpawner } from '../../hooks/use-spawner';
 import type { AgentBackend } from '../../types';
+import ConfirmDialog from '../ui/ConfirmDialog';
+
+interface PendingAction {
+  kind: 'stop' | 'remove';
+  id: string;
+  name: string;
+}
 
 export default function SpawnerPanel() {
   const { sessions, output, error, spawn, stop, remove } = useSpawner();
   const [showSpawn, setShowSpawn] = useState(false);
   const [selectedSession, setSelectedSession] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+
+  function handleConfirmAction(): void {
+    if (pendingAction === null) return;
+    if (pendingAction.kind === 'stop') {
+      void stop(pendingAction.id);
+    } else {
+      void remove(pendingAction.id);
+    }
+    setPendingAction(null);
+  }
 
   return (
     <div className="mt-4">
@@ -86,7 +104,7 @@ export default function SpawnerPanel() {
               {s.status === 'running' ? (
                 <button
                   type="button"
-                  onClick={() => void stop(s.id)}
+                  onClick={() => setPendingAction({ kind: 'stop', id: s.id, name: s.name })}
                   className="rounded bg-error-subtle px-2 py-0.5 text-[10px] text-error transition-colors hover:bg-error-subtle/70"
                 >
                   Stop
@@ -94,7 +112,7 @@ export default function SpawnerPanel() {
               ) : (
                 <button
                   type="button"
-                  onClick={() => void remove(s.id)}
+                  onClick={() => setPendingAction({ kind: 'remove', id: s.id, name: s.name })}
                   className="rounded bg-surface-2 px-2 py-0.5 text-[10px] text-fg-muted transition-colors hover:bg-surface-3"
                 >
                   Remove
@@ -113,6 +131,27 @@ export default function SpawnerPanel() {
       {sessions.length === 0 && !showSpawn ? (
         <p className="px-2 py-4 text-center text-[11px] text-fg-subtle">No local agents running</p>
       ) : null}
+
+      <ConfirmDialog
+        open={pendingAction !== null}
+        title={pendingAction?.kind === 'stop' ? 'Stop agent' : 'Remove agent'}
+        body={
+          pendingAction?.kind === 'stop' ? (
+            <>
+              Stop the agent session <strong className="text-fg">{pendingAction.name}</strong>?
+            </>
+          ) : (
+            <>
+              Remove the agent session <strong className="text-fg">{pendingAction?.name}</strong>?
+              It will disappear from this list.
+            </>
+          )
+        }
+        affectedItems={pendingAction ? [pendingAction.id] : undefined}
+        confirmLabel={pendingAction?.kind === 'stop' ? 'Stop' : 'Remove'}
+        onConfirm={handleConfirmAction}
+        onClose={() => setPendingAction(null)}
+      />
     </div>
   );
 }

--- a/apps/studio/src/components/dashboard/WelcomeBanner.tsx
+++ b/apps/studio/src/components/dashboard/WelcomeBanner.tsx
@@ -31,13 +31,13 @@ export default function WelcomeBanner() {
           <path d="M18 6 6 18M6 6l12 12" />
         </svg>
       </button>
-      <h2 className="text-sm font-semibold text-brand-text">Welcome to RevealUI Studio</h2>
+      <h2 className="text-sm font-semibold text-brand-text">
+        Run your agents on your own infrastructure
+      </h2>
       <p className="mt-1 text-xs leading-relaxed text-fg-muted">
-        Your native AI experience for managing agents and infrastructure. Use the sidebar to
-        navigate between services — check system status on the{' '}
-        <strong className="text-fg-muted">Dashboard</strong>, manage secrets in the{' '}
-        <strong className="text-fg-muted">Vault</strong>, and configure your environment in{' '}
-        <strong className="text-fg-muted">Setup</strong>.
+        Studio is where you start your agents and watch them work. Each one runs as a user you
+        govern, and every action it takes is recorded so you can check it. This is an early preview,
+        so expect a few rough edges.
       </p>
     </div>
   );

--- a/apps/studio/src/components/terminal/ConnectForm.tsx
+++ b/apps/studio/src/components/terminal/ConnectForm.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { sshBookmarkDelete, sshBookmarkList, sshBookmarkSave } from '../../lib/invoke';
 import type { SshAuth, SshBookmark, SshConnectParams } from '../../types';
 import Button from '../ui/Button';
+import ConfirmDialog from '../ui/ConfirmDialog';
 import Input from '../ui/Input';
 
 interface ConnectFormProps {
@@ -22,6 +23,7 @@ export default function ConnectForm({ onConnect, connecting }: ConnectFormProps)
   const [passphrase, setPassphrase] = useState('');
   const [bookmarks, setBookmarks] = useState<SshBookmark[]>([]);
   const [showBookmarks, setShowBookmarks] = useState(true);
+  const [pendingDeleteBookmark, setPendingDeleteBookmark] = useState<SshBookmark | null>(null);
 
   const loadBookmarks = useCallback(async () => {
     try {
@@ -112,7 +114,7 @@ export default function ConnectForm({ onConnect, connecting }: ConnectFormProps)
                 </button>
                 <button
                   type="button"
-                  onClick={() => handleDeleteBookmark(b.id)}
+                  onClick={() => setPendingDeleteBookmark(b)}
                   className="ml-2 text-xs text-fg-subtle opacity-0 transition-opacity hover:text-error group-hover:opacity-100"
                 >
                   remove
@@ -262,6 +264,24 @@ export default function ConnectForm({ onConnect, connecting }: ConnectFormProps)
           </div>
         </form>
       )}
+
+      <ConfirmDialog
+        open={pendingDeleteBookmark !== null}
+        title="Remove connection"
+        body={
+          <>
+            Remove the saved connection{' '}
+            <span className="font-mono text-fg">{pendingDeleteBookmark?.label}</span>?
+          </>
+        }
+        affectedItems={pendingDeleteBookmark ? [pendingDeleteBookmark.label] : undefined}
+        confirmLabel="Remove"
+        onConfirm={() => {
+          if (pendingDeleteBookmark) void handleDeleteBookmark(pendingDeleteBookmark.id);
+          setPendingDeleteBookmark(null);
+        }}
+        onClose={() => setPendingDeleteBookmark(null)}
+      />
     </div>
   );
 }

--- a/apps/studio/src/hooks/use-auth.ts
+++ b/apps/studio/src/hooks/use-auth.ts
@@ -172,38 +172,42 @@ export function useAuth(apiUrl: string, localMode = false): AuthContextValue {
     const refreshAt = expiresMs - 7 * 24 * 60 * 60 * 1000; // 7 days before expiry
     const delay = refreshAt - Date.now();
 
-    if (delay <= 0) {
-      // Already within refresh window — refresh now
-      refreshToken(apiUrl, tokenRef.current)
+    // A rejected/expired token (HttpError kind "client") means the refresh
+    // was explicitly denied — the stored token can't be trusted, so sign the
+    // user out with an actionable message. A network/server/parse failure
+    // means the API just couldn't be reached; the existing offline session
+    // (see the mount-time effect above) is preserved instead.
+    function performRefresh(): void {
+      const token = tokenRef.current;
+      if (!token) return;
+      refreshToken(apiUrl, token)
         .then(async (res) => {
           if (res.success && res.token) {
             tokenRef.current = res.token;
             await saveToken(res.token);
             setTokenExpiresAt(res.expiresAt ?? null);
+            return;
+          }
+          if (res.kind === 'client') {
+            tokenRef.current = null;
+            await clearToken();
+            setUser(null);
+            setTokenExpiresAt(null);
+            setStep('email');
+            setError('Your session could not be renewed. Please sign in again.');
           }
         })
         .catch(() => {
-          /* best-effort refresh */
+          /* API unreachable — best-effort refresh, keep offline access */
         });
+    }
+
+    if (delay <= 0) {
+      performRefresh();
       return;
     }
 
-    const timer = setTimeout(() => {
-      if (tokenRef.current) {
-        refreshToken(apiUrl, tokenRef.current)
-          .then(async (res) => {
-            if (res.success && res.token) {
-              tokenRef.current = res.token;
-              await saveToken(res.token);
-              setTokenExpiresAt(res.expiresAt ?? null);
-            }
-          })
-          .catch(() => {
-            /* best-effort refresh */
-          });
-      }
-    }, delay);
-
+    const timer = setTimeout(performRefresh, delay);
     return () => clearTimeout(timer);
   }, [step, tokenExpiresAt, apiUrl]);
 

--- a/apps/studio/src/hooks/use-sync.ts
+++ b/apps/studio/src/hooks/use-sync.ts
@@ -79,7 +79,7 @@ export function useSync() {
   return {
     syncingRepos: state.syncingRepos,
     anySyncing,
-    globalError: (state.errors['__all__'] ?? null) as string | null,
+    globalError: (state.errors.__all__ ?? null) as string | null,
     errors: state.errors,
     results: state.results,
     log: state.log,

--- a/apps/studio/src/lib/auth-api.ts
+++ b/apps/studio/src/lib/auth-api.ts
@@ -5,7 +5,7 @@
  * for device-based OTP authentication.
  */
 
-import { HttpError, httpRequest } from './http';
+import { HttpError, type HttpErrorKind, httpRequest } from './http';
 
 // ── Response types ──────────────────────────────────────────────────────────
 
@@ -33,6 +33,8 @@ export interface RefreshResponse {
   token?: string;
   expiresAt?: string;
   error?: string;
+  /** Categorized failure reason, set only when `success` is false. */
+  kind?: HttpErrorKind;
 }
 
 export interface StatusResponse {
@@ -138,12 +140,26 @@ export async function verifyDevice(
 
 /**
  * Rotate the bearer token. Returns a new token.
+ *
+ * On failure, `kind` carries the {@link HttpError} category so callers can
+ * distinguish a rejected/expired token (`client`) — which should sign the
+ * user out — from a transient network or server failure, which should not.
  */
 export async function refreshToken(apiUrl: string, token: string): Promise<RefreshResponse> {
-  return requestResult<RefreshResponse>(apiUrl, '/refresh', {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  try {
+    return await httpRequest<RefreshResponse>(
+      endpoint(apiUrl, '/refresh'),
+      jsonInit({
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    );
+  } catch (err) {
+    if (err instanceof HttpError) {
+      return { success: false, error: err.message, kind: err.kind };
+    }
+    throw err;
+  }
 }
 
 /**

--- a/apps/studio/src/lib/config.ts
+++ b/apps/studio/src/lib/config.ts
@@ -1,5 +1,6 @@
 import { invoke as tauriInvoke } from '@tauri-apps/api/core';
 import type { StudioConfig } from '../types';
+import { markDegraded } from './degraded-mode';
 
 function isTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
@@ -17,6 +18,7 @@ let cachedConfig: StudioConfig | null = null;
 
 export async function getConfig(): Promise<StudioConfig> {
   if (!isTauri()) {
+    markDegraded('Demo mode. Settings are not persisted, they reset on reload.');
     return cachedConfig ?? { ...DEFAULT_CONFIG };
   }
   const config = await tauriInvoke<StudioConfig>('get_config');
@@ -26,7 +28,10 @@ export async function getConfig(): Promise<StudioConfig> {
 
 export async function setConfig(config: StudioConfig): Promise<void> {
   cachedConfig = config;
-  if (!isTauri()) return;
+  if (!isTauri()) {
+    markDegraded('Demo mode. Settings are not persisted, they reset on reload.');
+    return;
+  }
   await tauriInvoke<void>('set_config', { config });
 }
 

--- a/apps/studio/src/lib/degraded-mode.ts
+++ b/apps/studio/src/lib/degraded-mode.ts
@@ -23,7 +23,7 @@ function isTauri(): boolean {
 }
 
 const BROWSER_REASON =
-  'Demo data — not connected to a real system (running outside the desktop app).';
+  'Demo data. Not connected to a real system (running outside the desktop app).';
 
 export interface DegradedState {
   degraded: boolean;

--- a/apps/studio/src/lib/deploy.ts
+++ b/apps/studio/src/lib/deploy.ts
@@ -45,7 +45,10 @@ export async function vercelSetEnv(
 }
 
 export async function vercelDeploy(token: string, projectId: string): Promise<string> {
-  if (!isTauri()) return 'mock-deploy-id';
+  if (!isTauri()) {
+    markDegraded('Demo mode. No deployment actually ran, this deploy id is a fake placeholder.');
+    return 'MOCK_DEPLOY_ID_DO_NOT_USE';
+  }
   return tauriInvoke<string>('vercel_deploy', { token, projectId });
 }
 
@@ -54,6 +57,7 @@ export async function vercelGetDeployment(
   deploymentId: string,
 ): Promise<VercelDeployment> {
   if (!isTauri()) {
+    markDegraded('Demo mode. This deployment status is fake, nothing is actually live.');
     return {
       uid: deploymentId,
       url: 'mock.vercel.app',
@@ -136,7 +140,7 @@ function mockSecret(label: string, length: number): string {
 
 export async function generateSecret(length: number): Promise<string> {
   if (!isTauri()) {
-    markDegraded('Demo mode — generated secrets are fake placeholders, not real keys.');
+    markDegraded('Demo mode. Generated secrets are fake placeholders, not real keys.');
     return mockSecret('SECRET', length);
   }
   return tauriInvoke<string>('generate_secret', { length });
@@ -144,7 +148,7 @@ export async function generateSecret(length: number): Promise<string> {
 
 export async function generateKek(): Promise<string> {
   if (!isTauri()) {
-    markDegraded('Demo mode — generated secrets are fake placeholders, not real keys.');
+    markDegraded('Demo mode. Generated secrets are fake placeholders, not real keys.');
     return mockSecret('KEK', 64);
   }
   return tauriInvoke<string>('generate_kek');
@@ -152,7 +156,7 @@ export async function generateKek(): Promise<string> {
 
 export async function generateRsaKeypair(): Promise<[string, string]> {
   if (!isTauri()) {
-    markDegraded('Demo mode — generated secrets are fake placeholders, not real keys.');
+    markDegraded('Demo mode. Generated secrets are fake placeholders, not real keys.');
     return ['MOCK_PRIVATE_KEY_DO_NOT_USE', 'MOCK_PUBLIC_KEY_DO_NOT_USE'];
   }
   return tauriInvoke<[string, string]>('generate_rsa_keypair');

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -422,6 +422,8 @@ export async function pairWithDaemon(daemonUrl: string, code: string): Promise<s
 
 let rpcId = 1;
 
+const HTTP_RPC_TIMEOUT_MS = 30_000;
+
 /** Make a JSON-RPC call to the daemon's HTTP gateway */
 async function httpRpc<T>(method: string, params: Record<string, unknown>): Promise<T> {
   const url = getDaemonUrl();
@@ -431,14 +433,28 @@ async function httpRpc<T>(method: string, params: Record<string, unknown>): Prom
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(`${url}/rpc`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ jsonrpc: '2.0', id: rpcId++, method, params }),
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), HTTP_RPC_TIMEOUT_MS);
+
+  let res: Response;
+  try {
+    res = await fetch(`${url}/rpc`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ jsonrpc: '2.0', id: rpcId++, method, params }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new Error('The daemon did not respond in time.');
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 
   if (res.status === 401 || res.status === 403) {
-    throw new Error('Authentication required — pair with daemon first');
+    throw new Error('Authentication required. Pair with the daemon first.');
   }
   if (!res.ok) {
     throw new Error(`HTTP ${res.status}`);

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -10,7 +10,11 @@ The RevDev Harness Daemon exposes a JSON-RPC 2.0 API over Unix socket at `~/.loc
 
 ## Authentication
 
-Local socket access is trust-based (mode 0600, owner-only). Identity is established by calling `session.register` once, then passing the returned `sessionId` as `actorAgentId` on subsequent calls.
+Local socket access is trust-based (mode 0600, owner-only). Identity is established by calling `session.register` once, then passing the returned `sessionId` as `actorAgentId` on subsequent calls (or keeping the socket open, which stays bound to that identity for its lifetime).
+
+### Signing
+
+Every mutation and every content-returning read additionally requires a verified Ed25519 request signature (the `x-revdev-signature` field on the JSON-RPC frame), not just a registered session. These methods reject an unsigned or `actorAgentId`-only caller with `-32003` before the handler ever runs, even after a successful `session.register`. They are marked **Signature: required** below. Most coordination methods (mail, tasks, memory, file reservations) accept either a verified signature or a daemon-minted bound identity instead. See `docs/SPEC.md` and `docs/KEY_GENERATION.md` for the full client-identity model.
 
 ## License Gating
 
@@ -25,22 +29,17 @@ Methods marked with a tier require that tier or higher. Free tier methods are al
 
 Returns a pong response to verify daemon connectivity.
 
-**Params**: none  
+**Params**: none
 **Response**: `{ pong: true, ts: number }`
 
 ---
 
 ### `harness.health`
-**Tier**: Free
+**Tier**: Pro
 
-Returns daemon health status, active session count, and optionally detailed checks and Prometheus metrics.
+Returns daemon health status, active session/task counts, prune state, and client-identity anchor consistency. Takes no params (any passed are ignored).
 
-**Params**:
-| Field | Type | Description |
-|-------|------|-------------|
-| `detailed` | boolean? | Include health check results |
-| `metrics` | boolean? | Include Prometheus metrics string |
-
+**Params**: none
 **Response**:
 ```json
 {
@@ -48,11 +47,28 @@ Returns daemon health status, active session count, and optionally detailed chec
   "activeSessions": 3,
   "openTasks": 5,
   "uptime": 86400,
-  "memoryUsage": 52428800,
-  "checks": { ... },
-  "metrics": "# HELP revdev_daemon_rpc_calls_total..."
+  "prune": { "lastRunAt": "2026-07-10T00:00:00.000Z", "lastAgedCount": 0, "lastDeletedCount": 0 },
+  "neonSyncActive": false,
+  "identitySignatureMode": "accept-if-present",
+  "anchorInconsistencies": []
 }
 ```
+
+---
+
+### `harness.prune`
+**Tier**: Pro
+**Signature**: required
+
+Run a stale-session reap pass on demand: marks sessions older than `staleDays` as ended, hard-deletes sessions ended longer than `hardDeleteDays` ago, and evicts filesystem roots for every reaped session. Also runs automatically on a periodic internal timer.
+
+**Params**:
+| Field | Type | Description |
+|-------|------|-------------|
+| `staleDays` | number? | Floored at 1 (default from daemon config) |
+| `hardDeleteDays` | number? | Floored at 1 (default from daemon config) |
+
+**Response**: `{ aged: number, deleted: number, runAt: string | null, staleDays: number, hardDeleteDays: number }`
 
 ---
 
@@ -61,17 +77,19 @@ Returns daemon health status, active session count, and optionally detailed chec
 ### `session.register`
 **Tier**: Free
 
-Register a new agent session. Returns a sessionId to use as identity.
+Register a new agent session. Returns a sessionId to use as identity. Two ownership models: pass `publicKeyPem` for a client-owned (Studio) identity, or omit it for a daemon-minted identity (headless hooks).
 
 **Params**:
 | Field | Type | Description |
 |-------|------|-------------|
 | `agentId` | string? | Stable ID (upserts if exists). Omit for ephemeral UUID. |
 | `agentName` | string? | Human-readable name (e.g., "agent-main") |
-| `workDir` | string? | Agent's working directory |
-| `backend` | string? | Agent backend type (e.g., "studio", "mcp-agent") |
+| `workDir` | string? | Agent's working directory (alias: `task`) |
+| `backend` | string? | Agent backend type, e.g. "studio", "mcp-agent" (alias: `env`) |
+| `pid` | number? | Caller process ID |
+| `publicKeyPem` | string? | Client-owned Ed25519 SPKI PEM public key (Studio zero-9P model); the fingerprint must be in the daemon's trust anchor or registration fails with -32004 |
 
-**Response**: `{ sessionId: string }`
+**Response**: `{ sessionId: string, agentId: string, agentName: string, backend: string, did: string, publicKeyPem: string, session: { id, env, task } }`
 
 ---
 
@@ -80,7 +98,7 @@ Register a new agent session. Returns a sessionId to use as identity.
 
 Attach to an existing session by ID. Binds the socket to that identity.
 
-**Params**: `{ sessionId: string }`  
+**Params**: `{ sessionId?: string, agentId?: string }` (one of the two is required; `agentId` is an alias for `sessionId`)
 **Response**: `{ attached: true }`
 
 ---
@@ -88,9 +106,9 @@ Attach to an existing session by ID. Binds the socket to that identity.
 ### `session.list`
 **Tier**: Free
 
-List all active sessions.
+List active sessions.
 
-**Params**: none  
+**Params**: `{ scope?: 'local' | 'fleet' }` (`local` queries the daemon's own PGlite store; `fleet` queries the Neon-backed cross-machine view)
 **Response**: Array of session objects.
 
 ---
@@ -98,20 +116,34 @@ List all active sessions.
 ### `session.update`
 **Tier**: Free
 
-Update the current session's task/files description.
+Update the current session's task/files description, or self-scoped activity state.
 
-**Params**: `{ task?: string, files?: string }`  
-**Response**: `{ updated: true }`
+**Params**: `{ task?: string, files?: string, state?: 'active' | 'blocked' | 'idle', blockedReason?: string }` (`state` always applies to the caller's own bound session, never to a targeted `sessionId`/`agentId`)
+**Response**: `{ updated: string }` (adds `stateScopedTo` when `state` was set)
 
 ---
 
 ### `session.end`
 **Tier**: Free
+**Signature**: required
 
-End the current session. Optionally record an exit summary.
+End the current session. Optionally record an exit summary. Self-scoped to the verified signer; a caller-supplied session/agent override is not honored.
 
-**Params**: `{ exitSummary?: string }`  
-**Response**: `{ ended: true }`
+**Params**: `{ exitSummary?: string }`
+**Response**: `{ ended: string }`
+
+---
+
+## Identity
+
+### `identity.rotate`
+**Tier**: Pro
+**Signature**: required (proof-of-possession from the CURRENT key)
+
+Rotate a client-owned identity's Ed25519 key. The new key's fingerprint must already be present in the daemon's trust anchor.
+
+**Params**: `{ newPublicKeyPem: string }`
+**Response**: identity result including the new DID and public key.
 
 ---
 
@@ -125,7 +157,7 @@ Send a message to another agent.
 **Params**:
 | Field | Type | Description |
 |-------|------|-------------|
-| `to` | string | Recipient agent ID |
+| `to` | string | Recipient agent ID (alias: `toAgent`) |
 | `subject` | string | Message subject (max 500 chars) |
 | `body` | string | Message body (max 50KB) |
 
@@ -136,12 +168,11 @@ Send a message to another agent.
 ### `mail.inbox`
 **Tier**: Pro
 
-Get messages for an agent.
+Get messages for the calling agent.
 
 **Params**:
 | Field | Type | Description |
 |-------|------|-------------|
-| `agentId` | string? | Target agent (defaults to caller) |
 | `unreadOnly` | boolean? | Only unread messages (default: true) |
 
 **Response**: `{ messages: Message[] }`
@@ -153,8 +184,8 @@ Get messages for an agent.
 
 Send a message to all active agents (except sender).
 
-**Params**: `{ subject: string, body: string }`  
-**Response**: `{ broadcast: true, sent: number }`
+**Params**: `{ subject: string, body: string }`
+**Response**: `{ broadcast: true, sent: number, recipients: number }`
 
 ---
 
@@ -163,7 +194,7 @@ Send a message to all active agents (except sender).
 
 Mark messages as read by ID.
 
-**Params**: `{ messageIds: number[] }`  
+**Params**: `{ messageIds: number[] }`
 **Response**: `{ marked: number }`
 
 ---
@@ -180,29 +211,29 @@ Reserve files for exclusive editing. Prevents other agents from modifying.
 |-------|------|-------------|
 | `filePath` | string? | Single file path |
 | `paths` | string[]? | Multiple file paths |
-| `ttlSeconds` | number? | Reservation TTL (default: 600, max: 86400) |
+| `ttlSeconds` | number? | Reservation TTL (default: 1800, max: 86400) |
 | `reason` | string? | Why the file is reserved |
 
-**Response**: `{ reserved: string[], conflicts: { path, holder }[] }`
+**Response**: `{ success: boolean, reserved: string[], conflicts: { path, holder }[] }`
 
 ---
 
 ### `files.check`
 **Tier**: Pro
 
-Check who holds a file reservation.
+Check reservation status. Only the caller's own reservations are returned in full; a path held by another agent collapses to a boolean so callers cannot learn who holds it.
 
-**Params**: `{ filePath?: string, paths?: string[] }`  
-**Response**: Array of reservations or null if unreserved.
+**Params**: `{ filePath?: string, paths?: string[] }`
+**Response**: `{ reservations: Reservation[], reservedByOther: boolean }`
 
 ---
 
 ### `files.release`
 **Tier**: Pro
 
-Release file reservations.
+Release file reservations. Omitting `filePath`/`paths` releases all of the caller's reservations.
 
-**Params**: `{ filePath?: string, paths?: string[] }`  
+**Params**: `{ filePath?: string, paths?: string[] }`
 **Response**: `{ released: number }`
 
 ---
@@ -210,10 +241,219 @@ Release file reservations.
 ### `files.list`
 **Tier**: Pro
 
-List all active file reservations.
+List the calling agent's active file reservations.
 
-**Params**: `{ agentId?: string }` (use `"__all__"` for all agents)  
-**Response**: Array of reservation objects.
+**Params**: none
+**Response**: `{ reservations: Reservation[] }`
+
+---
+
+## Projects and File I/O
+
+Single-repo file and git access is **Free** — RevDev is meant to be usable as a daily driver without a license. Multi-agent coordination (mail, tasks, files.\* reservations, memory, agent.\*, merge.\*) stays Pro/Max. Every method below is also **Signature: required**.
+
+### `project.open`
+**Tier**: Free
+**Signature**: required
+
+Register a git repository root the caller owns, so `file.*`/`git.*`/`agent.spawn` can operate inside it. Refuses non-existent paths and repos whose git config carries an exec-bearing key (`filter.*`/`diff.external` etc.).
+
+**Params**: `{ repoPath: string }`
+**Response**: `{ success: true, root: string, isGitRepo: boolean }`
+
+---
+
+### `project.grant`
+**Tier**: Pro
+**Signature**: required
+
+Grant another agent access to a root the caller owns. Only the owner may call this.
+
+**Params**: `{ repoPath: string, granteeAgentId: string }`
+**Response**: `{ granted: string, root: string }`
+
+---
+
+### `project.revoke`
+**Tier**: Pro
+**Signature**: required
+
+Revoke a grantee's access to a root. Blocks future operations (including `agent.spawn`) but does not kill PTY processes the grantee already spawned.
+
+**Params**: `{ repoPath: string, granteeAgentId: string }`
+**Response**: `{ revoked: string, root: string }`
+
+---
+
+### `file.read`
+**Tier**: Free
+**Signature**: required
+
+Read a file inside a registered project root.
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ content: string, bytes: number }`, or `{ tooLarge: true, bytes: number }` when the file exceeds the daemon's inline-read cap.
+
+---
+
+### `file.write`
+**Tier**: Free
+**Signature**: required
+
+Write (create/overwrite) a file inside a registered project root. Refuses `.git/` internals.
+
+**Params**: `{ repoPath: string, filePath: string, content: string }` (content capped at 768 KiB)
+**Response**: `{ success: true, bytes: number }`
+
+---
+
+### `file.delete`
+**Tier**: Free
+**Signature**: required
+
+Delete a file inside a registered project root. Refuses `.git/` internals.
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ success: true }`
+
+---
+
+### `file.stat`
+**Tier**: Free
+**Signature**: required
+
+Stat a path inside a registered project root.
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ exists: true, isFile: boolean, isDirectory: boolean, size: number, mtimeMs: number }`, or `{ exists: false }`
+
+---
+
+## Git
+
+All `git.*` methods operate inside a `project.open`'d root and are **Free** tier, **Signature: required**.
+
+### `git.status`
+
+Porcelain status plus current branch.
+
+**Params**: `{ repoPath: string }`
+**Response**: `{ success: true, branch: string | null, files: { status, path }[], clean: boolean }`
+
+---
+
+### `git.diffFile`
+
+Diff a single file (working tree vs. index, or index vs. HEAD when `staged`).
+
+**Params**: `{ repoPath: string, filePath: string, staged?: boolean }`
+**Response**: `{ success: true, diff: string }`
+
+---
+
+### `git.diffContent`
+
+The current working-tree content of a file, read directly off disk (for a diff view's "after" pane).
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ success: true, content: string, bytes: number }` or `{ success: true, tooLarge: true, bytes: number }`
+
+---
+
+### `git.readBlobAtHead`
+
+The committed (HEAD) content of a file.
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ success: true, content: string, bytes: number }` (or `success: false` on error)
+
+---
+
+### `git.readBlobAtIndex`
+
+The staged (index) content of a file.
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ success: true, content: string, bytes: number }` (or `success: false` on error)
+
+---
+
+### `git.listBranches`
+
+**Params**: `{ repoPath: string }`
+**Response**: `{ success: true, branches: string[], current: string | null }`
+
+---
+
+### `git.log`
+
+**Params**: `{ repoPath: string, limit?: number }` (default 50)
+**Response**: `{ success: true, commits: { hash, author, date, timestamp, subject }[] }`
+
+---
+
+### `git.stageFile`
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: `{ success: true, stdout: string }` or `{ success: false, error: string, code: number }`
+
+---
+
+### `git.unstageFile`
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: same shape as `git.stageFile`
+
+---
+
+### `git.discardFile`
+
+Discard unstaged working-tree edits to a file.
+
+**Params**: `{ repoPath: string, filePath: string }`
+**Response**: same shape as `git.stageFile`
+
+---
+
+### `git.createBranch`
+
+**Params**: `{ repoPath: string, name: string, baseBranch?: string }`
+**Response**: same shape as `git.stageFile`
+
+---
+
+### `git.switchBranch`
+
+**Params**: `{ repoPath: string, name: string }`
+**Response**: same shape as `git.stageFile`
+
+---
+
+### `git.deleteBranch`
+
+**Params**: `{ repoPath: string, name: string, force?: boolean }`
+**Response**: same shape as `git.stageFile`
+
+---
+
+### `git.commit`
+
+**Params**: `{ repoPath: string, message: string }`
+**Response**: `{ success: true, sha: string, shortSha: string, stdout: string }` or `{ success: false, error: string }`
+
+---
+
+### `git.push`
+
+**Params**: `{ repoPath: string, remote?: string, branch?: string }`
+**Response**: same shape as `git.stageFile`
+
+---
+
+### `git.pull`
+
+**Params**: `{ repoPath: string, remote?: string, branch?: string }`
+**Response**: same shape as `git.stageFile`
 
 ---
 
@@ -230,6 +470,7 @@ Create a coordination task.
 | `taskId` | string? | Custom ID (auto-generated if omitted) |
 | `title` | string? | Short title (max 500 chars) |
 | `description` | string? | Full description (max 50KB) |
+| `priority` | 'low' \| 'medium' \| 'high' \| 'critical' ? | Task priority |
 
 **Response**: `{ taskId: string, id: string }`
 
@@ -238,9 +479,9 @@ Create a coordination task.
 ### `tasks.list`
 **Tier**: Pro
 
-List tasks with optional filters.
+List tasks with optional filters. Filtering by a specific `owner` requires the caller to BE that owner (verified identity); otherwise only the unfiltered/open pool is visible.
 
-**Params**: `{ status?: string, owner?: string }`  
+**Params**: `{ status?: string, owner?: string }`
 **Response**: `{ tasks: Task[] }`
 
 ---
@@ -250,8 +491,8 @@ List tasks with optional filters.
 
 Claim an open task. Only one agent can own a task.
 
-**Params**: `{ taskId: string }`  
-**Response**: `{ success: boolean, owner: string }`
+**Params**: `{ taskId: string }`
+**Response**: `{ success: true, claimed: string, owner: string }` on success, or `{ success: false, claimed: false, owner: string | null, status: string }` if already claimed by someone else.
 
 ---
 
@@ -260,8 +501,8 @@ Claim an open task. Only one agent can own a task.
 
 Complete a claimed task. Only the owner can complete it.
 
-**Params**: `{ taskId: string }`  
-**Response**: `{ completed: true }`
+**Params**: `{ taskId: string, summary?: string }`
+**Response**: `{ ok: boolean, completed: string | null }` (`completed` is the taskId on success, `null` if the caller doesn't own the task)
 
 ---
 
@@ -270,8 +511,8 @@ Complete a claimed task. Only the owner can complete it.
 
 Release a claimed task back to open status.
 
-**Params**: `{ taskId: string }`  
-**Response**: `{ released: true }`
+**Params**: `{ taskId: string }`
+**Response**: `{ ok: boolean, released: string | null }` (`released` is the taskId on success, `null` if the caller doesn't own the task)
 
 ---
 
@@ -286,7 +527,7 @@ Log a structured event.
 | Field | Type | Description |
 |-------|------|-------------|
 | `eventType` | string | Event type (max 128 chars) |
-| `payload` | object? | JSON payload (max 100KB) |
+| `payload` | object? | JSON-serializable payload (max 100KB) |
 
 **Response**: `{ logged: true }`
 
@@ -297,7 +538,7 @@ Log a structured event.
 
 Query recent events.
 
-**Params**: `{ limit?: number, since?: string }`  
+**Params**: `{ limit?: number, since?: string }`
 **Response**: `{ events: Event[] }`
 
 ---
@@ -316,7 +557,7 @@ Store long-term agent memory.
 | `content` | string | Memory content (max 500KB) |
 | `metadata` | object? | Structured metadata |
 
-**Response**: `{ stored: true, id: number }`
+**Response**: `{ stored: string }` (the stored `memoryType`)
 
 ---
 
@@ -325,59 +566,130 @@ Store long-term agent memory.
 
 Query stored memories.
 
-**Params**: `{ memoryType?: string, limit?: number }`  
+**Params**: `{ memoryType?: string, query?: string, tags?: string[], limit?: number }`
 **Response**: `{ memories: Memory[] }`
 
 ---
 
 ## Inference
 
+Interacting with an already-running local model (`inference.status`/`chat`/`generate`) is a **Free** run surface. Model *management* (`pull`/`start`/`stop`) is **Max**. All `inference.*` methods are identity-exempt (no `session.register` required).
+
 ### `inference.status`
-**Tier**: Max (identity-exempt)
+**Tier**: Free (identity-exempt)
 
-Check Ollama inference status and loaded models.
+Check Ollama connectivity and loaded models.
 
-**Params**: none  
-**Response**: `{ available: boolean, models: Model[] }`
+**Params**: none
+**Response**: `{ running: boolean, url: string, version?: string, models?: { name, sizeMb, modified }[], error?: string }`
 
 ---
 
 ### `inference.pull`
-**Tier**: Max
+**Tier**: Max (identity-exempt)
 
 Download a model via Ollama.
 
-**Params**: `{ model: string }`  
-**Response**: `{ pulled: true }`
+**Params**: `{ model: string }`
+**Response**: `{ success: true, model: string, status: string }` or `{ success: false, error: string }`
 
 ---
 
 ### `inference.start` / `inference.stop`
-**Tier**: Max
+**Tier**: Max (identity-exempt)
 
 Warm up or unload a model.
 
 **Params**: `{ model: string }`
+**Response**: `{ loaded: boolean, model?: string, error?: string }` / `{ unloaded: boolean, model?: string, error?: string }`
 
 ---
 
 ### `inference.chat`
-**Tier**: Max
+**Tier**: Free (identity-exempt)
 
 Chat completion via Ollama.
 
-**Params**: `{ model: string, messages: { role, content }[] }`  
-**Response**: `{ message: { role, content } }`
+**Params**: `{ model: string, messages: { role: 'system' | 'user' | 'assistant', content: string }[], temperature?: number, maxTokens?: number }`
+**Response**: `{ message: { role, content }, stats: { totalMs, tokens, tokensPerSecond } }` or `{ error: string }`
 
 ---
 
 ### `inference.generate`
-**Tier**: Max
+**Tier**: Free (identity-exempt)
 
 Text generation via Ollama.
 
-**Params**: `{ model: string, prompt: string }`  
-**Response**: `{ response: string }`
+**Params**: `{ model: string, prompt: string, system?: string, temperature?: number, maxTokens?: number }`
+**Response**: `{ response: string, stats: { totalMs, tokens, tokensPerSecond } }` or `{ error: string }`
+
+---
+
+## Agent Processes
+
+PTY-backed process spawning under the daemon's sandbox. All five methods are **Pro** tier and **Signature: required**; `agent.spawn` additionally requires a `project.open`'d `repoPath` the caller owns or was granted via `project.grant`.
+
+### `agent.spawn`
+**Tier**: Pro
+**Signature**: required
+
+Spawn a command as a PTY process inside a granted project root, with an allow-listed environment (`TERM`, `LANG`, `LC_*`, `CI`, `NO_COLOR`, `REVDEV_*` only).
+
+**Params**:
+| Field | Type | Description |
+|-------|------|-------------|
+| `command` | string | Binary to run (not allow-listed itself) |
+| `args` | string[]? | Command arguments |
+| `repoPath` | string | A root the caller owns/was granted (via `project.open`/`project.grant`) |
+| `cwd` | string? | Working directory, must resolve inside `repoPath` |
+| `cols` / `rows` | number? | PTY size (default 80×24) |
+| `env` | object? | Caller env overrides, filtered by the allow-list |
+
+**Response**: `{ processId: string, pid: number }`
+
+---
+
+### `agent.stop`
+**Tier**: Pro
+**Signature**: required
+
+Send SIGTERM to a live PTY process. Only the owning agent may stop it.
+
+**Params**: `{ processId: string }`
+**Response**: `{ stopped: string, status: string }`
+
+---
+
+### `agent.input`
+**Tier**: Pro
+**Signature**: required
+
+Write bytes to a live PTY's stdin.
+
+**Params**: `{ processId: string, data: string }`
+**Response**: `{ written: true }`
+
+---
+
+### `agent.resize`
+**Tier**: Pro
+**Signature**: required
+
+Resize a live PTY window.
+
+**Params**: `{ processId: string, cols: number, rows: number }`
+**Response**: `{ resized: true, cols: number, rows: number }`
+
+---
+
+### `agent.output`
+**Tier**: Pro
+**Signature**: required
+
+Poll-based output retrieval. There is no server push over this transport; pass the returned cursor back on the next poll.
+
+**Params**: `{ processId: string, cursor?: string, limit?: number }` (limit default 100, max 1000)
+**Response**: buffered output chunks since `cursor`, plus process `status`.
 
 ---
 
@@ -385,29 +697,33 @@ Text generation via Ollama.
 
 ### `worktree.create`
 **Tier**: Pro
+**Signature**: required
 
-Create a git worktree for isolated branch work.
+Create a git worktree for isolated branch work. The worktree path is daemon-derived (a sibling of the registered root); a caller-supplied path is not honored.
 
-**Params**: `{ branch: string, baseBranch?: string }`  
-**Response**: `{ created: true, path: string }`
+**Params**: `{ repoPath: string, branch: string, baseBranch?: string }` (`baseBranch` defaults to `main`)
+**Response**: `{ success: true, branch: string, worktreePath: string, baseBranch: string }` or `{ success: false, error: string }`
 
 ---
 
 ### `worktree.list`
 **Tier**: Pro
 
-List active worktrees.
+List worktrees. Without `agentId`, returns all active worktrees; with it, all worktrees (any status) owned by that agent.
 
+**Params**: `{ agentId?: string }`
 **Response**: `{ worktrees: Worktree[] }`
 
 ---
 
 ### `worktree.remove`
 **Tier**: Pro
+**Signature**: required
 
-Remove a worktree.
+Remove a worktree previously created by the caller for the given `repoPath` + `branch`.
 
-**Response**: `{ removed: true }`
+**Params**: `{ repoPath: string, branch: string }`
+**Response**: `{ success: true, branch: string, worktreePath: string }` or `{ success: false, error: string }`
 
 ---
 
@@ -418,8 +734,8 @@ Remove a worktree.
 
 Create a merge request (tracked in daemon; PR creation is client-side).
 
-**Params**: `{ sourceBranch: string, baseBranch?: string, taskId?: string }`  
-**Response**: `{ mergeId: string }`
+**Params**: `{ sourceBranch: string, baseBranch?: string, taskId?: string, description?: string }` (`sourceBranch` alias: `branch`; `baseBranch` alias: `targetBranch`, defaults to `main`)
+**Response**: `{ success: true, mergeId: string, sourceBranch: string, baseBranch: string, status: 'pending' }`
 
 ---
 
@@ -428,8 +744,8 @@ Create a merge request (tracked in daemon; PR creation is client-side).
 
 Get merge request status.
 
-**Params**: `{ mergeId: string }`  
-**Response**: Merge request object.
+**Params**: `{ mergeId: string }`
+**Response**: `{ found: true, ...MergeRequest }` or `{ found: false }`
 
 ---
 
@@ -438,8 +754,8 @@ Get merge request status.
 
 List merge requests.
 
-**Params**: `{ status?: string }`  
-**Response**: Array of merge requests.
+**Params**: `{ status?: string, agentId?: string }`
+**Response**: `{ mergeRequests: MergeRequest[] }`
 
 ---
 
@@ -448,7 +764,7 @@ List merge requests.
 
 Update merge request status (e.g., after PR creation or CI result).
 
-**Params**: `{ mergeId: string, status?: string, prNumber?: number, prUrl?: string, errorMessage?: string }`  
+**Params**: `{ mergeId: string, status?: string, prNumber?: number, prUrl?: string, errorMessage?: string, ciOutput?: string }`
 **Response**: `{ updated: true }`
 
 ---
@@ -457,11 +773,14 @@ Update merge request status (e.g., after PR creation or CI result).
 
 | Code | Meaning |
 |------|---------|
-| -32700 | Parse error (malformed JSON) |
+| -32700 | Parse error (malformed JSON, or frame exceeded the max line size) |
 | -32601 | Method not found |
 | -32602 | Invalid params (Zod validation failed) |
 | -32001 | License required (tier too low) |
-| -32002 | Identity required (call session.register first) |
+| -32002 | Identity required (call session.register or session.attach first) |
+| -32003 | Signature required (missing or invalid Ed25519 signature on a Signature-required method) |
+| -32004 | Untrusted client key (identity enrollment/rotation rejected; fingerprint not in the trust anchor) |
+| -32099 | Server is shutting down |
 | -32000 | Internal error (handler threw) |
 
 ---
@@ -476,6 +795,7 @@ All params are validated with Zod schemas. Key limits:
 | Subject | 500 chars |
 | Body/description | 50 KB |
 | File path | 4,096 chars |
+| File write content | 768 KiB (786,432 bytes) |
 | Event payload | 100 KB |
 | Memory content | 500 KB |
 | Batch operations | 100-200 items |
@@ -483,3 +803,5 @@ All params are validated with Zod schemas. Key limits:
 | File TTL | 86,400 seconds (24h) |
 
 Path traversal (`../`) and system paths (`/etc/`, `/proc/`, `/sys/`) are blocked.
+
+`ping`, `identity.rotate`, `project.grant`, and `project.revoke` have no dedicated Zod schema — their params are checked only inside the handler, so malformed extra fields don't produce a -32602; a missing required field surfaces as a generic -32000 handler error instead.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -175,7 +175,7 @@ This gives the tool access to agent coordination, file reservations, and task ma
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `REVEALUI_LICENSE_KEY` | (none) | License key for Pro+ features — an `eyJ`-prefixed Ed25519 JWT |
-| `REVDEV_LICENSE_PUBLIC_KEY` | (none) | PEM Ed25519 public key the daemon verifies the license against. Required for activation — without it the daemon stays in Free mode |
+| `REVDEV_LICENSE_PUBLIC_KEY` | (none) | PEM Ed25519 public key the daemon verifies the license against. Optional; overrides the baked-in vendor key (needed only after a signing-key rotation or when testing your own keypair) |
 | `REVDEV_DAEMON_SOCKET` | `~/.local/share/revealui/harness.sock` | Socket path |
 | `REVDEV_DAEMON_DATA` | `~/.local/share/revealui` | Database directory |
 | `REVDEV_DAEMON_PID` | `~/.local/share/revealui/harness.pid` | PID file path |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -91,15 +91,14 @@ You're on the Free tier. Set `REVEALUI_LICENSE_KEY` and restart the daemon. See 
 
 ### "running in FREE (degraded) mode"
 
-No valid license key detected. Set `REVEALUI_LICENSE_KEY` (and `REVDEV_LICENSE_PUBLIC_KEY`) in your environment:
+No valid license key detected. Set `REVEALUI_LICENSE_KEY` in your environment:
 
 ```bash
 export REVEALUI_LICENSE_KEY="eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9..."
-export REVDEV_LICENSE_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEA...
------END PUBLIC KEY-----"
 systemctl --user restart revdev-daemon
 ```
+
+The daemon ships with the vendor public key baked in, so this is normally all you need. `REVDEV_LICENSE_PUBLIC_KEY` is only for key rotation or testing your own keypair; see "License key doesn't activate" below if the key is valid but still shows Free.
 
 <!-- doclint:allow-legacy-format:start — this section documents the REJECTED formats on purpose -->
 ### Old-format key (`RVUI-*` or `RVUI.v2.*`) rejected

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -77,7 +77,7 @@ Environment variables (all optional):
 
 | Var | Default | Purpose |
 |---|---|---|
-| `REVEALUI_LICENSE_KEY` | (none → FREE tier) | v2 Ed25519-signed license. Pro+ unlocks coordination RPCs |
+| `REVEALUI_LICENSE_KEY` | (none → FREE tier) | Ed25519-signed license. Pro+ unlocks coordination RPCs |
 | `REVDEV_LICENSE_PUBLIC_KEY` | (none) | Public key matching the license signature |
 | `REVDEV_DAEMON_SOCKET` | `~/.local/share/revealui/harness.sock` | Unix socket bind path |
 | `REVDEV_DAEMON_DATA` | `~/.local/share/revealui` | PGlite data directory |
@@ -97,7 +97,7 @@ Environment variables (all optional):
 ## Smoke test
 
 For local dev / smoke testing without a real license key, use the
-Ed25519 v2 test-license generator at
+Ed25519 test-license generator at
 [`src/__tests__/test-license-helper.ts`](src/__tests__/test-license-helper.ts).
 It produces a self-signed keypair on the fly and returns a license + public
 key suitable for the `enterprise` tier. The integration test suite at

--- a/packages/daemon/src/__tests__/adversarial-isolation.test.ts
+++ b/packages/daemon/src/__tests__/adversarial-isolation.test.ts
@@ -536,6 +536,98 @@ describe('adversarial agent isolation (B6 §6)', () => {
         await rm(repo, { recursive: true, force: true });
       }
     });
+
+    it('an unsigned peer cannot end another agent’s session (no eviction, no kill)', async () => {
+      // The hole: session.end used to read `params.sessionId` verbatim while the
+      // identity gate was satisfied by any `actorAgentId` string. One unsigned
+      // call evicted the victim's roots and killed its PTYs.
+      const repo = await initRepo('iso-j-crossagent-');
+      const victimId = 'iso-j-victim-agent';
+      const kpVictim = generateAgentKeypair();
+      const fpVictim = computeFingerprint(kpVictim.publicKeyRaw);
+      const didVictim = formatDid(victimId, fpVictim);
+
+      const anchorContent = await readFile(anchor, 'utf8');
+      await writeFile(anchor, `${anchorContent}${victimId}:${fpVictim}\n`);
+
+      const rpcVictim = (method: string, params: Record<string, unknown>) =>
+        rpcFrame(
+          socketPath,
+          method,
+          params,
+          signFor(victimId, didVictim, fpVictim, kpVictim, method, params),
+        );
+
+      try {
+        await rpcFrame(socketPath, 'session.register', {
+          agentId: victimId,
+          agentName: victimId,
+          backend: 'studio',
+          publicKeyPem: kpVictim.publicKeyPem,
+        });
+        expect((await rpcVictim('project.open', { repoPath: repo })).error).toBeUndefined();
+
+        // The attack, verbatim: unsigned, `actorAgentId` to pass the identity
+        // gate, `sessionId` naming the victim.
+        const attack = await rpcFrame(socketPath, 'session.end', {
+          actorAgentId: 'iso-j-attacker',
+          sessionId: victimId,
+        });
+        expect(attack.error).toBeDefined();
+        expect(attack.result).toBeUndefined();
+
+        // And the victim's root is still owned: C still hits a conflict, which
+        // it would not if notifyAgentEnded had run.
+        const cAfter = await rpcC('project.open', { repoPath: repo });
+        expect(cAfter.error?.message).toContain('conflict');
+      } finally {
+        await rm(repo, { recursive: true, force: true });
+      }
+    });
+
+    it('a signed agent cannot end a different agent’s session', async () => {
+      // C is a verified signer, so it clears the signature gate. It still must
+      // not be able to name someone else as the target: session.end self-scopes
+      // to ctx.agentId and ignores params entirely.
+      const repo = await initRepo('iso-j-signedcross-');
+      const victimId = 'iso-j-victim2-agent';
+      const kpVictim = generateAgentKeypair();
+      const fpVictim = computeFingerprint(kpVictim.publicKeyRaw);
+      const didVictim = formatDid(victimId, fpVictim);
+
+      const anchorContent = await readFile(anchor, 'utf8');
+      await writeFile(anchor, `${anchorContent}${victimId}:${fpVictim}\n`);
+
+      const rpcVictim = (method: string, params: Record<string, unknown>) =>
+        rpcFrame(
+          socketPath,
+          method,
+          params,
+          signFor(victimId, didVictim, fpVictim, kpVictim, method, params),
+        );
+
+      try {
+        await rpcFrame(socketPath, 'session.register', {
+          agentId: victimId,
+          agentName: victimId,
+          backend: 'studio',
+          publicKeyPem: kpVictim.publicKeyPem,
+        });
+        expect((await rpcVictim('project.open', { repoPath: repo })).error).toBeUndefined();
+
+        // C signs, but names the victim. The call succeeds as C ending C, and
+        // the victim is untouched.
+        const res = await rpcC('session.end', { sessionId: victimId, agentId: victimId });
+        expect(res.error).toBeUndefined();
+        expect((res.result as { ended: string }).ended).not.toBe(victimId);
+
+        // Victim still owns its root.
+        const cAfter = await rpcC('project.open', { repoPath: repo });
+        expect(cAfter.error?.message).toContain('conflict');
+      } finally {
+        await rm(repo, { recursive: true, force: true });
+      }
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/daemon/src/__tests__/confinement-integration.test.ts
+++ b/packages/daemon/src/__tests__/confinement-integration.test.ts
@@ -105,6 +105,7 @@ describe.skipIf(!RUN)('confinement integration (real bwrap)', () => {
       cwd: repoReal,
       agentHome,
       operatorHome,
+      dataDir: join(operatorHome, 'daemon-data'),
     });
     const r = spawnSync(file, argv, { encoding: 'utf8', timeout: 15_000 });
     return { status: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
@@ -160,12 +161,14 @@ describe.skipIf(!RUN)('confinement integration (real bwrap)', () => {
     // name before any sandbox is built — while the sibling happy-path spawn above
     // still succeeds (DAILY DRIVER). The guard fires in spawnConfined, so this
     // exercises the real entrypoint with a real secret-bearing home on disk.
+    const dataDir = join(operatorHome, 'daemon-data');
     expect(() =>
       backend.spawnConfined('/bin/sh', ['-c', 'true'], {
         repoReal: operatorHome,
         cwd: operatorHome,
         agentHome,
         operatorHome,
+        dataDir,
       }),
     ).toThrow(/is or contains the operator home/);
     expect(() =>
@@ -174,6 +177,7 @@ describe.skipIf(!RUN)('confinement integration (real bwrap)', () => {
         cwd: join(operatorHome, '.ssh'),
         agentHome,
         operatorHome,
+        dataDir,
       }),
     ).toThrow(/overlaps the never-bound secret path/);
   });

--- a/packages/daemon/src/__tests__/confinement-integration.test.ts
+++ b/packages/daemon/src/__tests__/confinement-integration.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration tests for confinement — REAL bwrap, real filesystem, real child
+ * processes. Proves the boundary actually holds (spec §10 tests 1, 2, 5, 6) and
+ * that the daily driver survives (test 6, repo read).
+ *
+ * Hermetic: a temp directory stands in for the operator home, seeded with fake
+ * secrets. This runs on any bwrap-capable Linux/WSL2 host without touching the
+ * real ~/.ssh, and is reproducible in CI. (§10's literal reads against the real
+ * operator paths are additionally verified by hand on WSL2 — see the PR body.)
+ *
+ * PROVE-RED is built in: each adversarial read is run first WITHOUT the sandbox
+ * (the `control` helper = the pre-fix behavior) and shown to LEAK, then WITH the
+ * sandbox and shown DENIED. A test that can only pass because the sandbox exists.
+ *
+ * The whole suite is skipped when bwrap cannot create unprivileged namespaces
+ * on the host (WSL1, hardened kernels, restricted CI) — that is the fail-closed
+ * platform, and there is nothing to prove there.
+ *
+ * @vitest-environment node
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { linuxBubblewrapBackend, resolveBwrapAbsPath } from '../confinement.js';
+
+const bwrapAbs = process.platform === 'linux' ? resolveBwrapAbsPath() : null;
+
+/**
+ * Probe whether bwrap can actually create unprivileged namespaces here. Presence
+ * of the binary is not enough (WSL1 / hardened kernels have it but it fails), so
+ * we run a trivial real sandbox and require exit 0.
+ */
+function bwrapUsable(): boolean {
+  if (!bwrapAbs) return false;
+  // Mirror the backend's merged-usr symlinks — WITHOUT /lib and /lib64 the ELF
+  // loader is missing inside and every exec fails ENOENT (a false negative).
+  const r = spawnSync(
+    bwrapAbs,
+    [
+      '--unshare-user',
+      '--unshare-pid',
+      '--ro-bind',
+      '/usr',
+      '/usr',
+      '--symlink',
+      'usr/bin',
+      '/bin',
+      '--symlink',
+      'usr/lib',
+      '/lib',
+      '--symlink',
+      'usr/lib64',
+      '/lib64',
+      '--proc',
+      '/proc',
+      '--dev',
+      '/dev',
+      '--',
+      '/bin/true',
+    ],
+    { timeout: 10_000 },
+  );
+  return r.status === 0;
+}
+
+const RUN = bwrapUsable();
+
+describe.skipIf(!RUN)('confinement integration (real bwrap)', () => {
+  const backend = linuxBubblewrapBackend(bwrapAbs as string);
+
+  let operatorHome: string;
+  let repoReal: string;
+  let agentHome: string;
+  let sshSecret: string;
+  let ageSecret: string;
+
+  beforeAll(async () => {
+    operatorHome = await mkdtemp(join(tmpdir(), 'confine-op-'));
+    repoReal = join(operatorHome, 'repo');
+    agentHome = join(operatorHome, 'agent');
+    sshSecret = join(operatorHome, '.ssh', 'id_secret');
+    ageSecret = join(operatorHome, '.age-identity');
+
+    await mkdir(join(operatorHome, '.ssh'), { recursive: true });
+    await writeFile(sshSecret, 'TOPSECRET-SSH-KEY\n', { mode: 0o600 });
+    await writeFile(ageSecret, 'AGE-SECRET-IDENTITY\n', { mode: 0o600 });
+    await mkdir(repoReal, { recursive: true });
+    await writeFile(join(repoReal, 'hello.txt'), 'REPO-VISIBLE\n');
+    await mkdir(agentHome, { recursive: true });
+    // A symlink inside the granted repo pointing at the ssh secret (§4.4 escape).
+    await symlink(sshSecret, join(repoReal, 'escape-link'));
+  });
+
+  afterAll(async () => {
+    await rm(operatorHome, { recursive: true, force: true });
+  });
+
+  /** Run `sh -c script` INSIDE the sandbox; return combined stdout. */
+  function confined(script: string): { status: number | null; out: string } {
+    const { file, argv } = backend.spawnConfined('/bin/sh', ['-c', script], {
+      repoReal,
+      cwd: repoReal,
+      agentHome,
+      operatorHome,
+    });
+    const r = spawnSync(file, argv, { encoding: 'utf8', timeout: 15_000 });
+    return { status: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+  }
+
+  /** Run `sh -c script` WITHOUT the sandbox (the pre-fix control = prove-red). */
+  function control(script: string): { status: number | null; out: string } {
+    const r = spawnSync('/bin/sh', ['-c', script], {
+      cwd: repoReal,
+      encoding: 'utf8',
+      timeout: 15_000,
+    });
+    return { status: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+  }
+
+  const readProbe = (p: string) => `cat '${p}' 2>/dev/null && echo __LEAK__ || echo __DENIED__`;
+
+  it('CONTROL: the ssh secret is readable WITHOUT the sandbox (prove-red)', () => {
+    const { out } = control(readProbe(sshSecret));
+    expect(out).toContain('TOPSECRET-SSH-KEY');
+    expect(out).toContain('__LEAK__');
+  });
+
+  it('denies reading ~/.ssh inside the sandbox (§10 test 1)', () => {
+    const { out } = confined(readProbe(sshSecret));
+    expect(out).not.toContain('TOPSECRET-SSH-KEY');
+    expect(out).toContain('__DENIED__');
+  });
+
+  it('denies reading ~/.age-identity inside the sandbox (§10 test 2)', () => {
+    expect(control(readProbe(ageSecret)).out).toContain('AGE-SECRET-IDENTITY'); // prove-red
+    const { out } = confined(readProbe(ageSecret));
+    expect(out).not.toContain('AGE-SECRET-IDENTITY');
+    expect(out).toContain('__DENIED__');
+  });
+
+  it('cannot read a secret THROUGH a repo symlink (§10 test 5, §4.4)', () => {
+    const link = join(repoReal, 'escape-link');
+    expect(control(readProbe(link)).out).toContain('TOPSECRET-SSH-KEY'); // prove-red: link works unsandboxed
+    const { out } = confined(readProbe(link));
+    expect(out).not.toContain('TOPSECRET-SSH-KEY');
+    expect(out).toContain('__DENIED__');
+  });
+
+  it('DAILY DRIVER: the granted repo IS readable inside the sandbox (§10 test 6)', () => {
+    const { out } = confined(`cat '${join(repoReal, 'hello.txt')}'`);
+    expect(out).toContain('REPO-VISIBLE');
+  });
+
+  it('HOME points at the agent home, not the operator home', () => {
+    const { out } = confined('echo "HOME=$HOME"');
+    expect(out).toContain(`HOME=${agentHome}`);
+  });
+
+  it('an ABSOLUTE command is still confined — PATH was never the control (§10 test 4)', () => {
+    // /bin/cat by absolute path; the ssh secret is still denied.
+    const { out } = confined(
+      `/bin/cat '${sshSecret}' 2>/dev/null && echo __LEAK__ || echo __DENIED__`,
+    );
+    expect(out).not.toContain('TOPSECRET-SSH-KEY');
+    expect(out).toContain('__DENIED__');
+  });
+});

--- a/packages/daemon/src/__tests__/confinement-integration.test.ts
+++ b/packages/daemon/src/__tests__/confinement-integration.test.ts
@@ -154,6 +154,30 @@ describe.skipIf(!RUN)('confinement integration (real bwrap)', () => {
     expect(out).toContain('REPO-VISIBLE');
   });
 
+  it('refuses a spawn whose granted root overlaps a real fixture secret (GAP-320a §5.D)', () => {
+    // End-to-end against the seeded operator-home layout: a granted root that IS
+    // the operator home, or that lives inside the seeded ~/.ssh, is refused by
+    // name before any sandbox is built — while the sibling happy-path spawn above
+    // still succeeds (DAILY DRIVER). The guard fires in spawnConfined, so this
+    // exercises the real entrypoint with a real secret-bearing home on disk.
+    expect(() =>
+      backend.spawnConfined('/bin/sh', ['-c', 'true'], {
+        repoReal: operatorHome,
+        cwd: operatorHome,
+        agentHome,
+        operatorHome,
+      }),
+    ).toThrow(/is or contains the operator home/);
+    expect(() =>
+      backend.spawnConfined('/bin/sh', ['-c', 'true'], {
+        repoReal: join(operatorHome, '.ssh'),
+        cwd: join(operatorHome, '.ssh'),
+        agentHome,
+        operatorHome,
+      }),
+    ).toThrow(/overlaps the never-bound secret path/);
+  });
+
   it('HOME points at the agent home, not the operator home', () => {
     const { out } = confined('echo "HOME=$HOME"');
     expect(out).toContain(`HOME=${agentHome}`);

--- a/packages/daemon/src/__tests__/confinement.test.ts
+++ b/packages/daemon/src/__tests__/confinement.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Unit tests for the confinement module (confinement.ts) — pure argv/env/backend
+ * logic, no real spawn and no socket. The real-bwrap adversarial reads live in
+ * confinement-integration.test.ts.
+ *
+ * @vitest-environment node
+ */
+
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  buildConfinedEnv,
+  ensureAgentHome,
+  filterCallerEnv,
+  linuxBubblewrapBackend,
+  resolveBwrapAbsPath,
+  resolveConfinementBackend,
+} from '../confinement.js';
+
+// ---------------------------------------------------------------------------
+// filterCallerEnv — the allow-list (spec §7, §10 test 3)
+// ---------------------------------------------------------------------------
+
+describe('filterCallerEnv', () => {
+  it('accepts the exact allow-list keys', () => {
+    const out = filterCallerEnv({ TERM: 'xterm', LANG: 'en_US.UTF-8', CI: '1', NO_COLOR: '1' });
+    expect(out).toEqual({ TERM: 'xterm', LANG: 'en_US.UTF-8', CI: '1', NO_COLOR: '1' });
+  });
+
+  it('accepts the namespaced prefixes (LC_*, REVDEV_*)', () => {
+    const out = filterCallerEnv({ LC_ALL: 'C', LC_TIME: 'C', REVDEV_FOO: 'bar' });
+    expect(out).toEqual({ LC_ALL: 'C', LC_TIME: 'C', REVDEV_FOO: 'bar' });
+  });
+
+  it('rejects HOME by name (the escape the tmpfs would otherwise absorb)', () => {
+    expect(() => filterCallerEnv({ HOME: '/home/op' })).toThrow(/"HOME" is not caller-settable/);
+  });
+
+  it('rejects PATH', () => {
+    expect(() => filterCallerEnv({ PATH: '/evil/bin' })).toThrow(/"PATH" is not caller-settable/);
+  });
+
+  it.each([
+    'LD_PRELOAD',
+    'LD_AUDIT',
+    'LD_LIBRARY_PATH',
+    'NODE_OPTIONS',
+    'GIT_SSH_COMMAND',
+    'BASH_ENV',
+    'PYTHONSTARTUP',
+  ])('rejects the loader/hook key %s', (key) => {
+    expect(() => filterCallerEnv({ [key]: 'x' })).toThrow(
+      new RegExp(`"${key}" is not caller-settable`),
+    );
+  });
+
+  it('names the FIRST offending key when several are present', () => {
+    // A near-miss (GIT_ prefix is NOT allow-listed; only LC_/REVDEV_ are).
+    expect(() => filterCallerEnv({ GIT_CONFIG_GLOBAL: '/tmp/x' })).toThrow(/"GIT_CONFIG_GLOBAL"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildConfinedEnv — deny-by-default baseline, no process.env leak
+// ---------------------------------------------------------------------------
+
+describe('buildConfinedEnv', () => {
+  it('points HOME at the agent home and pins PATH', () => {
+    const env = buildConfinedEnv({}, '/data/agent-homes/abc');
+    expect(env.HOME).toBe('/data/agent-homes/abc');
+    expect(env.PATH).toBe('/usr/bin:/bin');
+    expect(env.GIT_CONFIG_NOSYSTEM).toBe('1');
+  });
+
+  it('does not inherit process.env (no secret leak)', () => {
+    process.env.CONFINEMENT_SECRET_PROBE = 'leak-me';
+    try {
+      const env = buildConfinedEnv({}, '/data/agent');
+      expect(env.CONFINEMENT_SECRET_PROBE).toBeUndefined();
+    } finally {
+      delete process.env.CONFINEMENT_SECRET_PROBE;
+    }
+  });
+
+  it('layers allow-listed caller env on top', () => {
+    const env = buildConfinedEnv({ TERM: 'screen-256color', REVDEV_X: '1' }, '/data/agent');
+    expect(env.TERM).toBe('screen-256color');
+    expect(env.REVDEV_X).toBe('1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// linuxBubblewrapBackend — argv construction (spec §4.3, §4.4, §10 test 4)
+// ---------------------------------------------------------------------------
+
+describe('linuxBubblewrapBackend.spawnConfined', () => {
+  const backend = linuxBubblewrapBackend('/usr/bin/bwrap');
+  const opts = {
+    repoReal: '/home/op/repo',
+    cwd: '/home/op/repo/packages/x',
+    agentHome: '/home/op/.local/share/revealui/agent-homes/deadbeef',
+    operatorHome: '/home/op',
+  };
+
+  it('execs bwrap, not the raw command', () => {
+    const { file } = backend.spawnConfined('bash', ['-i'], opts);
+    expect(file).toBe('/usr/bin/bwrap');
+  });
+
+  it('still wraps an ABSOLUTE command — PATH was never the control (§10 test 4)', () => {
+    const { file, argv } = backend.spawnConfined('/bin/bash', [], opts);
+    expect(file).toBe('/usr/bin/bwrap');
+    // The command sits AFTER the `--` separator, never as the exec file.
+    const sep = argv.indexOf('--');
+    expect(sep).toBeGreaterThan(0);
+    expect(argv[sep + 1]).toBe('/bin/bash');
+  });
+
+  it('tmpfs-hides the operator home and re-binds only the granted root + agent home', () => {
+    const { argv } = backend.spawnConfined('bash', [], opts);
+    const s = argv.join(' ');
+    expect(s).toContain('--tmpfs /home/op');
+    expect(s).toContain(`--bind ${opts.repoReal} ${opts.repoReal}`);
+    expect(s).toContain(`--bind ${opts.agentHome} ${opts.agentHome}`);
+    // The operator-home tmpfs must come BEFORE the re-binds, or the binds get wiped.
+    const tmpfsIdx = argv.indexOf('/home/op'); // the --tmpfs operand
+    const repoBindIdx = argv.indexOf(opts.repoReal);
+    expect(tmpfsIdx).toBeLessThan(repoBindIdx);
+  });
+
+  it('never binds a secret path', () => {
+    const { argv } = backend.spawnConfined('bash', [], opts);
+    const s = argv.join(' ');
+    for (const secret of [
+      '.ssh',
+      '.age-identity',
+      'passage-store',
+      '.config/gh',
+      '.npmrc',
+      '.aws',
+    ]) {
+      expect(s).not.toContain(secret);
+    }
+  });
+
+  it('sets HOME + PATH authoritatively inside the sandbox', () => {
+    const { argv } = backend.spawnConfined('bash', [], opts);
+    const s = argv.join(' ');
+    expect(s).toContain(`--setenv HOME ${opts.agentHome}`);
+    expect(s).toContain('--setenv PATH /usr/bin:/bin');
+  });
+
+  it('unshares user/pid/ipc/uts/cgroup but NOT net, and dies with parent', () => {
+    const { argv } = backend.spawnConfined('bash', [], opts);
+    expect(argv).toContain('--unshare-user');
+    expect(argv).toContain('--unshare-pid');
+    expect(argv).toContain('--unshare-cgroup');
+    expect(argv).not.toContain('--unshare-net');
+    expect(argv).not.toContain('--new-session'); // §4.3 — breaks interactive job control
+    expect(argv).toContain('--die-with-parent');
+  });
+
+  it('starts in the granted cwd', () => {
+    const { argv } = backend.spawnConfined('bash', [], opts);
+    const s = argv.join(' ');
+    expect(s).toContain(`--chdir ${opts.cwd}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveConfinementBackend — fail-closed + escape hatch (spec §8)
+// ---------------------------------------------------------------------------
+
+describe('resolveConfinementBackend', () => {
+  it('linux + usable bwrap → linux-bubblewrap', () => {
+    const r = resolveConfinementBackend({
+      platform: 'linux',
+      bwrapPath: '/usr/bin/bwrap',
+      escapeHatchEnv: '',
+    });
+    expect(r.mode).toBe('linux-bubblewrap');
+    expect(r.backend).not.toBeNull();
+    expect(r.escapeHatch).toBe(false);
+  });
+
+  it('linux WITHOUT usable bwrap → fail closed (backend null, not escape hatch)', () => {
+    const r = resolveConfinementBackend({ platform: 'linux', bwrapPath: null, escapeHatchEnv: '' });
+    expect(r.mode).toBe('none');
+    expect(r.backend).toBeNull();
+    expect(r.escapeHatch).toBe(false);
+    expect(r.reason).toMatch(/fails closed/);
+  });
+
+  it.each(['darwin', 'win32'] as const)('%s → fail closed (no backend)', (platform) => {
+    const r = resolveConfinementBackend({ platform, bwrapPath: null, escapeHatchEnv: '' });
+    expect(r.backend).toBeNull();
+    expect(r.escapeHatch).toBe(false);
+    expect(r.reason).toMatch(/fails closed/);
+  });
+
+  it('escape hatch overrides every platform → unconfined, recorded', () => {
+    const r = resolveConfinementBackend({
+      platform: 'linux',
+      bwrapPath: '/usr/bin/bwrap',
+      escapeHatchEnv: 'none',
+    });
+    expect(r.mode).toBe('none');
+    expect(r.backend).toBeNull();
+    expect(r.escapeHatch).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveBwrapAbsPath
+// ---------------------------------------------------------------------------
+
+describe('resolveBwrapAbsPath', () => {
+  it('returns null for a nonexistent candidate', () => {
+    expect(resolveBwrapAbsPath('/nonexistent/bwrap-xyz')).toBeNull();
+  });
+
+  it('rejects a non-root-owned candidate (any user-writable file in tmp)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'bwrap-probe-'));
+    try {
+      const fake = join(dir, 'bwrap');
+      await writeFile(fake, '#!/bin/sh\n', { mode: 0o755 });
+      // Owned by the test user, not root → refused.
+      expect(resolveBwrapAbsPath(fake)).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureAgentHome (spec §5, §6)
+// ---------------------------------------------------------------------------
+
+describe('ensureAgentHome', () => {
+  let dataDir: string;
+
+  beforeAll(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'agent-home-test-'));
+  });
+  afterAll(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it('creates a hashed home with a signing-OFF gitconfig and no signingkey', async () => {
+    const home = await ensureAgentHome(dataDir, 'did:key:zSignerABC');
+    expect(home).toContain(join(dataDir, 'agent-homes'));
+    // Hashed — the raw agentId never appears in the path.
+    expect(home).not.toContain('zSignerABC');
+
+    const gitconfig = await readFile(join(home, '.gitconfig'), 'utf8');
+    expect(gitconfig).toContain('gpgsign = false');
+    expect(gitconfig).not.toContain('signingkey');
+
+    // Writable scaffold dirs exist.
+    for (const d of ['.cache', '.config', join('.local', 'share')]) {
+      const s = await stat(join(home, d));
+      expect(s.isDirectory()).toBe(true);
+    }
+  });
+
+  it('is idempotent and stable per agentId', async () => {
+    const a = await ensureAgentHome(dataDir, 'did:key:zStable');
+    const b = await ensureAgentHome(dataDir, 'did:key:zStable');
+    expect(a).toBe(b);
+  });
+
+  it('gives different agents different homes', async () => {
+    const a = await ensureAgentHome(dataDir, 'did:key:zOne');
+    const b = await ensureAgentHome(dataDir, 'did:key:zTwo');
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/daemon/src/__tests__/confinement.test.ts
+++ b/packages/daemon/src/__tests__/confinement.test.ts
@@ -115,6 +115,7 @@ describe('linuxBubblewrapBackend.spawnConfined', () => {
     cwd: '/base/op/repo/packages/x',
     agentHome: '/base/op/.local/share/revealui/agent-homes/deadbeef',
     operatorHome: '/base/op',
+    dataDir: '/base/op/.local/share/revealui',
   };
 
   it('execs bwrap, not the raw command', () => {
@@ -297,33 +298,34 @@ describe('ensureAgentHome', () => {
 
 describe('assertGrantedRootBindable', () => {
   const HOME = '/base/op';
+  const DATADIR = '/base/op/.local/share/revealui';
 
   it('refuses the operator home itself', () => {
-    expect(() => assertGrantedRootBindable(HOME, HOME)).toThrow(/is or contains the operator home/);
+    expect(() => assertGrantedRootBindable(HOME, HOME, DATADIR)).toThrow(/is or contains the operator home/);
   });
 
   it('refuses an ANCESTOR of the operator home', () => {
     // repoReal = /base contains /base/op — the tmpfs-then-bind would carry the home.
-    expect(() => assertGrantedRootBindable('/base', HOME)).toThrow(
+    expect(() => assertGrantedRootBindable('/base', HOME, DATADIR)).toThrow(
       /is or contains the operator home/,
     );
   });
 
   it('refuses a granted root that IS a secret path', () => {
-    expect(() => assertGrantedRootBindable(join(HOME, '.ssh'), HOME)).toThrow(
+    expect(() => assertGrantedRootBindable(join(HOME, '.ssh'), HOME, DATADIR)).toThrow(
       /overlaps the never-bound secret path/,
     );
   });
 
   it('refuses a granted root INSIDE a secret path', () => {
-    expect(() => assertGrantedRootBindable(join(HOME, '.ssh', 'sub'), HOME)).toThrow(
+    expect(() => assertGrantedRootBindable(join(HOME, '.ssh', 'sub'), HOME, DATADIR)).toThrow(
       /overlaps the never-bound secret path/,
     );
   });
 
   it('refuses a granted root that CONTAINS a secret path (.revealui over passage-store)', () => {
     // repoReal = <home>/.revealui contains <home>/.revealui/passage-store.
-    expect(() => assertGrantedRootBindable(join(HOME, '.revealui'), HOME)).toThrow(
+    expect(() => assertGrantedRootBindable(join(HOME, '.revealui'), HOME, DATADIR)).toThrow(
       /overlaps the never-bound secret path/,
     );
   });
@@ -333,27 +335,51 @@ describe('assertGrantedRootBindable', () => {
     // itself (equal direction). Fixtures avoid the Windows-user and trailing-slash
     // mount shapes the private-leak scanner flags — the refusal is identical for
     // any path on those mounts.
-    expect(() => assertGrantedRootBindable('/mnt/c/project', HOME)).toThrow(
+    expect(() => assertGrantedRootBindable('/mnt/c/project', HOME, DATADIR)).toThrow(
       /overlaps the never-bound secret path/,
     );
-    expect(() => assertGrantedRootBindable('/mnt/e', HOME)).toThrow(
+    expect(() => assertGrantedRootBindable('/mnt/e', HOME, DATADIR)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('refuses a granted root that IS the daemon data dir', () => {
+    expect(() => assertGrantedRootBindable(DATADIR, HOME, DATADIR)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('refuses a granted root that CONTAINS the daemon data dir', () => {
+    // repoReal = <home>/.local/share contains the daemon dir under it.
+    expect(() => assertGrantedRootBindable(join(HOME, '.local', 'share'), HOME, DATADIR)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('refuses the daemon data dir even when it is configured OUTSIDE the home', () => {
+    const outHome = '/var/lib/revealui-daemon';
+    expect(() => assertGrantedRootBindable(outHome, HOME, outHome)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+    // A root beneath it (e.g. the grants DB dir) is refused too.
+    expect(() => assertGrantedRootBindable(`${outHome}/pglite`, HOME, outHome)).toThrow(
       /overlaps the never-bound secret path/,
     );
   });
 
   it('does NOT refuse the normal case: a project root beneath the home', () => {
     // The supported shape — ~/revfleet/<repo>. Must NOT throw.
-    expect(() => assertGrantedRootBindable(join(HOME, 'revfleet', 'revealui'), HOME)).not.toThrow();
+    expect(() => assertGrantedRootBindable(join(HOME, 'revfleet', 'revealui'), HOME, DATADIR)).not.toThrow();
   });
 
   it('does NOT refuse a sibling of the home that shares a name prefix (separator-safe)', () => {
     // /base/op-scratch must not match /base/op via a naive startsWith.
-    expect(() => assertGrantedRootBindable('/base/op-scratch/repo', HOME)).not.toThrow();
+    expect(() => assertGrantedRootBindable('/base/op-scratch/repo', HOME, DATADIR)).not.toThrow();
   });
 
   it('does NOT refuse a repo whose name merely prefixes a secret name (.sshkeep)', () => {
     // <home>/.sshkeep is not <home>/.ssh — separator-safe within() must not match.
-    expect(() => assertGrantedRootBindable(join(HOME, '.sshkeep'), HOME)).not.toThrow();
+    expect(() => assertGrantedRootBindable(join(HOME, '.sshkeep'), HOME, DATADIR)).not.toThrow();
   });
 
   it('refuses a SYMLINKED secret dir via the realpath-if-exists form', async () => {
@@ -367,7 +393,7 @@ describe('assertGrantedRootBindable', () => {
       await symlink(target, join(home, '.ssh'));
       // realpath the target the same way requireRootAndDir would hand it in.
       const repoReal = await realpath(target);
-      expect(() => assertGrantedRootBindable(repoReal, home)).toThrow(
+      expect(() => assertGrantedRootBindable(repoReal, home, join(home, 'daemon-data'))).toThrow(
         /overlaps the never-bound secret path/,
       );
     } finally {
@@ -399,7 +425,7 @@ describe('resolveOperatorHome (GAP-320a review S1)', () => {
 
 describe('neverBoundSet', () => {
   it('materializes the home-relative secrets and absolute mounts', () => {
-    const set = neverBoundSet('/base/op');
+    const set = neverBoundSet('/base/op', '/base/op/.local/share/revealui');
     for (const p of [
       '/base/op/.ssh',
       '/base/op/.age-identity',
@@ -418,7 +444,7 @@ describe('neverBoundSet', () => {
 
   it('includes /run/user/<uid> when getuid is available', () => {
     if (typeof process.getuid !== 'function') return;
-    const set = neverBoundSet('/base/op');
+    const set = neverBoundSet('/base/op', '/base/op/.local/share/revealui');
     expect(set).toContain(`/run/user/${process.getuid()}`);
   });
 });
@@ -433,6 +459,7 @@ describe('linuxBubblewrapBackend.spawnConfined — overlap guard', () => {
     cwd: '/base/op/.ssh',
     agentHome: '/base/op/.local/share/revealui/agent-homes/deadbeef',
     operatorHome: '/base/op',
+    dataDir: '/base/op/.local/share/revealui',
   };
 
   it('refuses to build argv when the granted root overlaps a secret path', () => {
@@ -441,12 +468,23 @@ describe('linuxBubblewrapBackend.spawnConfined — overlap guard', () => {
     );
   });
 
+  it('refuses to build argv when the granted root overlaps the daemon data dir', () => {
+    expect(() =>
+      backend.spawnConfined('bash', [], {
+        ...base,
+        repoReal: '/base/op/.local/share/revealui',
+        cwd: '/base/op/.local/share/revealui',
+      }),
+    ).toThrow(/overlaps the never-bound secret path/);
+  });
+
   it('still builds argv for a normal project root beneath the home', () => {
     const { argv } = backend.spawnConfined('bash', [], {
       repoReal: '/base/op/revfleet/repo',
       cwd: '/base/op/revfleet/repo',
       agentHome: base.agentHome,
       operatorHome: base.operatorHome,
+      dataDir: base.dataDir,
     });
     expect(argv).toContain('--bind');
     expect(argv.join(' ')).toContain('--bind /base/op/revfleet/repo /base/op/revfleet/repo');

--- a/packages/daemon/src/__tests__/confinement.test.ts
+++ b/packages/daemon/src/__tests__/confinement.test.ts
@@ -301,7 +301,9 @@ describe('assertGrantedRootBindable', () => {
   const DATADIR = '/base/op/.local/share/revealui';
 
   it('refuses the operator home itself', () => {
-    expect(() => assertGrantedRootBindable(HOME, HOME, DATADIR)).toThrow(/is or contains the operator home/);
+    expect(() => assertGrantedRootBindable(HOME, HOME, DATADIR)).toThrow(
+      /is or contains the operator home/,
+    );
   });
 
   it('refuses an ANCESTOR of the operator home', () => {
@@ -369,7 +371,9 @@ describe('assertGrantedRootBindable', () => {
 
   it('does NOT refuse the normal case: a project root beneath the home', () => {
     // The supported shape — ~/revfleet/<repo>. Must NOT throw.
-    expect(() => assertGrantedRootBindable(join(HOME, 'revfleet', 'revealui'), HOME, DATADIR)).not.toThrow();
+    expect(() =>
+      assertGrantedRootBindable(join(HOME, 'revfleet', 'revealui'), HOME, DATADIR),
+    ).not.toThrow();
   });
 
   it('does NOT refuse a sibling of the home that shares a name prefix (separator-safe)', () => {

--- a/packages/daemon/src/__tests__/confinement.test.ts
+++ b/packages/daemon/src/__tests__/confinement.test.ts
@@ -19,6 +19,7 @@ import {
   neverBoundSet,
   resolveBwrapAbsPath,
   resolveConfinementBackend,
+  resolveOperatorHome,
 } from '../confinement.js';
 
 // ---------------------------------------------------------------------------
@@ -372,6 +373,27 @@ describe('assertGrantedRootBindable', () => {
     } finally {
       await rm(home, { recursive: true, force: true });
     }
+  });
+});
+
+describe('resolveOperatorHome (GAP-320a review S1)', () => {
+  it('realpaths a symlinked home so the guard compares canonical paths', async () => {
+    // /real-home is the true dir; /link-home is a symlink to it. Resolving the
+    // symlink yields the same canonical path repoReal would realpath to.
+    const base = await mkdtemp(join(tmpdir(), 'op-home-'));
+    try {
+      const realHome = join(base, 'real-home');
+      const linkHome = join(base, 'link-home');
+      await mkdir(realHome, { recursive: true });
+      await symlink(realHome, linkHome);
+      expect(await resolveOperatorHome(linkHome)).toBe(await realpath(realHome));
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the lexical value when the path does not resolve', () => {
+    expect(resolveOperatorHome('/no/such/dir/xyzzy')).toBe('/no/such/dir/xyzzy');
   });
 });
 

--- a/packages/daemon/src/__tests__/confinement.test.ts
+++ b/packages/daemon/src/__tests__/confinement.test.ts
@@ -6,15 +6,17 @@
  * @vitest-environment node
  */
 
-import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
+  assertGrantedRootBindable,
   buildConfinedEnv,
   ensureAgentHome,
   filterCallerEnv,
   linuxBubblewrapBackend,
+  neverBoundSet,
   resolveBwrapAbsPath,
   resolveConfinementBackend,
 } from '../confinement.js';
@@ -40,6 +42,16 @@ describe('filterCallerEnv', () => {
 
   it('rejects PATH', () => {
     expect(() => filterCallerEnv({ PATH: '/evil/bin' })).toThrow(/"PATH" is not caller-settable/);
+  });
+
+  it('rejects REVDEV_SPAWN_CONFINEMENT by name despite the REVDEV_ prefix (GAP-320b)', () => {
+    expect(() => filterCallerEnv({ REVDEV_SPAWN_CONFINEMENT: 'none' })).toThrow(
+      /"REVDEV_SPAWN_CONFINEMENT" is not caller-settable/,
+    );
+    // The deny check runs FIRST, so it wins even when a benign REVDEV_ key precedes it.
+    expect(() => filterCallerEnv({ REVDEV_HINT: 'ok', REVDEV_SPAWN_CONFINEMENT: 'none' })).toThrow(
+      /"REVDEV_SPAWN_CONFINEMENT" is not caller-settable/,
+    );
   });
 
   it.each([
@@ -275,5 +287,146 @@ describe('ensureAgentHome', () => {
     const a = await ensureAgentHome(dataDir, 'did:key:zOne');
     const b = await ensureAgentHome(dataDir, 'did:key:zTwo');
     expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertGrantedRootBindable — the overlap guard (GAP-320a, spec §4.3)
+// ---------------------------------------------------------------------------
+
+describe('assertGrantedRootBindable', () => {
+  const HOME = '/base/op';
+
+  it('refuses the operator home itself', () => {
+    expect(() => assertGrantedRootBindable(HOME, HOME)).toThrow(/is or contains the operator home/);
+  });
+
+  it('refuses an ANCESTOR of the operator home', () => {
+    // repoReal = /base contains /base/op — the tmpfs-then-bind would carry the home.
+    expect(() => assertGrantedRootBindable('/base', HOME)).toThrow(
+      /is or contains the operator home/,
+    );
+  });
+
+  it('refuses a granted root that IS a secret path', () => {
+    expect(() => assertGrantedRootBindable(join(HOME, '.ssh'), HOME)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('refuses a granted root INSIDE a secret path', () => {
+    expect(() => assertGrantedRootBindable(join(HOME, '.ssh', 'sub'), HOME)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('refuses a granted root that CONTAINS a secret path (.revealui over passage-store)', () => {
+    // repoReal = <home>/.revealui contains <home>/.revealui/passage-store.
+    expect(() => assertGrantedRootBindable(join(HOME, '.revealui'), HOME)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('refuses the absolute NTFS mounts', () => {
+    // A root INSIDE the first NTFS mount (within direction), and the second mount
+    // itself (equal direction). Fixtures avoid the Windows-user and trailing-slash
+    // mount shapes the private-leak scanner flags — the refusal is identical for
+    // any path on those mounts.
+    expect(() => assertGrantedRootBindable('/mnt/c/project', HOME)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+    expect(() => assertGrantedRootBindable('/mnt/e', HOME)).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('does NOT refuse the normal case: a project root beneath the home', () => {
+    // The supported shape — ~/revfleet/<repo>. Must NOT throw.
+    expect(() => assertGrantedRootBindable(join(HOME, 'revfleet', 'revealui'), HOME)).not.toThrow();
+  });
+
+  it('does NOT refuse a sibling of the home that shares a name prefix (separator-safe)', () => {
+    // /base/op-scratch must not match /base/op via a naive startsWith.
+    expect(() => assertGrantedRootBindable('/base/op-scratch/repo', HOME)).not.toThrow();
+  });
+
+  it('does NOT refuse a repo whose name merely prefixes a secret name (.sshkeep)', () => {
+    // <home>/.sshkeep is not <home>/.ssh — separator-safe within() must not match.
+    expect(() => assertGrantedRootBindable(join(HOME, '.sshkeep'), HOME)).not.toThrow();
+  });
+
+  it('refuses a SYMLINKED secret dir via the realpath-if-exists form', async () => {
+    // Fixture: a real operator-home layout where <home>/.ssh -> <home>/real-ssh.
+    // A grant of the symlink TARGET (which is what requireRootAndDir realpaths to)
+    // must still be refused, even though the lexical secret entry is <home>/.ssh.
+    const home = await mkdtemp(join(tmpdir(), 'nb-symlink-'));
+    try {
+      const target = join(home, 'real-ssh');
+      await mkdir(target, { recursive: true });
+      await symlink(target, join(home, '.ssh'));
+      // realpath the target the same way requireRootAndDir would hand it in.
+      const repoReal = await realpath(target);
+      expect(() => assertGrantedRootBindable(repoReal, home)).toThrow(
+        /overlaps the never-bound secret path/,
+      );
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('neverBoundSet', () => {
+  it('materializes the home-relative secrets and absolute mounts', () => {
+    const set = neverBoundSet('/base/op');
+    for (const p of [
+      '/base/op/.ssh',
+      '/base/op/.age-identity',
+      '/base/op/.revealui/passage-store',
+      '/base/op/.config/gh',
+      '/base/op/.npmrc',
+      '/base/op/.aws',
+      '/base/op/.docker/config.json',
+      '/base/op/.claude',
+      '/mnt/c',
+      '/mnt/e',
+    ]) {
+      expect(set).toContain(p);
+    }
+  });
+
+  it('includes /run/user/<uid> when getuid is available', () => {
+    if (typeof process.getuid !== 'function') return;
+    const set = neverBoundSet('/base/op');
+    expect(set).toContain(`/run/user/${process.getuid()}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spawnConfined guard wiring — the backend refuses an overlapping root (GAP-320a)
+// ---------------------------------------------------------------------------
+
+describe('linuxBubblewrapBackend.spawnConfined — overlap guard', () => {
+  const backend = linuxBubblewrapBackend('/usr/bin/bwrap');
+  const base = {
+    cwd: '/base/op/.ssh',
+    agentHome: '/base/op/.local/share/revealui/agent-homes/deadbeef',
+    operatorHome: '/base/op',
+  };
+
+  it('refuses to build argv when the granted root overlaps a secret path', () => {
+    expect(() => backend.spawnConfined('bash', [], { ...base, repoReal: '/base/op/.ssh' })).toThrow(
+      /overlaps the never-bound secret path/,
+    );
+  });
+
+  it('still builds argv for a normal project root beneath the home', () => {
+    const { argv } = backend.spawnConfined('bash', [], {
+      repoReal: '/base/op/revfleet/repo',
+      cwd: '/base/op/revfleet/repo',
+      agentHome: base.agentHome,
+      operatorHome: base.operatorHome,
+    });
+    expect(argv).toContain('--bind');
+    expect(argv.join(' ')).toContain('--bind /base/op/revfleet/repo /base/op/revfleet/repo');
   });
 });

--- a/packages/daemon/src/__tests__/confinement.test.ts
+++ b/packages/daemon/src/__tests__/confinement.test.ts
@@ -35,7 +35,7 @@ describe('filterCallerEnv', () => {
   });
 
   it('rejects HOME by name (the escape the tmpfs would otherwise absorb)', () => {
-    expect(() => filterCallerEnv({ HOME: '/home/op' })).toThrow(/"HOME" is not caller-settable/);
+    expect(() => filterCallerEnv({ HOME: '/base/op' })).toThrow(/"HOME" is not caller-settable/);
   });
 
   it('rejects PATH', () => {
@@ -98,10 +98,10 @@ describe('buildConfinedEnv', () => {
 describe('linuxBubblewrapBackend.spawnConfined', () => {
   const backend = linuxBubblewrapBackend('/usr/bin/bwrap');
   const opts = {
-    repoReal: '/home/op/repo',
-    cwd: '/home/op/repo/packages/x',
-    agentHome: '/home/op/.local/share/revealui/agent-homes/deadbeef',
-    operatorHome: '/home/op',
+    repoReal: '/base/op/repo',
+    cwd: '/base/op/repo/packages/x',
+    agentHome: '/base/op/.local/share/revealui/agent-homes/deadbeef',
+    operatorHome: '/base/op',
   };
 
   it('execs bwrap, not the raw command', () => {
@@ -121,11 +121,11 @@ describe('linuxBubblewrapBackend.spawnConfined', () => {
   it('tmpfs-hides the operator home and re-binds only the granted root + agent home', () => {
     const { argv } = backend.spawnConfined('bash', [], opts);
     const s = argv.join(' ');
-    expect(s).toContain('--tmpfs /home/op');
+    expect(s).toContain('--tmpfs /base/op');
     expect(s).toContain(`--bind ${opts.repoReal} ${opts.repoReal}`);
     expect(s).toContain(`--bind ${opts.agentHome} ${opts.agentHome}`);
     // The operator-home tmpfs must come BEFORE the re-binds, or the binds get wiped.
-    const tmpfsIdx = argv.indexOf('/home/op'); // the --tmpfs operand
+    const tmpfsIdx = argv.indexOf('/base/op'); // the --tmpfs operand
     const repoBindIdx = argv.indexOf(opts.repoReal);
     expect(tmpfsIdx).toBeLessThan(repoBindIdx);
   });

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -387,11 +387,15 @@ describe('GAP-153: stale-session prune', () => {
       agentName: 'hard-delete-test',
       backend: 'test',
     });
-    await rpc(socketPath, 'session.end', {
-      actorAgentId: 'hard-delete-test',
-      sessionId: 'hard-delete-test',
-      summary: 'test end',
-    });
+    // session.end is signature-required and self-scopes to the signer, so it is
+    // signed as the session's own identity and passes no target.
+    const ender = await seedIdentity('hard-delete-test');
+    await signedRpc(
+      socketPath,
+      'session.end',
+      { summary: 'test end' },
+      { did: ender.did, fingerprint: ender.fingerprint, privateKeyPem: ender.privateKeyPem },
+    );
     await new Promise((r) => setTimeout(r, 1100));
 
     const result = (await rpc(socketPath, 'harness.prune', {

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -344,36 +344,43 @@ describe('GAP-153: stale-session prune', () => {
     expect(typeof health.prune?.lastDeletedCount).toBe('number');
   });
 
+  // harness.prune is signature-required (GAP-312). These tests sign the call,
+  // and because the threshold is now floored at 1 day they age rows by
+  // BACKDATING `started_at` / `ended_at` through the _db handle rather than by
+  // passing a sub-day threshold and sleeping. Backdating is both correct (it is
+  // what a genuinely stale session looks like) and faster (no real-time waits,
+  // no flake).
+
   it('ages out a session whose age exceeds the stale threshold', async () => {
-    // Register a stable-id session, then wait briefly so its started_at
-    // is older than the threshold we'll pass to prune.
     await rpc(socketPath, 'session.register', {
       agentId: 'stale-test',
       agentName: 'stale-test',
       backend: 'test',
     });
 
-    // Sanity: row is currently active in session.list (which filters
-    // to ended_at IS NULL).
+    // Sanity: row is active in session.list (filters to ended_at IS NULL).
     const before = (await rpc(socketPath, 'session.list')) as {
       sessions: Array<{ id: string }>;
     };
     expect(before.sessions.find((s) => s.id === 'stale-test')).toBeDefined();
 
-    await new Promise((r) => setTimeout(r, 1100));
+    // Make it genuinely stale: started 10 days ago.
+    await db.query(
+      "UPDATE agent_sessions SET started_at = NOW() - INTERVAL '10 days' WHERE id = $1",
+      ['stale-test'],
+    );
 
-    // staleDays = 0.00001 → ≈ 0.86s. With the 1.1s sleep above, the
-    // session is past the threshold.
-    const result = (await rpc(socketPath, 'harness.prune', {
-      staleDays: 0.00001,
-      hardDeleteDays: 365,
-    })) as { aged: number; deleted: number };
+    const pruner = await seedIdentity('pruner-stale');
+    const result = (await signedRpc(
+      socketPath,
+      'harness.prune',
+      { staleDays: 7, hardDeleteDays: 365 },
+      { did: pruner.did, fingerprint: pruner.fingerprint, privateKeyPem: pruner.privateKeyPem },
+    )) as { aged: number; deleted: number };
     expect(result.aged).toBeGreaterThanOrEqual(1);
     expect(result.deleted).toBe(0);
 
-    // After prune, the row is no longer in session.list (proof its
-    // ended_at + exit_summary were populated by runPrune; session.list
-    // hides any row with ended_at IS NOT NULL).
+    // After prune the row leaves session.list (its ended_at was populated).
     const after = (await rpc(socketPath, 'session.list')) as {
       sessions: Array<{ id: string }>;
     };
@@ -381,14 +388,12 @@ describe('GAP-153: stale-session prune', () => {
   });
 
   it('hard-deletes a session ended longer than hardDeleteDays', async () => {
-    // Register, end, then prune with a tiny hardDeleteDays.
     await rpc(socketPath, 'session.register', {
       agentId: 'hard-delete-test',
       agentName: 'hard-delete-test',
       backend: 'test',
     });
-    // session.end is signature-required and self-scopes to the signer, so it is
-    // signed as the session's own identity and passes no target.
+    // session.end is signature-required and self-scopes to the signer.
     const ender = await seedIdentity('hard-delete-test');
     await signedRpc(
       socketPath,
@@ -396,12 +401,19 @@ describe('GAP-153: stale-session prune', () => {
       { summary: 'test end' },
       { did: ender.did, fingerprint: ender.fingerprint, privateKeyPem: ender.privateKeyPem },
     );
-    await new Promise((r) => setTimeout(r, 1100));
+    // Backdate the end so it is older than hardDeleteDays.
+    await db.query(
+      "UPDATE agent_sessions SET ended_at = NOW() - INTERVAL '40 days' WHERE id = $1",
+      ['hard-delete-test'],
+    );
 
-    const result = (await rpc(socketPath, 'harness.prune', {
-      staleDays: 365,
-      hardDeleteDays: 0.00001,
-    })) as { aged: number; deleted: number };
+    const pruner = await seedIdentity('pruner-hard');
+    const result = (await signedRpc(
+      socketPath,
+      'harness.prune',
+      { staleDays: 365, hardDeleteDays: 30 },
+      { did: pruner.did, fingerprint: pruner.fingerprint, privateKeyPem: pruner.privateKeyPem },
+    )) as { aged: number; deleted: number };
 
     expect(result.deleted).toBeGreaterThanOrEqual(1);
 
@@ -412,7 +424,13 @@ describe('GAP-153: stale-session prune', () => {
   });
 
   it('harness.health reports prune state after a prune run', async () => {
-    await rpc(socketPath, 'harness.prune', { staleDays: 365, hardDeleteDays: 365 });
+    const pruner = await seedIdentity('pruner-health');
+    await signedRpc(
+      socketPath,
+      'harness.prune',
+      { staleDays: 365, hardDeleteDays: 365 },
+      { did: pruner.did, fingerprint: pruner.fingerprint, privateKeyPem: pruner.privateKeyPem },
+    );
     const health = (await rpc(socketPath, 'harness.health')) as {
       prune: { lastRunAt: string | null; lastAgedCount: number; lastDeletedCount: number };
     };
@@ -423,23 +441,60 @@ describe('GAP-153: stale-session prune', () => {
     expect(health.prune.lastDeletedCount).toBe(0);
   });
 
-  it('clamps negative thresholds to zero (defensive)', async () => {
-    // staleDays=0 → "older than NOW" → matches every session with
-    // ended_at IS NULL. We need at least one such session to verify
-    // the clamp is wider than negative-would-be (which Postgres
-    // semantics handle the same way as 0 here, but the explicit
-    // clamp is what we're checking the call doesn't error on).
+  // GAP-312 adversarial isolation. The prior test here ("clamps negative
+  // thresholds to zero (defensive)") asserted the VULNERABILITY as intended:
+  // it fired an UNSIGNED prune with staleDays: -100, expected it to succeed,
+  // and expected it to age every unended session. That is exactly the
+  // fleet-wide kill switch. It is replaced by the two properties the fix must
+  // hold. Both were shown red against the pre-fix handler before landing.
+
+  it('rejects an UNSIGNED harness.prune and evicts nothing (GAP-312)', async () => {
+    // A live session the attacker would try to reap.
     await rpc(socketPath, 'session.register', {
-      agentId: 'clamp-test',
-      agentName: 'clamp-test',
+      agentId: 'victim-unsigned',
+      agentName: 'victim-unsigned',
       backend: 'test',
     });
-    const result = (await rpc(socketPath, 'harness.prune', {
-      staleDays: -100,
-      hardDeleteDays: 365,
-    })) as { aged: number };
-    // Negative was clamped to 0 → matches all unended sessions.
-    expect(result.aged).toBeGreaterThanOrEqual(1);
+
+    // A valid-schema threshold, so this isolates the SIGNATURE gate rather than
+    // the floor: an unsigned caller is rejected with -32003 before the handler.
+    // (The staleDays: 0 exploit frame is covered by the floor test below, where
+    // the schema rejects it with -32602 first.)
+    await expect(
+      rpc(socketPath, 'harness.prune', { staleDays: 7, hardDeleteDays: 30 }),
+    ).rejects.toThrow(/-32003|[Ss]ignature required/);
+
+    // The victim is untouched: still active in session.list.
+    const listing = (await rpc(socketPath, 'session.list')) as {
+      sessions: Array<{ id: string }>;
+    };
+    expect(listing.sessions.find((s) => s.id === 'victim-unsigned')).toBeDefined();
+  });
+
+  it('rejects a SIGNED harness.prune with a sub-day threshold (GAP-312 floor)', async () => {
+    await rpc(socketPath, 'session.register', {
+      agentId: 'victim-floor',
+      agentName: 'victim-floor',
+      backend: 'test',
+    });
+
+    // Even a validly signed caller cannot select "every session": the schema
+    // floors staleDays at 1, so 0 (and any value < 1) is rejected as invalid
+    // params before the handler runs.
+    const pruner = await seedIdentity('pruner-floor');
+    await expect(
+      signedRpc(
+        socketPath,
+        'harness.prune',
+        { staleDays: 0 },
+        { did: pruner.did, fingerprint: pruner.fingerprint, privateKeyPem: pruner.privateKeyPem },
+      ),
+    ).rejects.toThrow();
+
+    const listing = (await rpc(socketPath, 'session.list')) as {
+      sessions: Array<{ id: string }>;
+    };
+    expect(listing.sessions.find((s) => s.id === 'victim-floor')).toBeDefined();
   });
 });
 

--- a/packages/daemon/src/__tests__/filegit-enrollment.test.ts
+++ b/packages/daemon/src/__tests__/filegit-enrollment.test.ts
@@ -14,6 +14,7 @@
  * pointed at a fixture (production writes it root-owned at install).
  */
 
+import { execFileSync } from 'node:child_process';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
@@ -119,6 +120,9 @@ describe('daemon enrollment gate + per-agent root scoping', () => {
     dataDir = await mkdtemp(join(tmpdir(), 'revdev-enroll-'));
     repoA = await mkdtemp(join(tmpdir(), 'revdev-enroll-repoA-'));
     repoB = await mkdtemp(join(tmpdir(), 'revdev-enroll-repoB-'));
+    // project.open now rejects a non-repo root (GAP-326 D1); make the fixtures repos.
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repoA });
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repoB });
     socketPath = join(dataDir, 'harness.sock');
     const anchor = join(dataDir, 'trusted-client-fingerprint');
     // Anchor trusts the (agentId, fingerprint) PAIRS of A and B but NOT evil.

--- a/packages/daemon/src/__tests__/filegit-neverbound-unit.test.ts
+++ b/packages/daemon/src/__tests__/filegit-neverbound-unit.test.ts
@@ -1,0 +1,227 @@
+/**
+ * GAP-326 — file-layer never-bound guards, UNIT coverage via the @internal
+ * seams (no socket): the D1/D3 registration-refusal matrix, the D2 resolution
+ * belt in isolation (a pre-fix persisted overlapping root seeded directly), and
+ * the D3 startup eviction of a persisted overlapping row.
+ *
+ * The end-to-end attack + regression live in filegit-neverbound.test.ts (real
+ * socket, no seams). This file drives the individual guards where a seam is the
+ * cheapest faithful surface.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, realpath, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGlite } from '@electric-sql/pglite';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture the eviction log line (D3) without a real logger. Only createLogger is
+// stubbed; every other logger export keeps its real implementation.
+const { warnCalls } = vi.hoisted(() => ({
+  warnCalls: [] as Array<{ msg: string; meta: unknown }>,
+}));
+vi.mock('@revealui/utils/logger', async (importActual) => {
+  const actual = await importActual<typeof import('@revealui/utils/logger')>();
+  const stub = (): Record<string, unknown> => ({
+    debug() {},
+    info() {},
+    error() {},
+    fatal() {},
+    warn(msg: string, meta?: unknown) {
+      warnCalls.push({ msg, meta });
+    },
+    child() {
+      return stub();
+    },
+  });
+  return { ...actual, createLogger: () => stub() };
+});
+
+import {
+  _addRootForTest,
+  _assertRootAvoidsNeverBoundForTest,
+  _clearRegisteredRootsForTest,
+  _resetNeverBoundForTest,
+  _resolveInRootForTest,
+  _setNeverBoundForTest,
+  restoreProjectRoots,
+} from '../filegit.js';
+import { MIGRATIONS } from '../migrations/index.js';
+import { migrate } from '../storage/migrate.js';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+// ---------------------------------------------------------------------------
+// D1/D3 registration-refusal matrix (pure — lexical fixtures, no fs)
+// ---------------------------------------------------------------------------
+
+describe('D1/D3 never-bound root gate — registration refusal matrix', () => {
+  const HOME = '/base/op';
+  const DATADIR = '/base/op/.local/share/revealui';
+
+  afterEach(() => _resetNeverBoundForTest());
+
+  it('refuses the operator home itself', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest(HOME)).toThrow(/operator home/);
+  });
+
+  it('refuses an ancestor of the operator home', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest('/base')).toThrow(/operator home/);
+  });
+
+  it('refuses a root that IS a secret path', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest(join(HOME, '.ssh'))).toThrow(
+      /never-bound secret path/,
+    );
+  });
+
+  it('refuses a root INSIDE a secret path', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest(join(HOME, '.ssh', 'sub'))).toThrow(
+      /never-bound secret path/,
+    );
+  });
+
+  it('refuses a root that CONTAINS a never-bound path (not the home itself)', () => {
+    // Home elsewhere so this isolates "never-bound inside root" from the home check:
+    // the root /base/proj contains the daemon data dir /base/proj/data.
+    _setNeverBoundForTest('/other/home', '/base/proj/data');
+    expect(() => _assertRootAvoidsNeverBoundForTest('/base/proj')).toThrow(
+      /never-bound secret path/,
+    );
+  });
+
+  it('names the CLASS, never the full secret path (no oracle back to a hostile caller)', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest(join(HOME, '.ssh'))).toThrow(/ssh keys/);
+    expect(() => _assertRootAvoidsNeverBoundForTest(join(HOME, '.ssh'))).not.toThrow(
+      /\/base\/op\/\.ssh/,
+    );
+  });
+
+  it('does NOT refuse a normal project root beneath the home', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest(join(HOME, 'revfleet', 'repo'))).not.toThrow();
+  });
+
+  it('is separator-safe: a sibling sharing a name prefix is not refused', () => {
+    _setNeverBoundForTest(HOME, DATADIR);
+    expect(() => _assertRootAvoidsNeverBoundForTest('/base/op-scratch/repo')).not.toThrow();
+    expect(() => _assertRootAvoidsNeverBoundForTest(join(HOME, '.sshkeep'))).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D2 resolution belt in isolation — a pre-fix overlapping root cannot resolve
+// a target onto the never-bound set (seed the root directly, bypassing D1).
+// ---------------------------------------------------------------------------
+
+describe('D2 resolution belt (isolation)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    _clearRegisteredRootsForTest();
+    root = await realpath(await mkdtemp(join(tmpdir(), 'revdev-nb-belt-')));
+    await mkdir(join(root, 'secrets'));
+    await writeFile(join(root, 'secrets', 'key.txt'), 'PRIVATE\n');
+    await writeFile(join(root, 'ok.txt'), 'fine\n');
+    // Simulate a pre-fix persisted row: register the overlapping root directly,
+    // bypassing project.open's D1 gate.
+    await _addRootForTest(root);
+    // Pin never-bound so <root>/secrets is a secret path (the daemon dataDir entry).
+    _setNeverBoundForTest('/no/such/home', join(root, 'secrets'));
+  });
+
+  afterEach(async () => {
+    _resetNeverBoundForTest();
+    _clearRegisteredRootsForTest();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('refuses a read target inside the never-bound set (mustExist=true)', async () => {
+    await expect(_resolveInRootForTest(root, 'secrets/key.txt', true)).rejects.toThrow(
+      /never-bound secret path/,
+    );
+  });
+
+  it('refuses a write target inside the never-bound set (mustExist=false)', async () => {
+    await expect(_resolveInRootForTest(root, 'secrets/new.txt', false)).rejects.toThrow(
+      /never-bound secret path/,
+    );
+  });
+
+  it('still resolves a legit target that does not overlap', async () => {
+    await expect(_resolveInRootForTest(root, 'ok.txt', true)).resolves.toBe(join(root, 'ok.txt'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D3 startup eviction — restoreProjectRoots evicts a persisted overlapping (or
+// non-repo) row, keeps the clean one, and logs each eviction.
+// ---------------------------------------------------------------------------
+
+describe('D3 startup re-validation (restoreProjectRoots eviction)', () => {
+  let db: PGlite;
+  let scratchDataDir: string;
+  let overlapRepo: string;
+  let cleanRepo: string;
+  let nonRepoRow: string;
+
+  beforeEach(async () => {
+    warnCalls.length = 0;
+    _clearRegisteredRootsForTest();
+    db = new PGlite();
+    await migrate(db, MIGRATIONS);
+
+    scratchDataDir = await realpath(await mkdtemp(join(tmpdir(), 'revdev-nb-evict-')));
+    // An active (not-ended) session so the rows are not treated as orphans.
+    await db.query(`INSERT INTO agent_sessions (id) VALUES ($1)`, ['evict-agent']);
+
+    overlapRepo = join(scratchDataDir, 'overlap-repo');
+    execFileSync('mkdir', ['-p', overlapRepo]);
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: overlapRepo });
+
+    cleanRepo = await realpath(await mkdtemp(join(tmpdir(), 'revdev-nb-clean-')));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: cleanRepo });
+
+    nonRepoRow = await realpath(await mkdtemp(join(tmpdir(), 'revdev-nb-nonrepo-')));
+
+    for (const p of [overlapRepo, cleanRepo, nonRepoRow]) {
+      const s = await stat(p);
+      await db.query(
+        `INSERT INTO project_roots (dev, ino, real_path, agent_id) VALUES ($1, $2, $3, $4)`,
+        [BigInt(s.dev), BigInt(s.ino), p, 'evict-agent'],
+      );
+    }
+
+    // Pin never-bound: <scratchDataDir> is the daemon data dir (never-bound), so
+    // overlapRepo (inside it) overlaps; cleanRepo / nonRepoRow do not.
+    _setNeverBoundForTest('/no/such/home', scratchDataDir);
+  });
+
+  afterEach(async () => {
+    _resetNeverBoundForTest();
+    _clearRegisteredRootsForTest();
+    await db.close().catch(() => {});
+    for (const p of [scratchDataDir, cleanRepo, nonRepoRow]) {
+      await rm(p, { recursive: true, force: true });
+    }
+  });
+
+  it('evicts the overlapping + non-repo rows, keeps the clean one, and logs each eviction', async () => {
+    await restoreProjectRoots(db);
+
+    const rows = await db.query<{ real_path: string }>(`SELECT real_path FROM project_roots`);
+    const survivors = rows.rows.map((r) => r.real_path);
+    expect(survivors).toContain(cleanRepo);
+    expect(survivors).not.toContain(overlapRepo);
+    expect(survivors).not.toContain(nonRepoRow);
+
+    const evictions = warnCalls.filter((c) => c.msg.includes('evicting persisted project root'));
+    expect(evictions.length).toBe(2);
+  });
+});

--- a/packages/daemon/src/__tests__/filegit-neverbound.test.ts
+++ b/packages/daemon/src/__tests__/filegit-neverbound.test.ts
@@ -1,0 +1,200 @@
+/**
+ * GAP-326 — file.* never-bound reachability, END-TO-END over a real signed
+ * socket (the prove-red attack + the registration/resolution refusals it must
+ * produce, plus a legit-repo regression control).
+ *
+ * The attack (gap description): a client-owned, verified signer project.open's a
+ * secret-bearing tree, then file.read's a secret inside it — no spawn, so the
+ * confinement never-bound guard never runs. This suite drives that attack
+ * through the daemon and proves it is refused at project.open (D1). The daemon
+ * data directory is itself a never-bound entry (it holds the integrity DB, the
+ * socket, the per-agent homes), so a git repo placed INSIDE dataDir is a
+ * self-contained secret-bearing tree that needs no real operator secret to
+ * exercise the guard. Reverting the source (confinement.ts + filegit.ts) makes
+ * both refusals disappear (project.open succeeds, the secret reads back) — that
+ * is the red-first proof this file carries. It uses ONLY the real RPC handlers,
+ * no @internal seams, so it runs unchanged against the pre-fix daemon.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { formatDid } from '@revdev/protocol/did';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  generateNonce,
+  hashParams,
+  serializeEnvelope,
+  signEnvelope,
+} from '../agent-identity-crypto.js';
+import { startDaemon } from '../server.js';
+// Side-effect import: registers project.open / file.* / git.* handlers.
+import '../filegit.js';
+
+// PGlite cold-init can exceed the 10s default hook budget under load.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+interface RpcResult {
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+function rpcFrame(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown>,
+  signature?: string,
+): Promise<RpcResult> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req: Record<string, unknown> = { jsonrpc: '2.0', id: 1, method, params };
+    if (signature) req['x-revdev-signature'] = signature;
+    sock.on('connect', () => sock.write(`${JSON.stringify(req)}\n`));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      sock.end();
+      try {
+        resolve(JSON.parse(buf.slice(0, nl)) as RpcResult);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error(`rpc timeout: ${method}`));
+    });
+  });
+}
+
+describe('GAP-326 file-layer never-bound reachability (end-to-end)', () => {
+  let daemon: { close: () => Promise<void> };
+  let socketPath: string;
+  let dataDir: string;
+  const agentId = 'gap326-e2e';
+
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid(agentId, fingerprint);
+
+  function sign(method: string, params: Record<string, unknown>): string {
+    const payload = {
+      did,
+      kid: fingerprint,
+      nonce: generateNonce(),
+      ts: Math.floor(Date.now() / 1000),
+      method,
+      paramsHash: hashParams(method, params),
+    };
+    return serializeEnvelope(signEnvelope(payload, kp.privateKeyPem));
+  }
+
+  function signedRpc(method: string, params: Record<string, unknown>): Promise<RpcResult> {
+    return rpcFrame(socketPath, method, params, sign(method, params));
+  }
+
+  /** git-init a directory so it passes the D1 non-repo check. */
+  function gitInit(dir: string): void {
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+    execFileSync('git', ['config', 'user.email', 'test@revdev.local'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'RevDev Test'], { cwd: dir });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+  }
+
+  beforeAll(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-gap326-'));
+    socketPath = join(dataDir, 'harness.sock');
+    const anchor = join(dataDir, 'trusted-client-fingerprint');
+    await writeFile(anchor, `${agentId}:${fingerprint}\n`);
+    daemon = await startDaemon({
+      socketPath,
+      dataDir,
+      trustedClientFingerprintPath: anchor,
+      trustedAnchorRequireRootOwned: false,
+    });
+    const reg = await rpcFrame(socketPath, 'session.register', {
+      agentId,
+      agentName: 'studio-ui',
+      backend: 'studio',
+      publicKeyPem: kp.publicKeyPem,
+    });
+    expect((reg.result as { did: string }).did).toBe(did);
+  });
+
+  afterAll(async () => {
+    await daemon.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it('REFUSES the never-bound attack: project.open a secret-bearing tree, then read a secret inside (prove-red)', async () => {
+    // The daemon data dir is a never-bound entry. A git repo placed inside it is
+    // a secret-bearing tree with no real operator secret involved.
+    const secretRepo = join(dataDir, 'secret-repo');
+    execFileSync('mkdir', ['-p', secretRepo]);
+    gitInit(secretRepo);
+    // A stand-in for ~/.ssh/id_ed25519 — the thing the attack wants to read.
+    await writeFile(join(secretRepo, 'id_ed25519'), 'PRIVATE-KEY-MATERIAL\n');
+
+    // D1: project.open must refuse a root that overlaps the never-bound set.
+    // (pre-fix: this SUCCEEDS — the attack's first step works.)
+    const open = await signedRpc('project.open', { repoPath: secretRepo });
+    expect(open.error).toBeDefined();
+    expect(open.error?.message ?? '').toContain('never-bound secret path');
+    // The class is named, the full secret path is NOT echoed back to the caller.
+    expect(open.error?.message ?? '').not.toContain('id_ed25519');
+
+    // The secret is therefore unreadable: the root was never registered.
+    // (pre-fix: project.open registered it and this returns the key material.)
+    const read = await signedRpc('file.read', { repoPath: secretRepo, filePath: 'id_ed25519' });
+    expect((read.result as { content?: string })?.content).toBeUndefined();
+    expect(read.error?.message ?? '').toContain('not registered');
+  });
+
+  it('REFUSES a non-repo root at project.open (makes the drifted comment true)', async () => {
+    // (pre-fix: registering a bare directory SUCCEEDED — file.* over an arbitrary
+    // tree.)
+    const bare = await mkdtemp(join(tmpdir(), 'revdev-gap326-bare-'));
+    try {
+      const open = await signedRpc('project.open', { repoPath: bare });
+      expect(open.error).toBeDefined();
+      expect(open.error?.message ?? '').toContain('not a git repository');
+    } finally {
+      await rm(bare, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves a legit repo root unaffected: open + file.write/read + git.status all succeed (regression)', async () => {
+    // A normal project root (a sibling of dataDir under /tmp, not overlapping any
+    // never-bound entry) must behave exactly as before.
+    const legit = await mkdtemp(join(tmpdir(), 'revdev-gap326-legit-'));
+    try {
+      gitInit(legit);
+      const open = await signedRpc('project.open', { repoPath: legit });
+      expect((open.result as { success: boolean }).success).toBe(true);
+
+      const w = await signedRpc('file.write', {
+        repoPath: legit,
+        filePath: 'note.txt',
+        content: 'hello',
+      });
+      expect((w.result as { success: boolean }).success).toBe(true);
+
+      const r = await signedRpc('file.read', { repoPath: legit, filePath: 'note.txt' });
+      expect((r.result as { content: string }).content).toBe('hello');
+      // And it actually hit ext4.
+      expect(await readFile(join(legit, 'note.txt'), 'utf8')).toBe('hello');
+
+      const st = await signedRpc('git.status', { repoPath: legit });
+      expect((st.result as { success: boolean }).success).toBe(true);
+    } finally {
+      await rm(legit, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/daemon/src/__tests__/filegit-signed.test.ts
+++ b/packages/daemon/src/__tests__/filegit-signed.test.ts
@@ -13,6 +13,7 @@
  * side): produce envelopes byte-compatible with what this test sends.
  */
 
+import { execFileSync } from 'node:child_process';
 import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
@@ -105,6 +106,8 @@ describe('Studio client-key signing (zero-9P P1)', () => {
   beforeAll(async () => {
     dataDir = await mkdtemp(join(tmpdir(), 'revdev-signed-'));
     repo = await mkdtemp(join(tmpdir(), 'revdev-signed-repo-'));
+    // project.open now rejects a non-repo root (GAP-326 D1); make the fixture a repo.
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo });
     socketPath = join(dataDir, 'harness.sock');
     // Trust anchor: provision THIS client's fingerprint so enrollment is
     // allowed (the production install writes this root-owned; the test points

--- a/packages/daemon/src/__tests__/neon-sync.test.ts
+++ b/packages/daemon/src/__tests__/neon-sync.test.ts
@@ -12,23 +12,60 @@ import { vi } from 'vitest';
 
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { formatDid } from '@revdev/protocol/did';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  generateNonce,
+  hashParams,
+  serializeEnvelope,
+  signEnvelope,
+} from '../agent-identity-crypto.js';
 import { _resetForTesting, setNeonClientForTesting } from '../neon.js';
 import { startDaemon } from '../server.js';
+
+/**
+ * `session.end` is signature-required (it evicts roots and kills PTYs), so the
+ * test that exercises its Neon dual-write has to sign like a real client.
+ */
+function makeSigner(agentId: string) {
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid(agentId, fingerprint);
+  const sign = (method: string, params: Record<string, unknown>): string =>
+    serializeEnvelope(
+      signEnvelope(
+        {
+          did,
+          kid: fingerprint,
+          nonce: generateNonce(),
+          ts: Math.floor(Date.now() / 1000),
+          method,
+          paramsHash: hashParams(method, params),
+        },
+        kp.privateKeyPem,
+      ),
+    );
+  return { agentId, fingerprint, publicKeyPem: kp.publicKeyPem, sign };
+}
 
 function rpc(
   socketPath: string,
   method: string,
   params: Record<string, unknown> = {},
+  signature?: string,
 ): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const sock: Socket = connect(socketPath);
     let buf = '';
-    const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
+    const frame: Record<string, unknown> = { jsonrpc: '2.0', id: 1, method, params };
+    if (signature) frame['x-revdev-signature'] = signature;
+    const req = `${JSON.stringify(frame)}\n`;
     sock.on('connect', () => sock.write(req));
     sock.on('data', (d) => {
       buf += d.toString();
@@ -57,6 +94,9 @@ interface RecordedCall {
   values: unknown[];
 }
 
+/** Client-owned identity used by the signature-required session.end test. */
+const ender = makeSigner('sync-test-4');
+
 let dataDir: string;
 let socketPath: string;
 let close: () => Promise<void>;
@@ -70,8 +110,17 @@ beforeAll(async () => {
   setTestLicenseEnv(generateTestLicense('enterprise'));
   dataDir = await mkdtemp(join(tmpdir(), 'revdev-neon-'));
   socketPath = join(dataDir, 'harness.sock');
+  // Provision the signer's fingerprint so it can enroll a client-owned key.
+  const anchor = join(dataDir, 'trusted-client-fingerprint');
+  await writeFile(anchor, `${ender.agentId}:${ender.fingerprint}\n`);
   // Disable periodic prune so it doesn't touch the test DB unexpectedly.
-  const d = await startDaemon({ socketPath, dataDir, pruneIntervalMs: 0 });
+  const d = await startDaemon({
+    socketPath,
+    dataDir,
+    pruneIntervalMs: 0,
+    trustedClientFingerprintPath: anchor,
+    trustedAnchorRequireRootOwned: false,
+  });
   close = d.close;
 });
 
@@ -170,18 +219,19 @@ describe('GAP-154: daemon → Neon dual-write wiring', () => {
   });
 
   it('session.end triggers UPDATE setting ended_at + status=ended + summary in metadata', async () => {
+    // Register the client-owned key so the daemon can verify the signature.
     await rpc(socketPath, 'session.register', {
-      agentId: 'sync-test-4',
-      agentName: 'sync-test-4',
+      agentId: ender.agentId,
+      agentName: ender.agentId,
       backend: 'test',
+      publicKeyPem: ender.publicKeyPem,
     });
     recordedCalls = [];
 
-    await rpc(socketPath, 'session.end', {
-      actorAgentId: 'sync-test-4',
-      sessionId: 'sync-test-4',
-      summary: 'all done',
-    });
+    // session.end is signature-required and self-scopes to the signer, so no
+    // sessionId is passed: the signer IS the target.
+    const endParams = { summary: 'all done' };
+    await rpc(socketPath, 'session.end', endParams, ender.sign('session.end', endParams));
 
     expect(recordedCalls.length).toBe(1);
     const [endRecord] = recordedCalls;

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -60,6 +60,9 @@ const SIGNED = [
   // session.end evicts the target's roots and kills its PTYs, and is self-scoped
   // to the verified signer. Signature-required so the signer IS the target.
   'session.end',
+  // harness.prune reaches the same eviction primitive as session.end but fans
+  // it across every matched session. Was unsigned + identity-exempt (GAP-312).
+  'harness.prune',
 ];
 
 // Only payload-free, repo-agnostic coordination methods stay signature-OPTIONAL.

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -57,6 +57,9 @@ const SIGNED = [
   'agent.input',
   'agent.resize',
   'agent.output',
+  // session.end evicts the target's roots and kills its PTYs, and is self-scoped
+  // to the verified signer. Signature-required so the signer IS the target.
+  'session.end',
 ];
 
 // Only payload-free, repo-agnostic coordination methods stay signature-OPTIONAL.

--- a/packages/daemon/src/__tests__/signature-telemetry.test.ts
+++ b/packages/daemon/src/__tests__/signature-telemetry.test.ts
@@ -254,9 +254,14 @@ describe('P2 signature-status telemetry', () => {
        VALUES ($1, 'identity.signature_status', '{}'::jsonb, NOW())`,
       ['prune-fresh-marker'],
     );
-    // harness.prune is IDENTITY_EXEMPT — no signature needed. Default
-    // hardDeleteDays is 30, so the 40-day row is dropped, the fresh one kept.
-    await rpcFrame(socketPath, 'harness.prune', {});
+    // harness.prune is signature-required (GAP-312), so it must be signed.
+    // Default hardDeleteDays is 30, so the 40-day row is dropped, fresh kept.
+    await rpcFrame(
+      socketPath,
+      'harness.prune',
+      {},
+      sign('harness.prune', {}, did, fingerprint, kp.privateKeyPem),
+    );
     const remaining = await db.query<{ agent_id: string }>(
       `SELECT agent_id FROM events
         WHERE event_type = 'identity.signature_status'

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -323,7 +323,7 @@ describe('agent.spawn', () => {
       signedRpc(owner, 'agent.spawn', {
         command: 'bash',
         repoPath: repoRoot,
-        env: { HOME: '/home/op' },
+        env: { HOME: '/base/op' },
       }),
     ).rejects.toThrow(/not caller-settable/);
   });

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -74,6 +74,7 @@ vi.mock('node-pty', () => ({
 // Imports (after mock declarations)
 // ---------------------------------------------------------------------------
 
+import { execFileSync } from 'node:child_process';
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
@@ -235,6 +236,9 @@ beforeAll(async () => {
   // signer cannot spawn into a root it neither owns nor was granted.
   repoRoot = await mkdtemp(join(tmpdir(), 'revdev-spawn-root-'));
   otherRoot = await mkdtemp(join(tmpdir(), 'revdev-spawn-otherroot-'));
+  // project.open now rejects a non-repo root (GAP-326 D1); make the fixtures repos.
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: otherRoot });
   await signedRpc(owner, 'project.open', { repoPath: repoRoot });
   await signedRpc(other, 'project.open', { repoPath: otherRoot });
 });

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -78,6 +78,7 @@ import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { PGlite } from '@electric-sql/pglite';
 import { formatDid } from '@revdev/protocol/did';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import {
@@ -173,6 +174,7 @@ const other = makeSigner('spawn-test-other');
 let dataDir: string;
 let socketPath: string;
 let close: () => Promise<void>;
+let db: PGlite;
 /** A project root `owner` opens; agent.spawn now authorizes against it. */
 let repoRoot: string;
 /** A root owned by `other`, used to prove cross-agent spawn is refused. */
@@ -190,6 +192,13 @@ async function signedRpc(
 }
 
 beforeAll(async () => {
+  // These tests exercise the signature gate, ownership, and project-grant
+  // authorization — NOT the OS sandbox (that is proven with real bwrap in
+  // confinement-integration.test.ts). node-pty is mocked here, so an actual
+  // bwrap wrap is neither observable nor desirable, and the daemon must not
+  // fail closed on a CI runner without bwrap. Run these under the operator
+  // escape hatch: spawns are unconfined and record confinement='none'.
+  process.env.REVDEV_SPAWN_CONFINEMENT = 'none';
   setTestLicenseEnv(generateTestLicense('enterprise'));
   dataDir = await mkdtemp(join(tmpdir(), 'revdev-spawn-test-'));
   socketPath = join(dataDir, 'harness.sock');
@@ -206,6 +215,7 @@ beforeAll(async () => {
     trustedAnchorRequireRootOwned: false,
   });
   close = d.close;
+  db = d._db;
 
   // Persist each client's public key so the daemon can Ed25519-verify their
   // signed agent.* calls (the trust anchor only holds the fingerprint). One-time
@@ -233,6 +243,7 @@ afterAll(async () => {
   await close?.();
   await rm(dataDir, { recursive: true, force: true });
   clearTestLicenseEnv();
+  delete process.env.REVDEV_SPAWN_CONFINEMENT;
 });
 
 beforeEach(() => {
@@ -285,6 +296,46 @@ describe('agent.spawn', () => {
         cwd: join(repoRoot, 'nonexistent', 'does-not-exist'),
       }),
     ).rejects.toThrow();
+  });
+
+  // Under the escape hatch a spawn is unconfined, but it leaves a receipt: the
+  // audit row records confinement='none' (spec §8.1).
+  it("records confinement='none' on the row under the escape hatch", async () => {
+    const { processId } = (await signedRpc(owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+    })) as { processId: string };
+    const row = await db.query<{ confinement: string | null }>(
+      `SELECT confinement FROM agent_processes WHERE id = $1`,
+      [processId],
+    );
+    expect(row.rows[0]?.confinement).toBe('none');
+    // Release the live-count slot — mock ptys never exit on their own, and the
+    // per-agent cap (10) is shared across every owner spawn in this file.
+    _lastPty?._fireExit(0);
+  });
+
+  // The env allow-list (spec §7) runs regardless of confinement mode, so it is
+  // enforced even under the escape hatch. A non-allow-listed key is rejected by
+  // name (§10 test 3).
+  it('rejects a caller env key outside the allow-list', async () => {
+    await expect(
+      signedRpc(owner, 'agent.spawn', {
+        command: 'bash',
+        repoPath: repoRoot,
+        env: { HOME: '/home/op' },
+      }),
+    ).rejects.toThrow(/not caller-settable/);
+  });
+
+  it('accepts an allow-listed caller env key (TERM)', async () => {
+    const result = (await signedRpc(owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+      env: { TERM: 'screen-256color' },
+    })) as { processId: string };
+    expect(typeof result.processId).toBe('string');
+    _lastPty?._fireExit(0);
   });
 });
 

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -64,31 +64,17 @@ vi.mock('node-pty', () => ({
   }),
 }));
 
-// ---------------------------------------------------------------------------
-// Mock node:fs/promises stat so cwd validation passes for /tmp paths
-// ---------------------------------------------------------------------------
-
-vi.mock('node:fs/promises', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs/promises')>();
-  return {
-    ...actual,
-    stat: vi.fn(async (p: string) => {
-      if (p === '/tmp' || (p.startsWith('/tmp/') && !p.includes('nonexistent'))) {
-        return { isDirectory: () => true };
-      }
-      const err = Object.assign(new Error(`ENOENT: no such file or directory, stat '${p}'`), {
-        code: 'ENOENT',
-      });
-      throw err;
-    }),
-  };
-});
+// `node:fs/promises` is deliberately NOT mocked. agent.spawn now authorizes its
+// cwd against a registered project root, and that check rests on real inode
+// identity (dev/ino) and real symlink resolution. A stubbed `stat` would fake
+// the filesystem the security boundary is built on, so these tests use real
+// temp directories instead.
 
 // ---------------------------------------------------------------------------
 // Imports (after mock declarations)
 // ---------------------------------------------------------------------------
 
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -187,6 +173,10 @@ const other = makeSigner('spawn-test-other');
 let dataDir: string;
 let socketPath: string;
 let close: () => Promise<void>;
+/** A project root `owner` opens; agent.spawn now authorizes against it. */
+let repoRoot: string;
+/** A root owned by `other`, used to prove cross-agent spawn is refused. */
+let otherRoot: string;
 
 /** Signed RPC that throws on error (the common happy-path wrapper). */
 async function signedRpc(
@@ -229,6 +219,14 @@ beforeAll(async () => {
     });
     if (reg.error) throw new Error(`register ${s.agentId} failed: ${reg.error.message}`);
   }
+
+  // agent.spawn authorizes its cwd against a registered project root, so each
+  // identity opens one. `owner` drives the happy paths; `otherRoot` proves a
+  // signer cannot spawn into a root it neither owns nor was granted.
+  repoRoot = await mkdtemp(join(tmpdir(), 'revdev-spawn-root-'));
+  otherRoot = await mkdtemp(join(tmpdir(), 'revdev-spawn-otherroot-'));
+  await signedRpc(owner, 'project.open', { repoPath: repoRoot });
+  await signedRpc(other, 'project.open', { repoPath: otherRoot });
 });
 
 afterAll(async () => {
@@ -248,7 +246,10 @@ beforeEach(() => {
 
 describe('signature gate', () => {
   it('rejects an UNSIGNED agent.spawn (no Ed25519 envelope)', async () => {
-    const resp = await rpcFrame(socketPath, 'agent.spawn', { command: 'bash', cwd: '/tmp' });
+    const resp = await rpcFrame(socketPath, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+    });
     // The dispatch gate refuses a MUTATING_OR_CONTENT_METHODS call that is not
     // signature-verified — the unsigned host process can no longer exec as the
     // daemon UID. No processId is returned.
@@ -262,7 +263,7 @@ describe('agent.spawn', () => {
     const result = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
       args: ['-i'],
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string; pid: number };
 
     expect(result.processId).toMatch(
@@ -273,16 +274,113 @@ describe('agent.spawn', () => {
   });
 
   it('rejects when command is missing (schema validation)', async () => {
-    await expect(signedRpc(owner, 'agent.spawn', { cwd: '/tmp' })).rejects.toThrow();
+    await expect(signedRpc(owner, 'agent.spawn', { repoPath: repoRoot })).rejects.toThrow();
   });
 
   it('rejects a nonexistent cwd', async () => {
     await expect(
       signedRpc(owner, 'agent.spawn', {
         command: 'bash',
-        cwd: '/tmp/nonexistent/does-not-exist',
+        repoPath: repoRoot,
+        cwd: join(repoRoot, 'nonexistent', 'does-not-exist'),
       }),
     ).rejects.toThrow();
+  });
+});
+
+describe('agent.spawn authorization (project grant)', () => {
+  it('rejects when repoPath is absent — no implicit $HOME cwd', async () => {
+    await expect(signedRpc(owner, 'agent.spawn', { command: 'bash' })).rejects.toThrow();
+  });
+
+  it('rejects an unregistered repoPath', async () => {
+    const stray = await mkdtemp(join(tmpdir(), 'revdev-spawn-stray-'));
+    try {
+      await expect(
+        signedRpc(owner, 'agent.spawn', { command: 'bash', repoPath: stray }),
+      ).rejects.toThrow(/not registered/);
+    } finally {
+      await rm(stray, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects spawning into another agent's root", async () => {
+    await expect(
+      signedRpc(owner, 'agent.spawn', { command: 'bash', repoPath: otherRoot }),
+    ).rejects.toThrow(/not registered/);
+  });
+
+  it('allows spawning into another agent root once granted, and refuses after revoke', async () => {
+    await signedRpc(other, 'project.grant', {
+      repoPath: otherRoot,
+      granteeAgentId: owner.agentId,
+    });
+
+    const granted = (await signedRpc(owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: otherRoot,
+    })) as { processId: string };
+    expect(typeof granted.processId).toBe('string');
+
+    await signedRpc(other, 'project.revoke', {
+      repoPath: otherRoot,
+      granteeAgentId: owner.agentId,
+    });
+
+    await expect(
+      signedRpc(owner, 'agent.spawn', { command: 'bash', repoPath: otherRoot }),
+    ).rejects.toThrow(/not registered/);
+  });
+
+  // `join()` normalizes the `..` away, so this string never contains one: the
+  // schema's safePath refinement cannot see it and the HANDLER's within() check
+  // is what rejects it. Pinned to that message so it cannot pass for some other
+  // reason (e.g. a missing directory).
+  it('rejects a cwd that resolves outside the authorized root', async () => {
+    await expect(
+      signedRpc(owner, 'agent.spawn', {
+        command: 'bash',
+        repoPath: repoRoot,
+        cwd: join(repoRoot, '..'),
+      }),
+    ).rejects.toThrow(/escapes project root/);
+  });
+
+  // The unnormalized form does carry a literal `..`, and is refused earlier, at
+  // schema validation. Both layers are exercised.
+  it('rejects a literal .. in cwd at the schema boundary', async () => {
+    await expect(
+      signedRpc(owner, 'agent.spawn', {
+        command: 'bash',
+        repoPath: repoRoot,
+        cwd: `${repoRoot}/../etc`,
+      }),
+    ).rejects.toThrow(/Invalid params/);
+  });
+
+  it('rejects a cwd symlink pointing outside the authorized root', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'revdev-spawn-outside-'));
+    const link = join(repoRoot, 'escape-link');
+    try {
+      await symlink(outside, link, 'dir');
+      await expect(
+        signedRpc(owner, 'agent.spawn', { command: 'bash', repoPath: repoRoot, cwd: link }),
+      ).rejects.toThrow(/escapes project root/);
+    } finally {
+      await rm(link, { force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a real subdirectory of the authorized root', async () => {
+    const sub = join(repoRoot, 'packages', 'nested');
+    await mkdir(sub, { recursive: true });
+    const result = (await signedRpc(owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+      cwd: sub,
+    })) as { processId: string };
+    expect(typeof result.processId).toBe('string');
   });
 });
 
@@ -290,7 +388,7 @@ describe('agent.input', () => {
   it('writes data to the mocked pty', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     const result = await signedRpc(owner, 'agent.input', {
@@ -305,7 +403,7 @@ describe('agent.input', () => {
   it('rejects input to a process owned by another agent', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     await expect(
@@ -321,7 +419,7 @@ describe('agent.resize', () => {
   it('calls pty.resize with the given dimensions', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     const result = (await signedRpc(owner, 'agent.resize', {
@@ -339,7 +437,7 @@ describe('agent.resize', () => {
   it('rejects resize for a process owned by another agent', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     await expect(
@@ -356,7 +454,7 @@ describe('agent.stop', () => {
   it('kills the mocked pty and returns status killed', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     const result = (await signedRpc(owner, 'agent.stop', {
@@ -371,7 +469,7 @@ describe('agent.stop', () => {
   it('rejects stop for a process owned by another agent', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     await expect(
@@ -394,7 +492,7 @@ describe('agent.output', () => {
   it('returns buffered chunks and a cursor', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     _lastPty?._fireData('hello world\r\n');
@@ -422,7 +520,7 @@ describe('agent.output', () => {
   it('rejects output poll for a process owned by another agent', async () => {
     const { processId } = (await signedRpc(owner, 'agent.spawn', {
       command: 'bash',
-      cwd: '/tmp',
+      repoPath: repoRoot,
     })) as { processId: string };
 
     await expect(

--- a/packages/daemon/src/__tests__/validation.test.ts
+++ b/packages/daemon/src/__tests__/validation.test.ts
@@ -352,12 +352,27 @@ describe('harness.prune validation', () => {
     expect(validateParams('harness.prune', { staleDays: 7, hardDeleteDays: 30 }).valid).toBe(true);
   });
 
-  it('accepts fractional days (test helpers use these to avoid long sleeps)', () => {
-    expect(validateParams('harness.prune', { staleDays: 0.00001 }).valid).toBe(true);
+  it('accepts a fractional threshold >= 1 day', () => {
+    // The floor is 1, not "integer". A fractional day at or above the floor is
+    // harmless, and keeping the constraint minimal is intentional.
+    expect(validateParams('harness.prune', { staleDays: 1.5 }).valid).toBe(true);
   });
 
-  it('accepts negative days (handler defensive clamp is the safety net)', () => {
-    expect(validateParams('harness.prune', { staleDays: -1, hardDeleteDays: -7 }).valid).toBe(true);
+  it('REJECTS a sub-day staleDays (GAP-312 floor)', () => {
+    // staleDays: 0.00001 selected ≈0.86s of age, and staleDays: 0 selected
+    // every live session. The schema floors at 1 day so neither reaches the
+    // handler. Test helpers that once shrank time now backdate started_at.
+    expect(validateParams('harness.prune', { staleDays: 0.00001 }).valid).toBe(false);
+    expect(validateParams('harness.prune', { staleDays: 0 }).valid).toBe(false);
+  });
+
+  it('REJECTS negative days (GAP-312 floor; no clamp-to-zero)', () => {
+    // Previously accepted on the theory that the handler's Math.max(0, ...) was
+    // "the safety net". A zero floor is not a net: it is the fleet-wide
+    // selector. Rejected at the boundary now.
+    expect(validateParams('harness.prune', { staleDays: -1, hardDeleteDays: -7 }).valid).toBe(
+      false,
+    );
   });
 
   it('rejects non-numeric staleDays', () => {

--- a/packages/daemon/src/confinement.ts
+++ b/packages/daemon/src/confinement.ts
@@ -51,6 +51,15 @@ export interface ConfinementOpts {
   agentHome: string;
   /** The operator's real home; tmpfs'd to hide everything beneath it. */
   operatorHome: string;
+  /**
+   * The daemon data directory (`getDaemonConfig().dataDir`, default
+   * `~/.local/share/revealui`). Never-bound: it holds the PGlite integrity DB
+   * (grants, identities, roots), the control socket, and the per-agent homes —
+   * a confined agent that could read/write it could rewrite its own
+   * authorization state. A specific per-agent home subdir IS bound (that is the
+   * agent's own home); the guard only refuses a GRANTED ROOT overlapping dataDir.
+   */
+  dataDir: string;
 }
 
 export interface ConfinementResult {
@@ -239,18 +248,25 @@ const NEVER_BOUND_ABSOLUTE = ['/mnt/c', '/mnt/e'] as const;
 
 /**
  * Materialize spec §4.3's never-bound secret set for this host, from the
- * operator home. Each entry is carried in two forms: its lexical path, and its
- * realpath WHEN the entry exists (realpath-if-exists). Rationale: `repoReal`
- * arrives already realpath'd (requireRootAndDir), so a lexical-only compare
- * misses a secret directory that is itself a symlink (`~/.ssh -> /data/ssh`).
- * Entries absent on this host stay lexical-only. Computed per spawn (a handful
- * of joins plus at most a few stats), so a secret path or symlink that appears
- * after daemon start is guarded without a restart. Zero authored regex.
+ * operator home and the daemon data directory. Each entry is carried in two
+ * forms: its lexical path, and its realpath WHEN the entry exists
+ * (realpath-if-exists). Rationale: `repoReal` arrives already realpath'd
+ * (requireRootAndDir), so a lexical-only compare misses a secret directory that
+ * is itself a symlink (`~/.ssh -> /data/ssh`). Entries absent on this host stay
+ * lexical-only. Computed per spawn (a handful of joins plus at most a few
+ * stats), so a secret path or symlink that appears after daemon start is guarded
+ * without a restart. Zero authored regex.
+ *
+ * `dataDir` is included because it holds the daemon's integrity DB, control
+ * socket, and per-agent homes (the authorization state itself); it is often but
+ * not always under the operator home, so it gets its own entry regardless of
+ * where it is configured.
  */
-export function neverBoundSet(operatorHome: string): string[] {
+export function neverBoundSet(operatorHome: string, dataDir: string): string[] {
   const lexical: string[] = [
     ...NEVER_BOUND_HOME_RELATIVE.map((p) => join(operatorHome, p)),
     ...NEVER_BOUND_ABSOLUTE,
+    dataDir,
   ];
   // /run/user/<uid> carries the ssh-agent socket (spec §4.3).
   if (typeof process.getuid === 'function') {
@@ -284,7 +300,11 @@ export function neverBoundSet(operatorHome: string): string[] {
  * @throws naming the granted root, the colliding path, and the reason. Both are
  *   operator-known material (their own home layout), so naming them is not an oracle.
  */
-export function assertGrantedRootBindable(repoReal: string, operatorHome: string): void {
+export function assertGrantedRootBindable(
+  repoReal: string,
+  operatorHome: string,
+  dataDir: string,
+): void {
   // repoReal IS the home, or is an ANCESTOR of it (e.g. `/base` over `/base/op`):
   // the tmpfs-then-bind sequence would re-expose the entire home read-write.
   if (repoReal === operatorHome || within(repoReal, operatorHome)) {
@@ -292,7 +312,7 @@ export function assertGrantedRootBindable(repoReal: string, operatorHome: string
       `agent.spawn: refusing to bind granted root "${repoReal}" — it is or contains the operator home "${operatorHome}" (confinement would re-expose the entire home read-write). Grant a project root beneath the home, not the home itself.`,
     );
   }
-  for (const nb of neverBoundSet(operatorHome)) {
+  for (const nb of neverBoundSet(operatorHome, dataDir)) {
     // within(repoReal, nb): the secret lives INSIDE the granted root (bind exposes it).
     // within(nb, repoReal): the granted root IS or lives INSIDE a secret path.
     if (within(repoReal, nb) || within(nb, repoReal)) {
@@ -340,12 +360,12 @@ export function linuxBubblewrapBackend(bwrapAbs: string): ConfinementBackend {
   return {
     name: 'linux-bubblewrap',
     spawnConfined(command, args, opts): ConfinementResult {
-      const { repoReal, cwd, agentHome, operatorHome } = opts;
+      const { repoReal, cwd, agentHome, operatorHome, dataDir } = opts;
 
-      // Refuse a granted root that overlaps a secret path or the operator home
-      // BEFORE any argv is assembled — the invariant lives next to the bind
-      // sequence that creates the hazard (GAP-320a, spec §4.3).
-      assertGrantedRootBindable(repoReal, operatorHome);
+      // Refuse a granted root that overlaps a secret path, the operator home, or
+      // the daemon data dir BEFORE any argv is assembled — the invariant lives
+      // next to the bind sequence that creates the hazard (GAP-320a, spec §4.3).
+      assertGrantedRootBindable(repoReal, operatorHome, dataDir);
 
       const a: string[] = [];
 

--- a/packages/daemon/src/confinement.ts
+++ b/packages/daemon/src/confinement.ts
@@ -1,0 +1,387 @@
+/**
+ * agent.spawn confinement — the kernel boundary (Phase 1).
+ *
+ * Spec: `.jv` docs/specs/2026-07-10-agent-spawn-confinement-phase-1.md (GAP-288).
+ *
+ * A verified, authorized `agent.spawn` still runs as the daemon UID with the
+ * daemon's entire filesystem view. Env-scoping (a curated HOME + minimal PATH)
+ * does NOT contain it: `open("/home/<op>/.ssh/id")` never consults $HOME, so a
+ * deliberate reader ignores it. The only real boundary is an OS one.
+ *
+ * This module resolves the actual argv handed to node-pty. On Linux and WSL2 it
+ * wraps the command in `bwrap` (bubblewrap) with a deny-by-default bind set:
+ * nothing is visible inside the sandbox unless explicitly bound, and the
+ * operator's home is tmpfs'd so `~/.ssh`, `~/.age-identity`, and the revvault
+ * store are gone. On platforms with no backend it FAILS CLOSED — a caller can
+ * never tell an absent sandbox from a broken one, so the absent case refuses.
+ *
+ * Confinement does NOT replace authorization. `requireDirInRoot` still decides
+ * WHICH root is bound; a defect here must never grant a root the caller was not
+ * granted (spec §4.2 invariant 3).
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, realpathSync, statSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createLogger } from '@revealui/utils/logger';
+
+const log = createLogger({ service: 'revdev-daemon/confinement' });
+
+// ---------------------------------------------------------------------------
+// Backend interface
+// ---------------------------------------------------------------------------
+
+export interface ConfinementOpts {
+  /** Realpath'd granted root (from requireRootAndDir) — bound read-write. */
+  repoReal: string;
+  /** Directory the sandboxed process starts in (at or beneath repoReal). */
+  cwd: string;
+  /** Per-agent persistent home (§5), bound read-write; HOME points here. */
+  agentHome: string;
+  /** The operator's real home; tmpfs'd to hide everything beneath it. */
+  operatorHome: string;
+}
+
+export interface ConfinementResult {
+  /** The binary node-pty execs: the resolved bwrap abspath (confined), or the raw command (escape hatch). */
+  file: string;
+  /** Full argv. For bwrap: every sandbox flag, then `--`, then command + args. */
+  argv: string[];
+}
+
+export interface ConfinementBackend {
+  readonly name: string;
+  spawnConfined(command: string, args: string[], opts: ConfinementOpts): ConfinementResult;
+}
+
+// ---------------------------------------------------------------------------
+// bwrap resolution — once, to an absolute realpath, verified trustworthy
+// ---------------------------------------------------------------------------
+
+const BWRAP_CANDIDATE = '/usr/bin/bwrap';
+
+/**
+ * Resolve `bwrap` to an absolute realpath and verify it is root-owned and not
+ * group- or other-writable (spec §4.2 invariant 1). Never resolved through a
+ * caller-influenced PATH — a bare-name reference is shadowable, so the parent
+ * spec's finding forbids it. Returns the abspath, or null if bwrap is absent,
+ * not a regular file, not root-owned, or writable by non-root.
+ */
+export function resolveBwrapAbsPath(candidate: string = BWRAP_CANDIDATE): string | null {
+  let real: string;
+  try {
+    real = realpathSync(candidate);
+  } catch {
+    return null;
+  }
+  let st: ReturnType<typeof statSync>;
+  try {
+    st = statSync(real);
+  } catch {
+    return null;
+  }
+  if (!st.isFile()) return null;
+  if (st.uid !== 0) {
+    log.warn('bwrap is not root-owned; refusing to use it', { path: real, uid: st.uid });
+    return null;
+  }
+  // Group-writable (0o020) or other-writable (0o002) means a non-root principal
+  // could replace the boundary binary. Reject.
+  if ((st.mode & 0o022) !== 0) {
+    log.warn('bwrap is group- or other-writable; refusing to use it', {
+      path: real,
+      mode: (st.mode & 0o777).toString(8),
+    });
+    return null;
+  }
+  return real;
+}
+
+// ---------------------------------------------------------------------------
+// Caller env allow-list (spec §7)
+// ---------------------------------------------------------------------------
+
+/** Exact keys a caller may set. */
+const CALLER_ENV_EXACT = new Set(['TERM', 'LANG', 'CI', 'NO_COLOR']);
+/** Namespaced prefixes a caller may set. */
+const CALLER_ENV_PREFIXES = ['LC_', 'REVDEV_'] as const;
+
+/**
+ * Filter caller-supplied env to the allow-list. A deny-list of dangerous keys
+ * always loses eventually, so this is an allow-list: `HOME`, `PATH`, the loader
+ * set (`LD_PRELOAD`, `LD_AUDIT`, `LD_LIBRARY_PATH`, `NODE_OPTIONS`,
+ * `GIT_CONFIG_GLOBAL`, `GIT_SSH_COMMAND`, `BASH_ENV`, `PYTHONSTARTUP`, …) are
+ * simply not on it and are rejected by name. Zero authored regex — a Set
+ * membership test plus `startsWith` for the namespaces.
+ *
+ * @throws naming the first disallowed key.
+ */
+export function filterCallerEnv(extraEnv: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(extraEnv)) {
+    if (CALLER_ENV_EXACT.has(k)) {
+      out[k] = v;
+      continue;
+    }
+    let allowed = false;
+    for (const prefix of CALLER_ENV_PREFIXES) {
+      if (k.startsWith(prefix)) {
+        allowed = true;
+        break;
+      }
+    }
+    if (allowed) {
+      out[k] = v;
+      continue;
+    }
+    throw new Error(
+      `agent.spawn: env key "${k}" is not caller-settable. Allowed: TERM, LANG, LC_*, CI, NO_COLOR, REVDEV_*.`,
+    );
+  }
+  return out;
+}
+
+/**
+ * Build the environment node-pty is given (and, without --clearenv, that bwrap
+ * inherits before its own --setenv). `process.env` is deliberately NOT
+ * inherited — the daemon's revvault secrets, signing material, and API keys
+ * never reach the child. HOME points at the per-agent home; PATH is fixed.
+ * Allow-listed caller env layers on top but can never contain HOME or PATH
+ * (filterCallerEnv rejected them upstream).
+ */
+export function buildConfinedEnv(
+  callerEnv: Record<string, string>,
+  agentHome: string,
+): Record<string, string> {
+  const env: Record<string, string> = {
+    HOME: agentHome,
+    PATH: '/usr/bin:/bin',
+    TERM: 'xterm-color',
+    LANG: 'C.UTF-8',
+    GIT_CONFIG_NOSYSTEM: '1',
+  };
+  for (const [k, v] of Object.entries(callerEnv)) env[k] = v;
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// linux-bubblewrap backend (spec §4.3)
+// ---------------------------------------------------------------------------
+
+/** /etc entries bound read-only for DNS, TLS, and name resolution (only if present). */
+const ETC_RO_BINDS = [
+  '/etc/resolv.conf',
+  '/etc/ssl',
+  '/etc/ca-certificates',
+  '/etc/passwd',
+  '/etc/group',
+  '/etc/nsswitch.conf',
+  '/etc/alternatives',
+] as const;
+
+/**
+ * The Linux/WSL2 backend. Builds a deny-by-default bwrap argv:
+ *   - /usr read-only, the merged-usr symlinks, minimal /etc, /proc, /dev, /tmp;
+ *   - the operator home tmpfs'd (hides everything beneath it), THEN the granted
+ *     root and the per-agent home re-bound read-write on top;
+ *   - shared caches (pnpm store, cargo registry/git) bound by EXACT subdirectory,
+ *     never the secret-bearing parent, and only when they exist on the host;
+ *   - HOME and PATH set authoritatively inside the sandbox;
+ *   - user/pid/ipc/uts/cgroup namespaces unshared (NOT net — pnpm/cargo/claude
+ *     need egress; NOT --new-session — it setsid()s and breaks interactive job
+ *     control, and node-pty already hands a dedicated pty slave, spec §4.3).
+ *
+ * A symlink inside the repo pointing at ~/.ssh resolves against the SANDBOX
+ * root, where ~/.ssh does not exist — symlink escape is closed for free (§4.4).
+ */
+export function linuxBubblewrapBackend(bwrapAbs: string): ConfinementBackend {
+  return {
+    name: 'linux-bubblewrap',
+    spawnConfined(command, args, opts): ConfinementResult {
+      const { repoReal, cwd, agentHome, operatorHome } = opts;
+      const a: string[] = [];
+
+      // System, read-only + merged-usr symlinks.
+      a.push('--ro-bind', '/usr', '/usr');
+      a.push('--symlink', 'usr/bin', '/bin');
+      a.push('--symlink', 'usr/sbin', '/sbin');
+      a.push('--symlink', 'usr/lib', '/lib');
+      a.push('--symlink', 'usr/lib64', '/lib64');
+
+      // Minimal /etc (each only if present on the host).
+      for (const p of ETC_RO_BINDS) {
+        if (existsSync(p)) a.push('--ro-bind', p, p);
+      }
+
+      // Kernel + device surfaces, and a private /tmp.
+      a.push('--proc', '/proc');
+      a.push('--dev', '/dev');
+      a.push('--tmpfs', '/tmp');
+
+      // Hide the entire operator home. Everything the caller is allowed to see
+      // beneath it is re-bound AFTER this line (bwrap applies args in order).
+      a.push('--tmpfs', operatorHome);
+
+      // The granted root and the per-agent home, read-write.
+      a.push('--bind', repoReal, repoReal);
+      a.push('--bind', agentHome, agentHome);
+
+      // Shared caches — bound by exact subdirectory, never `~/.cargo` (which may
+      // hold `credentials`) or `~/.local/share` (which holds the daemon's own
+      // DB). Only when present.
+      const sharedCaches = [
+        join(operatorHome, '.local/share/pnpm/store'),
+        join(operatorHome, '.cargo/registry'),
+        join(operatorHome, '.cargo/git'),
+      ];
+      for (const p of sharedCaches) {
+        if (existsSync(p)) a.push('--bind', p, p);
+      }
+
+      // Authoritative in-sandbox HOME + PATH.
+      a.push('--setenv', 'HOME', agentHome);
+      a.push('--setenv', 'PATH', '/usr/bin:/bin');
+
+      // Namespaces. NOT --unshare-net (kept: pnpm, cargo, claude need egress).
+      a.push(
+        '--unshare-user',
+        '--unshare-pid',
+        '--unshare-ipc',
+        '--unshare-uts',
+        '--unshare-cgroup',
+      );
+      a.push('--die-with-parent');
+
+      // Start in the granted cwd (bound above), then the command.
+      a.push('--chdir', cwd);
+      a.push('--', command, ...args);
+
+      return { file: bwrapAbs, argv: a };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Backend resolution — fail-closed, with an operator escape hatch (spec §8)
+// ---------------------------------------------------------------------------
+
+export type ConfinementMode = 'linux-bubblewrap' | 'none';
+
+export interface ResolvedConfinement {
+  /** The value persisted in the `agent_processes.confinement` audit column. */
+  mode: ConfinementMode;
+  /** The active backend, or null when spawns must fail closed / run unconfined. */
+  backend: ConfinementBackend | null;
+  /** True only when confinement is deliberately disabled via the operator escape hatch. */
+  escapeHatch: boolean;
+  /** Human-readable reason, for the startup log and the fail-closed error. */
+  reason: string;
+}
+
+/**
+ * Resolve the confinement backend for this host. Called once at daemon start
+ * and cached. Optional injections make it unit-testable without touching the
+ * real filesystem or `process.platform`.
+ *
+ *   - `REVDEV_SPAWN_CONFINEMENT=none` in the DAEMON's own env (never a caller
+ *     param): spawns run UNCONFINED, each logged at warn, each row recording
+ *     `confinement='none'`. If an agent did it, there is a receipt.
+ *   - Linux/WSL2 with a usable bwrap: `linux-bubblewrap`.
+ *   - Linux without a usable bwrap, or macOS/Windows: no backend — agent.spawn
+ *     FAILS CLOSED. An unimplemented platform refuses to spawn; it never
+ *     silently spawns unprotected (spec §8.1).
+ */
+export function resolveConfinementBackend(opts?: {
+  platform?: NodeJS.Platform;
+  /** Resolved bwrap abspath or null. `undefined` (default) resolves for real. */
+  bwrapPath?: string | null;
+  /** The escape-hatch env value. `undefined` (default) reads process.env. */
+  escapeHatchEnv?: string;
+}): ResolvedConfinement {
+  const platform = opts?.platform ?? process.platform;
+  const escapeHatchValue =
+    opts?.escapeHatchEnv !== undefined ? opts.escapeHatchEnv : process.env.REVDEV_SPAWN_CONFINEMENT;
+
+  if (escapeHatchValue === 'none') {
+    return {
+      mode: 'none',
+      backend: null,
+      escapeHatch: true,
+      reason: 'REVDEV_SPAWN_CONFINEMENT=none — spawns run UNCONFINED (operator escape hatch)',
+    };
+  }
+
+  if (platform === 'linux') {
+    const bwrapAbs = opts?.bwrapPath !== undefined ? opts.bwrapPath : resolveBwrapAbsPath();
+    if (bwrapAbs) {
+      return {
+        mode: 'linux-bubblewrap',
+        backend: linuxBubblewrapBackend(bwrapAbs),
+        escapeHatch: false,
+        reason: `linux-bubblewrap (${bwrapAbs})`,
+      };
+    }
+    return {
+      mode: 'none',
+      backend: null,
+      escapeHatch: false,
+      reason:
+        'no usable bwrap found (absent, not root-owned, or writable); agent.spawn fails closed',
+    };
+  }
+
+  // macOS: the darwin-seatbelt backend is staged but disabled until its
+  // acceptance suite is green on a macos-latest runner (spec §8.2/§8.3), so it
+  // resolves to fail-closed today. Windows native: no backend.
+  return {
+    mode: 'none',
+    backend: null,
+    escapeHatch: false,
+    reason: `no confinement backend for platform "${platform}"; agent.spawn fails closed (spec §8)`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent persistent home (spec §5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure the per-agent home exists at `<dataDir>/agent-homes/<hash(agentId)>/`
+ * and return its path. Persistent (NOT per-spawn tmpfs — that would discard the
+ * pnpm store links and node_modules state every spawn and make the daily driver
+ * unusable; the sandbox is the per-spawn unit, the home is durable).
+ *
+ * `agentId` is the VERIFIED signer (requireAgent returns it only when
+ * boundVia==='signature'), a signing-key identity — not the hook-side
+ * `agent-system` string, so this does not inherit GAP-311's collision. The path
+ * is hashed so a DID cannot traverse.
+ *
+ * Contains a synthesized minimal `.gitconfig` (identity present, signing OFF,
+ * no signingkey — spec §6) and writable `.cache`, `.config`, `.local/share`.
+ * Never contains anything on the never-bound list of §4.3.
+ */
+export async function ensureAgentHome(dataDir: string, agentId: string): Promise<string> {
+  const hash = createHash('sha256').update(agentId).digest('hex').slice(0, 32);
+  const home = join(dataDir, 'agent-homes', hash);
+  await mkdir(join(home, '.cache'), { recursive: true });
+  await mkdir(join(home, '.config'), { recursive: true });
+  await mkdir(join(home, '.local', 'share'), { recursive: true });
+
+  // Synthesized gitconfig: a spawned agent commits locally and UNSIGNED. It has
+  // no ~/.ssh and no signing key, so it cannot forge a commit GitHub marks
+  // Verified as the operator (spec §6 — "signing must break, and that is the
+  // correct outcome"). commit.gpgsign is pinned false and user.signingkey omitted.
+  const gitconfig = `${[
+    '[user]',
+    '\tname = RevealUI Agent',
+    '\temail = agent@revealui.local',
+    '[commit]',
+    '\tgpgsign = false',
+    '[tag]',
+    '\tgpgsign = false',
+  ].join('\n')}\n`;
+  await writeFile(join(home, '.gitconfig'), gitconfig, { mode: 0o600 });
+
+  return home;
+}

--- a/packages/daemon/src/confinement.ts
+++ b/packages/daemon/src/confinement.ts
@@ -284,6 +284,27 @@ export function neverBoundSet(operatorHome: string, dataDir: string): string[] {
 }
 
 /**
+ * Return the first never-bound entry that overlaps `real` in either direction,
+ * or `null` when none does. Pure, zero I/O (the caller passes a precomputed
+ * `neverBound` list) and zero regex — the shared overlap predicate.
+ *
+ *   - `within(real, nb)`: the secret lives INSIDE `real` (a bind/read exposes it).
+ *   - `within(nb, real)`: `real` IS or lives INSIDE a secret path.
+ *
+ * Consumed by BOTH the spawn side (`assertGrantedRootBindable`, which formats a
+ * full-path error because a granted root is operator-known material) and the
+ * file side (`filegit.ts` D1/D2/D3, which formats a CLASS-only error because a
+ * `project.open` caller may be hostile). One never-bound set (`neverBoundSet`),
+ * one predicate, no copied logic (extend-before-create, GAP-326).
+ */
+export function findNeverBoundOverlap(real: string, neverBound: readonly string[]): string | null {
+  for (const nb of neverBound) {
+    if (within(real, nb) || within(nb, real)) return nb;
+  }
+  return null;
+}
+
+/**
  * Refuse to bind a granted root that overlaps the never-bound secret set or the
  * operator home (GAP-320a). The bind sequence tmpfs-hides the operator home and
  * then re-binds `repoReal` read-write on top (§4.3); if `repoReal` IS, CONTAINS,
@@ -312,14 +333,13 @@ export function assertGrantedRootBindable(
       `agent.spawn: refusing to bind granted root "${repoReal}" — it is or contains the operator home "${operatorHome}" (confinement would re-expose the entire home read-write). Grant a project root beneath the home, not the home itself.`,
     );
   }
-  for (const nb of neverBoundSet(operatorHome, dataDir)) {
-    // within(repoReal, nb): the secret lives INSIDE the granted root (bind exposes it).
-    // within(nb, repoReal): the granted root IS or lives INSIDE a secret path.
-    if (within(repoReal, nb) || within(nb, repoReal)) {
-      throw new Error(
-        `agent.spawn: refusing to bind granted root "${repoReal}" — it overlaps the never-bound secret path "${nb}" (confinement would re-expose it read-write). Grant a root that does not contain secret material.`,
-      );
-    }
+  // within(repoReal, nb): the secret lives INSIDE the granted root (bind exposes it).
+  // within(nb, repoReal): the granted root IS or lives INSIDE a secret path.
+  const nb = findNeverBoundOverlap(repoReal, neverBoundSet(operatorHome, dataDir));
+  if (nb !== null) {
+    throw new Error(
+      `agent.spawn: refusing to bind granted root "${repoReal}" — it overlaps the never-bound secret path "${nb}" (confinement would re-expose it read-write). Grant a root that does not contain secret material.`,
+    );
   }
 }
 

--- a/packages/daemon/src/confinement.ts
+++ b/packages/daemon/src/confinement.ts
@@ -23,10 +23,20 @@
 import { createHash } from 'node:crypto';
 import { existsSync, realpathSync, statSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { createLogger } from '@revealui/utils/logger';
 
 const log = createLogger({ service: 'revdev-daemon/confinement' });
+
+/**
+ * True when `target` is `root` itself or a descendant of it. Separator-safe
+ * (never a bare `startsWith`, which would treat `/a/bc` as within `/a/b`).
+ * Local to this module — same shape as filegit.ts `within()`, kept here so the
+ * confinement layer carries no dependency on the file layer. Zero regex.
+ */
+function within(root: string, target: string): boolean {
+  return target === root || target.startsWith(root + sep);
+}
 
 // ---------------------------------------------------------------------------
 // Backend interface
@@ -52,6 +62,12 @@ export interface ConfinementResult {
 
 export interface ConfinementBackend {
   readonly name: string;
+  /**
+   * Resolve the argv for this backend. Every backend MUST validate the granted
+   * root against the never-bound secret set (via `assertGrantedRootBindable`)
+   * before building its argv — a backend that skips it re-exposes secrets a
+   * broad grant overlaps (GAP-320a). Throws the guard's named error on overlap.
+   */
   spawnConfined(command: string, args: string[], opts: ConfinementOpts): ConfinementResult;
 }
 
@@ -106,6 +122,19 @@ export function resolveBwrapAbsPath(candidate: string = BWRAP_CANDIDATE): string
 const CALLER_ENV_EXACT = new Set(['TERM', 'LANG', 'CI', 'NO_COLOR']);
 /** Namespaced prefixes a caller may set. */
 const CALLER_ENV_PREFIXES = ['LC_', 'REVDEV_'] as const;
+/**
+ * Daemon-control keys a caller may NEVER set, even under an allowed prefix
+ * (GAP-320b). Membership criterion: an env var the daemon itself reads to
+ * configure or WEAKEN a security boundary. `REVDEV_SPAWN_CONFINEMENT` is the
+ * only member — it is inert in a child today (resolveConfinementBackend reads
+ * only the daemon's own `process.env`, never caller env), but a caller-seedable
+ * escape-hatch key sitting in a sandboxed process's environment invites a future
+ * misread that it is load-bearing. Prune knobs (`REVDEV_STALE_THRESHOLD_DAYS`,
+ * `REVDEV_HARD_DELETE_DAYS`) do NOT qualify: they configure nothing in a child
+ * and mislead nobody about a boundary. Keep this set tiny — the allow-list is
+ * the load-bearing control; a deny-list always loses eventually.
+ */
+const CALLER_ENV_DENY_EXACT = new Set(['REVDEV_SPAWN_CONFINEMENT']);
 
 /**
  * Filter caller-supplied env to the allow-list. A deny-list of dangerous keys
@@ -120,6 +149,13 @@ const CALLER_ENV_PREFIXES = ['LC_', 'REVDEV_'] as const;
 export function filterCallerEnv(extraEnv: Record<string, string>): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(extraEnv)) {
+    // Daemon-control keys are rejected FIRST, before the prefix allowance that
+    // would otherwise wave `REVDEV_SPAWN_CONFINEMENT` through (GAP-320b).
+    if (CALLER_ENV_DENY_EXACT.has(k)) {
+      throw new Error(
+        `agent.spawn: env key "${k}" is not caller-settable — it is a daemon-control key that configures the confinement boundary (the REVDEV_ prefix is otherwise allowed).`,
+      );
+    }
     if (CALLER_ENV_EXACT.has(k)) {
       out[k] = v;
       continue;
@@ -180,6 +216,93 @@ const ETC_RO_BINDS = [
   '/etc/alternatives',
 ] as const;
 
+// ---------------------------------------------------------------------------
+// Never-bound secret set + granted-root overlap guard (spec §4.3, GAP-320a)
+// ---------------------------------------------------------------------------
+
+/** Home-relative secret paths (spec §4.3), joined onto the operator home. */
+const NEVER_BOUND_HOME_RELATIVE = [
+  '.ssh',
+  '.age-identity',
+  '.revealui/passage-store',
+  '.config/gh',
+  '.npmrc',
+  '.aws',
+  '.docker/config.json',
+  '.claude',
+] as const;
+
+/** Absolute mounts that must never be bound (spec §4.3). No development happens
+ *  on the NTFS mounts; /mnt/c carries the Windows credential stores, /mnt/e the
+ *  LTS backups. */
+const NEVER_BOUND_ABSOLUTE = ['/mnt/c', '/mnt/e'] as const;
+
+/**
+ * Materialize spec §4.3's never-bound secret set for this host, from the
+ * operator home. Each entry is carried in two forms: its lexical path, and its
+ * realpath WHEN the entry exists (realpath-if-exists). Rationale: `repoReal`
+ * arrives already realpath'd (requireRootAndDir), so a lexical-only compare
+ * misses a secret directory that is itself a symlink (`~/.ssh -> /data/ssh`).
+ * Entries absent on this host stay lexical-only. Computed per spawn (a handful
+ * of joins plus at most a few stats), so a secret path or symlink that appears
+ * after daemon start is guarded without a restart. Zero authored regex.
+ */
+export function neverBoundSet(operatorHome: string): string[] {
+  const lexical: string[] = [
+    ...NEVER_BOUND_HOME_RELATIVE.map((p) => join(operatorHome, p)),
+    ...NEVER_BOUND_ABSOLUTE,
+  ];
+  // /run/user/<uid> carries the ssh-agent socket (spec §4.3).
+  if (typeof process.getuid === 'function') {
+    lexical.push(`/run/user/${process.getuid()}`);
+  }
+  const out = new Set<string>(lexical);
+  for (const p of lexical) {
+    try {
+      out.add(realpathSync(p));
+    } catch {
+      // absent on this host — the lexical form stays, realpath is skipped
+    }
+  }
+  return [...out];
+}
+
+/**
+ * Refuse to bind a granted root that overlaps the never-bound secret set or the
+ * operator home (GAP-320a). The bind sequence tmpfs-hides the operator home and
+ * then re-binds `repoReal` read-write on top (§4.3); if `repoReal` IS, CONTAINS,
+ * or lives INSIDE a secret path, that rw bind re-exposes the secret inside the
+ * sandbox. We REFUSE (fail closed) rather than mask: a mask that misses a path
+ * exposes it silently, whereas an over-broad refusal fails loud and is fixed the
+ * same day. Confinement does not replace authorization (spec §4.2 invariant 3) —
+ * this only refuses grants the confinement layer cannot actually confine.
+ *
+ * `repoReal` BENEATH the operator home (`within(operatorHome, repoReal)`) is the
+ * normal, supported case (`~/revfleet/<repo>`) and is NOT refused. Every backend
+ * MUST call this before building its argv (see the ConfinementBackend contract).
+ *
+ * @throws naming the granted root, the colliding path, and the reason. Both are
+ *   operator-known material (their own home layout), so naming them is not an oracle.
+ */
+export function assertGrantedRootBindable(repoReal: string, operatorHome: string): void {
+  // repoReal IS the home, or is an ANCESTOR of it (e.g. `/base` over `/base/op`):
+  // the tmpfs-then-bind sequence would re-expose the entire home read-write.
+  if (repoReal === operatorHome || within(repoReal, operatorHome)) {
+    throw new Error(
+      `agent.spawn: refusing to bind granted root "${repoReal}" — it is or contains the operator home "${operatorHome}" (confinement would re-expose the entire home read-write). Grant a project root beneath the home, not the home itself.`,
+    );
+  }
+  for (const nb of neverBoundSet(operatorHome)) {
+    // within(repoReal, nb): the secret lives INSIDE the granted root (bind exposes it).
+    // within(nb, repoReal): the granted root IS or lives INSIDE a secret path.
+    if (within(repoReal, nb) || within(nb, repoReal)) {
+      throw new Error(
+        `agent.spawn: refusing to bind granted root "${repoReal}" — it overlaps the never-bound secret path "${nb}" (confinement would re-expose it read-write). Grant a root that does not contain secret material.`,
+      );
+    }
+  }
+}
+
 /**
  * The Linux/WSL2 backend. Builds a deny-by-default bwrap argv:
  *   - /usr read-only, the merged-usr symlinks, minimal /etc, /proc, /dev, /tmp;
@@ -200,6 +323,12 @@ export function linuxBubblewrapBackend(bwrapAbs: string): ConfinementBackend {
     name: 'linux-bubblewrap',
     spawnConfined(command, args, opts): ConfinementResult {
       const { repoReal, cwd, agentHome, operatorHome } = opts;
+
+      // Refuse a granted root that overlaps a secret path or the operator home
+      // BEFORE any argv is assembled — the invariant lives next to the bind
+      // sequence that creates the hazard (GAP-320a, spec §4.3).
+      assertGrantedRootBindable(repoReal, operatorHome);
+
       const a: string[] = [];
 
       // System, read-only + merged-usr symlinks.

--- a/packages/daemon/src/confinement.ts
+++ b/packages/daemon/src/confinement.ts
@@ -304,6 +304,24 @@ export function assertGrantedRootBindable(repoReal: string, operatorHome: string
 }
 
 /**
+ * Resolve the operator's real home, realpath'd. `assertGrantedRootBindable`
+ * compares the home against an already-realpath'd `repoReal`, and the backend
+ * tmpfs-hides this path; realpath'ing here keeps both consistent, so a symlinked
+ * `$HOME` component can't make the guard's home-identity/ancestor checks
+ * lexical-only and diverge from the canonical path (GAP-320a review S1). Falls
+ * back to the lexical value when it does not resolve (e.g. an absent `/root`),
+ * which never WIDENS the guard — the never-bound entries carry their own
+ * realpath-if-exists forms, so a real secret is still caught.
+ */
+export function resolveOperatorHome(rawHome: string = process.env.HOME ?? '/root'): string {
+  try {
+    return realpathSync(rawHome);
+  } catch {
+    return rawHome;
+  }
+}
+
+/**
  * The Linux/WSL2 backend. Builds a deny-by-default bwrap argv:
  *   - /usr read-only, the merged-usr symlinks, minimal /etc, /proc, /dev, /tmp;
  *   - the operator home tmpfs'd (hides everything beneath it), THEN the granted

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -29,9 +29,13 @@ import { open, readFile, realpath, stat, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
+import { createLogger } from '@revealui/utils/logger';
+import { findNeverBoundOverlap, neverBoundSet, resolveOperatorHome } from './confinement.js';
 import { onAgentEnded, onDaemonStarted } from './eviction.js';
 import { getDaemonConfig, registerHandler } from './server.js';
 import { runGit, type ShellResult } from './vcs.js';
+
+const log = createLogger({ service: 'revdev-daemon/filegit' });
 
 // ---------------------------------------------------------------------------
 // Registered project roots
@@ -140,9 +144,41 @@ export async function restoreProjectRoots(db: PGlite): Promise<void> {
      FROM project_roots pr
      INNER JOIN agent_sessions s ON s.id = pr.agent_id AND s.ended_at IS NULL`,
   );
+  // D3 (GAP-326): re-validation below uses neverBoundContext(), which lazily
+  // computes from this started daemon's config (getDaemonConfig() is set before
+  // this hook fires) — so a restart under a new dataDir is reflected without an
+  // explicit reset. Tests pin the context via _setNeverBoundForTest first.
   for (const row of rows.rows) {
     const dev = BigInt(row.dev);
     const ino = BigInt(row.ino);
+    // D3 (GAP-326): re-validate every persisted root against D1's checks. A row
+    // written before this gate existed — or before the never-bound set grew —
+    // may now be a non-repo or overlap a secret path; such a row is EVICTED
+    // (deleted + logged), never restored into the serving map, so set growth
+    // becomes retroactively protective. The path is the operator's own material
+    // and this is the operator's own daemon log, so naming it is not an oracle.
+    let evictReason: string | null = null;
+    const isRepo = await stat(join(row.real_path, '.git')).then(
+      () => true,
+      () => false,
+    );
+    if (!isRepo) {
+      evictReason = 'not a git repository';
+    } else {
+      try {
+        assertRootAvoidsNeverBound(row.real_path);
+      } catch (e) {
+        evictReason = e instanceof Error ? e.message : String(e);
+      }
+    }
+    if (evictReason !== null) {
+      log.warn('evicting persisted project root that fails never-bound re-validation', {
+        root: row.real_path,
+        reason: evictReason,
+      });
+      await db.query(`DELETE FROM project_roots WHERE dev = $1 AND ino = $2`, [row.dev, row.ino]);
+      continue;
+    }
     registeredRoots.set(inodeKey(dev, ino), {
       real: row.real_path,
       agentId: row.agent_id,
@@ -200,6 +236,117 @@ function expandTilde(p: string): string {
 /** True when `target` is `root` itself or a descendant of it. */
 function within(root: string, target: string): boolean {
   return target === root || target.startsWith(root + sep);
+}
+
+// ---------------------------------------------------------------------------
+// Never-bound secret set at the file layer (GAP-326)
+//
+// The confinement layer (agent.spawn) refuses to BIND a granted root that
+// overlaps the operator's secret set. The SAME set must gate the file.*/git.*
+// surface, or a client-owned verified signer can project.open a secret-bearing
+// tree — the operator home, ~/.ssh, the passage store — and read it straight
+// through file.read with no spawn involved (so confinement never runs). One
+// never-bound set (confinement.ts's `neverBoundSet`), imported here and shared
+// via `findNeverBoundOverlap` — never a second literal list.
+// ---------------------------------------------------------------------------
+
+/**
+ * Memoized (operatorHome, never-bound list) for this daemon. Computed lazily on
+ * first use — in a running daemon that is during restoreProjectRoots or the
+ * first file op, both after getDaemonConfig() is set, so it reflects the active
+ * dataDir/home without an explicit reset. Precomputed once thereafter so the D2
+ * resolution belt adds no per-call I/O. Tests override it via _setNeverBoundForTest.
+ */
+let neverBoundCache: { operatorHome: string; list: string[] } | null = null;
+
+function neverBoundContext(): { operatorHome: string; list: string[] } {
+  if (neverBoundCache === null) {
+    const operatorHome = resolveOperatorHome();
+    neverBoundCache = {
+      operatorHome,
+      list: neverBoundSet(operatorHome, getDaemonConfig().dataDir),
+    };
+  }
+  return neverBoundCache;
+}
+
+/**
+ * @internal — test seam: pin the never-bound context to a scratch home/dataDir
+ * so a test can register an overlapping "secret" tree without touching the real
+ * operator home.
+ */
+export function _setNeverBoundForTest(operatorHome: string, dataDir: string): void {
+  const home = resolveOperatorHome(operatorHome);
+  neverBoundCache = { operatorHome: home, list: neverBoundSet(home, dataDir) };
+}
+
+/** @internal — test seam: drop the pinned/memoized never-bound context. */
+export function _resetNeverBoundForTest(): void {
+  neverBoundCache = null;
+}
+
+/**
+ * Coarse CLASS of a never-bound entry, for an error handed back to a possibly
+ * hostile project.open/file.* caller. We name the CLASS ("ssh keys"), never the
+ * full path — echoing the operator's home layout back would be an oracle. The
+ * secret CATEGORIES are public knowledge; a specific home path is not. Zero
+ * regex (substring membership only).
+ */
+function neverBoundClass(entry: string): string {
+  if (entry.includes('/.ssh')) return 'ssh keys';
+  if (entry.includes('.age-identity')) return 'the age identity';
+  if (entry.includes('passage-store')) return 'the credential store';
+  if (entry.includes('/.config/gh')) return 'github credentials';
+  if (entry.includes('.npmrc')) return 'npm credentials';
+  if (entry.includes('/.aws')) return 'aws credentials';
+  if (entry.includes('.docker')) return 'docker credentials';
+  if (entry.includes('/.claude')) return 'agent credentials';
+  if (entry.includes('/mnt/c') || entry.includes('/mnt/e')) return 'a mounted credential volume';
+  if (entry.includes('/run/user')) return 'the runtime socket directory';
+  return 'daemon secret state';
+}
+
+/**
+ * D1/D3 root gate (GAP-326): refuse a project root that IS or CONTAINS the
+ * operator home, or that overlaps the never-bound secret set in either
+ * direction. Same semantics as confinement's `assertGrantedRootBindable`,
+ * sharing `findNeverBoundOverlap` + `neverBoundSet`; class-only errors (a root
+ * beneath the home, the normal `~/revfleet/<repo>` shape, is NOT refused).
+ */
+function assertRootAvoidsNeverBound(real: string): void {
+  const { operatorHome, list } = neverBoundContext();
+  if (real === operatorHome || within(real, operatorHome)) {
+    throw new Error(
+      'project root is or contains the operator home (it would expose the entire home through file.*)',
+    );
+  }
+  const nb = findNeverBoundOverlap(real, list);
+  if (nb !== null) {
+    throw new Error(`project root overlaps a never-bound secret path (${neverBoundClass(nb)})`);
+  }
+}
+
+/**
+ * D2 resolution belt (GAP-326): refuse a resolved target that lands on the
+ * never-bound set. Defense-in-depth behind D1 — the invariant holds even for a
+ * root that came to be registered before this gate existed (a pre-fix persisted
+ * row D3 eviction has not reached, or a never-bound entry that grew). One
+ * precomputed prefix scan, no added I/O (the caller already realpath'd).
+ */
+function assertTargetAvoidsNeverBound(target: string): void {
+  const nb = findNeverBoundOverlap(target, neverBoundContext().list);
+  if (nb !== null) {
+    throw new Error(`path resolves onto a never-bound secret path (${neverBoundClass(nb)})`);
+  }
+}
+
+/**
+ * @internal — test seam: exercise the D1/D3 never-bound root gate on an
+ * already-realpath'd root (the same check project.open and restoreProjectRoots
+ * run). Throws the class-only refusal; returns void on a clean root.
+ */
+export function _assertRootAvoidsNeverBoundForTest(real: string): void {
+  assertRootAvoidsNeverBound(real);
 }
 
 /**
@@ -265,6 +412,7 @@ async function resolveInRoot(
       throw new Error(`file not found: ${filePathRaw}`);
     }
     if (!within(repoReal, real)) throw new Error(`path escapes project root: ${filePathRaw}`);
+    assertTargetAvoidsNeverBound(real);
     return real;
   }
 
@@ -276,7 +424,9 @@ async function resolveInRoot(
     throw new Error(`parent directory does not exist: ${filePathRaw}`);
   }
   if (!within(repoReal, parentReal)) throw new Error(`path escapes project root: ${filePathRaw}`);
-  return join(parentReal, basename(abs));
+  const target = join(parentReal, basename(abs));
+  assertTargetAvoidsNeverBound(target);
+  return target;
 }
 
 /**
@@ -506,12 +656,26 @@ registerHandler('project.open', async (params, db, ctx) => {
   } catch {
     throw new Error(`project root does not exist: ${repoPathRaw}`);
   }
-  // Confirm it is actually a git repository — registering a non-repo root
-  // would let file.* operate on an arbitrary directory tree.
+  // D1 (GAP-326): confirm it is actually a git repository. Registering a non-repo
+  // root would let file.* operate on an arbitrary directory tree — the comment
+  // here has claimed this policy since the surface shipped; the code now enforces
+  // it. A non-repo root also skips assertNoExecConfig below, so rejecting it
+  // closes both gaps at once. A future non-repo need arrives as a new,
+  // separately-reviewed method — never by silently widening project.open.
   const isRepo = await stat(join(real, '.git')).then(
     () => true,
     () => false,
   );
+  if (!isRepo) {
+    throw new Error(`project root is not a git repository: ${repoPathRaw}`);
+  }
+  // D1 (GAP-326): refuse a root that overlaps the never-bound secret set (in
+  // either direction) or the operator home, BEFORE any registration side effect.
+  // Without this a client-owned verified signer could project.open("~") or
+  // project.open("~/.ssh") and read secrets straight through file.read — no spawn,
+  // so the confinement layer never runs. Same never-bound set the spawn side
+  // enforces (confinement.ts), imported — never a second copy.
+  assertRootAvoidsNeverBound(real);
   if (ctx.agentId === null) {
     // Unreachable in practice: project.open is in MUTATING_OR_CONTENT_METHODS,
     // so the dispatch signature gate binds ctx.agentId to the verified signer
@@ -535,8 +699,9 @@ registerHandler('project.open', async (params, db, ctx) => {
   // project.open is the trust boundary for a third-party repo: without this a
   // routine `git.diffFile`/`git.stageFile`/checkout would run attacker code as
   // the daemon UID (e.g. exfil ~/.age-identity/keys.txt). Done BEFORE adding to
-  // registeredRoots so a refused repo is never usable by file.*/git.*.
-  if (isRepo) await assertNoExecConfig(real);
+  // registeredRoots so a refused repo is never usable by file.*/git.*. isRepo is
+  // guaranteed true here (non-repo roots are rejected by D1 above).
+  await assertNoExecConfig(real);
   // Stat to get the canonical inode key.
   const s = await stat(real);
   const dev = BigInt(s.dev);

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -294,8 +294,23 @@ export async function requireDirInRoot(
   cwdRaw: string | undefined,
   callerAgentId: string | null,
 ): Promise<string> {
+  return (await requireRootAndDir(repoPathRaw, cwdRaw, callerAgentId)).cwd;
+}
+
+/**
+ * Like `requireDirInRoot`, but returns BOTH the realpath'd granted root and the
+ * resolved cwd. `agent.spawn` confinement binds the whole root read-write and
+ * then chdirs into the (at-or-beneath) cwd, so it needs both — the root to
+ * bind, the cwd to start in. Same authorization; a single realpath+ownership
+ * check backs both values so the two surfaces cannot drift.
+ */
+export async function requireRootAndDir(
+  repoPathRaw: string,
+  cwdRaw: string | undefined,
+  callerAgentId: string | null,
+): Promise<{ repoReal: string; cwd: string }> {
   const repoReal = await requireRoot(repoPathRaw, callerAgentId);
-  if (cwdRaw === undefined || cwdRaw === '') return repoReal;
+  if (cwdRaw === undefined || cwdRaw === '') return { repoReal, cwd: repoReal };
 
   // mustExist=true realpaths the target itself, so a symlink pointing outside
   // the root resolves before `within()` sees it.
@@ -307,7 +322,7 @@ export async function requireDirInRoot(
     throw new Error(`cwd does not exist: ${cwdRaw}`);
   }
   if (!s.isDirectory()) throw new Error(`cwd is not a directory: ${cwdRaw}`);
-  return real;
+  return { repoReal, cwd: real };
 }
 
 /**

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -280,6 +280,37 @@ async function resolveInRoot(
 }
 
 /**
+ * Authorize a working directory for a caller: the repo root must be registered
+ * and owned-or-granted by `callerAgentId`, and `cwdRaw` must resolve to a real
+ * directory at or beneath that root.
+ *
+ * Exported for `agent.spawn`, which forks a caller-supplied command as the
+ * daemon UID. Authentication (the Ed25519 signature gate) proves *who* is
+ * asking; this proves they are allowed to run it *there*. Both invariants stay
+ * in this module so the spawn surface cannot drift from the file surface.
+ */
+export async function requireDirInRoot(
+  repoPathRaw: string,
+  cwdRaw: string | undefined,
+  callerAgentId: string | null,
+): Promise<string> {
+  const repoReal = await requireRoot(repoPathRaw, callerAgentId);
+  if (cwdRaw === undefined || cwdRaw === '') return repoReal;
+
+  // mustExist=true realpaths the target itself, so a symlink pointing outside
+  // the root resolves before `within()` sees it.
+  const real = await resolveInRoot(repoReal, cwdRaw, true);
+  let s: Awaited<ReturnType<typeof stat>>;
+  try {
+    s = await stat(real);
+  } catch {
+    throw new Error(`cwd does not exist: ${cwdRaw}`);
+  }
+  if (!s.isDirectory()) throw new Error(`cwd is not a directory: ${cwdRaw}`);
+  return real;
+}
+
+/**
  * Lexical repo-relative path for a git pathspec argument. The repo root is
  * already a realpath'd registered root, and git itself confines pathspecs to
  * the work tree, so a lexical `..`/absolute-escape check is sufficient here
@@ -567,6 +598,15 @@ registerHandler('project.grant', async (params, _db, ctx) => {
   return { granted: granteeAgentId, root: entry.real };
 });
 
+/**
+ * Revoke a grantee's access to a root.
+ *
+ * NOT a kill-switch. This blocks FUTURE operations, including `agent.spawn`.
+ * PTY processes the grantee already spawned keep running: they are keyed to the
+ * spawning `ownerAgentId`, not to an ongoing grant, and survive until they exit
+ * or the grantee's session ends (see the eviction cascade above). To stop live
+ * work, end the grantee's session.
+ */
 registerHandler('project.revoke', async (params, _db, ctx) => {
   const repoPathRaw = requireStr(params.repoPath, 'repoPath');
   const granteeAgentId = requireStr(params.granteeAgentId, 'granteeAgentId');

--- a/packages/daemon/src/migrations/0006-agent-process-confinement.ts
+++ b/packages/daemon/src/migrations/0006-agent-process-confinement.ts
@@ -1,0 +1,23 @@
+/**
+ * Migration 0006 — agent process confinement audit column.
+ *
+ * Adds `agent_processes.confinement` recording the confinement mode a PTY
+ * process ran under ('linux-bubblewrap' when sandboxed, 'none' when the
+ * operator escape hatch REVDEV_SPAWN_CONFINEMENT=none was set). Nullable: rows
+ * written before this migration predate the column and carry NULL. The
+ * agent.spawn handler always writes it for new rows. "If an agent did it, there
+ * is a receipt" (spec §8.1).
+ */
+
+import type { Migration } from '../storage/migrate.js';
+
+const SQL = `
+  ALTER TABLE agent_processes
+    ADD COLUMN IF NOT EXISTS confinement TEXT;
+`;
+
+export const MIGRATION_0006: Migration = {
+  version: 6,
+  name: 'agent-process-confinement',
+  sql: SQL,
+};

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -21,6 +21,7 @@ import { MIGRATION_0002 } from './0002-key-origin.js';
 import { MIGRATION_0003 } from './0003-project-roots.js';
 import { MIGRATION_0004 } from './0004-agent-processes.js';
 import { MIGRATION_0005 } from './0005-session-activity-state.js';
+import { MIGRATION_0006 } from './0006-agent-process-confinement.js';
 
 export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0001,
@@ -28,4 +29,5 @@ export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0003,
   MIGRATION_0004,
   MIGRATION_0005,
+  MIGRATION_0006,
 ];

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -209,6 +209,14 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   'agent.input',
   'agent.resize',
   'agent.output',
+  // session.end fans out to notifyAgentEnded, which evicts the target's project
+  // roots and kills every PTY it owns. It used to take a caller-supplied target
+  // and sat OUTSIDE this set, so any socket peer could end an arbitrary agent's
+  // session unsigned: the identity gate is satisfied by a bare `actorAgentId`
+  // string, while the handler read `sessionId`. Signature-REQUIRED so the target
+  // is the verified signer and nothing else. Cross-language contract: signing.rs
+  // requires_signature() must mark this too.
+  'session.end',
 ]);
 
 // ---------------------------------------------------------------------------
@@ -1020,9 +1028,21 @@ registerHandler('session.list', async (params, db) => {
 });
 
 registerHandler('session.end', async (params, db, ctx) => {
-  // Prefer caller's own session, but allow explicit override (e.g. admin cleanup).
-  const target = strOrNull(params.sessionId) ?? strOrNull(params.agentId) ?? ctx.agentId;
-  if (!target) throw new Error('No session to end');
+  // Self-scoped to the VERIFIED signer. session.end is in
+  // MUTATING_OR_CONTENT_METHODS, so the dispatch gate has already bound
+  // ctx.agentId via boundVia==='signature' before this runs; the check below is
+  // the defense-in-depth backstop, mirroring agent.spawn's requireAgent.
+  //
+  // The old `params.sessionId ?? params.agentId` override ("admin cleanup") had
+  // NO caller: harness.prune reaps aged sessions by calling notifyAgentEnded
+  // directly, and every real caller passes its own id. It existed only as the
+  // attack surface, so it is gone rather than gated behind an unused admin role.
+  if (ctx.boundVia !== 'signature' || !ctx.agentId) {
+    throw new Error(
+      'session.end requires a signed request (verified Ed25519 signature); unsigned or param-bound actor rejected',
+    );
+  }
+  const target = ctx.agentId;
   // Canonical: exitSummary (matches DB column `exit_summary`).
   // Compat alias: summary (for callers using shorter name).
   const exitSummary = strOrNull(params.exitSummary) ?? strOrNull(params.summary);

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -114,7 +114,10 @@ const IDENTITY_EXEMPT = new Set([
   'session.attach',
   'session.list',
   'harness.health',
-  'harness.prune',
+  // `harness.prune` was here. It reaches notifyAgentEnded for EVERY matched
+  // session, so an identity-exempt, unsigned caller could evict every agent's
+  // roots and kill every agent's PTY with one frame. See GAP-312 and the
+  // MUTATING_OR_CONTENT_METHODS entry below.
   'inference.status',
   'inference.pull',
   'inference.start',
@@ -217,6 +220,19 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   // is the verified signer and nothing else. Cross-language contract: signing.rs
   // requires_signature() must mark this too.
   'session.end',
+  // harness.prune reaches the SAME eviction primitive as session.end
+  // (notifyAgentEnded → evictRootsForAgent + the spawn.ts PTY-kill hook), but
+  // fans it out across EVERY matched session rather than one. It was
+  // IDENTITY_EXEMPT and absent from this set, so a single unsigned frame from
+  // any same-UID socket peer ended the whole fleet's sessions and killed every
+  // PTY. `staleDays` is the amplifier: it had no floor, so 0 (or any negative,
+  // which clamped to 0) selected `started_at < NOW()`, i.e. all live sessions.
+  // Signature-REQUIRED, and the schema now floors both thresholds at 1 day so
+  // no caller can select "everything". The periodic internal sweep is
+  // unaffected: it calls runPrune directly, never through this RPC.
+  // Cross-language contract: signing.rs requires_signature() must mark this too.
+  // GAP-312. Sibling of the session.end fix (GAP-288, revdev#261).
+  'harness.prune',
 ]);
 
 // ---------------------------------------------------------------------------
@@ -261,11 +277,17 @@ async function runPrune(
   staleDays: number,
   hardDeleteDays: number,
 ): Promise<{ aged: number; deleted: number }> {
-  // Clamp non-negative + finite. Defends against bad caller input — a
-  // negative or NaN threshold would otherwise widen the WHERE clause to
-  // include all-or-no rows depending on Postgres semantics.
-  const stale = Number.isFinite(staleDays) ? Math.max(0, staleDays) : 7;
-  const hard = Number.isFinite(hardDeleteDays) ? Math.max(0, hardDeleteDays) : 30;
+  // Floor at ONE DAY, not zero. The previous Math.max(0, ...) let a caller pass
+  // staleDays: 0 (or any negative, which clamped to 0), turning the WHERE
+  // clause into `started_at < NOW()`, every live session, and fanning
+  // notifyAgentEnded across the whole fleet. A zero threshold has no
+  // legitimate meaning for a reaper of *stale* sessions. NaN still falls back
+  // to the defaults. This is the last line of defense: the RPC schema floors
+  // these too, and it also covers the env-var path
+  // (REVDEV_STALE_THRESHOLD_DAYS / REVDEV_HARD_DELETE_DAYS to cfg to here).
+  // GAP-312.
+  const stale = Number.isFinite(staleDays) ? Math.max(1, staleDays) : 7;
+  const hard = Number.isFinite(hardDeleteDays) ? Math.max(1, hardDeleteDays) : 30;
 
   // Parameterized interval avoids SQL injection on the days value.
   const aged = await db.query<{ id: string }>(
@@ -1591,11 +1613,23 @@ registerHandler('harness.health', async (_params, db) => {
   };
 });
 
-registerHandler('harness.prune', async (params, db) => {
-  // Allow ops / tests to run a prune pass on demand. Defaults match
-  // DAEMON_DEFAULTS so callers can invoke with no params.
-  const staleDays = num(params.staleDays, DAEMON_DEFAULTS.staleSessionDays);
-  const hardDeleteDays = num(params.hardDeleteDays, DAEMON_DEFAULTS.hardDeleteDays);
+registerHandler('harness.prune', async (params, db, ctx) => {
+  // Allow ops to run a prune pass on demand. Defaults match DAEMON_DEFAULTS so
+  // callers can invoke with no params.
+  //
+  // Signature-REQUIRED (GAP-312). This RPC reaches notifyAgentEnded for every
+  // matched session, so it must not be drivable by an unsigned socket peer.
+  // The dispatch gate already rejects unsigned callers before we get here;
+  // this is the defense-in-depth backstop, mirroring spawn.ts requireAgent.
+  if (ctx.boundVia !== 'signature' || !ctx.agentId) {
+    throw new Error(
+      'harness.prune requires a signed request (verified Ed25519 signature); unsigned or param-bound caller rejected',
+    );
+  }
+  // The schema floors both thresholds at 1 day. Re-floor here so a schema
+  // regression cannot hand runPrune a fleet-wide selector.
+  const staleDays = Math.max(1, num(params.staleDays, DAEMON_DEFAULTS.staleSessionDays));
+  const hardDeleteDays = Math.max(1, num(params.hardDeleteDays, DAEMON_DEFAULTS.hardDeleteDays));
   const result = await runPrune(db, staleDays, hardDeleteDays);
   return {
     aged: result.aged,

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -16,13 +16,15 @@
  * Authorization: agent.spawn additionally requires the signer to hold (own, or
  * have been granted) the project root its command will run in. See the handler.
  *
- * This is a least-privilege gate, NOT a sandbox. `command` and `args` are
- * unconstrained, and buildSafeEnv still passes the operator's HOME and PATH, so
- * an authorized caller runs arbitrary code as the daemon UID and can read
- * ~/.age-identity, ~/.ssh, and the revvault store regardless of which cwd it was
- * granted. The cwd check bounds where a process STARTS, not what it may touch.
- * The missing control is a command allow-list; until that ships, the trust
- * anchor deciding who may sign at all is what actually holds this surface.
+ * Containment (Phase 1, GAP-288, spec 2026-07-10-agent-spawn-confinement-phase-1):
+ * on Linux and WSL2 the command runs inside a `bwrap` sandbox with a
+ * deny-by-default bind set — the operator home is tmpfs'd, so ~/.ssh,
+ * ~/.age-identity, and the revvault store are unreadable even though the process
+ * still runs as the daemon UID. Only the granted root and a per-agent home are
+ * bound read-write. On platforms with no backend, agent.spawn FAILS CLOSED (an
+ * absent sandbox is indistinguishable from a broken one, so it refuses). The
+ * operator escape hatch REVDEV_SPAWN_CONFINEMENT=none spawns unconfined and
+ * records confinement='none' on the row. See confinement.ts.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -30,9 +32,16 @@ import type { PGlite } from '@electric-sql/pglite';
 import { createLogger } from '@revealui/utils/logger';
 import type { IDisposable, IPty } from 'node-pty';
 import * as nodePty from 'node-pty';
-import { onAgentEnded } from './eviction.js';
-import { requireDirInRoot } from './filegit.js';
-import { registerHandler, type SocketContext } from './server.js';
+import {
+  buildConfinedEnv,
+  ensureAgentHome,
+  filterCallerEnv,
+  type ResolvedConfinement,
+  resolveConfinementBackend,
+} from './confinement.js';
+import { onAgentEnded, onDaemonStarted } from './eviction.js';
+import { requireRootAndDir } from './filegit.js';
+import { getDaemonConfig, registerHandler, type SocketContext } from './server.js';
 
 const log = createLogger({ service: 'revdev-daemon/spawn' });
 
@@ -127,30 +136,30 @@ onAgentEnded((agentId: string) => {
 });
 
 // ---------------------------------------------------------------------------
-// Minimal safe environment for spawned processes
+// Confinement backend — resolved ONCE at daemon start (spec §4.2 invariant 1),
+// cached module-level. bwrap is realpath'd + ownership-checked here, never
+// through a caller-influenced PATH.
 // ---------------------------------------------------------------------------
 
-/**
- * Build a minimal environment for a spawned PTY process. We do NOT inherit
- * `process.env` blindly because that would pass revvault secrets, API keys,
- * and signing material to the child.
- *
- * P4-IDENTITY TODO: once the B6 project.grant model ships, gate which env
- * keys a spawned-agent DID may request against the grant.
- */
-function buildSafeEnv(extraEnv: Record<string, string>): Record<string, string> {
-  const base: Record<string, string> = {
-    GIT_CONFIG_NOSYSTEM: '1',
-    HOME: process.env.HOME ?? '/tmp',
-    PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
-    TERM: 'xterm-color',
-    LANG: 'C.UTF-8',
-  };
-  for (const [k, v] of Object.entries(extraEnv)) {
-    base[k] = v;
+let _confinement: ResolvedConfinement | null = null;
+
+onDaemonStarted(async () => {
+  _confinement = resolveConfinementBackend();
+  if (_confinement.backend) {
+    log.info('agent.spawn confinement active', {
+      mode: _confinement.mode,
+      reason: _confinement.reason,
+    });
+  } else if (_confinement.escapeHatch) {
+    log.warn('agent.spawn confinement DISABLED via escape hatch — spawns run unconfined', {
+      reason: _confinement.reason,
+    });
+  } else {
+    log.warn('agent.spawn has NO confinement backend — spawns will fail closed', {
+      reason: _confinement.reason,
+    });
   }
-  return base;
-}
+});
 
 // ---------------------------------------------------------------------------
 // Local parameter extraction helpers
@@ -214,13 +223,17 @@ function safeEnvRecord(v: unknown): Record<string, string> {
  *   - Signature-gated: requireAgent() accepts only a verified Ed25519 signer,
  *     never a caller-supplied actorAgentId.
  *   - Authorized: `repoPath` must be a registered root the signer owns or was
- *     granted, and `cwd` must resolve at or beneath it (requireDirInRoot).
+ *     granted, and `cwd` must resolve at or beneath it (requireRootAndDir).
  *     There is no default cwd; a missing repoPath is a hard error.
- *   - env is built from a minimal baseline (see buildSafeEnv).
+ *   - Confined: on Linux/WSL2 the command runs inside a bwrap sandbox; on
+ *     platforms with no backend the spawn fails closed (confinement.ts).
+ *   - env is an allow-list (filterCallerEnv) over a deny-by-default baseline
+ *     with HOME pointed at the per-agent home (buildConfinedEnv).
  *   - Per-agent concurrency is capped at MAX_PROCESSES_PER_AGENT.
  *
- * Still open: `command` itself is not constrained to an allow-list, so an
- * authorized caller may run any binary within a root it holds.
+ * `command` is not constrained to an allow-list — an authorized caller may run
+ * any binary — but the sandbox bounds what that binary can touch to the granted
+ * root and the agent home. A command allow-list is out of Phase 1 scope.
  */
 registerHandler('agent.spawn', async (params, db, ctx) => {
   const ownerAgentId = requireAgent(ctx, params);
@@ -231,12 +244,12 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   const args = stringArrayParam(params, 'args');
   const cols = positiveInt(params.cols, 80);
   const rows = positiveInt(params.rows, 24);
-  const extraEnv = safeEnvRecord(params.env);
 
   // Authorization. The signature gate above proves WHO is asking; this proves
   // they may run a command THERE. `repoPath` must be a root the signer opened
   // or was granted via project.grant, and `cwd` must resolve to a real
-  // directory at or beneath it.
+  // directory at or beneath it. We keep BOTH the realpath'd root (bound
+  // read-write) and the resolved cwd (started in) — see requireRootAndDir.
   //
   // Fail closed: `repoPath` is required. The previous default silently fell
   // back to $HOME, so any verified agent could fork a command as the daemon UID
@@ -245,11 +258,16 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   if (!repoPath) {
     throw new Error('agent.spawn: missing repoPath (call project.open on the root first)');
   }
-  const cwd = await requireDirInRoot(
+  const { repoReal, cwd } = await requireRootAndDir(
     repoPath,
     stringParam(params, 'cwd') || undefined,
     ownerAgentId,
   );
+
+  // Env allow-list (spec §7). A non-allow-listed caller key (HOME, PATH, any
+  // LD_*/GIT_*/NODE_OPTIONS loader key) is rejected by name here, before any
+  // home is built or process spawned.
+  const callerEnv = filterCallerEnv(safeEnvRecord(params.env));
 
   if (liveCountForAgent(ownerAgentId) >= MAX_PROCESSES_PER_AGENT) {
     throw new Error(
@@ -257,12 +275,44 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
     );
   }
 
-  const processId = randomUUID();
-  const env = buildSafeEnv(extraEnv);
+  // Per-agent persistent home (spec §5); HOME points here inside the sandbox.
+  const agentHome = await ensureAgentHome(getDaemonConfig().dataDir, ownerAgentId);
+  const env = buildConfinedEnv(callerEnv, agentHome);
 
-  // P4-IDENTITY TODO: before spawning, verify the caller holds a project.grant
-  // for the command/cwd combination. Requires the grant model from the B6 lane.
-  const pty = nodePty.spawn(command, args, {
+  // Resolve the confinement backend (cached at daemon start; lazy fallback for
+  // a handler somehow invoked before the startDaemon hook fired).
+  const conf = _confinement ?? resolveConfinementBackend();
+  const operatorHome = process.env.HOME ?? '/root';
+
+  let file: string;
+  let argv: string[];
+  let confinement: string;
+  if (conf.backend) {
+    // Confined: node-pty execs bwrap, which execs the command inside the sandbox.
+    ({ file, argv } = conf.backend.spawnConfined(command, args, {
+      repoReal,
+      cwd,
+      agentHome,
+      operatorHome,
+    }));
+    confinement = conf.mode;
+  } else if (conf.escapeHatch) {
+    // Operator explicitly disabled confinement. Spawn unconfined, but leave a
+    // receipt: warn, and persist confinement='none' on the row.
+    file = command;
+    argv = args;
+    confinement = 'none';
+    log.warn('agent.spawn running UNCONFINED via escape hatch', { command, ownerAgentId, cwd });
+  } else {
+    // No backend and no escape hatch — refuse rather than spawn unprotected.
+    throw new Error(
+      `agent.spawn: refusing to spawn without confinement (${conf.reason}). ` +
+        'Set REVDEV_SPAWN_CONFINEMENT=none in the daemon environment to override (audited).',
+    );
+  }
+
+  const processId = randomUUID();
+  const pty = nodePty.spawn(file, argv, {
     name: 'xterm-color',
     cols,
     rows,
@@ -271,9 +321,9 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   });
 
   await db.query(
-    `INSERT INTO agent_processes (id, owner_agent, command, args, cwd, pid, status)
-     VALUES ($1, $2, $3, $4::jsonb, $5, $6, 'running')`,
-    [processId, ownerAgentId, command, JSON.stringify(args), cwd, pty.pid],
+    `INSERT INTO agent_processes (id, owner_agent, command, args, cwd, pid, status, confinement)
+     VALUES ($1, $2, $3, $4::jsonb, $5, $6, 'running', $7)`,
+    [processId, ownerAgentId, command, JSON.stringify(args), cwd, pty.pid, confinement],
   );
 
   const entry: ProcessEntry = {

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -277,7 +277,8 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   }
 
   // Per-agent persistent home (spec §5); HOME points here inside the sandbox.
-  const agentHome = await ensureAgentHome(getDaemonConfig().dataDir, ownerAgentId);
+  const dataDir = getDaemonConfig().dataDir;
+  const agentHome = await ensureAgentHome(dataDir, ownerAgentId);
   const env = buildConfinedEnv(callerEnv, agentHome);
 
   // Resolve the confinement backend (cached at daemon start; lazy fallback for
@@ -297,6 +298,7 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
       cwd,
       agentHome,
       operatorHome,
+      dataDir,
     }));
     confinement = conf.mode;
   } else if (conf.escapeHatch) {

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -38,6 +38,7 @@ import {
   filterCallerEnv,
   type ResolvedConfinement,
   resolveConfinementBackend,
+  resolveOperatorHome,
 } from './confinement.js';
 import { onAgentEnded, onDaemonStarted } from './eviction.js';
 import { requireRootAndDir } from './filegit.js';
@@ -282,7 +283,9 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   // Resolve the confinement backend (cached at daemon start; lazy fallback for
   // a handler somehow invoked before the startDaemon hook fired).
   const conf = _confinement ?? resolveConfinementBackend();
-  const operatorHome = process.env.HOME ?? '/root';
+  // Realpath'd so the overlap guard (which compares against a realpath'd
+  // repoReal) and the tmpfs bind agree on the canonical home (GAP-320a review S1).
+  const operatorHome = resolveOperatorHome();
 
   let file: string;
   let argv: string[];

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -9,22 +9,29 @@
  *   - Enforces per-agent ownership: only the spawning agent may send input,
  *     resize, or stop a process it owns
  *
- * P4-IDENTITY TODO: Once the "B6" identity lane ships its signature-gating
- * rewrite, add 'agent.spawn', 'agent.stop', 'agent.input', 'agent.resize',
- * and 'agent.output' to MUTATING_OR_CONTENT_METHODS in server.ts AND to
- * requires_signature() in signing.rs. Until then these methods accept
- * actorAgentId param auth (same posture as mail.send / files.reserve), which
- * is gated only by the 0600 socket boundary. The deferred grant model
- * (spawned-agent DID + project.grant) should be designed as part of that lane.
+ * Authentication: all five methods are in MUTATING_OR_CONTENT_METHODS and in
+ * signing.rs requires_signature(), so the dispatch gate binds ctx.agentId to a
+ * verified Ed25519 signer. The spoofable actorAgentId param auth is gone.
+ *
+ * Authorization: agent.spawn additionally requires the signer to hold (own, or
+ * have been granted) the project root its command will run in. See the handler.
+ *
+ * This is a least-privilege gate, NOT a sandbox. `command` and `args` are
+ * unconstrained, and buildSafeEnv still passes the operator's HOME and PATH, so
+ * an authorized caller runs arbitrary code as the daemon UID and can read
+ * ~/.age-identity, ~/.ssh, and the revvault store regardless of which cwd it was
+ * granted. The cwd check bounds where a process STARTS, not what it may touch.
+ * The missing control is a command allow-list; until that ships, the trust
+ * anchor deciding who may sign at all is what actually holds this surface.
  */
 
 import { randomUUID } from 'node:crypto';
-import { stat } from 'node:fs/promises';
 import type { PGlite } from '@electric-sql/pglite';
 import { createLogger } from '@revealui/utils/logger';
 import type { IDisposable, IPty } from 'node-pty';
 import * as nodePty from 'node-pty';
 import { onAgentEnded } from './eviction.js';
+import { requireDirInRoot } from './filegit.js';
 import { registerHandler, type SocketContext } from './server.js';
 
 const log = createLogger({ service: 'revdev-daemon/spawn' });
@@ -204,11 +211,16 @@ function safeEnvRecord(v: unknown): Record<string, string> {
  * agent.spawn — fork a PTY child process and return processId + pid.
  *
  * Security:
- *   - cwd is validated to exist via stat() before passing to node-pty.
+ *   - Signature-gated: requireAgent() accepts only a verified Ed25519 signer,
+ *     never a caller-supplied actorAgentId.
+ *   - Authorized: `repoPath` must be a registered root the signer owns or was
+ *     granted, and `cwd` must resolve at or beneath it (requireDirInRoot).
+ *     There is no default cwd; a missing repoPath is a hard error.
  *   - env is built from a minimal baseline (see buildSafeEnv).
  *   - Per-agent concurrency is capped at MAX_PROCESSES_PER_AGENT.
- *   - P4-IDENTITY TODO: signature-gate once B6 ships; add to
- *     MUTATING_OR_CONTENT_METHODS and to signing.rs requires_signature().
+ *
+ * Still open: `command` itself is not constrained to an allow-list, so an
+ * authorized caller may run any binary within a root it holds.
  */
 registerHandler('agent.spawn', async (params, db, ctx) => {
   const ownerAgentId = requireAgent(ctx, params);
@@ -217,19 +229,27 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   if (!command) throw new Error('agent.spawn: missing command');
 
   const args = stringArrayParam(params, 'args');
-  const cwd = stringParam(params, 'cwd') || (process.env.HOME ?? '/tmp');
   const cols = positiveInt(params.cols, 80);
   const rows = positiveInt(params.rows, 24);
   const extraEnv = safeEnvRecord(params.env);
 
-  // Validate cwd exists and is a directory
-  try {
-    const s = await stat(cwd);
-    if (!s.isDirectory()) throw new Error(`agent.spawn: cwd is not a directory: ${cwd}`);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`agent.spawn: cwd not accessible: ${msg}`);
+  // Authorization. The signature gate above proves WHO is asking; this proves
+  // they may run a command THERE. `repoPath` must be a root the signer opened
+  // or was granted via project.grant, and `cwd` must resolve to a real
+  // directory at or beneath it.
+  //
+  // Fail closed: `repoPath` is required. The previous default silently fell
+  // back to $HOME, so any verified agent could fork a command as the daemon UID
+  // anywhere in the operator's home directory.
+  const repoPath = stringParam(params, 'repoPath');
+  if (!repoPath) {
+    throw new Error('agent.spawn: missing repoPath (call project.open on the root first)');
   }
+  const cwd = await requireDirInRoot(
+    repoPath,
+    stringParam(params, 'cwd') || undefined,
+    ownerAgentId,
+  );
 
   if (liveCountForAgent(ownerAgentId) >= MAX_PROCESSES_PER_AGENT) {
     throw new Error(

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -500,15 +500,20 @@ export const schemas: Record<string, z.ZodType> = {
     .passthrough(),
 
   // -- Agent process spawning (P4) -------------------------------------------
-  // P4-IDENTITY TODO: once the B6 identity lane ships signature gating, add
-  // all five agent.* methods to MUTATING_OR_CONTENT_METHODS in server.ts and
-  // to requires_signature() in signing.rs. The grant model (spawned-agent DID
-  // + project.grant) is deferred to that lane.
+  // All five agent.* methods are signature-gated (MUTATING_OR_CONTENT_METHODS
+  // in server.ts, requires_signature() in signing.rs), and agent.spawn is
+  // additionally authorized against a project.grant on `repoPath`.
   'agent.spawn': z
     .object({
       command: z.string().min(1).max(MAX_PATH_LENGTH),
       args: z.array(z.string().max(MAX_PATH_LENGTH)).max(128).optional(),
-      cwd: z.string().max(MAX_PATH_LENGTH).optional(),
+      // Required: the registered project root the caller owns or was granted.
+      // Without it the handler cannot authorize where the command runs.
+      // `safePath` for symmetry with every other repoPath-taking method. The
+      // handler's requireDirInRoot is the load-bearing check; this is depth,
+      // and it rejects a `..` cwd before the handler ever resolves it.
+      repoPath: safePath,
+      cwd: safePath.optional(),
       cols: z.number().int().min(1).max(1000).optional(),
       rows: z.number().int().min(1).max(500).optional(),
       // Caller-supplied env overrides (merged onto a minimal safe baseline).

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -526,8 +526,11 @@ export const schemas: Record<string, z.ZodType> = {
       cwd: safePath.optional(),
       cols: z.number().int().min(1).max(1000).optional(),
       rows: z.number().int().min(1).max(500).optional(),
-      // Caller-supplied env overrides (merged onto a minimal safe baseline).
-      // Values must be strings; non-string values are dropped by the handler.
+      // Caller-supplied env. The handler enforces an ALLOW-LIST (filterCallerEnv,
+      // spec §7): only TERM, LANG, LC_*, CI, NO_COLOR, REVDEV_* are accepted; any
+      // other key (HOME, PATH, LD_*/GIT_*/NODE_OPTIONS loader keys) is rejected by
+      // name. The schema stays permissive so the rejection is a clear handler
+      // error naming the offending key, not a generic schema failure.
       env: z.record(z.string(), z.string()).optional(),
       actorAgentId,
     })

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -346,15 +346,25 @@ export const schemas: Record<string, z.ZodType> = {
   // `harness.prune`) previously bypassed `validateParams` because no
   // schema existed in the registry. Adding them here completes the
   // Option A direction (schemas as canonical) shipped by GAP-173 —
-  // every live handler should have a schema entry. Schemas are
-  // intentionally TYPE-ONLY (no integer / non-negative / upper-bound
-  // constraints on `staleDays` / `hardDeleteDays`): the prune handler
-  // already runs a defensive clamp via `Number.isFinite` + `Math.max(0,
-  // ...)`, AND the integration tests legitimately pass fractional days
-  // (e.g. `staleDays: 0.00001` ≈ 0.86s) to exercise the prune logic
-  // without 24h sleeps + negative days to verify the defensive clamp.
-  // Adding `int()` / `min(0)` here would break those tests and move
-  // safety enforcement away from the handler where it belongs.
+  // every live handler should have a schema entry.
+  //
+  // These schemas WERE intentionally type-only, delegating safety to the
+  // handler's `Math.max(0, ...)` clamp so that integration tests could pass
+  // fractional days (`staleDays: 0.00001`) and negative days. That reasoning
+  // was wrong, and GAP-312 is the bill: a clamp whose floor is ZERO is not a
+  // defense. `staleDays: 0` (and every negative, which clamped to 0) turns
+  // prune's WHERE clause into `started_at < NOW()`, every live session, and
+  // runPrune fans `notifyAgentEnded` across all of them, evicting each agent's
+  // project roots and killing each agent's PTYs. Fleet-wide, from one frame.
+  //
+  // The threshold is now floored at ONE DAY here, at the untrusted boundary,
+  // and again in runPrune. A reaper of *stale* sessions has no legitimate
+  // sub-day threshold. The tests that needed one were testing a time-based
+  // reaper by shrinking time; they now backdate `started_at` instead, which is
+  // both correct and faster (no sleeps, no flake).
+  //
+  // Not `.int()`: a fractional threshold >= 1 is harmless, and the floor is
+  // the security property. Keep the constraint minimal and legible.
   'harness.health': z
     .object({
       actorAgentId,
@@ -363,8 +373,8 @@ export const schemas: Record<string, z.ZodType> = {
 
   'harness.prune': z
     .object({
-      staleDays: z.number().optional(),
-      hardDeleteDays: z.number().optional(),
+      staleDays: z.number().min(1).optional(),
+      hardDeleteDays: z.number().min(1).optional(),
       actorAgentId,
     })
     .passthrough(),

--- a/scripts/ci/prove-red.mjs
+++ b/scripts/ci/prove-red.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+// Prove-red gate (verification-enforcement lane, spec 2026-07-10).
+//
+// A test that passes whether or not the fix is present proves nothing. This
+// gate mechanises "prove red": on a PR that changes BOTH product source and
+// test files, it reverts the source changes to the merge base, re-runs each
+// CHANGED test file, and REQUIRES each to be red against the base. A changed
+// test file that stays green without the source change is inert, and the gate
+// blocks it.
+//
+// Honest limits (kept in lockstep with the spec §4.2):
+//   - It proves "the changed test file does not PASS against base", which is
+//     weaker than "fails on an assertion": a file that fails to import because
+//     it references a symbol the PR added counts as red here. So the gate kills
+//     the worthless regression guard but does not certify test STRENGTH.
+//   - Granularity is the FILE, not the individual test case. A changed file
+//     whose NEW test is inert but whose OLD test goes red against base still
+//     passes. Raising this to per-test needs diff-hunk attribution; deferred.
+//   - TypeScript/vitest only in Phase 1a. Rust (`cargo test`) and Go
+//     (`go test`) changed-test prove-red is NOT covered and is logged loudly
+//     below rather than silently skipped.
+//
+// Zero authored regex (fleet rule): path classification is suffix/substring
+// membership only.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+
+const REPO_ROOT = process.cwd();
+
+// --- path classification (suffix/substring only) ---------------------------
+
+const TEST_SUFFIXES = [
+  '.test.ts',
+  '.test.tsx',
+  '.test.js',
+  '.test.mjs',
+  '.spec.ts',
+  '.spec.tsx',
+  '.spec.js',
+  '.spec.mjs',
+];
+const CODE_SUFFIXES = ['.ts', '.tsx', '.js', '.mjs', '.cjs'];
+
+function isTestFile(p) {
+  if (p.includes('/__tests__/')) return true;
+  for (const s of TEST_SUFFIXES) if (p.endsWith(s)) return true;
+  return false;
+}
+
+function isCodeSource(p) {
+  if (isTestFile(p)) return false;
+  if (p.endsWith('.d.ts')) return false;
+  for (const s of CODE_SUFFIXES) if (p.endsWith(s)) return true;
+  return false;
+}
+
+// Non-TS test files we cannot prove-red yet, surfaced rather than silently dropped.
+function isUncoveredTestFile(p) {
+  if (p.endsWith('_test.go')) return true;
+  if (p.includes('/tests/') && p.endsWith('.rs')) return true;
+  return false;
+}
+
+// --- git helpers -----------------------------------------------------------
+
+function git(args) {
+  return execFileSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8' });
+}
+
+function mergeBase(baseRef) {
+  return git(['merge-base', baseRef, 'HEAD']).trim();
+}
+
+// `--no-renames` so a rename shows as add+delete, which the revert logic below
+// handles without a separate R-status branch.
+function changedFiles(base) {
+  const out = git(['diff', '--no-renames', '--name-status', base, 'HEAD']).trim();
+  if (!out) return [];
+  return out.split('\n').map((line) => {
+    const tab = line.indexOf('\t');
+    return { status: line.slice(0, tab).trim(), path: line.slice(tab + 1).trim() };
+  });
+}
+
+// --- package resolution ----------------------------------------------------
+
+function nearestPackage(fileAbs) {
+  let dir = dirname(fileAbs);
+  while (dir.startsWith(REPO_ROOT)) {
+    const pkg = join(dir, 'package.json');
+    if (existsSync(pkg)) {
+      try {
+        const name = JSON.parse(readFileSync(pkg, 'utf8')).name;
+        if (name) return { name, dir };
+      } catch {
+        // unreadable or nameless package.json; keep walking up
+      }
+    }
+    if (dir === REPO_ROOT) break;
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+// --- main ------------------------------------------------------------------
+
+function fail(msg) {
+  console.error(`\n✗ prove-red: ${msg}`);
+  process.exit(1);
+}
+
+function skip(msg) {
+  console.log(`\n○ prove-red: ${msg}. Gate does not apply.`);
+  process.exit(0);
+}
+
+const baseRef = process.env.BASE_REF || process.env.BASE_SHA;
+if (!baseRef) fail('BASE_REF is not set (pass the PR base sha).');
+
+const base = mergeBase(baseRef);
+console.log(`prove-red: merge base = ${base}`);
+
+const changed = changedFiles(base);
+const changedSource = changed.filter((c) => isCodeSource(c.path));
+const changedTests = changed.filter((c) => isTestFile(c.path) && c.status !== 'D');
+const uncovered = changed.filter((c) => isUncoveredTestFile(c.path) && c.status !== 'D');
+
+if (uncovered.length > 0) {
+  console.log(
+    `prove-red: NOTE: ${uncovered.length} changed Rust/Go test file(s) are NOT prove-red covered in Phase 1a:`,
+  );
+  for (const u of uncovered) console.log(`    - ${u.path}`);
+}
+
+// Fire only when product CODE source AND test files both change. Test-only,
+// source-only, and docs/config-only PRs are out of scope by design.
+if (changedSource.length === 0 || changedTests.length === 0) {
+  skip(
+    `changed source files = ${changedSource.length}, changed TS test files = ${changedTests.length}`,
+  );
+}
+
+console.log(`prove-red: reverting ${changedSource.length} source file(s) to base ${base}`);
+for (const { status, path } of changedSource) {
+  if (status === 'A') {
+    // Added in the PR, absent at base. Remove it.
+    execFileSync('rm', ['-f', path], { cwd: REPO_ROOT });
+  } else {
+    // Modified or deleted in the PR; restore base content.
+    git(['checkout', base, '--', path]);
+  }
+}
+
+// Group changed test files by their owning package.
+const byPackage = new Map();
+for (const { path } of changedTests) {
+  const abs = join(REPO_ROOT, path);
+  const pkg = nearestPackage(abs);
+  if (!pkg) {
+    console.log(`prove-red: NOTE: no package.json owns ${path}; skipping it.`);
+    continue;
+  }
+  if (!byPackage.has(pkg.name)) byPackage.set(pkg.name, { dir: pkg.dir, files: [] });
+  byPackage.get(pkg.name).files.push(relative(pkg.dir, abs));
+}
+
+if (byPackage.size === 0) skip('no packaged TS test files to run');
+
+// Run each changed test file against the reverted base and classify it.
+//
+// PASS requires AT LEAST ONE changed test file to be red against base: the PR
+// must carry a failing-first test that genuinely depends on the change. A file
+// that stays green is either a legitimate compatibility update to an existing
+// test or an inert new one; the gate cannot tell those apart at file
+// granularity, so it REPORTS them but does not block on them. It blocks only
+// when NO changed test file is red, a source change with zero failing-first
+// evidence, which is exactly the "a passing test proves nothing until it fails
+// against the old code" failure this gate exists to catch.
+const redFiles = [];
+const greenFiles = [];
+for (const [name, { files }] of byPackage) {
+  for (const file of files) {
+    console.log(`\nprove-red: running ${name} :: ${file} against base`);
+    let exit = 0;
+    try {
+      execFileSync('pnpm', ['--filter', name, 'exec', 'vitest', 'run', '--no-coverage', file], {
+        cwd: REPO_ROOT,
+        stdio: 'inherit',
+      });
+    } catch (e) {
+      exit = typeof e.status === 'number' ? e.status : 1;
+    }
+    if (exit === 0) {
+      greenFiles.push(`${name} :: ${file}`);
+      console.log(`prove-red: · ${file} PASSED against base (compat update or inert)`);
+    } else {
+      redFiles.push(`${name} :: ${file}`);
+      console.log(`prove-red: ✓ ${file} is red against base, proves the change`);
+    }
+  }
+}
+
+if (greenFiles.length > 0) {
+  console.log('\nprove-red: NOTE: these changed test files passed WITHOUT the source change:');
+  for (const f of greenFiles) console.log(`    - ${f}`);
+  console.log(
+    '    They may be legitimate compatibility updates, or they may be inert.\n' +
+      '    The gate does not block on them; a reviewer should confirm which they are.',
+  );
+}
+
+if (redFiles.length === 0) {
+  console.error(
+    '\n✗ prove-red: NONE of the changed test files fail against the base. This PR\n' +
+      'changes product source but carries no failing-first test that depends on the\n' +
+      'change. Add a test that is red without the fix, or, for a genuine\n' +
+      'behavior-preserving refactor, carry the recorded verify:no-behavior-change\n' +
+      'label (applied by a non-author, per the verification-enforcement lane).',
+  );
+  process.exit(1);
+}
+
+console.log(`\n✓ prove-red: ${redFiles.length} changed test file(s) red against base.`);
+process.exit(0);

--- a/scripts/ci/prove-red.mjs
+++ b/scripts/ci/prove-red.mjs
@@ -1,31 +1,50 @@
 #!/usr/bin/env node
-// Prove-red gate (verification-enforcement lane, spec 2026-07-10).
+// Prove-red gate (verification-enforcement lane, spec 2026-07-10; language
+// coverage extended per lane item 1d).
 //
 // A test that passes whether or not the fix is present proves nothing. This
 // gate mechanises "prove red": on a PR that changes BOTH product source and
 // test files, it reverts the source changes to the merge base, re-runs each
-// CHANGED test file, and REQUIRES each to be red against the base. A changed
-// test file that stays green without the source change is inert, and the gate
-// blocks it.
+// CHANGED test, and REQUIRES at least one to be red against the base. A changed
+// test that stays green without the source change is inert, and the gate
+// blocks a PR whose only evidence is inert tests.
 //
-// Honest limits (kept in lockstep with the spec §4.2):
-//   - It proves "the changed test file does not PASS against base", which is
-//     weaker than "fails on an assertion": a file that fails to import because
+// The gate covers three toolchains. Each fires independently: a language is
+// "active" only when the PR changes BOTH that language's source AND its tests,
+// and each active language must produce >=1 red test of its own. Scope with
+// PROVE_RED_LANGS (comma list of: typescript, go, rust); default is all three.
+// CI runs one language per job so each job installs only the toolchain it needs.
+//
+// Coverage unit per language — stated honestly, because the granularity differs:
+//   - TypeScript/vitest — the test FILE. Each changed `*.test.ts` runs via
+//     `pnpm --filter <pkg> exec vitest run <file>` against reverted source.
+//   - Go/`go test` — the PACKAGE. `go test` compiles and runs a whole package;
+//     a single test FILE cannot be run in isolation (its funcs share the
+//     package's other files). So a changed `*_test.go` is proven at package
+//     granularity: the package, built from base non-test source plus the PR's
+//     test files, must have >=1 failing test.
+//   - Rust/`cargo test` — the integration-test FILE (`cargo test --test <name>`
+//     per crate manifest). Inline `#[cfg(test)]` unit tests inside `src/*.rs`
+//     are NOT covered: they compile together with the source they test, so
+//     reverting the source removes the very tests, and proving them needs
+//     per-hunk attribution. Same shape as the TS per-test deferral below.
+//
+// Honest limits shared by all three (kept in lockstep with the spec §4.2):
+//   - It proves "the changed test does not PASS against base", which is weaker
+//     than "fails on an assertion": a test that fails to compile/import because
 //     it references a symbol the PR added counts as red here. So the gate kills
 //     the worthless regression guard but does not certify test STRENGTH.
-//   - Granularity is the FILE, not the individual test case. A changed file
-//     whose NEW test is inert but whose OLD test goes red against base still
-//     passes. Raising this to per-test needs diff-hunk attribution; deferred.
-//   - TypeScript/vitest only in Phase 1a. Rust (`cargo test`) and Go
-//     (`go test`) changed-test prove-red is NOT covered and is logged loudly
-//     below rather than silently skipped.
+//   - Granularity is the unit above (file/package), not the individual test
+//     case. A changed unit whose NEW test is inert but whose OLD test goes red
+//     against base still passes. Raising this to per-test needs diff-hunk
+//     attribution; deferred.
 //
 // Zero authored regex (fleet rule): path classification is suffix/substring
 // membership only.
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join, relative } from 'node:path';
+import { basename, dirname, join, relative } from 'node:path';
 
 const REPO_ROOT = process.cwd();
 
@@ -43,24 +62,41 @@ const TEST_SUFFIXES = [
 ];
 const CODE_SUFFIXES = ['.ts', '.tsx', '.js', '.mjs', '.cjs'];
 
-function isTestFile(p) {
+// TypeScript / JavaScript ---------------------------------------------------
+function tsIsTest(p) {
   if (p.includes('/__tests__/')) return true;
   for (const s of TEST_SUFFIXES) if (p.endsWith(s)) return true;
   return false;
 }
-
-function isCodeSource(p) {
-  if (isTestFile(p)) return false;
+function tsIsSource(p) {
+  if (tsIsTest(p)) return false;
   if (p.endsWith('.d.ts')) return false;
   for (const s of CODE_SUFFIXES) if (p.endsWith(s)) return true;
   return false;
 }
 
-// Non-TS test files we cannot prove-red yet, surfaced rather than silently dropped.
-function isUncoveredTestFile(p) {
-  if (p.endsWith('_test.go')) return true;
-  if (p.includes('/tests/') && p.endsWith('.rs')) return true;
-  return false;
+// Go ------------------------------------------------------------------------
+function goIsTest(p) {
+  return p.endsWith('_test.go');
+}
+function goIsSource(p) {
+  return p.endsWith('.go') && !p.endsWith('_test.go');
+}
+
+// Rust — an integration test is a `.rs` whose parent directory is `tests`
+// (`<crate>/tests/<name>.rs`), run per-file with `cargo test --test <name>`.
+// Everything else under a crate (`src/**`) is source; inline `#[cfg(test)]`
+// unit tests inside src are not separable (see header). The parent-dir check
+// works whether the crate is the repo root (`tests/it.rs`) or nested
+// (`apps/studio/src-tauri/tests/harness_integration.rs`).
+function rustParentIsTests(p) {
+  return basename(dirname(p)) === 'tests';
+}
+function rustIsTest(p) {
+  return p.endsWith('.rs') && rustParentIsTests(p);
+}
+function rustIsSource(p) {
+  return p.endsWith('.rs') && !rustParentIsTests(p);
 }
 
 // --- git helpers -----------------------------------------------------------
@@ -84,8 +120,31 @@ function changedFiles(base) {
   });
 }
 
-// --- package resolution ----------------------------------------------------
+// Restore each file to its base content (added-in-PR files are removed).
+function revertToBase(files, base) {
+  for (const { status, path } of files) {
+    if (status === 'A') {
+      execFileSync('rm', ['-f', path], { cwd: REPO_ROOT });
+    } else {
+      git(['checkout', base, '--', path]);
+    }
+  }
+}
 
+// --- manifest resolution ---------------------------------------------------
+
+// Nearest ancestor dir (inclusive) containing `filename`.
+function nearestDirWith(startDir, filename) {
+  let dir = startDir;
+  while (dir.startsWith(REPO_ROOT)) {
+    if (existsSync(join(dir, filename))) return dir;
+    if (dir === REPO_ROOT) break;
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+// Nearest package.json with a `name`, walking up from a file.
 function nearestPackage(fileAbs) {
   let dir = dirname(fileAbs);
   while (dir.startsWith(REPO_ROOT)) {
@@ -104,7 +163,7 @@ function nearestPackage(fileAbs) {
   return null;
 }
 
-// --- main ------------------------------------------------------------------
+// --- command runner --------------------------------------------------------
 
 function fail(msg) {
   console.error(`\n✗ prove-red: ${msg}`);
@@ -116,111 +175,233 @@ function skip(msg) {
   process.exit(0);
 }
 
+// Run a test command; return its exit code (0 = green, non-zero = red). A
+// missing toolchain is an ENVIRONMENT error, not a red — it must fail the gate
+// loudly rather than be miscounted as failing-first evidence.
+function runCmd(file, args, opts) {
+  try {
+    execFileSync(file, args, { stdio: 'inherit', ...opts });
+    return 0;
+  } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      fail(
+        `toolchain '${file}' not found — cannot run \`${file} ${args.join(' ')}\`. ` +
+          'Install it or scope the run with PROVE_RED_LANGS.',
+      );
+    }
+    return typeof e.status === 'number' ? e.status : 1;
+  }
+}
+
+// --- per-language run plans -------------------------------------------------
+// Each plan turns changed test files into runnable "units" ({ label, exec }).
+
+function planTypescript(tests) {
+  const byPackage = new Map();
+  for (const { path } of tests) {
+    const abs = join(REPO_ROOT, path);
+    const pkg = nearestPackage(abs);
+    if (!pkg) {
+      console.log(`prove-red: NOTE: no package.json owns ${path}; skipping it.`);
+      continue;
+    }
+    if (!byPackage.has(pkg.name)) byPackage.set(pkg.name, { dir: pkg.dir, files: [] });
+    byPackage.get(pkg.name).files.push(relative(pkg.dir, abs));
+  }
+  const units = [];
+  for (const [name, { files }] of byPackage) {
+    for (const file of files) {
+      units.push({
+        label: `${name} :: ${file}`,
+        exec: () =>
+          runCmd('pnpm', ['--filter', name, 'exec', 'vitest', 'run', '--no-coverage', file], {
+            cwd: REPO_ROOT,
+          }),
+      });
+    }
+  }
+  return units;
+}
+
+function planGo(tests) {
+  // Group by owning module, then by package dir (relative to the module root).
+  const byModule = new Map(); // moduleDir -> Set<relPkg>
+  for (const { path } of tests) {
+    const abs = join(REPO_ROOT, path);
+    const moduleDir = nearestDirWith(dirname(abs), 'go.mod');
+    if (!moduleDir) {
+      console.log(`prove-red: NOTE: no go.mod owns ${path}; skipping it.`);
+      continue;
+    }
+    const rel = relative(moduleDir, dirname(abs)) || '.';
+    if (!byModule.has(moduleDir)) byModule.set(moduleDir, new Set());
+    byModule.get(moduleDir).add(rel);
+  }
+  const units = [];
+  for (const [moduleDir, pkgs] of byModule) {
+    for (const rel of pkgs) {
+      const target = rel === '.' ? './' : `./${rel}/`;
+      units.push({
+        label: `go ${relative(REPO_ROOT, moduleDir) || '.'} :: ${target}`,
+        exec: () => runCmd('go', ['test', target], { cwd: moduleDir }),
+      });
+    }
+  }
+  return units;
+}
+
+function planRust(tests) {
+  const units = [];
+  for (const { path } of tests) {
+    const abs = join(REPO_ROOT, path);
+    const manifestDir = nearestDirWith(dirname(abs), 'Cargo.toml');
+    if (!manifestDir) {
+      console.log(`prove-red: NOTE: no Cargo.toml owns ${path}; skipping it.`);
+      continue;
+    }
+    const stem = basename(path).slice(0, -'.rs'.length);
+    const manifest = relative(REPO_ROOT, join(manifestDir, 'Cargo.toml'));
+    units.push({
+      label: `cargo ${manifest} :: --test ${stem}`,
+      // --test-threads=1: the src-tauri integration tests route the harness
+      // client through process-global env and race in parallel (mirrors
+      // studio-rust-tests.yml). Harmless for the others.
+      exec: () =>
+        runCmd(
+          'cargo',
+          ['test', '--manifest-path', manifest, '--test', stem, '--', '--test-threads=1'],
+          { cwd: REPO_ROOT },
+        ),
+    });
+  }
+  return units;
+}
+
+const LANGS = {
+  typescript: {
+    label: 'TypeScript/vitest (unit: test FILE)',
+    isTest: tsIsTest,
+    isSource: tsIsSource,
+    plan: planTypescript,
+  },
+  go: {
+    label: 'Go/go test (unit: PACKAGE)',
+    isTest: goIsTest,
+    isSource: goIsSource,
+    plan: planGo,
+  },
+  rust: {
+    label: 'Rust/cargo test (unit: integration-test FILE)',
+    isTest: rustIsTest,
+    isSource: rustIsSource,
+    plan: planRust,
+  },
+};
+
+// --- main ------------------------------------------------------------------
+
 const baseRef = process.env.BASE_REF || process.env.BASE_SHA;
 if (!baseRef) fail('BASE_REF is not set (pass the PR base sha).');
 
+const ALL_LANGS = Object.keys(LANGS);
+const requested = (process.env.PROVE_RED_LANGS || ALL_LANGS.join(','))
+  .split(',')
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
+for (const id of requested) {
+  if (!LANGS[id]) {
+    fail(`unknown language '${id}' in PROVE_RED_LANGS (valid: ${ALL_LANGS.join(', ')})`);
+  }
+}
+
 const base = mergeBase(baseRef);
 console.log(`prove-red: merge base = ${base}`);
+console.log(`prove-red: languages requested = ${requested.join(', ')}`);
 
 const changed = changedFiles(base);
-const changedSource = changed.filter((c) => isCodeSource(c.path));
-const changedTests = changed.filter((c) => isTestFile(c.path) && c.status !== 'D');
-const uncovered = changed.filter((c) => isUncoveredTestFile(c.path) && c.status !== 'D');
 
-if (uncovered.length > 0) {
-  console.log(
-    `prove-red: NOTE: ${uncovered.length} changed Rust/Go test file(s) are NOT prove-red covered in Phase 1a:`,
-  );
-  for (const u of uncovered) console.log(`    - ${u.path}`);
-}
-
-// Fire only when product CODE source AND test files both change. Test-only,
-// source-only, and docs/config-only PRs are out of scope by design.
-if (changedSource.length === 0 || changedTests.length === 0) {
-  skip(
-    `changed source files = ${changedSource.length}, changed TS test files = ${changedTests.length}`,
-  );
-}
-
-console.log(`prove-red: reverting ${changedSource.length} source file(s) to base ${base}`);
-for (const { status, path } of changedSource) {
-  if (status === 'A') {
-    // Added in the PR, absent at base. Remove it.
-    execFileSync('rm', ['-f', path], { cwd: REPO_ROOT });
+// A language is active only when the PR changes BOTH its source and its tests.
+const active = [];
+for (const id of requested) {
+  const L = LANGS[id];
+  const source = changed.filter((c) => L.isSource(c.path));
+  const tests = changed.filter((c) => L.isTest(c.path) && c.status !== 'D');
+  if (source.length > 0 && tests.length > 0) {
+    active.push({ id, L, source, tests, units: L.plan(tests) });
   } else {
-    // Modified or deleted in the PR; restore base content.
-    git(['checkout', base, '--', path]);
+    console.log(
+      `prove-red: ${id}: source=${source.length} test=${tests.length} — inactive, skipping`,
+    );
   }
 }
 
-// Group changed test files by their owning package.
-const byPackage = new Map();
-for (const { path } of changedTests) {
-  const abs = join(REPO_ROOT, path);
-  const pkg = nearestPackage(abs);
-  if (!pkg) {
-    console.log(`prove-red: NOTE: no package.json owns ${path}; skipping it.`);
+if (active.length === 0) {
+  skip(`no requested language changed BOTH source and tests (requested: ${requested.join(', ')})`);
+}
+
+const totalUnits = active.reduce((n, a) => n + a.units.length, 0);
+if (totalUnits === 0) skip('no runnable test units resolved from the changed test files');
+
+// Revert every active language's source to base up front, then run each
+// language's changed tests against it and require >=1 red per language.
+for (const a of active) {
+  console.log(`\nprove-red [${a.id}]: reverting ${a.source.length} source file(s) to base ${base}`);
+  revertToBase(a.source, base);
+}
+
+let anyFail = false;
+for (const a of active) {
+  console.log(`\n=== prove-red [${a.id}] — ${a.L.label} ===`);
+  if (a.units.length === 0) {
+    // Activated but nothing runnable resolved (e.g. no owning manifest). Cannot
+    // prove; report rather than silently pass.
+    console.log(`prove-red [${a.id}]: no runnable test units resolved; no evidence produced.`);
     continue;
   }
-  if (!byPackage.has(pkg.name)) byPackage.set(pkg.name, { dir: pkg.dir, files: [] });
-  byPackage.get(pkg.name).files.push(relative(pkg.dir, abs));
-}
 
-if (byPackage.size === 0) skip('no packaged TS test files to run');
-
-// Run each changed test file against the reverted base and classify it.
-//
-// PASS requires AT LEAST ONE changed test file to be red against base: the PR
-// must carry a failing-first test that genuinely depends on the change. A file
-// that stays green is either a legitimate compatibility update to an existing
-// test or an inert new one; the gate cannot tell those apart at file
-// granularity, so it REPORTS them but does not block on them. It blocks only
-// when NO changed test file is red, a source change with zero failing-first
-// evidence, which is exactly the "a passing test proves nothing until it fails
-// against the old code" failure this gate exists to catch.
-const redFiles = [];
-const greenFiles = [];
-for (const [name, { files }] of byPackage) {
-  for (const file of files) {
-    console.log(`\nprove-red: running ${name} :: ${file} against base`);
-    let exit = 0;
-    try {
-      execFileSync('pnpm', ['--filter', name, 'exec', 'vitest', 'run', '--no-coverage', file], {
-        cwd: REPO_ROOT,
-        stdio: 'inherit',
-      });
-    } catch (e) {
-      exit = typeof e.status === 'number' ? e.status : 1;
-    }
+  const redFiles = [];
+  const greenFiles = [];
+  for (const unit of a.units) {
+    console.log(`\nprove-red [${a.id}]: running ${unit.label} against base`);
+    const exit = unit.exec();
     if (exit === 0) {
-      greenFiles.push(`${name} :: ${file}`);
-      console.log(`prove-red: · ${file} PASSED against base (compat update or inert)`);
+      greenFiles.push(unit.label);
+      console.log(
+        `prove-red [${a.id}]: · ${unit.label} PASSED against base (compat update or inert)`,
+      );
     } else {
-      redFiles.push(`${name} :: ${file}`);
-      console.log(`prove-red: ✓ ${file} is red against base, proves the change`);
+      redFiles.push(unit.label);
+      console.log(`prove-red [${a.id}]: ✓ ${unit.label} is red against base, proves the change`);
     }
+  }
+
+  if (greenFiles.length > 0) {
+    console.log(
+      `\nprove-red [${a.id}]: NOTE: these changed tests passed WITHOUT the source change:`,
+    );
+    for (const f of greenFiles) console.log(`    - ${f}`);
+    console.log(
+      '    They may be legitimate compatibility updates, or they may be inert.\n' +
+        '    The gate does not block on them; a reviewer should confirm which they are.',
+    );
+  }
+
+  if (redFiles.length === 0) {
+    anyFail = true;
+    console.error(
+      `\n✗ prove-red [${a.id}]: NONE of the changed ${a.id} tests fail against the base. This PR\n` +
+        `changes ${a.id} product source but carries no failing-first test that depends on the\n` +
+        'change. Add a test that is red without the fix, or, for a genuine\n' +
+        'behavior-preserving refactor, carry the recorded verify:no-behavior-change\n' +
+        'label (applied by a non-author, per the verification-enforcement lane).',
+    );
+  } else {
+    console.log(
+      `\n✓ prove-red [${a.id}]: ${redFiles.length} changed test unit(s) red against base.`,
+    );
   }
 }
 
-if (greenFiles.length > 0) {
-  console.log('\nprove-red: NOTE: these changed test files passed WITHOUT the source change:');
-  for (const f of greenFiles) console.log(`    - ${f}`);
-  console.log(
-    '    They may be legitimate compatibility updates, or they may be inert.\n' +
-      '    The gate does not block on them; a reviewer should confirm which they are.',
-  );
-}
-
-if (redFiles.length === 0) {
-  console.error(
-    '\n✗ prove-red: NONE of the changed test files fail against the base. This PR\n' +
-      'changes product source but carries no failing-first test that depends on the\n' +
-      'change. Add a test that is red without the fix, or, for a genuine\n' +
-      'behavior-preserving refactor, carry the recorded verify:no-behavior-change\n' +
-      'label (applied by a non-author, per the verification-enforcement lane).',
-  );
-  process.exit(1);
-}
-
-console.log(`\n✓ prove-red: ${redFiles.length} changed test file(s) red against base.`);
+if (anyFail) process.exit(1);
+console.log('\n✓ prove-red: all active languages carry failing-first evidence.');
 process.exit(0);


### PR DESCRIPTION
## Release — promote `test` to `main`

Post-crash-recovery fleet-wide release. `test` is ahead of `main` with 0 behind (clean fast-forward).

Part of the coordinated fleet release following the 2026-07-12 WSL crash recovery. All open PRs in this repo are merged and CI on the `test` head is green.
