### PR TITLE
feat(daemon): session-lifecycle advisory check surface

### DIFF
--- a/packages/daemon/src/__tests__/session-checks-integration.test.ts
+++ b/packages/daemon/src/__tests__/session-checks-integration.test.ts
@@ -1,0 +1,106 @@
+/**
+ * End-to-end proof that session.register runs the advisory checks and returns
+ * their warnings, without ever failing registration on a check error.
+ *
+ * Spins up a real daemon on a throwaway socket, registers a throwing check and
+ * a warning check AFTER startup (startDaemon's initSessionChecks already ran),
+ * then calls session.register over the wire.
+ *
+ * @vitest-environment node
+ */
+
+import { vi } from 'vitest';
+
+// Daemon startup can take >10s in CI (key generation + socket bind).
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { startDaemon } from '../server.js';
+import { clearSessionChecks, registerSessionCheck } from '../session-checks/index.js';
+
+function rpc(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown> = {},
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
+    sock.on('connect', () => sock.write(req));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      const line = buf.slice(0, nl);
+      sock.end();
+      try {
+        const resp = JSON.parse(line);
+        if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
+        else resolve(resp.result);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error(`RPC timeout: ${method}`));
+    });
+  });
+}
+
+let dataDir: string;
+let socketPath: string;
+let close: () => Promise<void>;
+
+beforeAll(async () => {
+  dataDir = await mkdtemp(join(tmpdir(), 'revdev-session-checks-'));
+  socketPath = join(dataDir, 'harness.sock');
+  const d = await startDaemon({ socketPath, dataDir });
+  close = d.close;
+});
+
+afterAll(async () => {
+  clearSessionChecks();
+  await close?.();
+  await rm(dataDir, { recursive: true, force: true });
+});
+
+describe('session.register advisory checks', () => {
+  it('returns an empty warnings array when no check reports drift', async () => {
+    const result = (await rpc(socketPath, 'session.register', {
+      agentName: 'clean',
+      workDir: '/tmp/clean',
+      backend: 'test',
+    })) as { sessionId: string; warnings: string[] };
+
+    expect(result.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('surfaces a warning check in the register response and survives a throwing check', async () => {
+    registerSessionCheck('boom', async () => {
+      throw new Error('advisory check exploded');
+    });
+    registerSessionCheck('warn', async (ctx) => ({
+      ok: false,
+      warnings: [`drift seen in ${ctx.workDir}`],
+    }));
+
+    const result = (await rpc(socketPath, 'session.register', {
+      agentName: 'drifting',
+      workDir: '/tmp/project-root',
+      backend: 'test',
+    })) as { sessionId: string; warnings: string[] };
+
+    // Registration succeeded despite the throwing check...
+    expect(result.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+    // ...and the healthy check's warning was surfaced.
+    expect(result.warnings).toEqual(['drift seen in /tmp/project-root']);
+  });
+});

--- a/packages/daemon/src/__tests__/session-checks.test.ts
+++ b/packages/daemon/src/__tests__/session-checks.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Session-check registry + runner + doc-locations check unit tests.
+ *
+ * Covers the surface's invariants directly (no socket):
+ *   - a passing check contributes no warnings
+ *   - a warning check surfaces its warnings
+ *   - a throwing check is skipped and never aborts the run
+ *   - the doc-locations check flags a configured violation and passes clean
+ *
+ * @vitest-environment node
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearSessionChecks,
+  createDocLocationsCheck,
+  registeredSessionCheckNames,
+  registerSessionCheck,
+  runSessionChecks,
+} from '../session-checks/index.js';
+
+const CTX = { workDir: '/tmp/does-not-matter', agentId: 'agent-test' };
+
+describe('session-check registry + runner', () => {
+  beforeEach(() => clearSessionChecks());
+  afterEach(() => clearSessionChecks());
+
+  it('a passing check contributes no warnings', async () => {
+    registerSessionCheck('pass', async () => ({ ok: true, warnings: [] }));
+    const warnings = await runSessionChecks(CTX);
+    expect(warnings).toEqual([]);
+  });
+
+  it('a warning check surfaces its warnings', async () => {
+    registerSessionCheck('warn', async () => ({
+      ok: false,
+      warnings: ['drift: X is misplaced'],
+    }));
+    const warnings = await runSessionChecks(CTX);
+    expect(warnings).toEqual(['drift: X is misplaced']);
+  });
+
+  it('a throwing check is skipped and never aborts the run', async () => {
+    registerSessionCheck('boom', async () => {
+      throw new Error('check exploded');
+    });
+    registerSessionCheck('warn', async () => ({ ok: false, warnings: ['still reported'] }));
+
+    // Must resolve (not reject) and still return the healthy check's warning.
+    const warnings = await runSessionChecks(CTX);
+    expect(warnings).toEqual(['still reported']);
+  });
+
+  it('collects warnings across multiple checks', async () => {
+    registerSessionCheck('a', async () => ({ ok: false, warnings: ['a1'] }));
+    registerSessionCheck('b', async () => ({ ok: false, warnings: ['b1', 'b2'] }));
+    const warnings = await runSessionChecks(CTX);
+    expect(warnings).toEqual(['a1', 'b1', 'b2']);
+  });
+
+  it('re-registering a name overwrites the prior check', () => {
+    registerSessionCheck('dup', async () => ({ ok: true, warnings: [] }));
+    registerSessionCheck('dup', async () => ({ ok: true, warnings: [] }));
+    expect(registeredSessionCheckNames()).toEqual(['dup']);
+  });
+});
+
+describe('doc-locations check', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'revdev-doc-loc-'));
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('empty config is a no-op', async () => {
+    const check = createDocLocationsCheck({});
+    const result = await check({ workDir: root, agentId: 'a' });
+    expect(result).toEqual({ ok: true, warnings: [] });
+  });
+
+  it('missing workDir returns clean', async () => {
+    const check = createDocLocationsCheck({
+      restrictedDirs: [{ dir: 'docs/handoffs', allowedFiles: ['README.md'] }],
+    });
+    const result = await check({ workDir: '', agentId: 'a' });
+    expect(result).toEqual({ ok: true, warnings: [] });
+  });
+
+  it('flags a misplaced file in a restricted directory', async () => {
+    await mkdir(join(root, 'docs', 'handoffs'), { recursive: true });
+    await writeFile(join(root, 'docs', 'handoffs', 'README.md'), '# ok');
+    await writeFile(join(root, 'docs', 'handoffs', 'STRAY.md'), '# drift');
+
+    const check = createDocLocationsCheck({
+      restrictedDirs: [
+        {
+          dir: 'docs/handoffs',
+          allowedFiles: ['README.md'],
+          allowedSubdirs: ['archive'],
+          hint: 'active handoffs belong at docs root',
+        },
+      ],
+    });
+    const result = await check({ workDir: root, agentId: 'a' });
+    expect(result.ok).toBe(false);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('docs/handoffs/STRAY.md');
+    expect(result.warnings[0]).toContain('active handoffs belong at docs root');
+  });
+
+  it('flags an unexpected subdirectory in a restricted directory', async () => {
+    await mkdir(join(root, 'docs', 'handoffs', 'archive'), { recursive: true });
+    await mkdir(join(root, 'docs', 'handoffs', 'weird'), { recursive: true });
+
+    const check = createDocLocationsCheck({
+      restrictedDirs: [
+        { dir: 'docs/handoffs', allowedFiles: ['README.md'], allowedSubdirs: ['archive'] },
+      ],
+    });
+    const result = await check({ workDir: root, agentId: 'a' });
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("'docs/handoffs/weird/'");
+  });
+
+  it('flags a subdirectory missing its required file', async () => {
+    await mkdir(join(root, 'docs', 'lanes', 'with-plan'), { recursive: true });
+    await writeFile(join(root, 'docs', 'lanes', 'with-plan', 'plan.md'), '# lane');
+    await mkdir(join(root, 'docs', 'lanes', 'no-plan'), { recursive: true });
+
+    const check = createDocLocationsCheck({
+      requiredFileInSubdirs: [
+        { parentDir: 'docs/lanes', requiredFile: 'plan.md', ignoreSubdirs: ['_closed'] },
+      ],
+    });
+    const result = await check({ workDir: root, agentId: 'a' });
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("'docs/lanes/no-plan' is missing required file 'plan.md'");
+  });
+
+  it('passes a clean tree', async () => {
+    await mkdir(join(root, 'docs', 'handoffs', 'archive'), { recursive: true });
+    await writeFile(join(root, 'docs', 'handoffs', 'README.md'), '# ok');
+    await mkdir(join(root, 'docs', 'lanes', 'good'), { recursive: true });
+    await writeFile(join(root, 'docs', 'lanes', 'good', 'plan.md'), '# lane');
+
+    const check = createDocLocationsCheck({
+      restrictedDirs: [
+        { dir: 'docs/handoffs', allowedFiles: ['README.md'], allowedSubdirs: ['archive'] },
+      ],
+      requiredFileInSubdirs: [{ parentDir: 'docs/lanes', requiredFile: 'plan.md' }],
+    });
+    const result = await check({ workDir: root, agentId: 'a' });
+    expect(result).toEqual({ ok: true, warnings: [] });
+  });
+
+  it('is a no-op when the configured directories do not exist', async () => {
+    const check = createDocLocationsCheck({
+      restrictedDirs: [{ dir: 'docs/handoffs', allowedFiles: ['README.md'] }],
+      requiredFileInSubdirs: [{ parentDir: 'docs/lanes', requiredFile: 'plan.md' }],
+    });
+    const result = await check({ workDir: root, agentId: 'a' });
+    expect(result).toEqual({ ok: true, warnings: [] });
+  });
+});

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -58,6 +58,7 @@ import {
 } from './neon.js';
 import { initObservability, onConnect, onDisconnect, trackRpcCall } from './observability.js';
 import { revvaultSet } from './revvault-client.js';
+import { initSessionChecks, runSessionChecks } from './session-checks/index.js';
 import { migrate } from './storage/migrate.js';
 import { initToolGuard } from './tool-guard/index.js';
 import { invalidParamsResponse, validateParams } from './validation/index.js';
@@ -770,6 +771,12 @@ registerHandler('session.register', async (params, db, ctx) => {
     ? await registerClientIdentity(db, id, clientPublicKeyPem)
     : await bootstrapAgentIdentity(db, id);
 
+  // Run the registered session-lifecycle advisory checks and surface their
+  // warnings to the client. Best-effort by construction: runSessionChecks
+  // catches per-check throws and always resolves, so registration can never
+  // fail on a check error.
+  const warnings = await runSessionChecks({ workDir, agentId: id });
+
   // Include `session: {id}` for back-compat with hook clients that read
   // `result.session.id`. New clients should use `sessionId`/`agentId`.
   return {
@@ -779,6 +786,7 @@ registerHandler('session.register', async (params, db, ctx) => {
     backend,
     did,
     publicKeyPem,
+    warnings,
     session: { id, env, task: workDir },
   };
 });
@@ -1738,6 +1746,11 @@ export async function startDaemon(
   // Initialize Neon sync (GAP-154 Phase 2). No-op when POSTGRES_URL is
   // unset — daemon runs single-machine fine; sync is purely additive.
   initNeonSync();
+
+  // Register the built-in session-lifecycle advisory checks. Ships with an
+  // empty rule set (a no-op) so nothing project-specific is baked in; a
+  // consuming project supplies canonical-path rules to activate them.
+  initSessionChecks();
 
   // Ensure data directory exists
   await mkdir(cfg.dataDir, { recursive: true });

--- a/packages/daemon/src/session-checks/doc-locations.ts
+++ b/packages/daemon/src/session-checks/doc-locations.ts
@@ -1,0 +1,147 @@
+/**
+ * Canonical doc-locations check — a generic structural advisory.
+ *
+ * Generalizes the kind of check the RevFleet `doc-locations-check.ts` scanner
+ * performs (misplaced docs in a restricted directory, a required index file
+ * missing from each of a directory's subdirectories) into a configurable rule
+ * set that carries NO project-specific paths. A consuming project supplies its
+ * own canonical-path rules; with an empty config this check is a no-op, so the
+ * daemon ships it provider-agnostic.
+ *
+ * It only reads the immediate children of the configured directories (no
+ * recursion, no traversal), reports warnings, and never mutates anything.
+ *
+ * Zero authored regex — path joins + `Set` / array membership only.
+ */
+
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { SessionCheck, SessionCheckResult } from './index.js';
+
+/**
+ * A directory whose direct children are restricted to an allowlist. Any file or
+ * subdirectory not on the allowlist is flagged as misplaced.
+ */
+export interface RestrictedDirRule {
+  /** Directory relative to the project root, e.g. "docs/handoffs". */
+  dir: string;
+  /** Filenames permitted directly in `dir`. All other files are flagged. */
+  allowedFiles?: string[];
+  /** Subdirectory names permitted in `dir`. All other subdirectories are flagged. */
+  allowedSubdirs?: string[];
+  /** Optional human-facing hint appended to each warning for this rule. */
+  hint?: string;
+}
+
+/**
+ * A directory each of whose immediate subdirectories must contain a required
+ * file (e.g. every `docs/lanes/<slug>/` must have a `plan.md`).
+ */
+export interface RequiredFileRule {
+  /** Parent directory relative to the project root, e.g. "docs/lanes". */
+  parentDir: string;
+  /** The file each immediate subdirectory must contain, e.g. "plan.md". */
+  requiredFile: string;
+  /** Subdirectory names to skip (e.g. meta directories). */
+  ignoreSubdirs?: string[];
+  /** Optional human-facing hint appended to each warning for this rule. */
+  hint?: string;
+}
+
+export interface DocLocationsConfig {
+  /** Directories whose direct children are restricted to an allowlist. */
+  restrictedDirs?: RestrictedDirRule[];
+  /** Directory groups whose subdirectories must each contain a required file. */
+  requiredFileInSubdirs?: RequiredFileRule[];
+}
+
+/** Append a hint to a warning line when the rule carries one. */
+function withHint(message: string, hint: string | undefined): string {
+  return hint ? `${message} (${hint})` : message;
+}
+
+/** Read a directory's entries, treating an absent/unreadable dir as empty. */
+async function readEntries(dir: string): Promise<import('node:fs').Dirent[]> {
+  try {
+    return await readdir(dir, { withFileTypes: true });
+  } catch {
+    // Absent or unreadable directory: nothing to inspect, not a violation.
+    return [];
+  }
+}
+
+async function checkRestrictedDir(
+  root: string,
+  rule: RestrictedDirRule,
+  warnings: string[],
+): Promise<void> {
+  const allowedFiles = new Set(rule.allowedFiles ?? []);
+  const allowedSubdirs = new Set(rule.allowedSubdirs ?? []);
+  const dirPath = join(root, rule.dir);
+  for (const entry of await readEntries(dirPath)) {
+    if (entry.isDirectory()) {
+      if (!allowedSubdirs.has(entry.name)) {
+        warnings.push(
+          withHint(
+            `doc-locations: unexpected subdirectory '${rule.dir}/${entry.name}/'`,
+            rule.hint,
+          ),
+        );
+      }
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!allowedFiles.has(entry.name)) {
+      warnings.push(
+        withHint(`doc-locations: unexpected file '${rule.dir}/${entry.name}'`, rule.hint),
+      );
+    }
+  }
+}
+
+async function checkRequiredFileInSubdirs(
+  root: string,
+  rule: RequiredFileRule,
+  warnings: string[],
+): Promise<void> {
+  const ignore = new Set(rule.ignoreSubdirs ?? []);
+  const parentPath = join(root, rule.parentDir);
+  for (const entry of await readEntries(parentPath)) {
+    if (!entry.isDirectory()) continue;
+    if (ignore.has(entry.name)) continue;
+    const children = await readEntries(join(parentPath, entry.name));
+    const hasRequired = children.some(
+      (child) => child.isFile() && child.name === rule.requiredFile,
+    );
+    if (!hasRequired) {
+      warnings.push(
+        withHint(
+          `doc-locations: '${rule.parentDir}/${entry.name}' is missing required file '${rule.requiredFile}'`,
+          rule.hint,
+        ),
+      );
+    }
+  }
+}
+
+/**
+ * Build a doc-locations advisory check bound to `config`. An empty config
+ * produces a check that always returns clean, so it is safe to register by
+ * default on any project.
+ */
+export function createDocLocationsCheck(config: DocLocationsConfig): SessionCheck {
+  return async (ctx): Promise<SessionCheckResult> => {
+    const warnings: string[] = [];
+    // No project root means nothing to inspect.
+    if (!ctx.workDir) return { ok: true, warnings };
+
+    for (const rule of config.restrictedDirs ?? []) {
+      await checkRestrictedDir(ctx.workDir, rule, warnings);
+    }
+    for (const rule of config.requiredFileInSubdirs ?? []) {
+      await checkRequiredFileInSubdirs(ctx.workDir, rule, warnings);
+    }
+
+    return { ok: warnings.length === 0, warnings };
+  };
+}

--- a/packages/daemon/src/session-checks/index.ts
+++ b/packages/daemon/src/session-checks/index.ts
@@ -1,0 +1,111 @@
+/**
+ * Session-lifecycle advisory-check surface.
+ *
+ * The per-SESSION sibling of the agent.spawn confinement / tool-guard
+ * (per-ACTION) boundary. Where confinement gates a single action, this runs a
+ * set of registered ADVISORY checks when a session registers and returns their
+ * warnings to the client. It NEVER blocks: a session always registers, and a
+ * check that throws is logged and skipped so a defect in one check can never
+ * fail registration.
+ *
+ * The invariant mirrors the fleet "hooks only read + warn" rule: checks are
+ * pure-ish reads that produce warnings, not gates. Studio / Console / any
+ * customer harness surfaces the returned warnings; the daemon takes no action
+ * on them.
+ *
+ * Zero authored regex. Reuses the shared @revealui/utils logger.
+ */
+
+import { createLogger } from '@revealui/utils/logger';
+import { createDocLocationsCheck, type DocLocationsConfig } from './doc-locations.js';
+
+const log = createLogger({ service: 'revdev-daemon/session-checks' });
+
+/** Context handed to every session check. */
+export interface SessionCheckContext {
+  /**
+   * Working directory / project root of the registering session. May be an
+   * empty string when the client did not supply one; checks must treat that as
+   * "nothing to inspect" and return a clean result.
+   */
+  workDir: string;
+  /** Bound agent identity for the session, for log attribution. */
+  agentId: string | null;
+}
+
+/** Result of a single advisory check. `ok` is false when warnings were found. */
+export interface SessionCheckResult {
+  ok: boolean;
+  warnings: string[];
+}
+
+/**
+ * An advisory check. Receives the session context, returns warnings. It must
+ * never mutate state and should never throw; the runner treats a throw as a
+ * skipped check, but a check that throws is a bug in that check.
+ */
+export type SessionCheck = (ctx: SessionCheckContext) => Promise<SessionCheckResult>;
+
+const checks = new Map<string, SessionCheck>();
+
+/**
+ * Register (or replace) an advisory check under `name`. Registration is a plain
+ * Map write and never fails; re-registering the same name overwrites, which
+ * keeps `initSessionChecks()` idempotent across daemon lifecycles.
+ */
+export function registerSessionCheck(name: string, fn: SessionCheck): void {
+  checks.set(name, fn);
+}
+
+/** Names of the currently registered checks (registration order). */
+export function registeredSessionCheckNames(): string[] {
+  return [...checks.keys()];
+}
+
+/** Remove all registered checks. Test-only isolation helper. */
+export function clearSessionChecks(): void {
+  checks.clear();
+}
+
+/**
+ * Run every registered check and collect their warnings. Best-effort: each
+ * check runs inside its own try/catch, so a throwing check is logged and
+ * skipped and never aborts the run. Always resolves (never rejects), so the
+ * caller — session.register — can never fail registration on a check error.
+ */
+export async function runSessionChecks(ctx: SessionCheckContext): Promise<string[]> {
+  const warnings: string[] = [];
+  for (const [name, fn] of checks) {
+    try {
+      const result = await fn(ctx);
+      for (const w of result.warnings) warnings.push(w);
+    } catch (err) {
+      log.warn('session check threw — skipped', {
+        check: name,
+        agentId: ctx.agentId,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return warnings;
+}
+
+/**
+ * Register the daemon's built-in advisory checks. Called once from
+ * startDaemon. Idempotent (each check registers under a fixed name).
+ *
+ * The built-in doc-locations check ships with an EMPTY ruleset, so it is a
+ * no-op until a consuming project supplies canonical-path rules. This keeps the
+ * surface provider-agnostic: nothing about RevFleet's own doc layout is baked
+ * into the daemon.
+ */
+export function initSessionChecks(config: { docLocations?: DocLocationsConfig } = {}): void {
+  registerSessionCheck('doc-locations', createDocLocationsCheck(config.docLocations ?? {}));
+}
+
+export type {
+  DocLocationsConfig,
+  RequiredFileRule,
+  RestrictedDirRule,
+} from './doc-locations.js';
+export { createDocLocationsCheck } from './doc-locations.js';


### PR DESCRIPTION
## What

Adds a native session-lifecycle advisory-check surface to the daemon: a check registry plus wiring into `session.register` that runs registered advisory checks warn-only and returns their warnings to the client.

This is the per-SESSION sibling of the per-ACTION `agent.spawn` confinement boundary. Where confinement gates a single action, this runs a set of registered ADVISORY checks when a session registers and hands their warnings back so Studio, Console, or any consuming harness can surface them. The daemon takes no action on the warnings.

## Registry API

`packages/daemon/src/session-checks/`

- `registerSessionCheck(name, fn)` where `fn: (ctx) => Promise<{ ok: boolean; warnings: string[] }>`. `ctx` carries the session `workDir` (project root) and `agentId`.
- `runSessionChecks(ctx)` runs every registered check and returns the collected warnings. Best-effort: each check runs inside its own try/catch, so a throwing check is logged and skipped and the run always resolves. Registration can never fail on a check error.
- `initSessionChecks()` registers the built-in checks; called once from `startDaemon`.
- `clearSessionChecks()` / `registeredSessionCheckNames()` support isolation and introspection.

`session.register` now runs the registered checks and adds a `warnings: string[]` field to its response. All existing response fields are unchanged. No new RPC method is added — the checks fire inside the existing handler, so the method contract is untouched.

## The ported check

A generic canonical **doc-locations** check. It takes a project root plus a config of path rules and carries no product-specific paths:

- `restrictedDirs` — directories whose direct children are restricted to an allowlist (misplaced files/subdirectories are flagged).
- `requiredFileInSubdirs` — parent directories whose immediate subdirectories must each contain a required index file.

It reads only the immediate children of the configured directories (no recursion, no traversal), reports warnings, and mutates nothing. The built-in registration ships an **empty** rule set, so the check is a no-op until a consuming project supplies its own canonical-path rules. This keeps the surface provider-agnostic.

### Deferred, on purpose

A doc-currency-style stale-fact check is intentionally NOT ported here. Its actual rules are deployment-specific stale facts that do not port verbatim to a customer project; porting it needs a customer-generic configurable-rule design first. No such facts are hardcoded into a shipped daemon check.

## Tests

- Registry/runner unit tests: a passing check contributes no warnings; a warning check surfaces its warnings; a throwing check is skipped and the run still succeeds; warnings collect across multiple checks.
- doc-locations unit tests: flags a misplaced file, an unexpected subdirectory, and a subdirectory missing its required file; passes a clean tree; empty config and absent directories are no-ops.
- Integration test: through a real daemon socket, `session.register` returns an empty `warnings` array on a clean run, and surfaces a warning check's message while a co-registered throwing check is skipped (registration still succeeds).

Prove-red confirmed: removing the response `warnings` field turns the integration test red.

## Verification

- `pnpm --filter "@revdev/daemon" test` — 690 passed (36 files), including the handler-contract coverage test.
- `pnpm -r --filter=!studio build` — clean.
- `pnpm --filter "@revdev/protocol" build` — clean.
- `pnpm typecheck:studio` — clean.
- Biome clean on touched files.

Constraints honored: TypeScript strict, ESM, zero authored regex (path joins + `Set`/array membership only), explicit return types on exports, no `any`, shared `@revealui/utils` logger, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)