### PR TITLE
feat(daemon): wire browser-mode agent list/remove and ollama rpc

### DIFF
--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -84,6 +84,11 @@ pub fn requires_signature(method: &str) -> bool {
             | "agent.input"
             | "agent.resize"
             | "agent.output"
+            // agent.list returns another-agent-invisible process metadata and
+            // agent.remove kills + prunes a process; both are self-scoped to the
+            // verified signer. MUST mirror server.ts MUTATING_OR_CONTENT_METHODS.
+            | "agent.list"
+            | "agent.remove"
             // session.end evicts the target's project roots and kills its PTYs.
             // Signature-required so the daemon can self-scope it to the verified
             // signer instead of a caller-supplied `sessionId`.
@@ -527,6 +532,8 @@ mod tests {
         assert!(requires_signature("agent.input"));
         assert!(requires_signature("agent.resize"));
         assert!(requires_signature("agent.output"));
+        assert!(requires_signature("agent.list"));
+        assert!(requires_signature("agent.remove"));
         assert!(requires_signature("session.end"));
         // GAP-312: same eviction primitive as session.end, fleet-wide fan-out.
         assert!(requires_signature("harness.prune"));

--- a/apps/studio/src/__tests__/lib/invoke.test.ts
+++ b/apps/studio/src/__tests__/lib/invoke.test.ts
@@ -249,3 +249,107 @@ describe('HARNESS_RPC_MAP contract', () => {
     ).toEqual([]);
   });
 });
+
+// Browser mode routes the newly-wired commands over the daemon HTTP gateway and
+// adapts each daemon result back to the Studio type. These drive the real
+// invoke() path with a mocked fetch so the mapping, param rename, and result
+// adapters are all exercised end to end.
+describe('browser-mode daemon adapters', () => {
+  const DAEMON_URL = 'https://daemon.test';
+
+  /** A fetch stub returning a JSON-RPC success envelope wrapping `result`. */
+  function rpcOk(result: unknown): ReturnType<typeof vi.fn> {
+    return vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ jsonrpc: '2.0', id: 1, result }),
+    } as unknown as Response);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+    localStorage.setItem('revdev-daemon-url', DAEMON_URL);
+    localStorage.setItem('revdev-daemon-token', 'test-token');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('adapts inference.status into OllamaStatus', async () => {
+    vi.stubGlobal(
+      'fetch',
+      rpcOk({ running: true, version: '0.1.30', url: 'http://localhost:11434', models: [] }),
+    );
+    const { inferenceOllamaStatus } = await import('../../lib/invoke');
+    const status = await inferenceOllamaStatus();
+    expect(status).toEqual({ installed: true, running: true, version: '0.1.30' });
+  });
+
+  it('adapts inference.status models into OllamaModel[] with a formatted size', async () => {
+    vi.stubGlobal(
+      'fetch',
+      rpcOk({
+        running: true,
+        version: '0.1.30',
+        models: [{ name: 'llama3:8b', sizeMb: 4700, modified: '2026-01-01' }],
+      }),
+    );
+    const { inferenceOllamaModels } = await import('../../lib/invoke');
+    const models = await inferenceOllamaModels();
+    expect(models).toEqual([{ name: 'llama3:8b', size: '4.7 GB', modified: '2026-01-01' }]);
+  });
+
+  it('renames modelName to model and adapts inference.pull into ModelPullResult', async () => {
+    const fetchMock = rpcOk({ success: true, model: 'llama3', status: 'success' });
+    vi.stubGlobal('fetch', fetchMock);
+    const { inferenceOllamaPull } = await import('../../lib/invoke');
+    const result = await inferenceOllamaPull('llama3');
+    expect(result).toEqual({ success: true, message: 'success' });
+    // The daemon schema requires `model`, not the wrapper's `modelName`.
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(body.params).toEqual({ model: 'llama3' });
+    expect(body.method).toBe('inference.pull');
+  });
+
+  it('adapts agent.list rows into AgentSessionInfo with a null backend', async () => {
+    vi.stubGlobal(
+      'fetch',
+      rpcOk([
+        {
+          processId: 'p1',
+          command: 'bash',
+          cwd: '/repo',
+          pid: 42,
+          status: 'running',
+          exitCode: null,
+        },
+        {
+          processId: 'p2',
+          command: 'node',
+          cwd: '/repo',
+          pid: null,
+          status: 'exited',
+          exitCode: 1,
+        },
+      ]),
+    );
+    const { agentList } = await import('../../lib/invoke');
+    const sessions = await agentList();
+    expect(sessions).toEqual([
+      { id: 'p1', name: 'bash', model: '', backend: null, prompt: '', status: 'running', pid: 42 },
+      {
+        id: 'p2',
+        name: 'node',
+        model: '',
+        backend: null,
+        prompt: '',
+        status: 'errored',
+        pid: null,
+      },
+    ]);
+  });
+});

--- a/apps/studio/src/components/agent/SpawnerPanel.tsx
+++ b/apps/studio/src/components/agent/SpawnerPanel.tsx
@@ -93,7 +93,7 @@ export default function SpawnerPanel() {
                   {s.name}
                 </span>
                 <span className="shrink-0 rounded bg-surface-2 px-1.5 py-0.5 text-[10px] text-fg-subtle">
-                  {s.backend === 'Snap' ? 'Snap' : 'Ollama'}
+                  {s.backend ?? 'PTY'}
                 </span>
               </div>
               <p className="mt-1 truncate text-[10px] text-fg-subtle">{s.model}</p>

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -347,25 +347,35 @@ export const HARNESS_RPC_MAP: Record<string, string> = {
   // Agent spawner
   agent_spawn: 'agent.spawn',
   agent_stop: 'agent.stop',
+  agent_list: 'agent.list',
+  agent_remove: 'agent.remove',
   agent_input: 'agent.input',
   agent_resize: 'agent.resize',
+  // Local inference (Ollama) — the daemon's inference.* handlers ARE the Ollama
+  // HTTP integration. Result shapes differ from the Tauri path and are adapted
+  // back to the Studio types by RESULT_ADAPTERS below. `inference_ollama_models`
+  // reuses inference.status because that method already returns the model list;
+  // there is no separate daemon "models" method to add.
+  inference_ollama_status: 'inference.status',
+  inference_ollama_models: 'inference.status',
+  inference_ollama_pull: 'inference.pull',
+  inference_ollama_delete: 'inference.delete',
 };
 
 /**
- * Commands implemented only by the Tauri (Rust) backend. The daemon has no
- * RPC equivalent: agent.list / agent.remove are not registered, and the
- * daemon's inference.* surface (inference.status/pull/start/stop) differs
- * from these commands in both namespace and result shape. When a remote
- * daemon IS configured, these fail loudly instead of silently calling a
- * nonexistent method or serving fabricated mock state next to real data.
+ * Commands implemented only by the Tauri (Rust) backend, with no daemon
+ * equivalent. When a remote daemon IS configured, these fail loudly instead of
+ * silently calling a nonexistent method or serving fabricated mock state next
+ * to real data.
+ *
+ *   - inference_ollama_start / _stop manage the Ollama SERVER lifecycle
+ *     (`ollama serve` / `pkill`). The daemon only speaks HTTP to an
+ *     already-running Ollama, so it cannot start or stop a host process. (The
+ *     daemon's inference.start/stop are model warm/unload, a different op.)
+ *   - inference_snap_* are host snap package management (sudo snap
+ *     install/remove); the daemon does not manage host packages.
  */
 const DESKTOP_ONLY_COMMANDS = new Set([
-  'agent_list',
-  'agent_remove',
-  'inference_ollama_status',
-  'inference_ollama_models',
-  'inference_ollama_pull',
-  'inference_ollama_delete',
   'inference_ollama_start',
   'inference_ollama_stop',
   'inference_snap_list',
@@ -385,8 +395,113 @@ function toRpcParams(cmd: string, args?: Record<string, unknown>): Record<string
   }
   // Special cases for harness_ping which returns boolean
   if (cmd === 'harness_ping') return {};
+  // The Ollama model commands take a `modelName` arg on the Studio wrappers, but
+  // the daemon's inference.pull/delete handlers read `model`. Rename so the
+  // daemon receives the key its schema requires.
+  if (
+    (cmd === 'inference_ollama_pull' || cmd === 'inference_ollama_delete') &&
+    params.modelName !== undefined
+  ) {
+    params.model = params.modelName;
+    delete params.modelName;
+  }
   return params;
 }
+
+// ── Browser-mode result adapters ────────────────────────────────────────────
+// The daemon's inference.* and agent.list results use the daemon's own vocabulary
+// and differ from the shapes the Tauri (Rust) path returns. These adapters map a
+// daemon result back to the Studio type so browser mode and desktop mode return
+// identical shapes to callers.
+
+interface DaemonOllamaStatus {
+  running?: boolean;
+  version?: string;
+  models?: Array<{ name: string; sizeMb: number; modified: string }>;
+}
+
+/** Format a daemon `sizeMb` integer as the human string the Tauri path emits. */
+function formatModelSize(sizeMb: number): string {
+  if (!Number.isFinite(sizeMb) || sizeMb <= 0) return '';
+  if (sizeMb >= 1000) return `${(sizeMb / 1000).toFixed(1)} GB`;
+  return `${sizeMb} MB`;
+}
+
+function adaptOllamaStatus(raw: unknown): OllamaStatus {
+  const s = (raw ?? {}) as DaemonOllamaStatus;
+  // The daemon speaks HTTP to Ollama; it can only confirm `installed` when the
+  // server answers. A not-running server is indistinguishable from a missing
+  // one over HTTP, so `installed` tracks `running` — the honest best effort.
+  const running = s.running === true;
+  return { installed: running, running, version: s.version ?? null };
+}
+
+function adaptOllamaModels(raw: unknown): OllamaModel[] {
+  const s = (raw ?? {}) as DaemonOllamaStatus;
+  return (s.models ?? []).map((m) => ({
+    name: m.name,
+    size: formatModelSize(m.sizeMb),
+    modified: m.modified,
+  }));
+}
+
+interface DaemonPullResult {
+  success?: boolean;
+  status?: string;
+  model?: string;
+  error?: string;
+}
+
+function adaptOllamaPull(raw: unknown): ModelPullResult {
+  const r = (raw ?? {}) as DaemonPullResult;
+  const success = r.success === true;
+  if (success) {
+    return { success: true, message: r.status ?? `Pulled ${r.model ?? ''}`.trim() };
+  }
+  return { success: false, message: r.error ?? 'Pull failed' };
+}
+
+interface DaemonAgentProcess {
+  processId: string;
+  command: string;
+  pid: number | null;
+  status: string;
+  exitCode: number | null;
+}
+
+function daemonStatusToSession(
+  status: string,
+  exitCode: number | null,
+): AgentSessionInfo['status'] {
+  if (status === 'running') return 'running';
+  if (status === 'exited') return exitCode !== null && exitCode !== 0 ? 'errored' : 'stopped';
+  // 'killed' and any unrecognized terminal state read as a clean stop.
+  return 'stopped';
+}
+
+function adaptAgentList(raw: unknown): AgentSessionInfo[] {
+  const rows = Array.isArray(raw) ? (raw as DaemonAgentProcess[]) : [];
+  // The daemon's agent.spawn is a generic command spawner: its registry has no
+  // inference backend, model, or prompt. `command` is the only human label; the
+  // rest are empty and `backend` is null (a daemon-spawned PTY, not Snap/Ollama).
+  return rows.map((r) => ({
+    id: r.processId,
+    name: r.command,
+    model: '',
+    backend: null,
+    prompt: '',
+    status: daemonStatusToSession(r.status, r.exitCode),
+    pid: r.pid,
+  }));
+}
+
+/** Per-command adapters applied to the daemon RPC result in browser mode. */
+const RESULT_ADAPTERS: Record<string, (raw: unknown) => unknown> = {
+  agent_list: adaptAgentList,
+  inference_ollama_status: adaptOllamaStatus,
+  inference_ollama_models: adaptOllamaModels,
+  inference_ollama_pull: adaptOllamaPull,
+};
 
 /** Get the configured daemon URL from localStorage */
 export function getDaemonUrl(): string | null {
@@ -498,7 +613,9 @@ function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
         .then(() => true as T)
         .catch(() => false as T);
     }
-    return httpRpc<T>(rpcMethod, params);
+    const call = httpRpc<unknown>(rpcMethod, params);
+    const adapter = RESULT_ADAPTERS[cmd];
+    return (adapter ? call.then(adapter) : call) as Promise<T>;
   }
 
   // Desktop-only commands with a live daemon configured: reject with a real

--- a/apps/studio/src/types.ts
+++ b/apps/studio/src/types.ts
@@ -91,7 +91,12 @@ export interface AgentSessionInfo {
   id: string;
   name: string;
   model: string;
-  backend: AgentBackend;
+  /**
+   * The inference backend, or `null` for a daemon-spawned PTY session (the
+   * daemon's agent registry has no Snap/Ollama concept — see the browser-mode
+   * adapter in `lib/invoke.ts`). The desktop path always sets a backend.
+   */
+  backend: AgentBackend | null;
   prompt: string;
   status: 'running' | 'stopped' | 'errored';
   pid: number | null;

--- a/packages/daemon/src/__tests__/guard.test.ts
+++ b/packages/daemon/src/__tests__/guard.test.ts
@@ -353,6 +353,8 @@ describe('handler tier-classification coverage', () => {
     // agent PTY + lifecycle
     'agent.spawn',
     'agent.stop',
+    'agent.list',
+    'agent.remove',
     'agent.input',
     'agent.output',
     'agent.resize',

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -57,6 +57,10 @@ const SIGNED = [
   'agent.input',
   'agent.resize',
   'agent.output',
+  // agent.list returns another-agent-invisible process metadata and agent.remove
+  // kills + prunes; both are self-scoped to the verified signer.
+  'agent.list',
+  'agent.remove',
   // session.end evicts the target's roots and kills its PTYs, and is self-scoped
   // to the verified signer. Signature-required so the signer IS the target.
   'session.end',

--- a/packages/daemon/src/__tests__/spawn.test.ts
+++ b/packages/daemon/src/__tests__/spawn.test.ts
@@ -595,3 +595,80 @@ describe('agent.output', () => {
     ).rejects.toThrow(/unknown processId/);
   });
 });
+
+interface ListedProcess {
+  processId: string;
+  command: string;
+  pid: number | null;
+  status: string;
+  exitCode: number | null;
+}
+
+// `owner` is already at the per-agent live-process cap (10) by the time these
+// run (every spawn above leaves a mock pty that never exits). `other` has
+// spawned nothing, so it drives the spawns here; `owner` is the cross-agent
+// foil for scoping/ownership checks.
+describe('agent.list', () => {
+  it("returns the caller's spawned processes, scoped to the verified signer", async () => {
+    const { processId } = (await signedRpc(other, 'agent.spawn', {
+      command: 'bash',
+      repoPath: otherRoot,
+    })) as { processId: string };
+
+    const mine = (await signedRpc(other, 'agent.list')) as ListedProcess[];
+    const found = mine.find((p) => p.processId === processId);
+    expect(found).toBeDefined();
+    expect(found?.command).toBe('bash');
+    expect(found?.status).toBe('running');
+
+    // A different agent never sees another agent's processes.
+    const theirs = (await signedRpc(owner, 'agent.list')) as ListedProcess[];
+    expect(theirs.some((p) => p.processId === processId)).toBe(false);
+  });
+
+  it('requires a signature (rejects an unsigned call)', async () => {
+    const resp = await rpcFrame(socketPath, 'agent.list', {});
+    expect(resp.error).toBeDefined();
+    expect(resp.result).toBeUndefined();
+  });
+});
+
+describe('agent.remove', () => {
+  it('stops a running process and prunes it from the list', async () => {
+    const { processId } = (await signedRpc(other, 'agent.spawn', {
+      command: 'bash',
+      repoPath: otherRoot,
+    })) as { processId: string };
+
+    const result = (await signedRpc(other, 'agent.remove', { processId })) as { removed: string };
+    expect(result.removed).toBe(processId);
+    expect(_lastPty?.kill).toHaveBeenCalled();
+
+    // The row is gone — the process no longer appears in the caller's list.
+    const mine = (await signedRpc(other, 'agent.list')) as ListedProcess[];
+    expect(mine.some((p) => p.processId === processId)).toBe(false);
+
+    // And the DB row (plus its cascaded output) is deleted.
+    const row = await db.query(`SELECT id FROM agent_processes WHERE id = $1`, [processId]);
+    expect(row.rows.length).toBe(0);
+  });
+
+  it('rejects removing a process owned by another agent', async () => {
+    const { processId } = (await signedRpc(other, 'agent.spawn', {
+      command: 'bash',
+      repoPath: otherRoot,
+    })) as { processId: string };
+
+    await expect(signedRpc(owner, 'agent.remove', { processId })).rejects.toThrow(
+      /not owned by caller/,
+    );
+  });
+
+  it('rejects removing an unknown processId', async () => {
+    await expect(
+      signedRpc(other, 'agent.remove', {
+        processId: '00000000-0000-0000-0000-000000000002',
+      }),
+    ).rejects.toThrow(/unknown processId/);
+  });
+});

--- a/packages/daemon/src/inference.ts
+++ b/packages/daemon/src/inference.ts
@@ -35,6 +35,7 @@ export const OLLAMA_TIMEOUTS = {
   chat: readTimeoutMs('REVDEV_OLLAMA_CHAT_TIMEOUT_MS', 300_000),
   generate: readTimeoutMs('REVDEV_OLLAMA_GENERATE_TIMEOUT_MS', 300_000),
   pull: readTimeoutMs('REVDEV_OLLAMA_PULL_TIMEOUT_MS', 1_800_000),
+  delete: readTimeoutMs('REVDEV_OLLAMA_DELETE_TIMEOUT_MS', 30_000),
 } as const;
 
 interface OllamaFetchOptions extends Omit<RequestInit, 'signal'> {
@@ -125,6 +126,43 @@ registerHandler('inference.pull', async (params) => {
       return { success: false, error: timeoutMessage('pull') };
     }
     return { success: false, error: CONNECT_ERROR };
+  }
+});
+
+// ---------------------------------------------------------------------------
+// inference.delete — remove a locally downloaded model
+// ---------------------------------------------------------------------------
+//
+// Unlike the value-returning inference.* handlers, this maps to a void caller
+// (Studio inference_ollama_delete). It THROWS on failure so the JSON-RPC error
+// path surfaces a rejection to the caller, matching the desktop `ollama rm`
+// path (a Rust Result::Err becomes a rejected invoke). Ollama exposes model
+// deletion at DELETE /api/delete with a `{ name }` body.
+
+registerHandler('inference.delete', async (params) => {
+  const { model } = params as { model: string };
+
+  try {
+    const res = await ollamaFetch('/api/delete', {
+      method: 'DELETE',
+      body: JSON.stringify({ name: model }),
+      timeoutMs: OLLAMA_TIMEOUTS.delete,
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Delete failed (${res.status}): ${text}`);
+    }
+
+    return { deleted: true, model };
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      throw new Error(timeoutMessage('delete'));
+    }
+    if (err instanceof Error && err.message.startsWith('Delete failed')) {
+      throw err;
+    }
+    throw new Error(CONNECT_ERROR);
   }
 });
 

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -124,8 +124,8 @@ const EXEMPT_METHODS = new Set([
  * Max-marketed `memory.*` (GAP-267).
  *
  * Only Max-tier methods are listed:
- *   - memory.store / memory.query   → full AI memory (working + episodic + vector)
- *   - inference.pull/start/stop     → local-model management (pull / spawn / teardown)
+ *   - memory.store / memory.query          → full AI memory (working + episodic + vector)
+ *   - inference.pull/delete/start/stop     → local-model management (pull / rm / spawn / teardown)
  * The FREE local-inference RUN surface (inference.status/chat/generate) is in
  * EXEMPT_METHODS; every other non-exempt method is Pro by default.
  */
@@ -133,6 +133,7 @@ export const METHOD_MIN_TIER = new Map<string, LicenseTier>([
   ['memory.store', 'max'],
   ['memory.query', 'max'],
   ['inference.pull', 'max'],
+  ['inference.delete', 'max'],
   ['inference.start', 'max'],
   ['inference.stop', 'max'],
 ]);

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -121,6 +121,7 @@ const IDENTITY_EXEMPT = new Set([
   // MUTATING_OR_CONTENT_METHODS entry below.
   'inference.status',
   'inference.pull',
+  'inference.delete',
   'inference.start',
   'inference.stop',
   'inference.chat',
@@ -213,6 +214,13 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   'agent.input',
   'agent.resize',
   'agent.output',
+  // agent.list returns another-agent-invisible process metadata (command, cwd),
+  // and agent.remove kills + prunes a process. Both are signature-required and
+  // self-scoped to the verified signer's owner_agent — an unsigned or spoofed
+  // caller can neither enumerate nor prune another agent's PTYs. Cross-language
+  // contract: signing.rs requires_signature() must mark these too.
+  'agent.list',
+  'agent.remove',
   // session.end fans out to notifyAgentEnded, which evicts the target's project
   // roots and kills every PTY it owns. It used to take a caller-supplied target
   // and sat OUTSIDE this set, so any socket peer could end an arbitrary agent's

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -410,6 +410,88 @@ registerHandler('agent.stop', async (params, db, ctx) => {
 });
 
 /**
+ * agent.list — enumerate the caller's spawned PTY processes.
+ *
+ * Scoped to the verified signer (owner_agent = ctx.agentId): a caller only
+ * ever sees its own processes, never another agent's — the same per-agent
+ * scoping git.status/list/log use, and why this method is signature-required
+ * (server.ts MUTATING_OR_CONTENT_METHODS). Rows are read from `agent_processes`
+ * (the persistent record), so exited/killed history is included until pruned by
+ * agent.remove. Fields are daemon-native — the caller (Studio invoke.ts) adapts
+ * them to its AgentSessionInfo shape; `command` is the only human label the
+ * daemon has (agent.spawn is a generic command spawner with no model/prompt).
+ */
+registerHandler('agent.list', async (params, db, ctx) => {
+  const callerAgentId = requireAgent(ctx, params);
+
+  const rows = await db.query<{
+    id: string;
+    command: string;
+    cwd: string;
+    pid: number | null;
+    status: string;
+    exit_code: number | null;
+  }>(
+    `SELECT id, command, cwd, pid, status, exit_code
+       FROM agent_processes
+      WHERE owner_agent = $1
+      ORDER BY created_at DESC`,
+    [callerAgentId],
+  );
+
+  return rows.rows.map((r) => ({
+    processId: r.id,
+    command: r.command,
+    cwd: r.cwd,
+    pid: r.pid,
+    status: r.status,
+    exitCode: r.exit_code,
+  }));
+});
+
+/**
+ * agent.remove — stop the process if it is live, then prune its record.
+ *
+ * Unlike agent.stop (which only kills and marks the row 'killed'), this
+ * removes the `agent_processes` row entirely; `agent_process_output` cascades
+ * (FK ON DELETE CASCADE). Ownership is checked against the verified signer,
+ * from the live registry when the process is running and from the persisted
+ * row otherwise, so a caller can never prune another agent's process.
+ */
+registerHandler('agent.remove', async (params, db, ctx) => {
+  const callerAgentId = requireAgent(ctx, params);
+  const processId = stringParam(params, 'processId');
+  if (!processId) throw new Error('agent.remove: missing processId');
+
+  const entry = registry.get(processId);
+  if (entry) {
+    if (entry.ownerAgentId !== callerAgentId) {
+      throw new Error(`agent.remove: process ${processId} is not owned by caller`);
+    }
+    try {
+      entry.pty.kill();
+    } catch {
+      // PTY kill is best-effort; it may already be dead
+    }
+    registry.delete(processId);
+  } else {
+    const row = await db.query<{ owner_agent: string }>(
+      `SELECT owner_agent FROM agent_processes WHERE id = $1`,
+      [processId],
+    );
+    if (row.rows.length === 0) throw new Error(`agent.remove: unknown processId ${processId}`);
+    const r = row.rows[0];
+    if (r && r.owner_agent !== callerAgentId) {
+      throw new Error(`agent.remove: process ${processId} is not owned by caller`);
+    }
+  }
+
+  await db.query(`DELETE FROM agent_processes WHERE id = $1`, [processId]);
+
+  return { removed: processId };
+});
+
+/**
  * agent.input — write bytes to a live PTY's stdin/tty.
  *
  * P4-IDENTITY TODO: signature-gate (see agent.spawn TODO above).

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -397,6 +397,13 @@ export const schemas: Record<string, z.ZodType> = {
     })
     .passthrough(),
 
+  'inference.delete': z
+    .object({
+      model: z.string().max(256),
+      actorAgentId,
+    })
+    .passthrough(),
+
   'inference.start': z
     .object({
       model: z.string().max(256),
@@ -537,6 +544,21 @@ export const schemas: Record<string, z.ZodType> = {
     .passthrough(),
 
   'agent.stop': z
+    .object({
+      processId: z.string().min(1),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  // agent.list takes no required params — the handler self-scopes to the
+  // verified signer's owner_agent.
+  'agent.list': z
+    .object({
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'agent.remove': z
     .object({
       processId: z.string().min(1),
       actorAgentId,

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -59,6 +59,8 @@ export const RPC_METHODS = {
   // Agent spawning
   'agent.spawn': 'agent.spawn',
   'agent.stop': 'agent.stop',
+  'agent.list': 'agent.list',
+  'agent.remove': 'agent.remove',
   'agent.input': 'agent.input',
   'agent.resize': 'agent.resize',
   'agent.output': 'agent.output',
@@ -66,6 +68,7 @@ export const RPC_METHODS = {
   // Inference management
   'inference.status': 'inference.status',
   'inference.pull': 'inference.pull',
+  'inference.delete': 'inference.delete',
   'inference.start': 'inference.start',
   'inference.stop': 'inference.stop',
   'inference.chat': 'inference.chat',


### PR DESCRIPTION
## What

Studio's browser mode (remote daemon over HTTP) previously rejected the agent-list/remove and Ollama inference commands as desktop-only, because the daemon had no matching RPC. This wires the commands the daemon can actually serve and adapts result shapes back to the Studio types, and leaves the genuinely host-only ones rejecting.

## Per-family decision

| Command family | Decision | Why |
|---|---|---|
| `agent.list` / `agent.remove` | **Wired** | The daemon owns a real process registry (`agent_processes` + the live PTY map) but had no way to enumerate or prune it over RPC. `agent.list` returns the caller's processes; `agent.remove` kills the live PTY then deletes the row (output cascades). Both are signature-required + Pro, exactly like the rest of `agent.*`. |
| `inference_ollama_status` / `_models` / `_pull` | **Wired** | The daemon's `inference.*` handlers ARE the Ollama HTTP integration. Status and models both come from `inference.status` (it already returns the model list, so no new "models" method); pull maps to `inference.pull`. Shapes are adapted at the Studio boundary. |
| `inference_ollama_delete` | **Wired (new daemon method)** | Ollama supports `DELETE /api/delete`. Added `inference.delete` as thin Max-tier model management alongside pull/start/stop. |
| `inference_ollama_start` / `_stop` | **Kept desktop-only** | These manage the Ollama **server** lifecycle (`ollama serve` / `pkill`). The daemon only speaks HTTP to an already-running server, so it cannot start or stop a host process. (The daemon's `inference.start`/`stop` are model warm/unload, a different op.) |
| `inference_snap_*` | **Kept desktop-only** | Host snap package management (`sudo snap install/remove`). No daemon equivalent, and the daemon does not manage host packages. |

## New daemon methods

- `agent.list` — enumerate the caller's `agent_processes` (owner-scoped), signature-required, Pro.
- `agent.remove` — stop-if-live + prune the row, signature-required, Pro.
- `inference.delete` — `DELETE /api/delete`, Max-tier (in `METHOD_MIN_TIER`), identity-exempt like its inference siblings.

All three were added to the protocol `RPC_METHODS`, the validation schemas, and the tier-classification set in lockstep. `agent.list`/`agent.remove` were mirrored into `server.ts` `MUTATING_OR_CONTENT_METHODS`, the `signature-gate` lock test, and the Rust `signing.rs` `requires_signature` set (+ its test).

The RPC contract test (`packages/daemon/src/__tests__/rpc-contract.test.ts`) asserts the daemon handler registry EXACTLY equals `RPC_METHODS`, so any new handler must be mirrored in `packages/protocol/src/methods.ts` or the build fails; that mirroring is included here.

## Shape adaptation

Browser mode returns the same types the Tauri path returns. Adapters in `apps/studio/src/lib/invoke.ts` map:
- `inference.status` -> `OllamaStatus { installed, running, version }` (`installed` tracks `running`: the daemon can only confirm install when Ollama answers over HTTP).
- `inference.status.models` -> `OllamaModel[]` (with a formatted size string).
- `inference.pull` -> `ModelPullResult { success, message }` (and `modelName` -> `model` param rename for the daemon schema).
- `agent.list` rows -> `AgentSessionInfo[]`. The daemon's `agent.spawn` is a generic command spawner with no inference backend/model/prompt, so `name` is the command and `backend` is `null`. `AgentSessionInfo.backend` was widened to `AgentBackend | null`, and SpawnerPanel labels a null backend as `PTY`.

## Tests

- Daemon: `agent.list` (owner-scoped, unsigned rejected) and `agent.remove` (stop+prune, cross-agent rejection, unknown id) in `spawn.test.ts`.
- Studio: browser-mode adapter integration tests (status/models/pull/agent-list) driving the real `invoke()` path with a mocked fetch, plus the existing `HARNESS_RPC_MAP` contract block.

## Verification

- `pnpm -r --filter=!studio build` — pass
- `pnpm --filter "@revdev/daemon" test` — 676 pass (incl. rpc-contract, guard tier-classification, signature-gate lock)
- `pnpm --filter "@revdev/protocol" build` — pass
- `pnpm typecheck:studio` — pass
- `pnpm --filter studio test` — 546 pass
- Biome clean on touched files

Rust (`signing.rs`) was not compiled locally (no cargo in this pass); the change is a two-arm match addition mirrored in its unit test, and CI compiles Rust via the typecheck-studio job's `generate-types.sh` (`cargo test --lib`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)