### PR TITLE
fix(daemon,bridge): Phase 0 RPC/docs honesty + worktree bridge signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to RevealUI Studio are documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Dates are ISO 8601 (UTC).
 
+## [Unreleased]
+
+### Fixed
+
+- **CLI / free-mode license help honesty.** Tier help is sourced from
+  `LICENSE_TIER_HELP` (aligned with `EXEMPT_METHODS` + `METHOD_MIN_TIER`): free
+  includes single-repo file/git + local inference run; Pro is multi-agent
+  coordination; Max is memory.* + inference management. CLI version string
+  matches package `0.2.0`.
+- **Bridge worktree tools (revdev#182).** `worktree_create` / `worktree_remove`
+  require `repoPath` and a signed client (`REVDEV_AGENT_DID` +
+  `REVDEV_AGENT_PRIVATE_KEY_PEM`); fail with an actionable error when unsigned
+  instead of a silent `-32003` / missing-param path.
+- **agent.* load-order stubs.** Header and errors no longer claim spawn is
+  desktop-only; production path is daemon PTY (`spawn.ts`) overwriting stubs.
+
+### Changed
+
+- **PLAN.md / SPEC.md truth-sweep (INIT-002 Phase 0).** W4 dogfood Phase 2 and
+  W8–W13 remediation marked shipped where code already landed; SPEC method
+  table matches the real registry (no phantom `harness.stats` / `events.tail`).
+
 ## [0.2.0] — 2026-07-17
 
 ### Added

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,16 +1,16 @@
 ---
 type: plan
 repo: revdev
-last-updated: 2026-06-23
+last-updated: 2026-07-21
 owner: RevealUI Studio
 staleness-status: FRESH
 ---
 
 # RevDev — Plan
 
-**Last Updated:** 2026-06-11 (statuses verified against code, merged PRs, and CI on this date)
-**Status:** Pre-1.0 — Studio + Console + harness daemon all buildable; no public releases yet
-**Owner:** RevealUI Studio (`founder@revealui.com`)
+**Last Updated:** 2026-07-21 (Phase 0 honesty pass — W4/W8–W13 + dogfood re-verified against `origin/test` code; earlier body below still carries 2026-06-11 detail where unchanged)
+**Status:** Pre-1.0 — Studio + Console + harness daemon buildable; tags `v0.1.1` / `v0.2.0` exist; auto-update customer loop still gated on H4
+**Owner:** RevealUI Studio
 
 > **The single RevDev plan.** [`MASTER_PLAN.md`](./MASTER_PLAN.md) is the stable entry point that references this file; the spec counterpart is [`SPEC.md`](./SPEC.md) (referenced by [`MASTER_SPEC.md`](./MASTER_SPEC.md)). This file absorbs and supersedes the former `PRODUCTION_LAUNCH_PLAN.md` (removed 2026-06-11) with every task status re-verified.
 
@@ -31,8 +31,9 @@ What is true today (each item verified, not carried forward):
 - **Daemon license lifecycle is production-shaped.** Expiry warnings (14d/7d/1d) + fail-closed start + `REVDEV_LICENSE_PUBLIC_KEY_FILE` support ([#88](https://github.com/RevealUIStudio/revdev/pull/88)); rotation script + weekly systemd timer ([#90](https://github.com/RevealUIStudio/revdev/pull/90)); signature verified before expiration check ([#94](https://github.com/RevealUIStudio/revdev/pull/94)).
 - **Per-RPC identity Phase 1 is shipped.** `agent_identity` / `agent_identity_keys` / `agent_identity_nonces` tables, DID bootstrap on `session.register`, and accept-if-present signature verification are in the daemon (`packages/daemon/src/server.ts`, `storage/schema.ts`, DID + crypto test suites). Phases 2–4 pending — see W2.
 - **RPC input validation is shipped** (former launch-plan task A1): every method has a Zod schema at `packages/daemon/src/validation/schemas.ts`.
-- **Studio dogfood Phase 1 is shipped, Phases 2–4 are not.** `apps/studio` consumes `@revealui/presentation` `^0.6.0` tokens; the 10-file shadow library at `apps/studio/src/components/ui/` still exists with its ~94 import sites — see W4.
-- **Open issues:** [#15](https://github.com/RevealUIStudio/revdev/issues/15) Studio deploy-email test step is a stub (needs durable SMTP probe), [#2](https://github.com/RevealUIStudio/revdev/issues/2) HTTP gateway (see W3 — the design has moved).
+- **Studio dogfood Phase 1 + Phase 2 are shipped** (tokens + shadow shims for StatusDot/PanelHeader/Tooltip/ErrorAlert/Badge/Button/Card/Input/Dialog/Modal via `@revealui/presentation` ^0.9.1). Phases 3–4 remain (orange residual + delete shadow + Biome guard) — see W4.
+- **RPC catalog honesty:** `RPC_METHODS` ↔ daemon registry is contract-tested; Studio `HARNESS_RPC_MAP` is tested against `RPC_METHODS`. Desktop-only inference lifecycle stays off the map (explicit fail).
+- **Open issues:** [#15](https://github.com/RevealUIStudio/revdev/issues/15) Studio deploy-email test step, [#2](https://github.com/RevealUIStudio/revdev/issues/2) HTTP gateway (see W3), [#182](https://github.com/RevealUIStudio/revdev/issues/182) bridge worktree (fixed in INIT-002 Phase 0 when this plan lands).
 
 ---
 
@@ -106,15 +107,16 @@ Phases 0–4 are shipped: best-effort daemon→Neon dual-write for sessions/mail
 
 ### W4 — Studio dogfood: adopt `@revealui/presentation`
 
-Phase 1 (token foundation) shipped 2026-05-16 via [#67](https://github.com/RevealUIStudio/revdev/pull/67)/[#68](https://github.com/RevealUIStudio/revdev/pull/68): Studio imports `@revealui/presentation/tokens.css` and inherits the fleet brand automatically. Remaining, in order:
+Phase 1 (token foundation) shipped 2026-05-16 via [#67](https://github.com/RevealUIStudio/revdev/pull/67)/[#68](https://github.com/RevealUIStudio/revdev/pull/68). Phase 2 shims landed on `test` (PR series through [#297](https://github.com/RevealUIStudio/revdev/pull/297)): shadow `components/ui/*` are thin wrappers over `@revealui/presentation` ^0.9.1 (StatusDot, PanelHeader, Tooltip, ErrorAlert, Badge, Button, Card, Input, Dialog, Modal; ConfirmDialog is Studio-local).
 
 | Phase | Scope | Status |
 |---|---|---|
-| 2 | Shim the 10 shadow primitives in `apps/studio/src/components/ui/` as thin wrappers over `@revealui/presentation` (5 PRs, lowest fan-out first: StatusDot+PanelHeader → Tooltip+ErrorAlert+Badge → Modal+Dialog → Input → Button+Card). Consumer code unchanged. | **OPEN** |
-| 3 | Sweep the ~19 bespoke `orange-*` brand sites in render code to semantic tokens; `rg 'orange-' apps/studio/src` → zero. | OPEN (after Phase 2) |
-| 4 | Delete the shadow library + add a Biome `noRestrictedImports` guard so it cannot return. | OPEN (after Phase 3) |
+| 1 | Token foundation (`tokens.css`) | ✅ **SHIPPED** |
+| 2 | Shim shadow primitives over `@revealui/presentation` | ✅ **SHIPPED** (2026-07) |
+| 3 | Sweep residual `orange-*` in render code (tip: terminal cursor only) to semantic tokens | **OPEN** (small) |
+| 4 | Delete the shadow library + Biome `noRestrictedImports` guard | **OPEN** (after Phase 3) |
 
-Carve-outs that stay: `codemirror`/`@codemirror/*` (editor) and `@xterm/*` (terminal) — domain primitives with no fleet equivalent. Operational sequencing for this workstream lives in the internal `studio-dogfood` lane; this table is the product-plan view.
+Carve-outs that stay: `codemirror`/`@codemirror/*` (editor) and `@xterm/*` (terminal). Operational sequencing: internal `studio-dogfood` lane (membership under frontend-excellence initiative for brand; daily-driver program does not dual-claim the lane).
 
 ### W5 — Console
 
@@ -142,18 +144,20 @@ The concrete delivery of **product exit criterion #1** ("messages injected autom
 
 ### W8–W13 — UX + durability audit remediation (2026-06-23)
 
-Source of truth: an internal UX + durability audit (2026-06-23) spanning Studio (React + Tauri Rust), Console (Go), the harness daemon, and protocol/bridge; the full audit is tracked privately. Most surfaced themes already map to the existing workstreams (W1–W7); the six workstreams below are the **net-new, previously-untracked** lanes it added. Execution runs one branch + PR per ordered item against `test`; these workstreams track the cross-cutting capabilities those PRs build.
+Source of truth: internal audit (2026-06-23) + 2026-07-09 remediation re-verify + 2026-07-21 daily-driver audit. **Most themes shipped** in code; do not re-open greenfield work from the old OPEN rows.
 
-| WS | Lane | Scope | Maps to audit | Status |
-|---|---|---|---|---|
-| W8 | Destructive-action confirmation | One reusable `ConfirmDialog` (with type-to-confirm variant) routed through every destructive action: vault delete, git discard-all, daemon stop/restart, snap/model delete, SSH bookmark delete, DB migrate/seed; separate "dismiss modal" from "commit state change" (SetupWizard). | Theme 3 | **OPEN** — item 5 (`feat/destructive-confirm`) |
-| W9 | Degraded/mock-mode visibility | One global "degraded mode" flag set wherever a fallback fires (`invoke()` MOCK_DATA, `deploy.ts`/`config.ts` non-Tauri short-circuits, console pricing-fetch failure) + one persistent shell banner; never emit realistic-looking secret values from mocks. | Theme 2 | **OPEN** — item 4 (`feat/degraded-mode-banner`) |
-| W10 | Tauri-backend hardening | The Rust supervision/lifecycle layer not called out under W1: agent-wait deadlock, kill-on-drop/orphans, tray-icon panic, poisoned platform Mutex, config non-atomic write, SSH channel-hang, `daemon_ctl` lifecycle (SIGKILL escalation / PID authority / stale-PID), prompt-corruption hand-rolled JSON. | Themes 5/6/10 (Rust) | **OPEN** — items 2, 6, 10 |
-| W11 | Error-contract sweep | Shared `httpRequest` helper (`res.ok` + 4xx/5xx/network split + guarded `json()`); mutation try/catch contract in hooks; PTY/SSH send+resize catch→onDisconnect; replace `void fn()` with `.catch`; map raw Go errors to actionable text. Durable enforcement: Biome lint banning bare `catch {}` + void-ed promises in `hooks/` + `lib/`. | Theme 4 + console twins | **OPEN** — item 8 (`refactor/error-contract`) |
-| W12 | Docs-accuracy CI gate | Beyond the one-time doc fix: CI tooling that fails on doc-vs-code drift. First piece shipped: `scripts/doc-lint-license-format.mjs` (fails on rejected `RVUI.v2.*`/`RVUI-*` license formats in tracked Markdown, with explicit allow-markers for rejection-documenting mentions). Extend to env-var coverage + emitted-string verification. | Theme 1 durability | **IN PROGRESS** — doc-lint landed with item 1 | <!-- doclint:allow-legacy-format -->
-| W13 | Accessibility | At-a-glance health invisible to assistive tech / ambiguous to colorblind users. Fix `StatusDot` once (`role="img"` + `aria-label` + non-color shape/icon cue); distinct text labels per status (resolve two-orange StepDeploy states); console per-session status text. | Theme 8 | **OPEN** — item 11 (`a11y/status-primitives`) |
+| WS | Lane | Scope | Status (2026-07-21) |
+|---|---|---|---|
+| W8 | Destructive-action confirmation | `ConfirmDialog` + type-to-confirm on vault/git/daemon/SSH/spawn/inference/setup/DB | ✅ **SHIPPED** (residual: re-audit any new destructive control) |
+| W9 | Degraded/mock-mode visibility | `markDegraded` → `DegradedBanner` → AppShell; mock secret sentinels | ✅ **SHIPPED** |
+| W10 | Tauri-backend hardening | Agent-wait deadlock, kill_all on exit, SSH channel split, SIGKILL escalate, tray Option, Windows E:\repos retired | ✅ **Mostly shipped** — residual: deploy-wizard Theme 7 honesty, any new Rust lifecycle bugs |
+| W11 | Error-contract sweep | http helper + mutation try/catch on high-traffic hooks | ✅ **Mostly shipped** — residual: Biome ban on bare `catch {}` / void promises if not yet wired |
+| W12 | Docs-accuracy CI gate | `scripts/doc-lint-license-format.mjs` | ✅ **SHIPPED** first piece; extend env-var/string coverage when needed | <!-- doclint:allow-legacy-format -->
+| W13 | Accessibility | `StatusDot` role/aria-label + text cues | ✅ **Mostly shipped** on StatusDot; residual: console session text, any color-only stragglers |
 
-**Owner-gated items carried out of the audit** (do not action without sign-off): a set of hardening, data-migration, and component-removal items is tracked privately and must not be actioned without owner sign-off. See the internal audit tracker for the itemized list.
+**Still open product residuals (not "re-do W8"):** deploy wizard durability (Theme 7), dogfood W4 Phases 3–4, dual agent-spawn stacks (daily-driver INIT-002 Phase 3), hooks signing (INIT-002 Phase 1), GAP-294 permission modes.
+
+**Owner-gated items** from the audit remain privately tracked; do not action without sign-off.
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -116,14 +116,21 @@ Method categories (the **authoritative method list** is `@revdev/protocol` plus 
 
 | Category | Representative methods | Purpose |
 |---|---|---|
-| `session.*` | `register`, `attach`, `list`, `end` | Logical agent identity lifecycle; `register` also bootstraps the agent's DID (see §Identity) |
+| `session.*` | `register`, `attach`, `list`, `end`, `update` | Logical agent identity lifecycle; `register` also bootstraps the agent's DID (see §Identity) |
 | `mail.*` | `send`, `inbox`, `broadcast`, `markRead` | Inter-agent messaging |
 | `files.*` | `reserve`, `release`, `check`, `list` | Advisory file-locking for conflict prevention |
 | `tasks.*` | `create`, `claim`, `complete`, `release`, `list` | Task queue across agent sessions (CAS claiming) |
-| `events.*` | `log`, `tail`, `subscribe` | Audit + observability |
-| `inference.*` | `status`, `pull`, `start`, `stop`, `chat`, `generate` | Local open-model inference management |
-| `harness.*` | `prune`, `stats`, `health`, `version` | Daemon ops; `health` reports `neonSyncActive` + identity signature mode |
-| `ping` | — | Liveness; returns `{pong: true, serverTimeMs, ...}` |
+| `events.*` | `log`, `query` | Audit + observability (no `tail`/`subscribe` RPC today) |
+| `agent.*` | `spawn`, `stop`, `list`, `remove`, `input`, `resize`, `output` | PTY spawn under bwrap confinement (Pro; signature-required) |
+| `project.*` / `file.*` / `git.*` | open/grant/revoke, read/write, status/commit/… | Single-repo I/O (Free; mutations signature-required) |
+| `worktree.*` / `merge.*` | create/list/remove, request/status/list/update | Isolation + merge pipeline |
+| `memory.*` | `store`, `query` | Full AI memory (**Max**) |
+| `inference.*` | `status`, `chat`, `generate` (Free run); `pull`, `delete`, `start`, `stop` (**Max** management) | Local open-model inference |
+| `harness.*` | `health`, `prune` only | Daemon ops; no `stats`/`version` RPC (use `ping` + package version) |
+| `identity.rotate` | — | DID key rotation (signature-required) |
+| `ping` | — | Liveness; returns `{pong: true, …}` |
+
+Authoritative enumeration: `@revdev/protocol` `RPC_METHODS` ↔ daemon `listRegisteredMethods()` (rpc-contract test).
 
 ### Health check
 

--- a/packages/bridge/src/__tests__/client-signing.test.ts
+++ b/packages/bridge/src/__tests__/client-signing.test.ts
@@ -161,4 +161,32 @@ describe('DaemonClient signing', () => {
     const config = resolveSigningConfig();
     expect(config).toBeNull();
   });
+
+  it('isSigned is true only when a signing config is present', () => {
+    const cfg = buildValidConfig();
+    expect(new DaemonClient('/tmp/test.sock', null).isSigned).toBe(false);
+    expect(
+      new DaemonClient('/tmp/test.sock', {
+        did: cfg.did,
+        fingerprint: cfg.fingerprint,
+        privateKeyPem: cfg.privateKeyPem,
+      }).isSigned,
+    ).toBe(true);
+  });
+
+  it('requireSigned throws with actionable message when unsigned', () => {
+    const client = new DaemonClient('/tmp/test.sock', null);
+    expect(() => client.requireSigned('worktree.create')).toThrow(/REVDEV_AGENT_DID/);
+    expect(() => client.requireSigned('worktree.create')).toThrow(/worktree\.create/);
+  });
+
+  it('requireSigned is a no-op when signed', () => {
+    const cfg = buildValidConfig();
+    const client = new DaemonClient('/tmp/test.sock', {
+      did: cfg.did,
+      fingerprint: cfg.fingerprint,
+      privateKeyPem: cfg.privateKeyPem,
+    });
+    expect(() => client.requireSigned('worktree.create')).not.toThrow();
+  });
 });

--- a/packages/bridge/src/client.ts
+++ b/packages/bridge/src/client.ts
@@ -46,6 +46,24 @@ export class DaemonClient {
     this.signingConfig = signingConfig !== undefined ? signingConfig : resolveSigningConfig();
   }
 
+  /** True when this client will attach an Ed25519 envelope on every call. */
+  get isSigned(): boolean {
+    return this.signingConfig !== null;
+  }
+
+  /**
+   * Signature-required methods need a signed client. Call before worktree /
+   * file mutations so operators get an actionable error instead of -32003.
+   */
+  requireSigned(method: string): void {
+    if (this.signingConfig !== null) return;
+    throw new Error(
+      `${method} requires a signed bridge client. Set REVDEV_AGENT_DID and ` +
+        `REVDEV_AGENT_PRIVATE_KEY_PEM (agent identity from session.register / revvault ` +
+        `revdev/agents/<id>/identity/*), then restart the bridge.`,
+    );
+  }
+
   async call(method: string, params?: Record<string, unknown>): Promise<unknown> {
     return new Promise((resolve, reject) => {
       const id = this.nextId++;

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -365,16 +365,24 @@ server.tool(
 );
 
 // -- Worktree management -----------------------------------------------------
+// worktree.create/remove are signature-required and require a project.open'd
+// repoPath (revdev#182 / INIT-002 Phase 0). The bridge only succeeds when
+// REVDEV_AGENT_DID + REVDEV_AGENT_PRIVATE_KEY_PEM are set (DaemonClient signs).
 
 server.tool(
   'worktree_create',
-  'Create a git worktree for isolated work',
+  'Create a git worktree for isolated work under a project.open root (signed; requires repoPath)',
   {
+    repoPath: z
+      .string()
+      .describe('Absolute path of a root opened via project.open that this agent owns or was granted'),
     branch: z.string().describe('Branch name for the worktree'),
     baseBranch: z.string().optional().describe('Base branch (default: main)'),
   },
-  async ({ branch, baseBranch }) => {
+  async ({ repoPath, branch, baseBranch }) => {
+    daemon.requireSigned('worktree.create');
     const result = await daemon.call(RPC_METHODS['worktree.create'], {
+      repoPath,
       branch,
       baseBranch: baseBranch ?? 'main',
     });
@@ -382,19 +390,30 @@ server.tool(
   },
 );
 
-server.tool('worktree_list', 'List active git worktrees', {}, async () => {
-  const result = await daemon.call(RPC_METHODS['worktree.list']);
-  return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
-});
+server.tool(
+  'worktree_list',
+  'List git worktrees tracked by the daemon (optional agentId filter)',
+  {
+    agentId: z.string().optional().describe('When set, list worktrees for this agent only'),
+  },
+  async ({ agentId }) => {
+    const result = await daemon.call(RPC_METHODS['worktree.list'], agentId ? { agentId } : {});
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+  },
+);
 
 server.tool(
   'worktree_remove',
-  'Remove a git worktree',
+  'Remove a git worktree previously created under a project.open root (signed; requires repoPath)',
   {
+    repoPath: z
+      .string()
+      .describe('Absolute path of the same project.open root used at create time'),
     branch: z.string().describe('Branch name of the worktree to remove'),
   },
-  async ({ branch }) => {
-    const result = await daemon.call(RPC_METHODS['worktree.remove'], { branch });
+  async ({ repoPath, branch }) => {
+    daemon.requireSigned('worktree.remove');
+    const result = await daemon.call(RPC_METHODS['worktree.remove'], { repoPath, branch });
     return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
   },
 );

--- a/packages/daemon/src/__tests__/guard.test.ts
+++ b/packages/daemon/src/__tests__/guard.test.ts
@@ -8,7 +8,7 @@ import {
   licenseErrorResponse,
   refreshLicense,
 } from '../guard.js';
-import { METHOD_MIN_TIER } from '../license.js';
+import { LICENSE_TIER_HELP, METHOD_MIN_TIER } from '../license.js';
 import {
   clearTestLicenseEnv,
   generateTestLicense,
@@ -196,6 +196,18 @@ describe('guardRpcMethod', () => {
       expect(guardRpcMethod('merge.request').tier).toBe('enterprise');
       expect(guardRpcMethod('memory.store').allowed).toBe(true);
       expect(guardRpcMethod('inference.pull').allowed).toBe(true);
+    });
+  });
+
+  // CLI --help must not re-introduce the old "pro includes memory" lie.
+  describe('LICENSE_TIER_HELP (CLI honesty)', () => {
+    it('places memory under max and free file/git under free', () => {
+      expect(LICENSE_TIER_HELP).toMatch(/free\s+Sessions, single-repo file\/git/);
+      expect(LICENSE_TIER_HELP).toMatch(/max\s+\+ full AI memory \(memory\.\*\)/);
+      // Pro line must not claim memory
+      const proLine = LICENSE_TIER_HELP.split('\n').find((l) => l.trimStart().startsWith('pro'));
+      expect(proLine).toBeDefined();
+      expect(proLine).not.toMatch(/memory/i);
     });
   });
 

--- a/packages/daemon/src/__tests__/rpc-contract.test.ts
+++ b/packages/daemon/src/__tests__/rpc-contract.test.ts
@@ -9,7 +9,7 @@
  *
  * Importing `../index.js` registers every handler group in the exact order
  * production startup does, including spawn.js overwriting the agent.js
- * DesktopOnlyError stubs. After that side effect, `listRegisteredMethods()`
+ * load-order placeholders. After that side effect, `listRegisteredMethods()`
  * reflects the real, post-startup surface.
  */
 

--- a/packages/daemon/src/agent.ts
+++ b/packages/daemon/src/agent.ts
@@ -1,39 +1,58 @@
 /**
- * agent.* stub handlers — register the agent spawning surface in the daemon
- * so browser+daemon mode receives a descriptive -32005 error instead of the
- * silent -32601 "Method not found" returned when no handler exists.
+ * agent.* load-order placeholders.
  *
- * Full agent spawning runs through spawner.rs in Tauri desktop mode; the
- * daemon does not own the PTY lifecycle. These stubs exist purely to surface
- * an actionable error in browser+daemon mode.
+ * Production entrypoints (`cli.ts`, `index.ts`) import this module FIRST, then
+ * `spawn.ts`, which overwrites every agent.* handler with the real PTY-backed
+ * implementations (signed, granted-root, bwrap-confined on Linux/WSL2).
+ *
+ * These stubs only fire if `spawn.ts` fails to load after this module — they
+ * are NOT the desktop-only surface. The live multi-agent spawn path is the
+ * daemon (see spawn.ts + confinement.ts), not Tauri `spawner.rs` (that path is
+ * local Ollama/Snap lifecycle, a separate Studio surface).
+ *
+ * Registering placeholders here also keeps the method names present for
+ * tooling that inspects partial import graphs; the rpc-contract test loads
+ * the full index (stubs then overwrite) so the public surface is spawn.ts.
  */
 
 import { registerHandler } from './server.js';
 
-class DesktopOnlyError extends Error {
+class SpawnSurfaceUnavailableError extends Error {
   readonly code = -32005;
   constructor(method: string) {
     super(
-      `${method} requires the RevDev desktop app (Tauri). Agent spawning is handled by the ` +
-        `native Rust backend (spawner.rs) and is not available via the JSON-RPC daemon socket. ` +
-        `Launch RevDev Studio to use agent operations.`,
+      `${method}: daemon agent PTY surface is not loaded. ` +
+        `Production entrypoints must import spawn.ts after agent.ts. ` +
+        `If you see this in a running daemon, the process is mis-bundled — restart or reinstall @revdev/daemon.`,
     );
-    this.name = 'DesktopOnlyError';
+    this.name = 'SpawnSurfaceUnavailableError';
   }
 }
 
 registerHandler('agent.spawn', async () => {
-  throw new DesktopOnlyError('agent.spawn');
+  throw new SpawnSurfaceUnavailableError('agent.spawn');
 });
 
 registerHandler('agent.stop', async () => {
-  throw new DesktopOnlyError('agent.stop');
+  throw new SpawnSurfaceUnavailableError('agent.stop');
+});
+
+registerHandler('agent.list', async () => {
+  throw new SpawnSurfaceUnavailableError('agent.list');
+});
+
+registerHandler('agent.remove', async () => {
+  throw new SpawnSurfaceUnavailableError('agent.remove');
 });
 
 registerHandler('agent.input', async () => {
-  throw new DesktopOnlyError('agent.input');
+  throw new SpawnSurfaceUnavailableError('agent.input');
 });
 
 registerHandler('agent.resize', async () => {
-  throw new DesktopOnlyError('agent.resize');
+  throw new SpawnSurfaceUnavailableError('agent.resize');
+});
+
+registerHandler('agent.output', async () => {
+  throw new SpawnSurfaceUnavailableError('agent.output');
 });

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -38,7 +38,7 @@ import './agent.js';
 // Must come AFTER ./agent.js (stubs) so the real implementations overwrite them.
 import './spawn.js';
 import { DAEMON_DEFAULTS } from './config.js';
-import { LicenseConfigError, LicenseExpiredError } from './license.js';
+import { LicenseConfigError, LicenseExpiredError, LICENSE_TIER_HELP } from './license.js';
 import { startDaemon } from './server.js';
 
 // Default log path for --detach mode. Use the user's data dir (mode 0700,
@@ -85,17 +85,14 @@ Environment:
   REVDEV_DAEMON_GIT_TIMEOUT_MS  Max wall-clock per git spawn (default: ${DAEMON_DEFAULTS.gitTimeoutMs} ms = ${DAEMON_DEFAULTS.gitTimeoutMs / 1000} s)
   REVDEV_DAEMON_SHUTDOWN_GRACE_MS  Max wait for in-flight handlers during close() (default: ${DAEMON_DEFAULTS.shutdownGracePeriodMs} ms = ${DAEMON_DEFAULTS.shutdownGracePeriodMs / 1000} s)
 
-License tiers:
-  free         Session management only
-  pro          + agent spawning, merge pipeline, memory
-  max          + inference management, advanced coordination
-  enterprise   Full access, all features
+${LICENSE_TIER_HELP}
 `);
   process.exit(0);
 }
 
 if (args.includes('--version') || args.includes('-v')) {
-  console.log('revdev-daemon 0.1.0');
+  // Keep in lockstep with packages/daemon/package.json version.
+  console.log('revdev-daemon 0.2.0');
   process.exit(0);
 }
 

--- a/packages/daemon/src/guard.ts
+++ b/packages/daemon/src/guard.ts
@@ -2,7 +2,8 @@
  * RPC license guard — enforces runtime paywall on daemon methods.
  *
  * Free tier: session management only (register, update, end, list, ping).
- * Pro+: full access to spawning, inference, merge pipeline, memory, etc.
+ * Pro+: multi-agent coordination (spawn, mail, tasks, merge, …).
+ * Max: + full AI memory + local-model management (pull/start/stop/delete).
  *
  * This is the runtime enforcement layer. The FSL-1.1-MIT license provides
  * legal protection; this guard provides operational protection.
@@ -109,8 +110,10 @@ export function initLicenseGuard(): { tier: LicenseTier; valid: boolean } {
     logExpiryWarning(ev);
   } else {
     console.log('[license] RevDev daemon running in FREE (degraded) mode');
-    console.log('[license] Set REVEALUI_LICENSE_KEY to unlock Pro features');
-    console.log('[license] Available: agent spawning, inference, merge pipeline, memory');
+    console.log('[license] Set REVEALUI_LICENSE_KEY to unlock Pro/Max features');
+    console.log(
+      '[license] Pro: multi-agent coordination (spawn, mail, tasks, merge, …). Max: + memory.* + inference management',
+    );
   }
 
   return cachedLicense;

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -139,6 +139,18 @@ export const METHOD_MIN_TIER = new Map<string, LicenseTier>([
 ]);
 
 /**
+ * Human-readable tier summary for CLI `--help` and operator docs.
+ * MUST stay aligned with EXEMPT_METHODS + METHOD_MIN_TIER + the Pro default
+ * for every other non-exempt method. A unit test locks the memory=Max and
+ * free-file/git claims so help cannot re-drift (INIT-002 Phase 0).
+ */
+export const LICENSE_TIER_HELP = `License tiers (method gate; source: EXEMPT_METHODS + METHOD_MIN_TIER):
+  free         Sessions, single-repo file/git, local inference run (status/chat/generate)
+  pro          Multi-agent coordination (mail, tasks, files.*, agent.*, merge.*, worktree, events, harness.prune, …)
+  max          + full AI memory (memory.*) and local-model management (inference.pull/delete/start/stop)
+  enterprise   Same method surface as max today; commercial terms differ`;
+
+/**
  * Ordinal rank of a tier within LICENSE_TIERS (free=0 < pro=1 < max=2 <
  * enterprise=3) — the array index doubles as the rank. Used by the RPC guard
  * for `>=` tier comparison. Returns -1 for an unrecognized tier (sorts below


### PR DESCRIPTION
## Summary

INIT-002 Phase 0 (honesty foundation) for RevDev daily driver:

1. **License help honesty** — `LICENSE_TIER_HELP` sourced from the same tables as the gate (`EXEMPT_METHODS` + `METHOD_MIN_TIER`). Free = sessions + file/git + inference run; Pro = multi-agent coordination; Max = memory.* + inference management. Free-mode boot log and CLI `--help` / version `0.2.0` updated. Unit test locks the help string.
2. **Bridge worktree (closes #182)** — `worktree_create` / `worktree_remove` pass `repoPath` and call `requireSigned()` so unsigned bridges fail with env instructions instead of `-32003` / missing params. `worktree_list` accepts optional `agentId`.
3. **agent.* stubs** — no longer claim spawn is desktop-only; document load-order overwrite by `spawn.ts` (confined PTY path).
4. **PLAN.md / SPEC.md truth-sweep** — W4 Phase 2 and W8–W13 remediations marked shipped where code already landed; SPEC method table matches registry (no phantom `harness.stats` / `events.tail`).

## Context

Much of the original “phantom RPC map” work already landed on `test` (v0.2.0 browser-mode wiring + rpc-contract test). This PR is the residual honesty pass from the 2026-07-21 daily-driver audit / INIT-002 Phase 0.

## Test plan

- [x] `pnpm --filter @revdev/daemon exec vitest run src/__tests__/guard.test.ts src/__tests__/rpc-contract.test.ts` (95 tests)
- [x] `pnpm --filter @revdev/bridge exec vitest run src/__tests__/client-signing.test.ts` (8 tests)
- [ ] CI green on PR

## Not in this PR

- Hooks client identity (INIT-002 Phase 1)
- GAP-294 permission modes (Phase 2)
- Studio spawn unify (Phase 3)