### PR TITLE
fix(ci): harden checkout credentials and backflow secret scope

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -4,9 +4,23 @@ name: backflow-main-into-test
 #   RevealUIStudio/.github/.github/workflows/backflow-reusable.yml
 # Requires the BACKFLOW_APP_ID / BACKFLOW_APP_PRIVATE_KEY secrets + the
 # revfleet-backflow App installed on this repo (Contents + Pull requests r/w).
+# Triggers on push to BOTH main and test:
+#   - push:main — main moved forward; open a backflow PR so test catches up.
+#   - push:test — self-heal: if a backflow PR was squash-merged (which strips
+#     main's parentage and leaves `test` not containing `main`), the next push
+#     to test re-detects the broken ancestry and re-opens a correct --no-ff
+#     backflow, instead of the gap lurking until the next promotion (where
+#     promotion-gate would then block it). The reusable no-ops when test already
+#     contains main, so the push:test path is a cheap guard.
 on:
   push:
-    branches: [main]
+    branches: [main, test]
+
+# Serialize backflow runs so the two triggers (and rapid pushes) can't race on
+# the force-push / PR open-or-update.
+concurrency:
+  group: backflow-main-into-test
+  cancel-in-progress: false
 
 jobs:
   backflow:
@@ -14,4 +28,9 @@ jobs:
     # later push to the shared repo cannot silently change this production gate.
     # Bump via Dependabot (github-actions) like every other pinned ref.
     uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@010a9388aee91d6f6fef8fce5a18f897af42443b # main @ 2026-07-06 (backflow signed-merge — .github#7)
-    secrets: inherit
+    # Scope to ONLY the two secrets the reusable declares (its workflow_call.secrets
+    # block documents this exact form) instead of `secrets: inherit`, which would
+    # forward every caller secret into it.
+    secrets:
+      BACKFLOW_APP_ID: ${{ secrets.BACKFLOW_APP_ID }}
+      BACKFLOW_APP_PRIVATE_KEY: ${{ secrets.BACKFLOW_APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -29,6 +31,8 @@ jobs:
     needs: quality
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -43,6 +47,8 @@ jobs:
     needs: quality
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Install Linux system dependencies (Tauri toolchain for ts-rs binding generation)
         run: |
           sudo apt-get update
@@ -74,6 +80,8 @@ jobs:
     needs: quality
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Install bubblewrap + enable unprivileged user namespaces (agent.spawn confinement tests)
         # confinement-integration.test.ts runs REAL bwrap adversarial reads proving
         # ~/.ssh, ~/.age-identity, and the revvault store are denied inside the
@@ -117,6 +125,7 @@ jobs:
       # source diff. See docs (verification-enforcement lane) for the mechanism.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -149,6 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -174,6 +184,8 @@ jobs:
     needs: [typecheck, test]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -188,6 +200,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: apps/console/go.mod
@@ -201,6 +215,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Scan for private paths and credentials
         run: bash scripts/check-no-private-leaks.sh
 
@@ -210,6 +226,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
@@ -224,6 +242,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24

--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -43,6 +43,7 @@ jobs:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 


### PR DESCRIPTION
This hardens the repo's CI workflows to match the fleet's reviewed canonical setup in the revealui repo.

- Adds `persist-credentials: false` to every `actions/checkout` step in `ci.yml` and `promotion-gate.yml` that was missing it. This stops the `GITHUB_TOKEN` from persisting on disk in the job workspace after checkout.
- Brings `backflow-main-into-test.yml` up to parity with the fleet canonical: triggers on push to both `main` and `test` (a self-heal path for a squash-merged backflow), adds a `concurrency` group so runs can't race, and replaces `secrets: inherit` with a scoped secrets block that only forwards `BACKFLOW_APP_ID` and `BACKFLOW_APP_PRIVATE_KEY` instead of every repo secret.

These changes are additive and do not restructure any other job logic. They mirror the already-reviewed canonical workflows in the revealui repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)