### PR TITLE
feat(daemon): add dup-work-claim check, harden doc-locations paths

### DIFF
--- a/packages/daemon/src/__tests__/dup-work-claim.test.ts
+++ b/packages/daemon/src/__tests__/dup-work-claim.test.ts
@@ -1,0 +1,167 @@
+/**
+ * dup-work-claim check unit tests.
+ *
+ * Covers the check's invariants:
+ *   - two worktrees claiming the same configured marker -> a warning
+ *   - distinct markers -> clean
+ *   - unconfigured (no markers) -> no-op, and git is never spawned
+ *   - a git failure (non-zero exit OR a throwing lister) -> clean, never throws
+ *
+ * The warning-path tests drive the REAL default lister (hardened `runGit`)
+ * against a throwaway git repo with linked worktrees, so the porcelain parse +
+ * extraction are exercised end to end. The edge cases inject a lister so no git
+ * is spawned and the failure paths are deterministic.
+ *
+ * @vitest-environment node
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDupWorkClaimCheck } from '../session-checks/index.js';
+import type { ShellResult } from '../vcs.js';
+
+vi.setConfig({ testTimeout: 20_000, hookTimeout: 20_000 });
+
+const CTX_AGENT = 'agent-test';
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', ['-c', 'user.name=t', '-c', 'user.email=t@t', ...args], {
+    cwd,
+    stdio: 'ignore',
+  });
+}
+
+describe('dup-work-claim check (real git worktrees)', () => {
+  let base: string;
+  let repo: string;
+
+  beforeEach(async () => {
+    base = await mkdtemp(join(tmpdir(), 'revdev-dup-work-'));
+    repo = join(base, 'repo');
+    await mkdir(repo, { recursive: true });
+    git(repo, ['init', '-q']);
+    await writeFile(join(repo, 'README.md'), '# seed');
+    git(repo, ['add', '.']);
+    git(repo, ['commit', '-q', '-m', 'seed']);
+  });
+
+  afterEach(async () => {
+    await rm(base, { recursive: true, force: true });
+  });
+
+  it('warns when the same marker is claimed by two worktrees', async () => {
+    git(repo, [
+      'worktree',
+      'add',
+      '-q',
+      '-b',
+      'feat/task-42-alpha',
+      join(base, 'wt-TASK-42-alpha'),
+    ]);
+    git(repo, ['worktree', 'add', '-q', '-b', 'feat/task-42-beta', join(base, 'wt-TASK-42-beta')]);
+
+    const check = createDupWorkClaimCheck({ claimMarkers: ['TASK-'] });
+    const result = await check({ workDir: repo, agentId: CTX_AGENT });
+
+    expect(result.ok).toBe(false);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("'task-42' is claimed by 2 worktrees");
+    expect(result.warnings[0]).toContain('wt-TASK-42-alpha');
+    expect(result.warnings[0]).toContain('wt-TASK-42-beta');
+  });
+
+  it('is clean when worktrees carry distinct markers', async () => {
+    git(repo, ['worktree', 'add', '-q', '-b', 'feat/task-42', join(base, 'wt-TASK-42')]);
+    git(repo, ['worktree', 'add', '-q', '-b', 'feat/task-99', join(base, 'wt-TASK-99')]);
+
+    const check = createDupWorkClaimCheck({ claimMarkers: ['TASK-'] });
+    const result = await check({ workDir: repo, agentId: CTX_AGENT });
+
+    expect(result).toEqual({ ok: true, warnings: [] });
+  });
+});
+
+describe('dup-work-claim check (injected lister)', () => {
+  const okResult = (stdout: string): ShellResult => ({ ok: true, stdout, stderr: '', code: 0 });
+
+  it('is a no-op when no markers are configured, and never spawns git', async () => {
+    let called = false;
+    const lister = async (): Promise<ShellResult> => {
+      called = true;
+      return okResult('');
+    };
+    const check = createDupWorkClaimCheck({}, lister);
+    const result = await check({ workDir: '/tmp/project', agentId: CTX_AGENT });
+
+    expect(result).toEqual({ ok: true, warnings: [] });
+    expect(called).toBe(false);
+  });
+
+  it('is a no-op when workDir is empty', async () => {
+    let called = false;
+    const lister = async (): Promise<ShellResult> => {
+      called = true;
+      return okResult('');
+    };
+    const check = createDupWorkClaimCheck({ claimMarkers: ['TASK-'] }, lister);
+    const result = await check({ workDir: '', agentId: CTX_AGENT });
+
+    expect(result).toEqual({ ok: true, warnings: [] });
+    expect(called).toBe(false);
+  });
+
+  it('returns clean (no throw) when the git lister exits non-zero', async () => {
+    const lister = async (): Promise<ShellResult> => ({
+      ok: false,
+      stdout: '',
+      stderr: 'fatal: not a git repository',
+      code: 128,
+    });
+    const check = createDupWorkClaimCheck({ claimMarkers: ['TASK-'] }, lister);
+    const result = await check({ workDir: '/tmp/not-a-repo', agentId: CTX_AGENT });
+
+    expect(result).toEqual({ ok: true, warnings: [] });
+  });
+
+  it('returns clean (no throw) when the git lister throws', async () => {
+    const lister = async (): Promise<ShellResult> => {
+      throw new Error('spawn git ENOENT');
+    };
+    const check = createDupWorkClaimCheck({ claimMarkers: ['TASK-'] }, lister);
+    await expect(check({ workDir: '/tmp/project', agentId: CTX_AGENT })).resolves.toEqual({
+      ok: true,
+      warnings: [],
+    });
+  });
+
+  it('extracts claims from branch names as well as paths', async () => {
+    // The path basename omits the marker; only the branch carries it.
+    const porcelain = [
+      'worktree /home/dev/project',
+      'HEAD 1111111111111111111111111111111111111111',
+      'branch refs/heads/main',
+      '',
+      'worktree /home/dev/alpha',
+      'HEAD 2222222222222222222222222222222222222222',
+      'branch refs/heads/feat/gap-7-x',
+      '',
+      'worktree /home/dev/beta',
+      'HEAD 3333333333333333333333333333333333333333',
+      'branch refs/heads/fix/gap-7-y',
+      '',
+    ].join('\n');
+    const check = createDupWorkClaimCheck({ claimMarkers: ['GAP-'] }, async () =>
+      okResult(porcelain),
+    );
+    const result = await check({ workDir: '/home/dev/project', agentId: CTX_AGENT });
+
+    expect(result.ok).toBe(false);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("'gap-7' is claimed by 2 worktrees");
+    expect(result.warnings[0]).toContain('/home/dev/alpha');
+    expect(result.warnings[0]).toContain('/home/dev/beta');
+  });
+});

--- a/packages/daemon/src/__tests__/dup-work-claim.test.ts
+++ b/packages/daemon/src/__tests__/dup-work-claim.test.ts
@@ -140,15 +140,15 @@ describe('dup-work-claim check (injected lister)', () => {
   it('extracts claims from branch names as well as paths', async () => {
     // The path basename omits the marker; only the branch carries it.
     const porcelain = [
-      'worktree /home/dev/project',
+      'worktree /work/project',
       'HEAD 1111111111111111111111111111111111111111',
       'branch refs/heads/main',
       '',
-      'worktree /home/dev/alpha',
+      'worktree /work/alpha',
       'HEAD 2222222222222222222222222222222222222222',
       'branch refs/heads/feat/gap-7-x',
       '',
-      'worktree /home/dev/beta',
+      'worktree /work/beta',
       'HEAD 3333333333333333333333333333333333333333',
       'branch refs/heads/fix/gap-7-y',
       '',
@@ -156,12 +156,12 @@ describe('dup-work-claim check (injected lister)', () => {
     const check = createDupWorkClaimCheck({ claimMarkers: ['GAP-'] }, async () =>
       okResult(porcelain),
     );
-    const result = await check({ workDir: '/home/dev/project', agentId: CTX_AGENT });
+    const result = await check({ workDir: '/work/project', agentId: CTX_AGENT });
 
     expect(result.ok).toBe(false);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("'gap-7' is claimed by 2 worktrees");
-    expect(result.warnings[0]).toContain('/home/dev/alpha');
-    expect(result.warnings[0]).toContain('/home/dev/beta');
+    expect(result.warnings[0]).toContain('/work/alpha');
+    expect(result.warnings[0]).toContain('/work/beta');
   });
 });

--- a/packages/daemon/src/__tests__/session-checks.test.ts
+++ b/packages/daemon/src/__tests__/session-checks.test.ts
@@ -167,4 +167,54 @@ describe('doc-locations check', () => {
     const result = await check({ workDir: root, agentId: 'a' });
     expect(result).toEqual({ ok: true, warnings: [] });
   });
+
+  it('skips a restrictedDirs rule whose dir escapes the project root and reads nothing outside', async () => {
+    // Lay out base/{project, outside}. A rule dir of '../outside' resolves to a
+    // sibling of the project root; it must be skipped, not read.
+    const base = await mkdtemp(join(tmpdir(), 'revdev-doc-loc-escape-'));
+    try {
+      const project = join(base, 'project');
+      await mkdir(project, { recursive: true });
+      const outside = join(base, 'outside');
+      await mkdir(outside, { recursive: true });
+      // A file that WOULD be flagged as misplaced if the rule read outside root.
+      await writeFile(join(outside, 'SECRET.md'), '# outside');
+
+      const check = createDocLocationsCheck({
+        restrictedDirs: [{ dir: '../outside', allowedFiles: [] }],
+      });
+      const result = await check({ workDir: project, agentId: 'a' });
+
+      expect(result.ok).toBe(false);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toBe(
+        "doc-locations: rule dir '../outside' escapes the project root, skipped",
+      );
+      // Proves the outside directory was never read.
+      expect(result.warnings[0]).not.toContain('SECRET.md');
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it('skips a requiredFileInSubdirs rule whose parentDir escapes the project root', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'revdev-doc-loc-escape-'));
+    try {
+      const project = join(base, 'project');
+      await mkdir(project, { recursive: true });
+      // A subdirectory outside root that lacks the required file — would warn if read.
+      await mkdir(join(base, 'outside', 'sub'), { recursive: true });
+
+      const check = createDocLocationsCheck({
+        requiredFileInSubdirs: [{ parentDir: '../outside', requiredFile: 'plan.md' }],
+      });
+      const result = await check({ workDir: project, agentId: 'a' });
+
+      expect(result.warnings).toEqual([
+        "doc-locations: rule parentDir '../outside' escapes the project root, skipped",
+      ]);
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/daemon/src/session-checks/doc-locations.ts
+++ b/packages/daemon/src/session-checks/doc-locations.ts
@@ -15,7 +15,7 @@
  */
 
 import { readdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import type { SessionCheck, SessionCheckResult } from './index.js';
 
 /**
@@ -60,6 +60,30 @@ function withHint(message: string, hint: string | undefined): string {
   return hint ? `${message} (${hint})` : message;
 }
 
+/**
+ * True when `target` is `root` itself or a descendant of it. Separator-safe
+ * (never a bare `startsWith`, which would treat `/a/bc` as within `/a/b`).
+ * Same shape as the confinement layer's `within()` (confinement.ts) — mirrored
+ * here so this check carries no dependency on the confinement module. Zero regex.
+ */
+function within(root: string, target: string): boolean {
+  return target === root || target.startsWith(root + sep);
+}
+
+/**
+ * Resolve `rel` beneath `root`, returning the absolute joined path only when it
+ * stays inside `root`. A config-supplied `dir` / `parentDir` carrying a `../`
+ * segment would otherwise resolve OUTSIDE the project root, and reading there
+ * would let an operator config walk out of the tree it is scoped to. Returning
+ * null for that case lets the caller skip the rule and warn instead of reading
+ * outside root. Zero regex — `resolve` + the separator-safe containment check.
+ */
+function resolveWithinRoot(root: string, rel: string): string | null {
+  const rootAbs = resolve(root);
+  const target = resolve(rootAbs, rel);
+  return within(rootAbs, target) ? target : null;
+}
+
 /** Read a directory's entries, treating an absent/unreadable dir as empty. */
 async function readEntries(dir: string): Promise<import('node:fs').Dirent[]> {
   try {
@@ -77,7 +101,11 @@ async function checkRestrictedDir(
 ): Promise<void> {
   const allowedFiles = new Set(rule.allowedFiles ?? []);
   const allowedSubdirs = new Set(rule.allowedSubdirs ?? []);
-  const dirPath = join(root, rule.dir);
+  const dirPath = resolveWithinRoot(root, rule.dir);
+  if (dirPath === null) {
+    warnings.push(`doc-locations: rule dir '${rule.dir}' escapes the project root, skipped`);
+    return;
+  }
   for (const entry of await readEntries(dirPath)) {
     if (entry.isDirectory()) {
       if (!allowedSubdirs.has(entry.name)) {
@@ -105,7 +133,13 @@ async function checkRequiredFileInSubdirs(
   warnings: string[],
 ): Promise<void> {
   const ignore = new Set(rule.ignoreSubdirs ?? []);
-  const parentPath = join(root, rule.parentDir);
+  const parentPath = resolveWithinRoot(root, rule.parentDir);
+  if (parentPath === null) {
+    warnings.push(
+      `doc-locations: rule parentDir '${rule.parentDir}' escapes the project root, skipped`,
+    );
+    return;
+  }
   for (const entry of await readEntries(parentPath)) {
     if (!entry.isDirectory()) continue;
     if (ignore.has(entry.name)) continue;

--- a/packages/daemon/src/session-checks/dup-work-claim.ts
+++ b/packages/daemon/src/session-checks/dup-work-claim.ts
@@ -1,0 +1,167 @@
+/**
+ * Duplicate-work-claim check — a generic concurrency advisory.
+ *
+ * Generalizes the kind of collision the RevFleet duplicate-gap-claim detector
+ * prevents (two concurrent sessions independently building the SAME unit of
+ * work) into a configurable marker scan that carries NO project-specific
+ * vocabulary. When the same claim identifier appears in 2+ git worktrees of a
+ * project, that is the visible signal two sessions are building the same thing;
+ * the signal is already in `git worktree list`, it just needs reading before a
+ * second worktree is opened.
+ *
+ * A consuming project supplies its own claim markers (e.g. "TASK-", "GAP-",
+ * "ISSUE-"). With no markers configured this check is a no-op, so the daemon
+ * ships it provider-agnostic — nothing about any one tracker's id scheme is
+ * baked in.
+ *
+ * Best-effort and read-only: any git error yields a clean (no-warning) result
+ * and the check never throws. It reuses the daemon's hardened `runGit` helper
+ * via a lazy import (a static import would form a load-time cycle: server.ts
+ * imports the session-check registry before its own handler map initializes,
+ * and vcs.ts registers handlers at module top-level).
+ *
+ * Zero authored regex — a substring scan plus a digit/letter walk extract each
+ * claim identifier; `Map` / `Set` group them.
+ */
+
+import { basename } from 'node:path';
+import type { ShellResult } from '../vcs.js';
+import type { SessionCheck, SessionCheckResult } from './index.js';
+
+export interface DupWorkClaimConfig {
+  /**
+   * Claim-marker prefixes to scan for, e.g. `["TASK-", "GAP-"]`. A claim
+   * identifier is a marker followed by a run of alphanumeric characters
+   * (`TASK-42` from a marker `TASK-`). Empty or unset makes the check a no-op.
+   */
+  claimMarkers?: string[];
+}
+
+/** One git worktree, as parsed from `git worktree list --porcelain`. */
+interface WorktreeEntry {
+  path: string;
+  /** Branch name (after `refs/heads/`), or "" when bare/detached. */
+  branch: string;
+}
+
+/**
+ * Runs `git worktree list --porcelain` in `cwd`. Injectable so tests can supply
+ * canned porcelain output or a forced failure without spawning git. The default
+ * lazily imports `runGit` (see the module note on the load-time cycle).
+ */
+export type WorktreeLister = (cwd: string) => Promise<ShellResult>;
+
+const defaultLister: WorktreeLister = async (cwd) => {
+  const { runGit } = await import('../vcs.js');
+  return runGit(['worktree', 'list', '--porcelain'], cwd);
+};
+
+/** True for an ASCII alphanumeric character. Zero regex. */
+function isIdentChar(c: string): boolean {
+  return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+/**
+ * Extract claim identifiers from arbitrary text by each configured marker.
+ * A match is the marker plus the following run of alphanumeric characters;
+ * a bare marker with no trailing identifier is ignored. Case-insensitive, so
+ * the returned ids are lowercased and collapse `.wt/TASK-42` with a branch
+ * `task-42`. Substring scan + character walk, no regex.
+ */
+function extractClaims(text: string, markers: readonly string[]): Set<string> {
+  const ids = new Set<string>();
+  if (!text) return ids;
+  const lower = text.toLowerCase();
+  for (const marker of markers) {
+    const m = marker.toLowerCase();
+    if (m.length === 0) continue;
+    let i = 0;
+    while (i < lower.length) {
+      const idx = lower.indexOf(m, i);
+      if (idx === -1) break;
+      let j = idx + m.length;
+      let tail = '';
+      while (j < lower.length) {
+        const c = lower[j];
+        if (c === undefined || !isIdentChar(c)) break;
+        tail += c;
+        j += 1;
+      }
+      if (tail.length > 0) ids.add(`${m}${tail}`);
+      i = idx + m.length;
+    }
+  }
+  return ids;
+}
+
+/** Parse `git worktree list --porcelain` into worktree entries. */
+function parseWorktrees(stdout: string): WorktreeEntry[] {
+  const entries: WorktreeEntry[] = [];
+  let current: WorktreeEntry | null = null;
+  const BRANCH_PREFIX = 'branch refs/heads/';
+  for (const line of stdout.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      if (current) entries.push(current);
+      current = { path: line.slice('worktree '.length).trim(), branch: '' };
+    } else if (line.startsWith(BRANCH_PREFIX) && current) {
+      current.branch = line.slice(BRANCH_PREFIX.length).trim();
+    }
+  }
+  if (current) entries.push(current);
+  return entries;
+}
+
+/**
+ * Build a duplicate-work-claim advisory check bound to `config`. With no
+ * markers configured the check always returns clean, so it is safe to register
+ * by default on any project. `lister` is injectable for tests; production uses
+ * the hardened `runGit`.
+ */
+export function createDupWorkClaimCheck(
+  config: DupWorkClaimConfig,
+  lister: WorktreeLister = defaultLister,
+): SessionCheck {
+  const markers = config.claimMarkers ?? [];
+  return async (ctx): Promise<SessionCheckResult> => {
+    const warnings: string[] = [];
+    // Unconfigured (no markers) or no project root: nothing to inspect.
+    if (markers.length === 0 || !ctx.workDir) return { ok: true, warnings };
+
+    let result: ShellResult;
+    try {
+      result = await lister(ctx.workDir);
+    } catch {
+      // Any spawn failure is a clean no-op — this is an advisory, not a gate.
+      return { ok: true, warnings };
+    }
+    if (!result.ok) return { ok: true, warnings };
+
+    // claim identifier -> distinct worktree paths that claim it.
+    const claims = new Map<string, Set<string>>();
+    for (const wt of parseWorktrees(result.stdout)) {
+      const ids = new Set<string>([
+        ...extractClaims(basename(wt.path), markers),
+        ...extractClaims(wt.branch, markers),
+      ]);
+      for (const id of ids) {
+        let paths = claims.get(id);
+        if (!paths) {
+          paths = new Set();
+          claims.set(id, paths);
+        }
+        paths.add(wt.path);
+      }
+    }
+
+    for (const [id, paths] of claims) {
+      if (paths.size >= 2) {
+        warnings.push(
+          `dup-work-claim: '${id}' is claimed by ${paths.size} worktrees (${[...paths].join(', ')}). ` +
+            'Two sessions may be building the same thing; coordinate before continuing.',
+        );
+      }
+    }
+
+    return { ok: warnings.length === 0, warnings };
+  };
+}

--- a/packages/daemon/src/session-checks/index.ts
+++ b/packages/daemon/src/session-checks/index.ts
@@ -18,6 +18,7 @@
 
 import { createLogger } from '@revealui/utils/logger';
 import { createDocLocationsCheck, type DocLocationsConfig } from './doc-locations.js';
+import { createDupWorkClaimCheck, type DupWorkClaimConfig } from './dup-work-claim.js';
 
 const log = createLogger({ service: 'revdev-daemon/session-checks' });
 
@@ -94,13 +95,16 @@ export async function runSessionChecks(ctx: SessionCheckContext): Promise<string
  * Register the daemon's built-in advisory checks. Called once from
  * startDaemon. Idempotent (each check registers under a fixed name).
  *
- * The built-in doc-locations check ships with an EMPTY ruleset, so it is a
- * no-op until a consuming project supplies canonical-path rules. This keeps the
- * surface provider-agnostic: nothing about RevFleet's own doc layout is baked
- * into the daemon.
+ * Every built-in check ships with an EMPTY config, so each is a no-op until a
+ * consuming project supplies rules (doc-locations) or claim markers
+ * (dup-work-claim). This keeps the surface provider-agnostic: nothing about
+ * RevFleet's own doc layout or work-tracking scheme is baked into the daemon.
  */
-export function initSessionChecks(config: { docLocations?: DocLocationsConfig } = {}): void {
+export function initSessionChecks(
+  config: { docLocations?: DocLocationsConfig; dupWorkClaim?: DupWorkClaimConfig } = {},
+): void {
   registerSessionCheck('doc-locations', createDocLocationsCheck(config.docLocations ?? {}));
+  registerSessionCheck('dup-work-claim', createDupWorkClaimCheck(config.dupWorkClaim ?? {}));
 }
 
 export type {
@@ -109,3 +113,5 @@ export type {
   RestrictedDirRule,
 } from './doc-locations.js';
 export { createDocLocationsCheck } from './doc-locations.js';
+export type { DupWorkClaimConfig, WorktreeLister } from './dup-work-claim.js';
+export { createDupWorkClaimCheck } from './dup-work-claim.js';


### PR DESCRIPTION
## Summary

Extends the session-lifecycle advisory-check surface (added in #288) with one hardening fix and one new advisory check. Both run inside `session.register` and surface warnings to the client; neither adds an RPC method, blocks registration, or throws.

### 1. Harden `doc-locations` against path escape

The config-supplied `dir` / `parentDir` were joined to the project root with no containment check, so an operator config carrying a `../` segment would read outside the project root. The check now resolves the joined path and, if it escapes root (separator-safe containment, mirroring the `within()` helper in `confinement.ts`), skips that rule and emits a single warning naming the offending rule instead of reading outside the tree. Still read-only and warn-only.

### 2. New `dup-work-claim` advisory check

The provider-agnostic sibling of the fleet's duplicate-work-claim detector. When the same configured claim identifier appears in two or more git worktrees of a project, that is the visible signal that two sessions are building the same thing (the signal is already in `git worktree list`, it just needs reading before a second worktree is opened).

- **Config:** `{ claimMarkers?: string[] }` (e.g. `["TASK-", "GAP-"]`). A claim identifier is a marker followed by a run of alphanumeric characters. **Empty or unset makes the check a no-op**, so nothing about any one tracker's id scheme is baked into the daemon. Registered by default with an empty config, exactly like `doc-locations`.
- Extracts identifiers from each worktree's path basename and branch name (substring scan plus a character walk, zero regex).
- Runs `git worktree list --porcelain` via the daemon's existing hardened `runGit` helper (lazily imported to avoid a module load-time cycle: `server.ts` imports the session-check registry before its own handler map initializes, and `vcs.ts` registers handlers at module top-level).
- Best-effort: any git error yields a clean, no-warning result and the check never throws.

## Tests

- `doc-locations`: a rule with `dir: '../outside'` / `parentDir: '../outside'` produces the skip warning and reads nothing outside root (proven-red against the base without the guard).
- `dup-work-claim`: two worktrees claiming the same marker warn (real temp git repo + `git worktree add`); distinct markers stay clean; unconfigured is a no-op and never spawns git; a non-zero git exit and a throwing lister both return clean without throwing; branch-only markers are extracted.
- Full `@revdev/daemon` suite green (699 tests), workspace build green (`pnpm -r --filter=!studio build`), `pnpm typecheck:studio` green, Biome clean on touched files.

## Notes

No new RPC method; `RPC_METHODS` and the rpc-contract test are untouched. Zero authored regex; explicit return types on exports; no em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)