### PR TITLE
feat(studio): register Inference Snap/Ollama agents on the daemon

### DIFF
--- a/apps/studio/src-tauri/src/commands/spawner.rs
+++ b/apps/studio/src-tauri/src/commands/spawner.rs
@@ -1,11 +1,15 @@
 use tauri::State;
 
 use super::error::StudioError;
-use crate::spawner::{AgentBackend, SpawnerState};
+use crate::spawner::{backend_daemon_label, AgentBackend, SpawnerState};
 
-/// Spawn a new agent process using local inference (Snap or Ollama).
+/// Spawn a new agent process using local inference (Ubuntu Inference Snap or Ollama).
+///
+/// Also registers a daemon-minted session (INIT-002 Phase 1) so Snap/Ollama
+/// agents appear in coordination as governed users — same identity model as
+/// Claude/Grok hooks, not a free-floating local process.
 #[tauri::command]
-pub fn agent_spawn(
+pub async fn agent_spawn(
     name: String,
     backend: AgentBackend,
     model: String,
@@ -13,18 +17,67 @@ pub fn agent_spawn(
     app_handle: tauri::AppHandle,
     state: State<'_, SpawnerState>,
 ) -> Result<String, StudioError> {
-    crate::spawner::spawn(name, backend, model, prompt, app_handle, state.sessions.clone())
-        .map_err(|e| StudioError::Process(e))
+    let session_id = crate::spawner::spawn(
+        name.clone(),
+        backend.clone(),
+        model.clone(),
+        prompt,
+        app_handle,
+        state.sessions.clone(),
+    )
+    .map_err(StudioError::Process)?;
+
+    // Best-effort daemon registration — process is already running.
+    let backend_label = backend_daemon_label(&backend);
+    let work_dir = std::env::current_dir()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let agent_name = if name.is_empty() {
+        format!("{backend_label}:{model}")
+    } else {
+        name
+    };
+    // agentId must be DID-safe: use snap- prefix + shortened uuid (hyphens ok).
+    let daemon_agent_id = format!("snap-{}", session_id.replace('-', "").get(..24).unwrap_or(&session_id));
+
+    match crate::harness::register_inference_agent(
+        &daemon_agent_id,
+        &agent_name,
+        backend_label,
+        &work_dir,
+    )
+    .await
+    {
+        Ok(creds) => {
+            let _ = crate::spawner::set_daemon_creds(
+                &session_id,
+                state.sessions.clone(),
+                creds,
+            );
+        }
+        Err(e) => {
+            // Non-fatal: local inference still works; coordination is degraded.
+            eprintln!("[revdev] inference agent daemon register failed: {e}");
+        }
+    }
+
+    Ok(session_id)
 }
 
-/// Stop a running agent process.
+/// Stop a running agent process and end its daemon session when registered.
 #[tauri::command]
-pub fn agent_stop(
+pub async fn agent_stop(
     session_id: String,
     state: State<'_, SpawnerState>,
 ) -> Result<(), StudioError> {
-    crate::spawner::stop(&session_id, state.sessions.clone())
-        .map_err(|e| StudioError::Process(e))
+    let creds = crate::spawner::take_daemon_creds(&session_id, state.sessions.clone());
+    crate::spawner::stop(&session_id, state.sessions.clone()).map_err(StudioError::Process)?;
+    if let Some(creds) = creds {
+        if let Err(e) = crate::harness::end_inference_agent(&creds).await {
+            eprintln!("[revdev] inference agent session.end failed: {e}");
+        }
+    }
+    Ok(())
 }
 
 /// List all agent sessions.
@@ -32,17 +85,23 @@ pub fn agent_stop(
 pub fn agent_list(
     state: State<'_, SpawnerState>,
 ) -> Result<Vec<crate::spawner::AgentSessionInfo>, StudioError> {
-    crate::spawner::list(state.sessions.clone()).map_err(|e| StudioError::Process(e))
+    crate::spawner::list(state.sessions.clone()).map_err(StudioError::Process)
 }
 
 /// Remove a stopped/errored agent session.
 #[tauri::command]
-pub fn agent_remove(
+pub async fn agent_remove(
     session_id: String,
     state: State<'_, SpawnerState>,
 ) -> Result<(), StudioError> {
-    crate::spawner::remove(&session_id, state.sessions.clone())
-        .map_err(|e| StudioError::Process(e))
+    let creds = crate::spawner::take_daemon_creds(&session_id, state.sessions.clone());
+    crate::spawner::remove(&session_id, state.sessions.clone()).map_err(StudioError::Process)?;
+    if let Some(creds) = creds {
+        if let Err(e) = crate::harness::end_inference_agent(&creds).await {
+            eprintln!("[revdev] inference agent session.end failed: {e}");
+        }
+    }
+    Ok(())
 }
 
 /// Write input data to a daemon PTY session (agent.input RPC).
@@ -53,7 +112,7 @@ pub async fn agent_input(session_id: String, data: String) -> Result<(), StudioE
         serde_json::json!({ "sessionId": session_id, "data": data }),
     )
     .await
-    .map_err(|e| StudioError::Other(e))?;
+    .map_err(StudioError::Other)?;
     Ok(())
 }
 
@@ -69,6 +128,6 @@ pub async fn agent_resize(
         serde_json::json!({ "sessionId": session_id, "cols": cols, "rows": rows }),
     )
     .await
-    .map_err(|e| StudioError::Other(e))?;
+    .map_err(StudioError::Other)?;
     Ok(())
 }

--- a/apps/studio/src-tauri/src/harness.rs
+++ b/apps/studio/src-tauri/src/harness.rs
@@ -135,6 +135,84 @@ pub async fn ensure_session() -> Result<String, String> {
     Ok(id)
 }
 
+/// Register a local inference agent (Ubuntu Inference Snap or Ollama) as a
+/// daemon session under a daemon-minted identity. Returns the one-shot
+/// private key so the caller can sign `session.end` later.
+///
+/// This is the Studio counterpart to Claude/Grok hook identity (INIT-002 Phase 1):
+/// every daily-driver agent harness — frontier hooks **and** local snaps — is a
+/// governed session on the same daemon, not a free-floating process.
+pub async fn register_inference_agent(
+    agent_id: &str,
+    agent_name: &str,
+    backend: &str,
+    work_dir: &str,
+) -> Result<InferenceAgentCreds, String> {
+    let result = rpc_call_raw(
+        "session.register",
+        serde_json::json!({
+            "agentId": agent_id,
+            "agentName": agent_name,
+            "workDir": work_dir,
+            "backend": backend,
+        }),
+        None,
+    )
+    .await?;
+    let did = result
+        .get("did")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "session.register did not return did".to_string())?
+        .to_string();
+    // One-shot private key only on first mint; re-spawn of same agentId may omit it.
+    let private_key_pem = result
+        .get("privateKeyPem")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    Ok(InferenceAgentCreds {
+        agent_id: agent_id.to_string(),
+        did,
+        private_key_pem,
+    })
+}
+
+/// Creds for a local inference agent session registered with the daemon.
+#[derive(Clone)]
+pub struct InferenceAgentCreds {
+    pub agent_id: String,
+    pub did: String,
+    /// Present only on first mint for this agentId.
+    pub private_key_pem: Option<String>,
+}
+
+/// End a local inference agent session with a verified signature when the
+/// one-shot private key is available; otherwise best-effort unsigned (prune
+/// still reaps). Prefer signed end for clean coordination state.
+pub async fn end_inference_agent(creds: &InferenceAgentCreds) -> Result<(), String> {
+    let params = serde_json::json!({
+        "exitSummary": format!("inference-agent-stop:{}", creds.agent_id),
+    });
+    let signature = match &creds.private_key_pem {
+        Some(pem) => {
+            let identity = signing::EphemeralAgentIdentity::from_daemon_mint(&creds.did, pem)?;
+            let ts = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e| format!("system clock before epoch: {e}"))?
+                .as_secs() as i64;
+            Some(identity.sign_request("session.end", &params, ts))
+        }
+        None => None,
+    };
+    match rpc_call_raw("session.end", params, signature).await {
+        Ok(_) => Ok(()),
+        Err(e) if e.contains("-32003") || e.contains("signed request") => {
+            // Unsigned end is expected when re-spawn had no private key re-emit.
+            Err(e)
+        }
+        Err(e) => Err(e),
+    }
+}
+
 /// Send a JSON-RPC request to the daemon, automatically injecting the cached
 /// Studio agent ID as `actorAgentId` so the daemon can attribute the call.
 ///

--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -195,6 +195,78 @@ pub struct StudioIdentity {
     pub public_key_pem: String,
 }
 
+/// Signing identity for a daemon-minted local agent (Ubuntu Inference Snap,
+/// Ollama, or other headless runner). Built from the one-shot `privateKeyPem`
+/// returned by `session.register` so Studio can sign `session.end` for that
+/// agent without reusing the Studio UI's client-owned key.
+pub struct EphemeralAgentIdentity {
+    signing_key: SigningKey,
+    pub did: String,
+    pub fingerprint: String,
+}
+
+impl EphemeralAgentIdentity {
+    /// Reconstruct from daemon register response (`did` + PKCS8 `privateKeyPem`).
+    /// Node `generateKeyPairSync('ed25519')` PKCS8 DER ends with the 32-byte seed.
+    pub fn from_daemon_mint(did: &str, private_key_pem: &str) -> Result<Self, String> {
+        let fingerprint = did
+            .rsplit(':')
+            .next()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| format!("invalid did (no fingerprint): {did}"))?
+            .to_string();
+        let signing_key = signing_key_from_pkcs8_pem(private_key_pem)?;
+        Ok(Self {
+            signing_key,
+            did: did.to_string(),
+            fingerprint,
+        })
+    }
+
+    pub fn sign_request(&self, method: &str, params: &Value, now_unix_secs: i64) -> String {
+        let header_b64 = b64url(HEADER_JSON.as_bytes());
+        let mut nonce_bytes = [0u8; 16];
+        {
+            use rand::RngCore;
+            rand::rng().fill_bytes(&mut nonce_bytes);
+        }
+        let payload = SignaturePayload {
+            did: &self.did,
+            kid: &self.fingerprint,
+            nonce: hex::encode(nonce_bytes),
+            ts: now_unix_secs,
+            method,
+            params_hash: hash_params(method, params),
+        };
+        let payload_json = serde_json::to_string(&payload).expect("payload serializes");
+        let payload_b64 = b64url(payload_json.as_bytes());
+        let message = format!("{header_b64}.{payload_b64}");
+        let signature = self.signing_key.sign(message.as_bytes());
+        let sig_b64 = b64url(&signature.to_bytes());
+        format!("{message}.{sig_b64}")
+    }
+}
+
+/// Extract the 32-byte Ed25519 seed from a PKCS8 PEM private key (Node/OpenSSL
+/// shape). The seed is the trailing 32 bytes of the DER payload.
+fn signing_key_from_pkcs8_pem(pem: &str) -> Result<SigningKey, String> {
+    use base64::Engine;
+    let b64: String = pem
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with("-----"))
+        .collect();
+    let der = base64::engine::general_purpose::STANDARD
+        .decode(b64.as_bytes())
+        .map_err(|e| format!("invalid private key PEM base64: {e}"))?;
+    if der.len() < 32 {
+        return Err("invalid private key PEM: too short".to_string());
+    }
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&der[der.len() - 32..]);
+    Ok(SigningKey::from_bytes(&seed))
+}
+
 impl StudioIdentity {
     /// Generate a fresh identity from OS randomness.
     pub fn generate(agent_id: String) -> Self {
@@ -447,6 +519,24 @@ mod tests {
             hash_params("git.status", &Value::Null),
             hash_params("git.status", &json!({}))
         );
+    }
+
+    #[test]
+    fn ephemeral_agent_from_pkcs8_trailing_seed() {
+        use base64::Engine;
+        let seed = [9u8; 32];
+        // Minimal DER: trailing 32 bytes are the seed (matches our parser).
+        let der = seed.to_vec();
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&der);
+        let pem = format!("-----BEGIN PRIVATE KEY-----\n{b64}\n-----END PRIVATE KEY-----\n");
+        let studio = StudioIdentity::from_seed("snap-agent".into(), &seed);
+        let eph = EphemeralAgentIdentity::from_daemon_mint(&studio.did, &pem).unwrap();
+        assert_eq!(eph.did, studio.did);
+        assert_eq!(eph.fingerprint, studio.fingerprint);
+        // Signatures for the same method/params/ts differ by nonce but both verify shape.
+        let params = json!({ "exitSummary": "test" });
+        let env = eph.sign_request("session.end", &params, 1_700_000_000);
+        assert_eq!(env.split('.').count(), 3);
     }
 
     #[test]

--- a/apps/studio/src-tauri/src/spawner.rs
+++ b/apps/studio/src-tauri/src/spawner.rs
@@ -58,6 +58,9 @@ pub struct AgentProcess {
     pub prompt: String,
     pub child: Child,
     pub status: String,
+    /// Daemon session creds (INIT-002 Phase 1) — Snap/Ollama agents register
+    /// as governed sessions, same as Claude/Grok hooks.
+    pub daemon_creds: Option<crate::harness::InferenceAgentCreds>,
 }
 
 /// Managed Tauri state for spawned agent sessions.
@@ -150,6 +153,7 @@ pub fn spawn(
                 prompt: prompt.clone(),
                 child,
                 status: "running".to_string(),
+                daemon_creds: None,
             },
         );
     }
@@ -287,6 +291,38 @@ fn wait_for_exit(state: &Arc<Mutex<HashMap<String, AgentProcess>>>, sid: &str) -
     }
 }
 
+/// Backend string recorded on the daemon session (harness-agnostic catalog).
+pub fn backend_daemon_label(backend: &AgentBackend) -> &'static str {
+    match backend {
+        AgentBackend::Snap => "inference-snap",
+        AgentBackend::Ollama => "ollama",
+    }
+}
+
+/// Attach daemon register creds to a running local agent (best-effort).
+pub fn set_daemon_creds(
+    session_id: &str,
+    state: Arc<Mutex<HashMap<String, AgentProcess>>>,
+    creds: crate::harness::InferenceAgentCreds,
+) -> Result<(), String> {
+    let mut sessions = state.lock().map_err(|e| format!("Lock poisoned: {e}"))?;
+    if let Some(proc) = sessions.get_mut(session_id) {
+        proc.daemon_creds = Some(creds);
+        Ok(())
+    } else {
+        Err(format!("No agent session with id {session_id}"))
+    }
+}
+
+/// Take daemon creds for a session (for signed session.end).
+pub fn take_daemon_creds(
+    session_id: &str,
+    state: Arc<Mutex<HashMap<String, AgentProcess>>>,
+) -> Option<crate::harness::InferenceAgentCreds> {
+    let mut sessions = state.lock().ok()?;
+    sessions.get_mut(session_id).and_then(|p| p.daemon_creds.take())
+}
+
 /// Stop a running agent process.
 pub fn stop(
     session_id: &str,
@@ -408,6 +444,7 @@ mod tests {
             prompt: "hi".into(),
             child,
             status: status.into(),
+            daemon_creds: None,
         }
     }
 
@@ -502,6 +539,7 @@ mod tests {
             prompt: "hi".into(),
             child,
             status: "running".into(),
+            daemon_creds: None,
         }
     }
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -91,7 +91,16 @@ Register a new agent session. Returns a sessionId to use as identity. Two owners
 
 **Response**: `{ sessionId: string, agentId: string, agentName: string, backend: string, did: string, publicKeyPem: string, privateKeyPem?: string, warnings?: unknown[], session: { id, env, task } }`
 
-`privateKeyPem` is returned **only** on the first daemon-minted bootstrap (headless hooks). It is never returned for client-owned enroll or for re-register of an existing identity. Cache it (hooks write `~/.local/share/revealui/hook-identities/<agentId>.json`) or load from revvault `revdev/agents/<agentId>/identity/ed25519-private` for subsequent signed calls (`session.end`, file/git mutations, …).
+`privateKeyPem` is returned **only** on the first daemon-minted bootstrap. It is never returned for client-owned enroll or for re-register of an existing identity. Intended consumers (all daily-driver harnesses, not Claude alone):
+
+| Client | How it stores the key |
+|--------|------------------------|
+| Claude Code / Grok hooks | `~/.local/share/revealui/hook-identities/<agentId>.json` |
+| Studio Ubuntu Inference Snap / Ollama spawn | in-memory on the agent process for signed `session.end` |
+| MCP bridge | `REVDEV_AGENT_DID` + `REVDEV_AGENT_PRIVATE_KEY_PEM` env |
+| Fallback | revvault `revdev/agents/<agentId>/identity/ed25519-private` |
+
+`backend` on register should name the harness: e.g. `claude-code`, `grok`, `inference-snap`, `ollama`, `mcp-agent`, `studio`.
 
 ---
 

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -36,7 +36,12 @@ server.tool(
   {
     agentName: z.string().describe('Name for this agent (e.g. "agent-main")'),
     workDir: z.string().describe('Working directory for this session'),
-    backend: z.string().optional().describe('Backend identifier (default: "mcp-agent")'),
+    backend: z
+      .string()
+      .optional()
+      .describe(
+        'Harness backend label (default: "mcp-agent"). Examples: claude-code, grok, inference-snap, ollama, studio',
+      ),
   },
   async ({ agentName, workDir, backend }) => {
     const result = await daemon.call(RPC_METHODS['session.register'], {

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -782,10 +782,12 @@ registerHandler('session.register', async (params, db, ctx) => {
   // `result.session.id`. New clients should use `sessionId`/`agentId`.
   //
   // `privateKeyPem` is returned ONLY on first daemon-minted bootstrap so
-  // headless clients (Claude/Grok hooks) can cache a signing key for
-  // session.end and other MUTATING_OR_CONTENT_METHODS. Client-owned enroll
-  // never returns a private key (Studio keeps it). Re-register of an
-  // existing identity never re-emits the private key — load from cache or
+  // headless harness clients can cache a signing key for session.end and
+  // other MUTATING_OR_CONTENT_METHODS. Consumers include Claude Code hooks,
+  // Grok dual-harness hooks, Ubuntu Inference Snap / Ollama agents registered
+  // from Studio, and the MCP bridge — not Claude/Grok alone. Client-owned
+  // enroll never returns a private key (Studio UI keeps it). Re-register of
+  // an existing identity never re-emits the private key — load from cache or
   // revvault (`revdev/agents/<id>/identity/ed25519-private`).
   return {
     sessionId: id,


### PR DESCRIPTION
## Summary

Follow-up to #301 (merged). That squash landed the daemon one-shot `privateKeyPem` mint; this PR is the Studio half that was pushed after merge:

- Snap / Ollama `agent_spawn` registers a daemon-minted session (`backend: inference-snap|ollama`)
- One-shot private key on the process; signed `session.end` on stop/remove
- `EphemeralAgentIdentity` for PKCS8 mint keys
- Docs/API: multi-harness consumers (not Claude/Grok only)

## Test plan
- [x] `cargo test -p revealui-studio --lib signing::` (was green pre-merge of sibling)
- [ ] CI green