### PR TITLE
fix(ci): studio release build misses @revdev/protocol dist

### DIFF
--- a/.github/workflows/studio-release.yml
+++ b/.github/workflows/studio-release.yml
@@ -71,6 +71,11 @@ jobs:
         shell: bash
         run: bash apps/studio/scripts/generate-types.sh
 
+      - name: Build workspace deps (@revdev/protocol)
+        # studio's typecheck imports @revdev/protocol (RPC_METHODS contract
+        # test); repo CI builds it before typecheck, this workflow must too.
+        run: pnpm --filter @revdev/protocol build
+
 
       - name: Build Studio (Tauri)
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0


### PR DESCRIPTION
The studio-v0.2.0 tag build failed TS2307 (Cannot find module '@revdev/protocol') on all three OS targets: the release workflow installs and generates ts-rs bindings but never builds workspace deps, and the new RPC_METHODS contract test imports @revdev/protocol. One step added, mirroring repo CI.

After this lands on main, the stale studio-v0.2.0 tag needs re-pointing (owner deletes it, then it gets re-pushed at the fixed commit) so the tag build runs with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)