### PR TITLE
test(protocol): add contract test suite for @revdev/protocol

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -40,10 +40,12 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "dev": "tsc --watch",
+    "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "engines": {
     "node": ">=24.13.0"

--- a/packages/protocol/src/__tests__/base58.test.ts
+++ b/packages/protocol/src/__tests__/base58.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { BASE58_ALPHABET, base58Decode, base58Encode } from '../base58.js';
+
+describe('BASE58_ALPHABET', () => {
+  it('has exactly 58 characters, all distinct', () => {
+    const chars = BASE58_ALPHABET.split('');
+    expect(chars.length).toBe(58);
+    expect(new Set(chars).size).toBe(58);
+  });
+
+  it('excludes the visually ambiguous characters (0, O, I, l)', () => {
+    for (const ambiguous of ['0', 'O', 'I', 'l']) {
+      expect(BASE58_ALPHABET.includes(ambiguous)).toBe(false);
+    }
+  });
+});
+
+describe('base58Encode', () => {
+  it('encodes an empty byte array as an empty string', () => {
+    expect(base58Encode(new Uint8Array(0))).toBe('');
+  });
+
+  it('encodes a single zero byte as a single leading-zero character', () => {
+    expect(base58Encode(new Uint8Array([0]))).toBe('1');
+  });
+
+  it('matches the well-known "Hello World!" base58 vector', () => {
+    const bytes = new TextEncoder().encode('Hello World!');
+    expect(base58Encode(bytes)).toBe('2NEpo7TZRRrLZSi2U');
+  });
+
+  it('preserves leading zero bytes as leading "1" characters', () => {
+    const encoded = base58Encode(new Uint8Array([0, 0, 1]));
+    expect(encoded.startsWith('11')).toBe(true);
+  });
+});
+
+describe('base58Decode', () => {
+  it('decodes an empty string to an empty byte array', () => {
+    expect(base58Decode('').length).toBe(0);
+  });
+
+  it('rejects a character outside the alphabet', () => {
+    expect(() => base58Decode('0')).toThrow();
+    expect(() => base58Decode('abcO')).toThrow();
+  });
+
+  it('reports the offending character and position', () => {
+    expect(() => base58Decode('ab0cd')).toThrow("invalid character '0' at position 2");
+  });
+});
+
+describe('base58 round trip', () => {
+  const vectors: Uint8Array[] = [
+    new Uint8Array(0),
+    new Uint8Array([0]),
+    new Uint8Array([0, 0, 0]),
+    new Uint8Array([1, 2, 3, 254, 255]),
+    new Uint8Array([0, 0, 1, 2, 3, 254, 255]),
+    new Uint8Array(Array.from({ length: 32 }, (_, i) => (i * 7) % 256)),
+  ];
+
+  for (const bytes of vectors) {
+    it(`recovers the original bytes for length ${bytes.length}`, () => {
+      const decoded = base58Decode(base58Encode(bytes));
+      expect(Array.from(decoded)).toEqual(Array.from(bytes));
+    });
+  }
+});

--- a/packages/protocol/src/__tests__/did.test.ts
+++ b/packages/protocol/src/__tests__/did.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DID_PREFIX,
+  formatDid,
+  isValidAgentId,
+  isValidAgentIdChar,
+  isValidFingerprint,
+  parseDid,
+} from '../did.js';
+
+describe('isValidAgentIdChar', () => {
+  it('accepts alphanumerics, underscore, and hyphen', () => {
+    for (const c of ['a', 'Z', '5', '_', '-']) {
+      expect(isValidAgentIdChar(c)).toBe(true);
+    }
+  });
+
+  it('rejects everything else, including empty and multi-char input', () => {
+    for (const c of [' ', ':', '.', '', 'ab']) {
+      expect(isValidAgentIdChar(c)).toBe(false);
+    }
+  });
+});
+
+describe('isValidAgentId', () => {
+  it('rejects the empty string', () => {
+    expect(isValidAgentId('')).toBe(false);
+  });
+
+  it('accepts exactly 128 characters', () => {
+    expect(isValidAgentId('a'.repeat(128))).toBe(true);
+  });
+
+  it('rejects 129 characters', () => {
+    expect(isValidAgentId('a'.repeat(129))).toBe(false);
+  });
+
+  it('rejects a string containing an invalid character', () => {
+    expect(isValidAgentId('agent id')).toBe(false);
+    expect(isValidAgentId('agent:id')).toBe(false);
+  });
+});
+
+describe('isValidFingerprint', () => {
+  it('rejects the empty string', () => {
+    expect(isValidFingerprint('')).toBe(false);
+  });
+
+  it('accepts exactly 128 characters drawn from the base58 alphabet', () => {
+    expect(isValidFingerprint('1'.repeat(128))).toBe(true);
+  });
+
+  it('rejects 129 characters', () => {
+    expect(isValidFingerprint('1'.repeat(129))).toBe(false);
+  });
+
+  it('rejects characters outside the base58 alphabet', () => {
+    expect(isValidFingerprint('abc0def')).toBe(false);
+    expect(isValidFingerprint('abcOdef')).toBe(false);
+  });
+});
+
+describe('formatDid', () => {
+  it('formats a valid agentId/fingerprint pair under DID_PREFIX', () => {
+    expect(formatDid('agt-001', 'abc123')).toBe(`${DID_PREFIX}agt-001:abc123`);
+  });
+
+  it('throws TypeError for an invalid agentId', () => {
+    expect(() => formatDid('', 'abc123')).toThrow(TypeError);
+    expect(() => formatDid('has space', 'abc123')).toThrow(TypeError);
+  });
+
+  it('throws TypeError for an invalid fingerprint', () => {
+    expect(() => formatDid('agt', '0OIl')).toThrow(TypeError);
+  });
+});
+
+describe('parseDid', () => {
+  it('round-trips through formatDid', () => {
+    const did = formatDid('agt-001', 'abc123');
+    expect(parseDid(did)).toEqual({ agentId: 'agt-001', fingerprint: 'abc123' });
+  });
+
+  it('returns null for a did without the expected prefix', () => {
+    expect(parseDid('did:other:agt:fp')).toBeNull();
+  });
+
+  it('returns null when there is no fingerprint separator', () => {
+    expect(parseDid(`${DID_PREFIX}agt-001`)).toBeNull();
+  });
+
+  it('returns null when the agentId or fingerprint segment is empty', () => {
+    expect(parseDid(`${DID_PREFIX}:fp`)).toBeNull();
+    expect(parseDid(`${DID_PREFIX}agt:`)).toBeNull();
+  });
+
+  it('returns null when the fingerprint segment itself contains a colon', () => {
+    expect(parseDid(`${DID_PREFIX}agt:fp:extra`)).toBeNull();
+  });
+});

--- a/packages/protocol/src/__tests__/index.test.ts
+++ b/packages/protocol/src/__tests__/index.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Barrel wiring for the package's one runtime export (everything else `index.ts`
+ * re-exports is type-only and erased at compile time, so tsc's own build
+ * already proves those bindings resolve; there is no separate runtime
+ * assertion to make for them).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { RPC_METHODS } from '../index.js';
+import { RPC_METHODS as RPC_METHODS_DIRECT } from '../methods.js';
+
+describe('index barrel', () => {
+  it('re-exports RPC_METHODS unchanged', () => {
+    expect(RPC_METHODS).toBe(RPC_METHODS_DIRECT);
+  });
+});

--- a/packages/protocol/src/__tests__/methods.test.ts
+++ b/packages/protocol/src/__tests__/methods.test.ts
@@ -1,0 +1,52 @@
+/**
+ * RPC_METHODS is a hand-maintained constant map (protocol has no compiler
+ * check that a key's string literal matches its value, and JS silently lets
+ * two distinct keys collide on the same value). These tests pin the
+ * self-consistency invariants that keep it trustworthy for consumers that
+ * index into it by key (e.g. `RPC_METHODS['session.register']`) and hand
+ * the value straight to the daemon as the wire method name.
+ *
+ * The cross-check that the daemon actually registers every method this
+ * constant declares (and nothing extra) lives in
+ * packages/daemon/src/__tests__/rpc-contract.test.ts, which imports the
+ * daemon's real handler registry. That test can't live here without an
+ * inverted workspace dependency (protocol depending on its own consumer),
+ * so it isn't duplicated in this suite.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { RPC_METHODS } from '../methods.js';
+
+describe('RPC_METHODS', () => {
+  const entries = Object.entries(RPC_METHODS);
+
+  it('declares at least one method', () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it('every key is a non-empty string', () => {
+    for (const [key] of entries) {
+      expect(typeof key).toBe('string');
+      expect(key.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every value is a non-empty string', () => {
+    for (const [, value] of entries) {
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every key equals its own value', () => {
+    for (const [key, value] of entries) {
+      expect(value).toBe(key);
+    }
+  });
+
+  it('has no two keys sharing the same method name', () => {
+    const values = entries.map(([, value]) => value);
+    const uniqueValues = new Set(values);
+    expect(uniqueValues.size).toBe(values.length);
+  });
+});

--- a/packages/protocol/src/__tests__/signature-schemas.test.ts
+++ b/packages/protocol/src/__tests__/signature-schemas.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SignatureEnvelopeSchema,
+  SignatureHeaderSchema,
+  SignaturePayloadSchema,
+} from '../signature-schemas.js';
+
+const validPayload = {
+  did: 'did:revfleet:agt-001:abc123',
+  kid: 'abc123',
+  nonce: '0'.repeat(32),
+  ts: 1234567890,
+  method: 'session.register',
+  paramsHash: 'deadbeef',
+};
+
+const validHeader = { alg: 'EdDSA', typ: 'jws' } as const;
+
+const validEnvelope = {
+  header: validHeader,
+  payload: validPayload,
+  signature: 'a'.repeat(86),
+  rawHeaderB64: 'a'.repeat(20),
+  rawPayloadB64: 'a'.repeat(100),
+};
+
+describe('SignaturePayloadSchema', () => {
+  it('accepts a well-formed payload', () => {
+    expect(SignaturePayloadSchema.safeParse(validPayload).success).toBe(true);
+  });
+
+  it('requires nonce to be exactly 32 characters', () => {
+    expect(
+      SignaturePayloadSchema.safeParse({ ...validPayload, nonce: '0'.repeat(31) }).success,
+    ).toBe(false);
+    expect(
+      SignaturePayloadSchema.safeParse({ ...validPayload, nonce: '0'.repeat(33) }).success,
+    ).toBe(false);
+  });
+
+  it('requires ts to be a non-negative integer', () => {
+    expect(SignaturePayloadSchema.safeParse({ ...validPayload, ts: -1 }).success).toBe(false);
+    expect(SignaturePayloadSchema.safeParse({ ...validPayload, ts: 1.5 }).success).toBe(false);
+  });
+
+  it('rejects an empty method, did, kid, or paramsHash', () => {
+    expect(SignaturePayloadSchema.safeParse({ ...validPayload, method: '' }).success).toBe(false);
+    expect(SignaturePayloadSchema.safeParse({ ...validPayload, did: '' }).success).toBe(false);
+    expect(SignaturePayloadSchema.safeParse({ ...validPayload, kid: '' }).success).toBe(false);
+    expect(SignaturePayloadSchema.safeParse({ ...validPayload, paramsHash: '' }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects fields past their DoS-guard bounds', () => {
+    expect(
+      SignaturePayloadSchema.safeParse({ ...validPayload, did: 'd'.repeat(513) }).success,
+    ).toBe(false);
+    expect(
+      SignaturePayloadSchema.safeParse({ ...validPayload, method: 'm'.repeat(129) }).success,
+    ).toBe(false);
+  });
+
+  it('rejects unknown properties (strict mode)', () => {
+    expect(SignaturePayloadSchema.safeParse({ ...validPayload, extra: 'nope' }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe('SignatureHeaderSchema', () => {
+  it('accepts the fixed EdDSA/jws header', () => {
+    expect(SignatureHeaderSchema.safeParse(validHeader).success).toBe(true);
+  });
+
+  it('rejects any other algorithm or type literal', () => {
+    expect(SignatureHeaderSchema.safeParse({ alg: 'RS256', typ: 'jws' }).success).toBe(false);
+    expect(SignatureHeaderSchema.safeParse({ alg: 'EdDSA', typ: 'jwt' }).success).toBe(false);
+  });
+
+  it('rejects unknown properties (strict mode)', () => {
+    expect(SignatureHeaderSchema.safeParse({ ...validHeader, extra: 'nope' }).success).toBe(false);
+  });
+});
+
+describe('SignatureEnvelopeSchema', () => {
+  it('accepts a well-formed envelope', () => {
+    expect(SignatureEnvelopeSchema.safeParse(validEnvelope).success).toBe(true);
+  });
+
+  it('rejects a nested payload or header that fails its own schema', () => {
+    expect(
+      SignatureEnvelopeSchema.safeParse({
+        ...validEnvelope,
+        payload: { ...validPayload, ts: -1 },
+      }).success,
+    ).toBe(false);
+    expect(
+      SignatureEnvelopeSchema.safeParse({
+        ...validEnvelope,
+        header: { alg: 'RS256', typ: 'jws' },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects fields past their DoS-guard bounds', () => {
+    expect(
+      SignatureEnvelopeSchema.safeParse({ ...validEnvelope, signature: 'a'.repeat(129) }).success,
+    ).toBe(false);
+    expect(
+      SignatureEnvelopeSchema.safeParse({ ...validEnvelope, rawHeaderB64: 'a'.repeat(257) })
+        .success,
+    ).toBe(false);
+    expect(
+      SignatureEnvelopeSchema.safeParse({ ...validEnvelope, rawPayloadB64: 'a'.repeat(8193) })
+        .success,
+    ).toBe(false);
+  });
+
+  it('rejects unknown properties (strict mode)', () => {
+    expect(SignatureEnvelopeSchema.safeParse({ ...validEnvelope, extra: 'nope' }).success).toBe(
+      false,
+    );
+  });
+});

--- a/packages/protocol/vitest.config.ts
+++ b/packages/protocol/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// `build` compiles the whole of `src` (including `src/__tests__`) into
+// `dist/__tests__/*.test.js`. Vitest's default excludes don't reliably keep
+// those compiled copies out of discovery once `dist` exists locally, which
+// double-runs every test against a possibly-stale build. Scope discovery to
+// the TypeScript sources.
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
 
   packages/theme:
     devDependencies:


### PR DESCRIPTION
## Summary

- Adds the first test suite for `packages/protocol` (~636 LOC, previously zero tests). 52 tests across 5 files under `packages/protocol/src/__tests__/`.
- Pins `RPC_METHODS` (non-empty keys/values, key-equals-value self-consistency, no two constant entries sharing the same method-name string).
- Pins base58 encode/decode: alphabet shape, round trips (including leading zero bytes), a known external base58 vector ("Hello World!" -> `2NEpo7TZRRrLZSi2U`), and invalid-character rejection.
- Pins DID formatting/parsing: `isValidAgentId`/`isValidFingerprint` boundary lengths (0, 128, 129 chars), `formatDid`/`parseDid` round trip, and the documented null/throw cases.
- Pins the signature zod schemas (`SignaturePayloadSchema`, `SignatureHeaderSchema`, `SignatureEnvelopeSchema`): valid envelope parses, strict-mode rejects unknown keys, and each DoS-guard bound (nonce length, ts non-negative integer, string max lengths) is exercised at the boundary.
- Adds `packages/protocol/vitest.config.ts` scoping discovery to `src/**/*.test.ts` — without it, vitest also picks up the compiled `dist/__tests__/*.test.js` copies left by `tsc` (protocol's build has no tsup entry-scoping like daemon/bridge), silently double-running every test and risking a stale-dist false pass.
- Wires `pnpm --filter @revdev/protocol test` via a `"test": "vitest run --passWithNoTests"` script, matching the existing `daemon`/`bridge` convention exactly. No CI workflow change needed: `ci.yml`'s `test` job runs `pnpm test` -> `pnpm -r test`, which already picks up any workspace package with a `test` script.
- devDependency added: `vitest@^4.1.10`, the same version/resolution already used by `daemon` and `bridge` (`pnpm install` reused the existing resolution, no new package fetched — 3-line lockfile diff).

## Consumer cross-check

The task asked for a check that the daemon's registered/dispatched RPC methods cover `RPC_METHODS`. That check already exists and currently passes: [`packages/daemon/src/__tests__/rpc-contract.test.ts`](../../blob/test/packages/daemon/src/__tests__/rpc-contract.test.ts) imports the daemon's real handler registry (`listRegisteredMethods()`) with no live server required and asserts exact equality against `RPC_METHODS` in both directions. Studio has an equivalent one-way check (`HARNESS_RPC_MAP` in `apps/studio/src/__tests__/lib/invoke.test.ts`). This PR doesn't duplicate either — duplicating them here would need protocol to depend on its own consumer (daemon), an inverted workspace dependency.

## Prove-red

Verified the uniqueness test actually catches the regression class it targets. Temporarily added a duplicate method-name entry to `RPC_METHODS` locally (`pingDuplicate: 'ping'`), re-ran `pnpm --filter @revdev/protocol test`, confirmed both `every key equals its own value` and `has no two keys sharing the same method name` failed red, then reverted before committing (not part of this diff).

## Test plan

- [x] `pnpm --filter @revdev/protocol test` -> 5 files, 52 tests passed
- [x] `pnpm --filter @revdev/protocol typecheck` -> clean
- [x] `pnpm typecheck` (repo-wide) -> clean
- [x] `pnpm lint` (repo-wide) -> no new findings
- [x] `pnpm install --frozen-lockfile` succeeds against the updated lockfile
- [x] Daemon's `rpc-contract.test.ts`, `did.test.ts`, `agent-identity-crypto.test.ts` re-run clean against the rebuilt protocol dist (no regression from these changes)