### PR TITLE
fix(studio): shift Button size map down to keep compact desktop density

### DIFF
--- a/apps/studio/src/__tests__/components/Button.test.tsx
+++ b/apps/studio/src/__tests__/components/Button.test.tsx
@@ -72,12 +72,23 @@ describe('Button', () => {
     expect(button.className).toContain('bg-success');
   });
 
-  it('applies size styles', () => {
-    const { rerender } = render(<Button size="sm">Small</Button>);
-    expect(screen.getByRole('button').className).toContain('h-10');
+  it('applies a compact size override for size="sm" (h-8, denser than presentation\'s h-10 base)', () => {
+    render(<Button size="sm">Small</Button>);
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('h-8');
+    expect(button.className).not.toContain('h-10');
+  });
 
-    rerender(<Button size="lg">Large</Button>);
-    expect(screen.getByRole('button').className).toContain('h-12');
+  it('applies presentation\'s smallest built-in size for size="md" (the default)', () => {
+    render(<Button>Default size</Button>);
+    expect(screen.getByRole('button').className).toContain('h-10');
+  });
+
+  it('applies presentation\'s default size for size="lg"', () => {
+    render(<Button size="lg">Large</Button>);
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('h-11');
+    expect(button.className).not.toContain('h-12');
   });
 
   it('has type="button" by default', () => {

--- a/apps/studio/src/components/ui/Button.tsx
+++ b/apps/studio/src/components/ui/Button.tsx
@@ -9,10 +9,27 @@ const variantMap = {
   success: 'secondary',
 } as const;
 
+/**
+ * Presentation's CVA size scale (`sm`=h-10/40px, `default`=h-11/44px,
+ * `lg`=h-12/48px) runs noticeably taller than Studio's old hand-rolled
+ * buttons (~24-36px, compact desktop chrome). Shifted down a step so
+ * Studio keeps its density: `md` (Studio's most-used size) takes
+ * presentation's smallest built-in size (`sm`); `lg` takes presentation's
+ * `default`. Presentation has nothing smaller than `sm`, so Studio's `sm`
+ * stays on presentation `sm` and layers a compact `className` override
+ * (h-8) on top — `cn()` appends the caller's `className` last, so it wins
+ * over the size variant's own `h-10 px-3 py-2`.
+ */
 const sizeMap = {
   sm: 'sm',
-  md: 'default',
-  lg: 'lg',
+  md: 'sm',
+  lg: 'default',
+} as const;
+
+const compactSizeOverride = {
+  sm: 'h-8 px-2 py-1 text-xs',
+  md: undefined,
+  lg: undefined,
 } as const;
 
 export type ButtonVariant = keyof typeof variantMap;
@@ -42,19 +59,21 @@ export default function Button({
   className,
   ...props
 }: ButtonProps) {
+  const overrideClassName = [
+    variant === 'success' && 'bg-success text-fg font-medium hover:brightness-110',
+    compactSizeOverride[size],
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <PresentationButton
       type={type}
       variant={variantMap[variant]}
       size={sizeMap[size]}
       isLoading={loading}
-      className={
-        variant === 'success'
-          ? ['bg-success text-fg font-medium hover:brightness-110', className]
-              .filter(Boolean)
-              .join(' ')
-          : className
-      }
+      className={overrideClassName || undefined}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

Follow-up to #296 (already merged by the owner as commit 6a73018, before
this review-requested fix was ready). #296 shimmed Studio's `Button` onto
`@revealui/presentation`'s `ButtonCVA`, whose size scale (`sm`=h-10/40px,
`default`=h-11/44px, `lg`=h-12/48px) runs noticeably taller than Studio's
old hand-rolled buttons (~24-36px, compact desktop chrome). The reviewer
flagged the resulting +~47% height jump as pervasive: `size="sm"` is used
on ~20+ `Button` call sites across the app (5 in `SshBookmarkSidebar`
alone).

## Change

`apps/studio/src/components/ui/Button.tsx` — shifted the size map down a
step so Studio keeps its density:
- Studio `md` (the default, most-used size) now takes presentation's
  smallest built-in size (`sm`, h-10) instead of `default` (h-11).
- Studio `lg` now takes presentation's `default` (h-11) instead of `lg`
  (h-12).
- Presentation has nothing smaller than `sm`, so Studio `sm` stays on
  presentation `sm` and layers a compact `className` override
  (`h-8 px-2 py-1 text-xs`) on top — `cn()` appends the caller's
  `className` last, so it wins over the size variant's own
  `h-10 px-3 py-2`, the same last-wins mechanism the other shims in #296
  already use.

Test assertions in `Button.test.tsx` updated to check the real rendered
heights (`h-8`/`h-10`/`h-11`) for each size, not tautologies.

## Verification

```
pnpm --filter studio typecheck   # clean
pnpm --filter studio test        # 548/548 passing (63 files)
pnpm --filter studio build       # clean
```

Confirmed empirically (not just by reading the source) that the override
actually wins: grepped the built CSS for `.h-8`/`.h-10`/`.h-11` and all
three generate (1 occurrence each), and the `Button.test.tsx` assertions
check both presence of the expected height class and absence of the
overridden one (e.g. `size="sm"` asserts `h-8` present AND `h-10` absent).

Not merging — opening for review per fleet policy.