### PR TITLE
fix(studio): stop browser mode calling unregistered daemon RPC methods

### DIFF
--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -321,7 +321,12 @@ const MOCK_DATA: Record<string, unknown> = {
 const DAEMON_URL_KEY = 'revdev-daemon-url';
 const DAEMON_TOKEN_KEY = 'revdev-daemon-token';
 
-/** Command-to-RPC method mapping for harness commands */
+/**
+ * Command-to-RPC method mapping for harness commands.
+ * Every value MUST be a method the daemon actually registers
+ * (packages/daemon registerHandler call sites) — an unregistered method
+ * dies as JSON-RPC -32601 with no useful signal to the user.
+ */
 const HARNESS_RPC_MAP: Record<string, string> = {
   harness_ping: 'ping',
   harness_sessions: 'session.list',
@@ -340,22 +345,32 @@ const HARNESS_RPC_MAP: Record<string, string> = {
   // Agent spawner
   agent_spawn: 'agent.spawn',
   agent_stop: 'agent.stop',
-  agent_list: 'agent.list',
-  agent_remove: 'agent.remove',
   agent_input: 'agent.input',
   agent_resize: 'agent.resize',
-  // Inference engine management
-  inference_ollama_status: 'inference.ollama.status',
-  inference_ollama_models: 'inference.ollama.models',
-  inference_ollama_pull: 'inference.ollama.pull',
-  inference_ollama_delete: 'inference.ollama.delete',
-  inference_ollama_start: 'inference.ollama.start',
-  inference_ollama_stop: 'inference.ollama.stop',
-  inference_snap_list: 'inference.snap.list',
-  inference_snap_status: 'inference.snap.status',
-  inference_snap_install: 'inference.snap.install',
-  inference_snap_remove: 'inference.snap.remove',
 };
+
+/**
+ * Commands implemented only by the Tauri (Rust) backend. The daemon has no
+ * RPC equivalent: agent.list / agent.remove are not registered, and the
+ * daemon's inference.* surface (inference.status/pull/start/stop) differs
+ * from these commands in both namespace and result shape. When a remote
+ * daemon IS configured, these fail loudly instead of silently calling a
+ * nonexistent method or serving fabricated mock state next to real data.
+ */
+const DESKTOP_ONLY_COMMANDS = new Set([
+  'agent_list',
+  'agent_remove',
+  'inference_ollama_status',
+  'inference_ollama_models',
+  'inference_ollama_pull',
+  'inference_ollama_delete',
+  'inference_ollama_start',
+  'inference_ollama_stop',
+  'inference_snap_list',
+  'inference_snap_status',
+  'inference_snap_install',
+  'inference_snap_remove',
+]);
 
 /** Map Tauri command args (snake_case) to RPC params (camelCase) */
 function toRpcParams(cmd: string, args?: Record<string, unknown>): Record<string, unknown> {
@@ -482,6 +497,17 @@ function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
         .catch(() => false as T);
     }
     return httpRpc<T>(rpcMethod, params);
+  }
+
+  // Desktop-only commands with a live daemon configured: reject with a real
+  // explanation. Falling through to mock data here would show fabricated
+  // agent/inference state alongside real daemon data.
+  if (DESKTOP_ONLY_COMMANDS.has(cmd) && getDaemonUrl()) {
+    return Promise.reject(
+      new Error(
+        `${cmd} is only available in the desktop app. The remote daemon has no equivalent RPC yet.`,
+      ),
+    );
   }
 
   // Fallback: mock data for non-harness commands. Serving fabricated system


### PR DESCRIPTION
## Summary

Browser mode's HARNESS_RPC_MAP targeted daemon methods that are never registered:

- `agent_list` / `agent_remove` mapped to `agent.list` / `agent.remove`; the daemon registers only `agent.spawn/stop/input/resize/output` (`packages/daemon/src/spawn.ts`).
- All ten `inference_*` commands mapped to `inference.ollama.*` / `inference.snap.*`; the daemon's surface is `inference.status/pull/start/stop/chat/generate` (`packages/daemon/src/inference.ts`), with different result shapes than the Studio types expect.

Every such call from browser mode died as JSON-RPC -32601, the exact silent-failure class the `agent.ts` DesktopOnlyError stubs were written to prevent.

## Change

- Remove the twelve phantom entries from `HARNESS_RPC_MAP` and document the invariant that every map value must be a registered daemon method.
- Add `DESKTOP_ONLY_COMMANDS`: with a remote daemon configured, these commands now reject with a clear desktop-only error instead of calling a nonexistent method (or serving fabricated mock state next to real daemon data).
- Demo mode (no daemon URL) is unchanged: the same commands keep falling through to `MOCK_DATA` with the degraded banner.

Adapting the daemon's `inference.*` results to the Studio types (or adding `agent.list`/`agent.remove` handlers) is deliberately out of scope; that needs the shape-adapter design plus the generated method-table CI check tracked internally.

## Verification

- `pnpm typecheck:studio` clean
- `biome check` clean on the touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
