### PR TITLE
feat(daemon): one-shot privateKeyPem on first identity mint for hooks

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -89,7 +89,9 @@ Register a new agent session. Returns a sessionId to use as identity. Two owners
 | `pid` | number? | Caller process ID |
 | `publicKeyPem` | string? | Client-owned Ed25519 SPKI PEM public key (Studio zero-9P model); the fingerprint must be in the daemon's trust anchor or registration fails with -32004 |
 
-**Response**: `{ sessionId: string, agentId: string, agentName: string, backend: string, did: string, publicKeyPem: string, session: { id, env, task } }`
+**Response**: `{ sessionId: string, agentId: string, agentName: string, backend: string, did: string, publicKeyPem: string, privateKeyPem?: string, warnings?: unknown[], session: { id, env, task } }`
+
+`privateKeyPem` is returned **only** on the first daemon-minted bootstrap (headless hooks). It is never returned for client-owned enroll or for re-register of an existing identity. Cache it (hooks write `~/.local/share/revealui/hook-identities/<agentId>.json`) or load from revvault `revdev/agents/<agentId>/identity/ed25519-private` for subsequent signed calls (`session.end`, file/git mutations, …).
 
 ---
 
@@ -124,12 +126,12 @@ Update the current session's task/files description, or self-scoped activity sta
 ---
 
 ### `session.end`
-**Tier**: Free
-**Signature**: required
+**Tier**: Free · **Signature: required**
 
-End the current session. Optionally record an exit summary. Self-scoped to the verified signer; a caller-supplied session/agent override is not honored.
+Self-scoped to the verified Ed25519 signer. The caller may not end another agent’s session via params (the old `sessionId` override was removed). Unsigned frames return an error before the handler runs.
 
-**Params**: `{ exitSummary?: string }`
+**Params**: `{ exitSummary?: string, summary?: string }` (aliases). Hook clients pass `actorAgentId` only for local identity cache lookup; it is not used as an end-target.
+
 **Response**: `{ ended: string }`
 
 ---

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -511,7 +511,7 @@ describe('agent identity bootstrap', () => {
       agentId: 'identity-test-first',
       agentName: 'identity-tester',
       backend: 'test',
-    })) as { sessionId: string; did: string; publicKeyPem: string };
+    })) as { sessionId: string; did: string; publicKeyPem: string; privateKeyPem?: string };
 
     expect(result.sessionId).toBe('identity-test-first');
     expect(result.did).toBe(
@@ -521,6 +521,8 @@ describe('agent identity bootstrap', () => {
     );
     expect(result.did.startsWith('did:revfleet:identity-test-first:')).toBe(true);
     expect(result.publicKeyPem).toContain('BEGIN PUBLIC KEY');
+    // INIT-002 Phase 1: one-shot private key so headless hooks can sign.
+    expect(result.privateKeyPem).toContain('BEGIN PRIVATE KEY');
   });
 
   it('idempotent re-register reuses the same keypair', async () => {
@@ -528,16 +530,19 @@ describe('agent identity bootstrap', () => {
       agentId: 'identity-test-idempotent',
       agentName: 'identity-tester',
       backend: 'test',
-    })) as { did: string; publicKeyPem: string };
+    })) as { did: string; publicKeyPem: string; privateKeyPem?: string };
 
     const r2 = (await rpc(socketPath, 'session.register', {
       agentId: 'identity-test-idempotent',
       agentName: 'identity-tester',
       backend: 'test',
-    })) as { did: string; publicKeyPem: string };
+    })) as { did: string; publicKeyPem: string; privateKeyPem?: string };
 
     expect(r2.did).toBe(r1.did);
     expect(r2.publicKeyPem).toBe(r1.publicKeyPem);
+    // Private key is emitted only on first mint — never re-emitted.
+    expect(r1.privateKeyPem).toContain('BEGIN PRIVATE KEY');
+    expect(r2.privateKeyPem).toBeUndefined();
   });
 
   it('forceRotate param is silently ignored — re-register returns the same keypair', async () => {

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -767,9 +767,10 @@ registerHandler('session.register', async (params, db, ctx) => {
   //   - DAEMON-MINTED (headless hooks): no key supplied, so the daemon
   //     generates the keypair and mirrors it to revvault, as before.
   const clientPublicKeyPem = strOrNull(params.publicKeyPem);
-  const { did, publicKeyPem } = clientPublicKeyPem
+  const identity = clientPublicKeyPem
     ? await registerClientIdentity(db, id, clientPublicKeyPem)
     : await bootstrapAgentIdentity(db, id);
+  const { did, publicKeyPem } = identity;
 
   // Run the registered session-lifecycle advisory checks and surface their
   // warnings to the client. Best-effort by construction: runSessionChecks
@@ -779,6 +780,13 @@ registerHandler('session.register', async (params, db, ctx) => {
 
   // Include `session: {id}` for back-compat with hook clients that read
   // `result.session.id`. New clients should use `sessionId`/`agentId`.
+  //
+  // `privateKeyPem` is returned ONLY on first daemon-minted bootstrap so
+  // headless clients (Claude/Grok hooks) can cache a signing key for
+  // session.end and other MUTATING_OR_CONTENT_METHODS. Client-owned enroll
+  // never returns a private key (Studio keeps it). Re-register of an
+  // existing identity never re-emits the private key — load from cache or
+  // revvault (`revdev/agents/<id>/identity/ed25519-private`).
   return {
     sessionId: id,
     agentId: id,
@@ -786,6 +794,7 @@ registerHandler('session.register', async (params, db, ctx) => {
     backend,
     did,
     publicKeyPem,
+    ...(identity.privateKeyPem !== undefined ? { privateKeyPem: identity.privateKeyPem } : {}),
     warnings,
     session: { id, env, task: workDir },
   };
@@ -794,6 +803,11 @@ registerHandler('session.register', async (params, db, ctx) => {
 interface IdentityResult {
   did: string;
   publicKeyPem: string;
+  /**
+   * Present only when this call freshly minted a daemon-held keypair.
+   * Never on client-owned enroll or re-register of an existing identity.
+   */
+  privateKeyPem?: string;
 }
 
 async function bootstrapAgentIdentity(db: PGlite, agentId: string): Promise<IdentityResult> {
@@ -823,9 +837,12 @@ async function bootstrapAgentIdentity(db: PGlite, agentId: string): Promise<Iden
     [fingerprint, agentId, kp.publicKeyPem],
   );
 
-  void persistIdentityToRevvault(agentId, kp.privateKeyPem, kp.publicKeyPem);
+  // Await vault mirror so hooks can fall back to revvault get if the one-shot
+  // privateKeyPem response is lost (INIT-002 Phase 1). Still best-effort: vault
+  // failures log and do not fail registration.
+  await persistIdentityToRevvault(agentId, kp.privateKeyPem, kp.publicKeyPem);
 
-  return { did, publicKeyPem: kp.publicKeyPem };
+  return { did, publicKeyPem: kp.publicKeyPem, privateKeyPem: kp.privateKeyPem };
 }
 
 /** Thrown when a client (agentId, key) pair is not in the trust anchor. */


### PR DESCRIPTION
## Summary

INIT-002 Phase 1 — **harness-agnostic** daemon identity for daily driver:

### Daemon
- `session.register` returns `privateKeyPem` **once** on first daemon-mint
- Await revvault persist for recovery
- Docs name all consumers: Claude, Grok, **Ubuntu Inference Snap**, Ollama, MCP bridge, Studio

### Studio (this PR)
- Snap / Ollama `agent_spawn` registers a daemon session (`backend: inference-snap|ollama`)
- One-shot private key held on the process; signed `session.end` on stop/remove
- `EphemeralAgentIdentity` signs with daemon-minted PKCS8 keys

Not Claude/Grok only — local open-model agents are first-class governed sessions.

## Test plan
- [x] coordination suite (privateKeyPem first-mint / re-register)
- [x] `cargo test -p revealui-studio --lib signing::` (10 pass, incl. ephemeral snap identity)
- [ ] CI green