### PR TITLE
feat(daemon): contract-test RPC_METHODS against the handler registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       # #143 failure mode) then `vite build`, mirroring build-windows.ps1's frontend
       # step, catching type errors AND bundling errors on every PR.
       - run: bash apps/studio/scripts/generate-types.sh
+      # Studio's contract test imports RPC_METHODS from @revdev/protocol, a
+      # workspace dep resolved from its dist output, so build it first.
+      - run: pnpm --filter "@revdev/protocol" build
       - run: pnpm --filter studio build
 
   test:

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
+    "@revdev/protocol": "workspace:*",
     "@tailwindcss/vite": "^4.3.2",
     "@tauri-apps/cli": "^2.11.4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/studio/src/__tests__/lib/invoke.test.ts
+++ b/apps/studio/src/__tests__/lib/invoke.test.ts
@@ -231,3 +231,21 @@ describe('invoke bridge (Tauri mode)', () => {
     expect(result.wsl_running).toBe(true);
   });
 });
+
+describe('HARNESS_RPC_MAP contract', () => {
+  it('routes every command to a method the daemon actually registers', async () => {
+    const { HARNESS_RPC_MAP } = await import('../../lib/invoke');
+    const { RPC_METHODS } = await import('@revdev/protocol');
+    const known = new Set<string>(Object.values(RPC_METHODS));
+
+    const unknownTargets = Object.entries(HARNESS_RPC_MAP)
+      .filter(([, method]) => !known.has(method))
+      .map(([command, method]) => `${command} -> ${method}`)
+      .sort();
+
+    expect(
+      unknownTargets,
+      `HARNESS_RPC_MAP targets methods absent from RPC_METHODS: ${JSON.stringify(unknownTargets)}`,
+    ).toEqual([]);
+  });
+});

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -325,9 +325,11 @@ const DAEMON_TOKEN_KEY = 'revdev-daemon-token';
  * Command-to-RPC method mapping for harness commands.
  * Every value MUST be a method the daemon actually registers
  * (packages/daemon registerHandler call sites) — an unregistered method
- * dies as JSON-RPC -32601 with no useful signal to the user.
+ * dies as JSON-RPC -32601 with no useful signal to the user. A studio vitest
+ * asserts every value here is a member of the protocol's RPC_METHODS, which is
+ * itself contract-tested against the daemon registry.
  */
-const HARNESS_RPC_MAP: Record<string, string> = {
+export const HARNESS_RPC_MAP: Record<string, string> = {
   harness_ping: 'ping',
   harness_sessions: 'session.list',
   harness_inbox: 'mail.inbox',

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -342,6 +342,28 @@ server.tool('merge_list', 'List all merge requests', {}, async () => {
   return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
 });
 
+server.tool(
+  'merge_update',
+  'Update a merge request as it moves through the pipeline (status, PR number/URL, or error)',
+  {
+    mergeId: z.string().describe('Merge request ID to update'),
+    status: z.string().optional().describe('New status (e.g. building, opened, merged, failed)'),
+    prNumber: z.number().int().optional().describe('Pull request number once opened'),
+    prUrl: z.string().optional().describe('Pull request URL once opened'),
+    errorMessage: z.string().optional().describe('Failure reason when the status is a failure'),
+  },
+  async ({ mergeId, status, prNumber, prUrl, errorMessage }) => {
+    const result = await daemon.call(RPC_METHODS['merge.update'], {
+      mergeId,
+      status,
+      prNumber,
+      prUrl,
+      errorMessage,
+    });
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
 // -- Worktree management -----------------------------------------------------
 
 server.tool(

--- a/packages/daemon/src/__tests__/rpc-contract.test.ts
+++ b/packages/daemon/src/__tests__/rpc-contract.test.ts
@@ -1,0 +1,49 @@
+/**
+ * RPC contract test.
+ *
+ * `RPC_METHODS` (protocol) and the daemon's handler registry are two lists that
+ * historically drifted: the constant declared methods no handler served
+ * (harness.list/execute/info/listRunning/syncConfig/diffConfig, session.history)
+ * and omitted whole registered surfaces (file.*, git.*, project.*, inference
+ * chat/generate, identity.rotate). This test pins them together.
+ *
+ * Importing `../index.js` registers every handler group in the exact order
+ * production startup does, including spawn.js overwriting the agent.js
+ * DesktopOnlyError stubs. After that side effect, `listRegisteredMethods()`
+ * reflects the real, post-startup surface.
+ */
+
+import { RPC_METHODS } from '@revdev/protocol';
+import { describe, expect, it } from 'vitest';
+import '../index.js';
+import { listRegisteredMethods } from '../server.js';
+
+function sortedDiff(a: string[], b: string[]): { onlyInA: string[]; onlyInB: string[] } {
+  const setB = new Set(b);
+  const setA = new Set(a);
+  return {
+    onlyInA: a.filter((m) => !setB.has(m)).sort(),
+    onlyInB: b.filter((m) => !setA.has(m)).sort(),
+  };
+}
+
+describe('RPC contract', () => {
+  it('RPC_METHODS exactly equals the daemon handler registry', () => {
+    const registered = listRegisteredMethods();
+    const declared = [...Object.values(RPC_METHODS)].sort();
+
+    const { onlyInA: registeredButUndeclared, onlyInB: declaredButUnregistered } = sortedDiff(
+      registered,
+      declared,
+    );
+
+    expect(
+      { registeredButUndeclared, declaredButUnregistered },
+      `RPC_METHODS drifted from the daemon registry.\n` +
+        `Registered but missing from RPC_METHODS: ${JSON.stringify(registeredButUndeclared)}\n` +
+        `In RPC_METHODS but not registered (phantoms): ${JSON.stringify(declaredButUnregistered)}`,
+    ).toEqual({ registeredButUndeclared: [], declaredButUnregistered: [] });
+
+    expect(registered).toEqual(declared);
+  });
+});

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -24,7 +24,7 @@ export {
   refreshLicense,
 } from './guard.js';
 export { checkLicense, LICENSE_TIERS, type LicenseTier } from './license.js';
-export { registerHandler, startDaemon } from './server.js';
+export { listRegisteredMethods, registerHandler, startDaemon } from './server.js';
 
 // Side-effect imports: register built-in handler groups.
 import './inference.js';

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -345,6 +345,15 @@ export function registerHandler(method: string, handler: RpcHandler): void {
   handlers.set(method, handler);
 }
 
+/**
+ * Returns the sorted names of every RPC method currently registered on the
+ * daemon. The contract test asserts this equals the protocol's `RPC_METHODS`
+ * constant, so the two lists cannot silently drift.
+ */
+export function listRegisteredMethods(): string[] {
+  return [...handlers.keys()].sort();
+}
+
 // ---------------------------------------------------------------------------
 // Shutdown signal — module-level AbortController whose `.signal` aborts when
 // the daemon is closing. Long-running helpers (e.g. git child-process spawn

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -3,6 +3,12 @@
  *
  * Every method the daemon exposes is listed here so Studio, Terminal,
  * and test code can reference them without string literals.
+ *
+ * This list is NOT hand-maintained: the daemon package's rpc-contract test
+ * registers all handlers exactly as production startup does and asserts that
+ * `listRegisteredMethods()` equals `Object.values(RPC_METHODS)` in both
+ * directions. A method added to or removed from the daemon that is not
+ * mirrored here fails that test, so the constant stays honest by construction.
  */
 
 export const RPC_METHODS = {
@@ -10,12 +16,6 @@ export const RPC_METHODS = {
   ping: 'ping',
 
   // Harness management
-  'harness.list': 'harness.list',
-  'harness.execute': 'harness.execute',
-  'harness.info': 'harness.info',
-  'harness.listRunning': 'harness.listRunning',
-  'harness.syncConfig': 'harness.syncConfig',
-  'harness.diffConfig': 'harness.diffConfig',
   'harness.health': 'harness.health',
   'harness.prune': 'harness.prune',
 
@@ -25,7 +25,9 @@ export const RPC_METHODS = {
   'session.update': 'session.update',
   'session.end': 'session.end',
   'session.list': 'session.list',
-  'session.history': 'session.history',
+
+  // Agent identity
+  'identity.rotate': 'identity.rotate',
 
   // Inter-agent messaging
   'mail.send': 'mail.send',
@@ -50,6 +52,10 @@ export const RPC_METHODS = {
   'events.log': 'events.log',
   'events.query': 'events.query',
 
+  // Agent memory
+  'memory.store': 'memory.store',
+  'memory.query': 'memory.query',
+
   // Agent spawning
   'agent.spawn': 'agent.spawn',
   'agent.stop': 'agent.stop',
@@ -62,6 +68,37 @@ export const RPC_METHODS = {
   'inference.pull': 'inference.pull',
   'inference.start': 'inference.start',
   'inference.stop': 'inference.stop',
+  'inference.chat': 'inference.chat',
+  'inference.generate': 'inference.generate',
+
+  // Project access
+  'project.open': 'project.open',
+  'project.grant': 'project.grant',
+  'project.revoke': 'project.revoke',
+
+  // File I/O
+  'file.read': 'file.read',
+  'file.write': 'file.write',
+  'file.delete': 'file.delete',
+  'file.stat': 'file.stat',
+
+  // Git operations
+  'git.status': 'git.status',
+  'git.diffFile': 'git.diffFile',
+  'git.diffContent': 'git.diffContent',
+  'git.readBlobAtHead': 'git.readBlobAtHead',
+  'git.readBlobAtIndex': 'git.readBlobAtIndex',
+  'git.listBranches': 'git.listBranches',
+  'git.log': 'git.log',
+  'git.stageFile': 'git.stageFile',
+  'git.unstageFile': 'git.unstageFile',
+  'git.discardFile': 'git.discardFile',
+  'git.createBranch': 'git.createBranch',
+  'git.switchBranch': 'git.switchBranch',
+  'git.deleteBranch': 'git.deleteBranch',
+  'git.commit': 'git.commit',
+  'git.push': 'git.push',
+  'git.pull': 'git.pull',
 
   // Worktree management
   'worktree.create': 'worktree.create',
@@ -73,8 +110,4 @@ export const RPC_METHODS = {
   'merge.status': 'merge.status',
   'merge.list': 'merge.list',
   'merge.update': 'merge.update',
-
-  // Agent memory
-  'memory.store': 'memory.store',
-  'memory.query': 'memory.query',
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
     devDependencies:
+      '@revdev/protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
       '@tailwindcss/vite':
         specifier: ^4.3.2
         version: 4.3.2(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))


### PR DESCRIPTION
## Problem

`RPC_METHODS` (protocol), the daemon handler registry, and Studio's `HARNESS_RPC_MAP` were three hand-maintained lists that had drifted apart. `RPC_METHODS` declared seven methods that no handler served and that nothing called:

- `harness.list`, `harness.execute`, `harness.info`, `harness.listRunning`, `harness.syncConfig`, `harness.diffConfig`
- `session.history`

It simultaneously omitted whole registered surfaces: `file.*`, `git.*`, `project.*`, `inference.chat`, `inference.generate`, and `identity.rotate`. The constant's own header claimed "every method the daemon exposes is listed here", which was false.

Separately, `merge.update` was registered and validated in the daemon but had zero callers, and the bridge (the MCP server for external tools) wrapped `merge.request/status/list` but not `merge.update`.

## Changes

- **Introspectable registry**: `listRegisteredMethods()` exported from the daemon returns the sorted registered method names at runtime.
- **Honest constant**: `RPC_METHODS` regenerated to exactly the 67 registered methods (seven phantoms dropped, the omitted surfaces added). Its header now states it is contract-tested against the daemon registry, not hand-maintained.
- **Contract test (daemon)**: `rpc-contract.test.ts` registers all handlers exactly as production startup does (importing the index side-effect graph, so `spawn.ts` overwrites the `agent.ts` desktop-only stubs) and asserts `listRegisteredMethods()` equals `Object.values(RPC_METHODS)` in both directions, with a sorted diff in the failure message.
- **Contract test (Studio)**: `HARNESS_RPC_MAP` is now exported, and the Studio invoke test asserts every value in it is a member of `RPC_METHODS`.
- **Bridge**: new `merge_update` MCP tool mirroring `merge_request/status/list`, giving the `merge.update` handler a real consumer. The daemon handler is unchanged.

## Deviation from brief (with rationale)

The brief asked for the Studio-map assertion to live inside the daemon contract test, importing `apps/studio/src/lib/invoke.ts`. That is not viable without breaking the build: the daemon's `tsc --emitDeclarationOnly` step compiles `src/**` (including `__tests__`) under `rootDir: "src"`, and the daemon has no dependency on the `studio` app. Importing an `apps/studio` file from a daemon test fails declaration emit (TS6059, file outside rootDir) and inverts the package to app dependency direction. The invariant "Studio's map only references real RPC methods" is owned by Studio, which already has an `invoke.test.ts` and a vitest setup. The assertion therefore lives there, still importing the map (no text parsing) and asserting membership against `RPC_METHODS`. This required adding `@revdev/protocol` as a Studio devDependency (test-only).

## Verification

- `pnpm -r --filter=!studio build` green (daemon `tsc` declaration step compiles the new test clean)
- `pnpm --filter @revdev/daemon test`: 32 files, 635 tests pass (includes the new contract test)
- `pnpm --filter @revdev/bridge test`: 5 pass
- Studio invoke test: 29 pass (includes the new `HARNESS_RPC_MAP` contract)
- `pnpm typecheck:studio` green (after generating ts-rs bindings)
- Biome clean on all touched files
- Prove-red: reintroducing a phantom and dropping a real method both turn the contract test red with a precise diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
