### PR TITLE
fix(studio): fail-closed challenge-response daemon pairing (GAP-397)

### DIFF
--- a/apps/studio/src/__tests__/lib/invoke.test.ts
+++ b/apps/studio/src/__tests__/lib/invoke.test.ts
@@ -353,3 +353,112 @@ describe('browser-mode daemon adapters', () => {
     ]);
   });
 });
+
+describe('pairWithDaemon (GAP-397 challenge-response)', () => {
+  const base = 'http://127.0.0.1:8787';
+  const secret = 'a'.repeat(64); // 32-byte secret as hex (UTF-8 key material)
+  const nonce = 'b'.repeat(64);
+  const token = 'c'.repeat(64);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('refuses the retired 6-digit code body shape (POST {code} never succeeds)', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/api/pair') && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body ?? '{}')) as Record<string, unknown>;
+        // Gateway rejects missing nonce/hmac
+        if (!('nonce' in body) || !('hmac' in body)) {
+          return new Response(JSON.stringify({ error: 'nonce and hmac are required' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+      }
+      return new Response('unexpected', { status: 500 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Legacy call shape: second arg was a 6-digit code string — type system no longer
+    // allows it; prove the wire contract rejects {code} if somehow posted.
+    const res = await fetch(`${base}/api/pair`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: '123456' }),
+    });
+    expect(res.status).toBe(400);
+    const err = (await res.json()) as { error: string };
+    expect(err.error).toMatch(/nonce and hmac/i);
+  });
+
+  it('completes GET nonce → HMAC → POST and stores bearer token', async () => {
+    const { hmacSha256Hex, pairWithDaemon, getDaemonToken, getDaemonUrl } =
+      await import('../../lib/invoke');
+    const expectedHmac = await hmacSha256Hex(secret, nonce);
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === `${base}/api/pair` && (!init || !init.method || init.method === 'GET')) {
+        return new Response(JSON.stringify({ nonce, expiresIn: 120 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url === `${base}/api/pair` && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body ?? '{}')) as {
+          nonce?: string;
+          hmac?: string;
+          label?: string;
+        };
+        expect(body.nonce).toBe(nonce);
+        expect(body.hmac).toBe(expectedHmac);
+        expect(body.label).toBe('studio');
+        // Prove we never send a pairing code
+        expect(body).not.toHaveProperty('code');
+        return new Response(
+          JSON.stringify({ token, expiresAt: new Date(Date.now() + 86_400_000).toISOString() }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response('unexpected', { status: 500 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const got = await pairWithDaemon({ daemonUrl: base, secret, label: 'studio' });
+    expect(got).toBe(token);
+    expect(getDaemonToken()).toBe(token);
+    expect(getDaemonUrl()).toBe(base);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces gateway errors from a failed HMAC response', async () => {
+    const { pairWithDaemon } = await import('../../lib/invoke');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith('/api/pair') && (!init?.method || init.method === 'GET')) {
+          return new Response(JSON.stringify({ nonce, expiresIn: 120 }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ error: 'Invalid pairing response' }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+
+    await expect(pairWithDaemon({ daemonUrl: base, secret })).rejects.toThrow(
+      /Invalid pairing response/,
+    );
+    expect(localStorage.getItem('revdev-daemon-token')).toBeNull();
+  });
+});

--- a/apps/studio/src/__tests__/lib/invoke.test.ts
+++ b/apps/studio/src/__tests__/lib/invoke.test.ts
@@ -401,13 +401,14 @@ describe('pairWithDaemon (GAP-397 challenge-response)', () => {
   });
 
   it('completes GET nonce → HMAC → POST and stores bearer token', async () => {
-    const { hmacSha256Hex, pairWithDaemon, getDaemonToken, getDaemonUrl } =
-      await import('../../lib/invoke');
+    const { hmacSha256Hex, pairWithDaemon, getDaemonToken, getDaemonUrl } = await import(
+      '../../lib/invoke'
+    );
     const expectedHmac = await hmacSha256Hex(secret, nonce);
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === `${base}/api/pair` && (!init || !init.method || init.method === 'GET')) {
+      if (url === `${base}/api/pair` && (!init?.method || init.method === 'GET')) {
         return new Response(JSON.stringify({ nonce, expiresIn: 120 }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -447,7 +448,9 @@ describe('pairWithDaemon (GAP-397 challenge-response)', () => {
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
         if (url.endsWith('/api/pair') && (!init?.method || init.method === 'GET')) {
-          return new Response(JSON.stringify({ nonce, expiresIn: 120 }), { status: 200 });
+          return new Response(JSON.stringify({ nonce, expiresIn: 120 }), {
+            status: 200,
+          });
         }
         return new Response(JSON.stringify({ error: 'Invalid pairing response' }), {
           status: 403,

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -535,19 +535,92 @@ export function setDaemonToken(token: string | null): void {
   }
 }
 
-/** Pair with a remote daemon using a 6-digit code */
-export async function pairWithDaemon(daemonUrl: string, code: string): Promise<string> {
-  const res = await fetch(`${daemonUrl}/api/pair`, {
+/**
+ * HMAC-SHA256(secret, message) → hex digest.
+ * Matches @revealui/harnesses HttpGateway (GAP-353): secret and nonce are
+ * hex strings treated as UTF-8 for createHmac / SubtleCrypto.
+ */
+export async function hmacSha256Hex(secret: string, message: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(message));
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export interface PairWithDaemonOptions {
+  /** Absolute gateway base URL (e.g. http://127.0.0.1:8787) */
+  daemonUrl: string;
+  /**
+   * Contents of the 0600 pairing-secret file printed at gateway boot
+   * (hex string). Used only as a local HMAC key — never sent on the wire.
+   */
+  secret: string;
+  /** Optional operator label stored with the durable token */
+  label?: string;
+}
+
+/**
+ * Pair with a fail-closed harness HTTP gateway (challenge-response).
+ *
+ * Contract (GAP-353 / @revealui/harnesses):
+ *   1. GET  /api/pair → { nonce, expiresIn }
+ *   2. POST /api/pair { nonce, hmac, label? } where hmac = HMAC-SHA256(secret, nonce)
+ *   3. Response { token, expiresAt } — store as bearer for /rpc
+ *
+ * The retired 6-digit pairing-code POST is gone; do not reintroduce it.
+ */
+export async function pairWithDaemon(options: PairWithDaemonOptions): Promise<string> {
+  const { daemonUrl, secret, label } = options;
+  const base = daemonUrl.replace(/\/$/, '');
+  if (!secret.trim()) {
+    throw new Error('Pairing secret is required (read the 0600 pairing-secret file).');
+  }
+
+  const nonceRes = await fetch(`${base}/api/pair`);
+  if (!nonceRes.ok) {
+    let detail = `Pairing challenge failed: ${nonceRes.status}`;
+    try {
+      const err = (await nonceRes.json()) as { error?: string };
+      if (err.error) detail = err.error;
+    } catch {
+      /* ignore non-JSON body */
+    }
+    throw new Error(detail);
+  }
+  const { nonce } = (await nonceRes.json()) as { nonce: string };
+  if (typeof nonce !== 'string' || !nonce) {
+    throw new Error('Pairing challenge returned no nonce');
+  }
+
+  const hmac = await hmacSha256Hex(secret.trim(), nonce);
+  const pairRes = await fetch(`${base}/api/pair`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ code }),
+    body: JSON.stringify({ nonce, hmac, ...(label ? { label } : {}) }),
   });
-  if (!res.ok) {
-    const err = (await res.json()) as { error: string };
-    throw new Error(err.error ?? `Pairing failed: ${res.status}`);
+  if (!pairRes.ok) {
+    let detail = `Pairing failed: ${pairRes.status}`;
+    try {
+      const err = (await pairRes.json()) as { error?: string };
+      if (err.error) detail = err.error;
+    } catch {
+      /* ignore */
+    }
+    throw new Error(detail);
   }
-  const { token } = (await res.json()) as { token: string };
-  setDaemonUrl(daemonUrl);
+  const { token } = (await pairRes.json()) as { token: string };
+  if (typeof token !== 'string' || !token) {
+    throw new Error('Pairing succeeded but no token was returned');
+  }
+  setDaemonUrl(base);
   setDaemonToken(token);
   return token;
 }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -7,7 +7,9 @@
  *
  * Transport:
  *   - Local: Unix socket (~/.local/share/revealui/harness.sock)
- *   - Remote: HTTP gateway with pairing-code auth
+ *   - Remote (optional): the @revealui/harnesses HTTP gateway with
+ *     fail-closed challenge-response pairing (GET/POST /api/pair) — not
+ *     served by this package; Studio pairs against that gateway when remote.
  *   - Protocol: JSON-RPC 2.0 over newline-delimited JSON
  *
  * License: FSL-1.1-MIT (converts to MIT after 2 years)


### PR DESCRIPTION
## Summary
Closes **GAP-397**: Studio still POSTed a retired 6-digit pairing code to the harness HTTP gateway. After GAP-353 the gateway is fail-closed and only accepts challenge-response.

### Changes
- `apps/studio/src/lib/invoke.ts`: `pairWithDaemon({ daemonUrl, secret, label? })`
  - `GET /api/pair` → nonce
  - `HMAC-SHA256(secret, nonce)` via SubtleCrypto (hex digest)
  - `POST /api/pair` `{ nonce, hmac, label? }` → store bearer token
  - Secret never leaves the machine on the wire
- Vitest: success path, gateway 403, and proof that legacy `POST {code}` is rejected
- `packages/daemon` docblock: no longer claims an in-daemon HTTP pairing-code gateway

**Not touched:** `LoginScreen.tsx` 6-digit OTP (email auth, unrelated).

## Peer coord
Claim note: `.jv/workboard.d/notes/2026-07-21T20-gap397-studio-pairing-claim.md`. Does not overlap VES P1 residual or revealui product lanes.

## Test plan
- [x] `pnpm --filter studio exec vitest run src/__tests__/lib/invoke.test.ts -t 'pairWithDaemon|challenge|6-digit|HMAC'` → 3 passed
- [ ] CI green on revdev
- [ ] Manual: boot harnesses gateway, pair Studio with pairing-secret file contents

## Security
Security-adjacent (pairing / auth). Non-author guardrail-2 review welcome; owner disposes merge.