### PR TITLE
feat(studio): Phase 2 remainder - shim Badge/Button/Card/Input via @revealui/presentation

### DIFF
--- a/apps/studio/src/__tests__/components/Badge.test.tsx
+++ b/apps/studio/src/__tests__/components/Badge.test.tsx
@@ -11,8 +11,8 @@ describe('Badge', () => {
   it('applies default variant styles', () => {
     render(<Badge>Default</Badge>);
     const badge = screen.getByText('Default');
-    expect(badge.className).toContain('bg-surface-2');
-    expect(badge.className).toContain('text-fg-subtle');
+    expect(badge.className).toContain('bg-muted');
+    expect(badge.className).toContain('text-muted-foreground');
   });
 
   it('applies success variant styles', () => {
@@ -24,37 +24,36 @@ describe('Badge', () => {
   it('applies warning variant styles', () => {
     render(<Badge variant="warning">Warn</Badge>);
     const badge = screen.getByText('Warn');
-    expect(badge.className).toContain('text-warning');
+    expect(badge.className).toContain('text-warning-foreground');
   });
 
   it('applies error variant styles', () => {
     render(<Badge variant="error">Fail</Badge>);
     const badge = screen.getByText('Fail');
-    expect(badge.className).toContain('text-error');
+    expect(badge.className).toContain('text-destructive');
   });
 
   it('applies info variant styles', () => {
     render(<Badge variant="info">Info</Badge>);
     const badge = screen.getByText('Info');
-    expect(badge.className).toContain('text-info');
+    expect(badge.className).toContain('text-sky-700');
   });
 
   it('applies brand variant styles', () => {
     render(<Badge variant="brand">Pro</Badge>);
     const badge = screen.getByText('Pro');
-    expect(badge.className).toContain('text-brand-text');
+    expect(badge.className).toContain('text-primary');
   });
 
-  it('applies sm size styles', () => {
+  it('accepts size="sm" without erroring (presentation Badge has no size axis; accepted no-op)', () => {
     render(<Badge size="sm">Small</Badge>);
-    const badge = screen.getByText('Small');
-    expect(badge.className).toContain('px-1.5');
+    expect(screen.getByText('Small')).toBeInTheDocument();
   });
 
-  it('applies md size styles by default', () => {
+  it('renders at presentation Badge default sizing regardless of size prop', () => {
     render(<Badge>Medium</Badge>);
     const badge = screen.getByText('Medium');
-    expect(badge.className).toContain('px-2');
+    expect(badge.className).toContain('text-sm/5');
   });
 
   it('applies custom className', () => {

--- a/apps/studio/src/__tests__/components/Button.test.tsx
+++ b/apps/studio/src/__tests__/components/Button.test.tsx
@@ -45,25 +45,25 @@ describe('Button', () => {
   it('applies primary variant styles', () => {
     render(<Button variant="primary">Primary</Button>);
     const button = screen.getByRole('button');
-    expect(button.className).toContain('bg-brand');
+    expect(button.className).toContain('bg-primary');
   });
 
   it('applies secondary variant styles by default', () => {
     render(<Button>Default</Button>);
     const button = screen.getByRole('button');
-    expect(button.className).toContain('bg-surface-2');
+    expect(button.className).toContain('bg-secondary');
   });
 
   it('applies ghost variant styles', () => {
     render(<Button variant="ghost">Ghost</Button>);
     const button = screen.getByRole('button');
-    expect(button.className).toContain('text-fg-muted');
+    expect(button.className).toContain('hover:text-accent-foreground');
   });
 
   it('applies danger variant styles', () => {
     render(<Button variant="danger">Delete</Button>);
     const button = screen.getByRole('button');
-    expect(button.className).toContain('text-error');
+    expect(button.className).toContain('bg-destructive');
   });
 
   it('applies success variant styles', () => {
@@ -74,10 +74,10 @@ describe('Button', () => {
 
   it('applies size styles', () => {
     const { rerender } = render(<Button size="sm">Small</Button>);
-    expect(screen.getByRole('button').className).toContain('text-xs');
+    expect(screen.getByRole('button').className).toContain('h-10');
 
     rerender(<Button size="lg">Large</Button>);
-    expect(screen.getByRole('button').className).toContain('py-2');
+    expect(screen.getByRole('button').className).toContain('h-12');
   });
 
   it('has type="button" by default', () => {

--- a/apps/studio/src/__tests__/components/Card.test.tsx
+++ b/apps/studio/src/__tests__/components/Card.test.tsx
@@ -11,8 +11,8 @@ describe('Card', () => {
   it('applies default variant styles', () => {
     const { container } = render(<Card>Content</Card>);
     const card = container.firstChild as HTMLElement;
-    expect(card.className).toContain('bg-surface-1');
-    expect(card.className).toContain('border-edge');
+    expect(card.className).toContain('bg-card');
+    expect(card.className).toContain('border-border');
   });
 
   it('applies elevated variant styles', () => {

--- a/apps/studio/src/__tests__/components/Input.test.tsx
+++ b/apps/studio/src/__tests__/components/Input.test.tsx
@@ -26,12 +26,17 @@ describe('Input', () => {
 
   it('applies mono font class when mono prop is true', () => {
     render(<Input mono />);
-    expect(screen.getByRole('textbox').className).toContain('font-mono');
+    // presentation's headless Input wraps the real <input> in a control span;
+    // className only accepts on that wrapper, so mono is a descendant-selector
+    // variant applied there rather than a class on the input itself.
+    const wrapper = screen.getByRole('textbox').parentElement;
+    expect(wrapper?.className).toContain('[&_input]:font-mono');
   });
 
   it('does not apply mono font by default', () => {
     render(<Input />);
-    expect(screen.getByRole('textbox').className).not.toContain('font-mono');
+    const wrapper = screen.getByRole('textbox').parentElement;
+    expect(wrapper?.className ?? '').not.toContain('font-mono');
   });
 
   it('forwards HTML input attributes', () => {

--- a/apps/studio/src/components/ui/Badge.tsx
+++ b/apps/studio/src/components/ui/Badge.tsx
@@ -1,21 +1,17 @@
+import { Badge as PresentationBadge } from '@revealui/presentation';
 import type { ReactNode } from 'react';
 
-const variantClasses = {
-  default: 'bg-surface-2 text-fg-subtle',
-  success: 'bg-success-subtle text-success',
-  warning: 'bg-warning-subtle text-warning',
-  error: 'bg-error-subtle text-error',
-  info: 'bg-info/15 text-info',
-  brand: 'bg-brand-subtle text-brand-text',
+const colorMap = {
+  default: 'muted',
+  success: 'success',
+  warning: 'warning',
+  error: 'danger',
+  info: 'sky',
+  brand: 'brand',
 } as const;
 
-const sizeClasses = {
-  sm: 'px-1.5 py-0.5 text-[10px]',
-  md: 'px-2 py-0.5 text-xs',
-} as const;
-
-export type BadgeVariant = keyof typeof variantClasses;
-export type BadgeSize = keyof typeof sizeClasses;
+export type BadgeVariant = keyof typeof colorMap;
+export type BadgeSize = 'sm' | 'md';
 
 interface BadgeProps {
   variant?: BadgeVariant;
@@ -24,22 +20,24 @@ interface BadgeProps {
   className?: string;
 }
 
-export default function Badge({
-  variant = 'default',
-  size = 'md',
-  children,
-  className = '',
-}: BadgeProps) {
+/**
+ * Phase 2 remainder (2026-07-18): shimmed to render
+ * `@revealui/presentation`'s `Badge`. Consumer API (default export,
+ * `variant`, `size`, `className`) unchanged.
+ *
+ * `size` is accepted but has no visible effect: presentation's `Badge`
+ * renders at one fixed size and always overwrites any `style` prop passed to
+ * it with its own internal `style` object (its JSX spreads `...props` before
+ * setting `style`, so a caller-supplied `style` is clobbered, not merged) —
+ * there is no override path. Kept in the type only so the one call site that
+ * passes `size="sm"` (SshBookmarkSidebar) keeps compiling; the visual size
+ * difference is an accepted narrowing of this shim, consistent with the
+ * lane's "visible behavior shifts as a side effect" premise.
+ */
+export default function Badge({ variant = 'default', children, className }: BadgeProps) {
   return (
-    <span
-      className={`inline-flex items-center rounded-full font-medium ${variantClasses[variant]} ${sizeClasses[size]} ${className}`}
-      style={{
-        borderRadius: 'var(--rvui-radius-full, 9999px)',
-        transition:
-          'background-color var(--rvui-duration-fast, 120ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1))',
-      }}
-    >
+    <PresentationBadge color={colorMap[variant]} className={className}>
       {children}
-    </span>
+    </PresentationBadge>
   );
 }

--- a/apps/studio/src/components/ui/Button.tsx
+++ b/apps/studio/src/components/ui/Button.tsx
@@ -1,21 +1,22 @@
+import { ButtonCVA as PresentationButton } from '@revealui/presentation';
 import type { ButtonHTMLAttributes } from 'react';
 
-const variantStyles = {
-  primary: 'bg-brand text-on-brand font-medium hover:bg-brand-hover',
-  secondary: 'bg-surface-2 text-fg-muted hover:bg-surface-3',
-  ghost: 'text-fg-muted hover:text-fg',
-  danger: 'bg-error/40 text-error hover:bg-error/60',
-  success: 'bg-success text-fg font-medium hover:brightness-110',
+const variantMap = {
+  primary: 'primary',
+  secondary: 'secondary',
+  ghost: 'ghost',
+  danger: 'destructive',
+  success: 'secondary',
 } as const;
 
-const sizeStyles = {
-  sm: 'px-2.5 py-1 text-xs rounded',
-  md: 'px-3 py-1.5 text-sm rounded-md',
-  lg: 'px-4 py-2 text-sm rounded-md',
+const sizeMap = {
+  sm: 'sm',
+  md: 'default',
+  lg: 'lg',
 } as const;
 
-export type ButtonVariant = keyof typeof variantStyles;
-export type ButtonSize = keyof typeof sizeStyles;
+export type ButtonVariant = keyof typeof variantMap;
+export type ButtonSize = keyof typeof sizeMap;
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
@@ -23,45 +24,38 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   loading?: boolean;
 }
 
+/**
+ * Phase 2 remainder (2026-07-18): shimmed to render
+ * `@revealui/presentation`'s CVA `Button`. Consumer API (default export,
+ * `variant`, `size`, `loading`, `className`) unchanged.
+ *
+ * `success` has no matching presentation variant, so it renders the
+ * `secondary` variant's base classes with a `className` color override —
+ * the package's `cn()` appends the caller's `className` last, so it wins
+ * over the variant's baked-in `bg-*`/`text-*` classes.
+ */
 export default function Button({
   variant = 'secondary',
   size = 'md',
   loading = false,
-  disabled,
-  children,
-  className = '',
+  type = 'button',
+  className,
   ...props
 }: ButtonProps) {
   return (
-    <button
-      type="button"
-      disabled={disabled || loading}
-      className={`inline-flex items-center justify-center transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
+    <PresentationButton
+      type={type}
+      variant={variantMap[variant]}
+      size={sizeMap[size]}
+      isLoading={loading}
+      className={
+        variant === 'success'
+          ? ['bg-success text-fg font-medium hover:brightness-110', className]
+              .filter(Boolean)
+              .join(' ')
+          : className
+      }
       {...props}
-    >
-      {loading && (
-        <svg
-          className="mr-1.5 size-3.5 animate-spin"
-          viewBox="0 0 24 24"
-          fill="none"
-          aria-hidden="true"
-        >
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          />
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.4 0 0 5.4 0 12h4z"
-          />
-        </svg>
-      )}
-      {children}
-    </button>
+    />
   );
 }

--- a/apps/studio/src/components/ui/Card.tsx
+++ b/apps/studio/src/components/ui/Card.tsx
@@ -1,20 +1,21 @@
+import { Card as PresentationCard } from '@revealui/presentation';
 import type { ReactNode } from 'react';
 
-const variantStyles = {
-  default: 'bg-surface-1 border border-edge rounded-lg',
-  elevated: 'bg-surface-1 border border-edge-strong rounded-lg shadow-lg',
-  ghost: 'bg-transparent border border-edge-subtle rounded-lg',
+const variantClassMap = {
+  default: '',
+  elevated: 'border-edge-strong shadow-lg hover:shadow-lg',
+  ghost: 'bg-transparent border-edge-subtle shadow-none hover:shadow-none',
 } as const;
 
-const paddingStyles = {
+const paddingClassMap = {
   none: '',
   sm: 'p-3',
   md: 'p-4',
   lg: 'p-6',
 } as const;
 
-export type CardVariant = keyof typeof variantStyles;
-export type CardPadding = keyof typeof paddingStyles;
+export type CardVariant = keyof typeof variantClassMap;
+export type CardPadding = keyof typeof paddingClassMap;
 
 interface CardProps {
   variant?: CardVariant;
@@ -24,17 +25,30 @@ interface CardProps {
   className?: string;
 }
 
+/**
+ * Phase 2 remainder (2026-07-18): shimmed to render
+ * `@revealui/presentation`'s `Card`. Consumer API (default export, `variant`,
+ * `padding`, `header`, `className`) unchanged. Presentation's `Card` has no
+ * variant/padding/header axis of its own, so those studio-specific concerns
+ * are layered on as `className` overrides (`cn()` appends the caller's
+ * `className` last, so it wins over the base `border-*`/`shadow-*` classes)
+ * plus the same header+divider markup that predates the shim.
+ */
 export default function Card({
   variant = 'default',
   padding = 'md',
   header,
   children,
-  className = '',
+  className,
 }: CardProps) {
   return (
-    <div className={`${variantStyles[variant]} ${paddingStyles[padding]} ${className}`}>
+    <PresentationCard
+      className={[variantClassMap[variant], paddingClassMap[padding], className]
+        .filter(Boolean)
+        .join(' ')}
+    >
       {header && <div className="mb-3 border-b border-edge pb-3">{header}</div>}
       {children}
-    </div>
+    </PresentationCard>
   );
 }

--- a/apps/studio/src/components/ui/Input.tsx
+++ b/apps/studio/src/components/ui/Input.tsx
@@ -1,4 +1,5 @@
-import type { InputHTMLAttributes } from 'react';
+import { Input as PresentationInput } from '@revealui/presentation';
+import type { ComponentProps, InputHTMLAttributes } from 'react';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
@@ -6,12 +7,26 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   mono?: boolean;
 }
 
+/**
+ * Phase 2 remainder (2026-07-18): shimmed to render `@revealui/presentation`'s
+ * headless `Input`, per the studio-dogfood lane plan's audit table. Consumer
+ * API (default export, `label`, `hint`, `mono`, `id`, `className`) unchanged.
+ *
+ * Presentation's headless `Input` exposes `className` on its OUTER wrapping
+ * `<span>` only, not the inner `<input>` element, so `mono` is applied via an
+ * arbitrary descendant-selector variant (`[&_input]:font-mono`) rather than a
+ * plain utility class. `type` is cast at the boundary: this component's public
+ * API keeps the full HTML input type surface (unchanged from before the
+ * shim), while presentation's `Input` only types the subset every current
+ * call site actually passes (email/number/password/text, verified by audit).
+ */
 export default function Input({
   label,
   hint,
   mono = false,
   id,
-  className = '',
+  className,
+  type,
   ...props
 }: InputProps) {
   return (
@@ -22,9 +37,12 @@ export default function Input({
           {hint && <span className="ml-1 text-fg-subtle">({hint})</span>}
         </label>
       )}
-      <input
+      <PresentationInput
         id={id}
-        className={`w-full rounded-md border border-edge bg-surface-2 px-3 py-2 text-sm text-fg placeholder:text-fg-subtle focus:border-brand focus:outline-none ${mono ? 'font-mono' : ''} ${className}`}
+        type={type as ComponentProps<typeof PresentationInput>['type']}
+        className={
+          [mono && '[&_input]:font-mono', className].filter(Boolean).join(' ') || undefined
+        }
         {...props}
       />
     </div>

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -4,6 +4,13 @@
 @import "@fontsource-variable/inter-tight";
 @import "@fontsource-variable/jetbrains-mono";
 
+/* Tailwind v4 does not scan node_modules by default. Without this, the
+ * utility classes baked into @revealui/presentation components (Button's
+ * bg-primary, Badge's bg-muted/bg-destructive, Alert, etc.) never generate
+ * and the Phase 2 shimmed components render unstyled. Mirrors the marketing
+ * app's @source directive (apps/marketing/app/index.css). */
+@source "../node_modules/@revealui/presentation/dist/**/*.js";
+
 /* ── Tailwind v4 Theme — maps --rvui-* tokens to utility classes ────────── */
 @theme {
   /* Colors — Surfaces */
@@ -50,6 +57,23 @@
   --color-error-subtle: var(--rvui-error-subtle);
   --color-info: var(--rvui-info);
   --color-info-subtle: var(--rvui-info-subtle);
+
+  /* Colors — shadcn-convention bridge (needed by @revealui/presentation's
+   * Button/Badge/Alert/Card, which are authored against these names; see
+   * apps/marketing/app/index.css for the same bridge in another consumer). */
+  --color-background: var(--rvui-surface-0);
+  --color-primary: var(--rvui-brand);
+  --color-primary-foreground: var(--rvui-text-on-brand);
+  --color-secondary: var(--rvui-surface-2);
+  --color-secondary-foreground: var(--rvui-text-0);
+  --color-muted: var(--rvui-surface-2);
+  --color-muted-foreground: var(--rvui-text-2);
+  --color-accent-foreground: var(--rvui-text-on-accent);
+  --color-destructive: var(--rvui-error);
+  --color-destructive-foreground: var(--rvui-text-0);
+  --color-card: var(--rvui-surface-1);
+  --color-card-foreground: var(--rvui-text-0);
+  --color-ring: var(--rvui-brand);
 
   /* Typography */
   --font-sans: var(--rvui-font-sans);


### PR DESCRIPTION
**Post-merge note:** the owner merged this PR (commit `6a73018`) before the
size-remap fix below was pushed — the review verdict landed after merge, not
before. The `Button` size-map change described in this body shipped
separately as follow-up PR **#297**, not in this PR's merged commit. Left
this body's description of the intended fix in place for the record; #297
has the actual diff and its own verification.

## Summary

Studio-dogfood lane Phase 2 remainder: shims Studio's last 4 portable
`src/components/ui/` shadow primitives (`Badge`, `Button`, `Card`, `Input`)
onto their `@revealui/presentation` equivalents. PR-1 through PR-3
(`StatusDot`/`PanelHeader`, `Tooltip`, `Modal`/`Dialog`) already merged in
#71–#74; this closes out the remaining PR-4/PR-5 scope from the lane plan.

Default export + prop shape are unchanged for all 4 components, so none of
the ~94 call sites need to change.

## What changed

- **`Badge.tsx`** → wraps presentation's `Badge`. `variant` maps to
  presentation's `color` (`default→muted`, `success→success`,
  `warning→warning`, `error→danger`, `info→sky`, `brand→brand`). `size` is
  now an accepted no-op: presentation's `Badge` has no size axis, and its
  JSX spreads `...props` *before* setting its own `style` object, so a
  caller-supplied `style` gets clobbered rather than merged — there is no
  override path. Re-audited call sites (correction from an earlier revision
  of this PR body): **no non-test call site passes `size=` to `Badge` at
  all**, so this is a no-op with zero live impact, not a narrowing of an
  in-use prop.
- **`Button.tsx`** → wraps presentation's `ButtonCVA` (the brand-token CVA
  button; presentation's *bare* `Button` export is a different, Catalyst-style
  `color`-prop component used internally by `Dropdown` — verified against the
  package's own docblock before picking the import). `variant` maps directly
  (`danger→destructive`); `success` has no presentation variant, so it
  renders `secondary`'s base classes plus a `className` color override
  (`cn()` appends the caller's `className` last, so it wins).
  **Size remap (post-review fix):** presentation's CVA size scale
  (`sm`=h-10/40px, `default`=h-11/44px, `lg`=h-12/48px) runs noticeably
  taller than Studio's old hand-rolled buttons (~24-36px, compact desktop
  chrome) — the reviewer flagged the resulting height jump as pervasive
  (`size="sm"` is used on ~20+ `Button` call sites across the app, e.g. 5 in
  `SshBookmarkSidebar` alone; **not** on `Badge` — my first draft of this
  section wrongly attributed the call-site count to `Badge`). Shifted down a
  step: Studio's `md` (the default, most-used size) now takes presentation's
  smallest built-in size (`sm`, h-10); Studio's `lg` takes presentation's
  `default` (h-11). Presentation has nothing smaller than `sm`, so Studio's
  `sm` stays on presentation `sm` and layers a compact `className` override
  (`h-8 px-2 py-1 text-xs`) on top, via the same last-wins `className`
  mechanism.
- **`Card.tsx`** → wraps presentation's `Card`. `variant`/`padding`/`header`
  are studio-only axes layered on as `className` overrides + the pre-existing
  header/divider markup (presentation's `Card` has none of these).
- **`Input.tsx`** → wraps presentation's headless `Input` (bare `Input`
  export, per the lane plan's own audit table — not the styled `InputCVA`).
  `mono` is applied as `[&_input]:font-mono` on the outer wrapper, since
  presentation's headless `Input` only exposes `className` on the wrapping
  `<span>`, not the inner `<input>` it renders. `type` is cast at the
  boundary: this component keeps the full HTML input-type surface publicly,
  while presentation's type is a narrower union — audited every call site
  first (email/number/password/text only).
- **`apps/studio/src/styles.css`** → adds the `@theme` bridge entries
  (`--color-primary`, `--color-secondary(-foreground)`, `--color-muted(-foreground)`,
  `--color-destructive(-foreground)`, `--color-card(-foreground)`, `--color-ring`,
  `--color-background`, `--color-accent-foreground`) plus a
  `@source "../node_modules/@revealui/presentation/dist/**/*.js"` directive.
  **Without this, none of the above shims render any color at all** —
  verified empirically: before this change, `bg-primary`/`bg-destructive`/
  `bg-muted`/`bg-secondary` had zero occurrences in the built CSS; after, each
  generates correctly. Mirrors the identical bridge already in
  `apps/marketing/app/index.css` in the sibling `revealui` repo (the docblock
  there names the exact same failure mode).

## Left alone (with reasons)

- **`ErrorAlert.tsx`** — **not shimmed.** Retroactively closes the PR #73
  title/code drift found during audit (#73 was titled "shim Tooltip +
  ErrorAlert + Badge" but only `Tooltip` actually landed in that PR; `Badge`
  is shimmed here, in this PR). Investigated both presentation candidates:
  - `Alert` is a **modal dialog** (portal, `aria-modal`, focus trap, backdrop,
    requires `open`/`onClose`). Studio's `ErrorAlert` is an always-inline
    `role="alert"` banner under a form field. Using `Alert` here would turn
    inline validation errors into blocking modals — a real regression, not a
    style difference.
  - `Callout` is the right *shape* (inline, no portal) but hardcodes
    `role="note"` and accepts no rest props, so there is no way to restore
    `role="alert"`'s assertive screen-reader semantics through it.
  Neither is a faithful equivalent without a real behavior or accessibility
  regression. Porting a fix into `@revealui/presentation` itself is outside
  this PR's scope (extend-before-create decisions on the presentation package
  are an owner/design call, not something to improvise here) — filing as a
  gap candidate for the presentation maintainers rather than shipping a
  workaround.
- **`StatusDot.tsx`** — left alone per direction: already ratified as a
  promotion candidate into `@revealui/presentation` via the Phase-3
  component-sovereignty spec §5 (PR-1 quartet). Not touched here.
- **`ConfirmDialog.tsx`** — left alone: not in the lane plan's original
  10-file list (added since), and it already renders through the previously-
  shimmed `Modal.tsx`, so it's transitively covered.

## Verification

```
pnpm --filter studio typecheck   # clean
pnpm --filter studio build       # clean (vite build; generated ts-rs bindings + @revdev/protocol built from source for this check)
pnpm --filter studio test        # 548/548 passing (63 files), incl. all 5 rewritten/updated test files for the touched components
pnpm --filter studio lint        # clean (1 pre-existing unrelated warning in LoginScreen.tsx, not touched by this PR)
```

Test files updated to match the shims' real rendered output (className
assertions against presentation's actual classes, not the old hand-rolled
ones), per the lane plan's own per-PR workflow step 4. Behavioral assertions
(renders children, click handling, disabled state, spinner, label
association, value changes, HTML attribute forwarding) are unchanged.

Confirmed empirically that the CSS bridge fix (`@source` + `@theme`
entries) was load-bearing, not cosmetic: built the app before and after
that one change and grepped the output CSS for `bg-primary`/`bg-destructive`/
`bg-muted` (0 occurrences before, 1 each after). Same empirical check on the
size-remap fix: grepped the built CSS for `.h-8`/`.h-10`/`.h-11` and
confirmed all three generate (1 occurrence each).

## Not in scope for this PR

- No changes to `@revealui/presentation` itself.
- No merge — opening for review per fleet policy (manual squash-merge after
  CI green, no `--auto`).
