### PR TITLE
feat(daemon): GAP-294 Phase 0 permission shadow gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+### Added
+
+- **GAP-294 Phase 0 permission shadow gate.** Every RPC is classified
+  (`routine` / `consequential` / `critical` per owner-countersigned map) and
+  emits `permission.would_allow` / `permission.would_require_approval` events
+  without blocking. Simulated mode via `REVDEV_PERMISSION_SHADOW_AS=manual|auto`
+  (default manual). Enforcement (-32004 queue) is Phase 1.
+
 ### Fixed
 
 - **CLI / free-mode license help honesty.** Tier help is sourced from

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -380,7 +380,9 @@ server.tool(
   {
     repoPath: z
       .string()
-      .describe('Absolute path of a root opened via project.open that this agent owns or was granted'),
+      .describe(
+        'Absolute path of a root opened via project.open that this agent owns or was granted',
+      ),
     branch: z.string().describe('Branch name for the worktree'),
     baseBranch: z.string().optional().describe('Base branch (default: main)'),
   },

--- a/packages/daemon/src/__tests__/permission.test.ts
+++ b/packages/daemon/src/__tests__/permission.test.ts
@@ -1,0 +1,106 @@
+/**
+ * GAP-294 Phase 0 — action-class map + shadow evaluation.
+ */
+import { RPC_METHODS } from '@revdev/protocol';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  classifyMethod,
+  evaluateShadow,
+  expectedClassifiedMethods,
+  METHOD_ACTION_CLASS,
+  shadowWouldAuto,
+  shadowWouldManual,
+} from '../permission.js';
+
+describe('METHOD_ACTION_CLASS coverage', () => {
+  it('classifies every RPC_METHODS value', () => {
+    for (const method of Object.values(RPC_METHODS)) {
+      expect(
+        METHOD_ACTION_CLASS.has(method),
+        `RPC method ${method} missing from METHOD_ACTION_CLASS`,
+      ).toBe(true);
+    }
+  });
+
+  it('classifies expectedClassifiedMethods without gaps for protocol set', () => {
+    const expected = new Set(expectedClassifiedMethods());
+    for (const method of Object.values(RPC_METHODS)) {
+      expect(expected.has(method)).toBe(true);
+    }
+  });
+
+  it('unmapped method fails closed to critical', () => {
+    expect(classifyMethod('totally.unknown.method')).toBe('critical');
+  });
+});
+
+describe('shadow would (manual simulation)', () => {
+  it('routine allows', () => {
+    expect(shadowWouldManual('routine')).toBe('allow');
+  });
+  it('consequential and critical require approval', () => {
+    expect(shadowWouldManual('consequential')).toBe('require_approval');
+    expect(shadowWouldManual('critical')).toBe('require_approval');
+  });
+});
+
+describe('shadow would (auto simulation)', () => {
+  it('routine and consequential allow; critical requires approval', () => {
+    expect(shadowWouldAuto('routine')).toBe('allow');
+    expect(shadowWouldAuto('consequential')).toBe('allow');
+    expect(shadowWouldAuto('critical')).toBe('require_approval');
+  });
+});
+
+describe('evaluateShadow', () => {
+  afterEach(() => {
+    delete process.env.REVDEV_PERMISSION_SHADOW_AS;
+  });
+
+  it('ping is routine would_allow under default manual shadow-as', () => {
+    const r = evaluateShadow('ping');
+    expect(r.actionClass).toBe('routine');
+    expect(r.would).toBe('allow');
+    expect(r.eventType).toBe('permission.would_allow');
+  });
+
+  it('git.push is critical would_require_approval under manual shadow-as', () => {
+    process.env.REVDEV_PERMISSION_SHADOW_AS = 'manual';
+    const r = evaluateShadow('git.push');
+    expect(r.actionClass).toBe('critical');
+    expect(r.would).toBe('require_approval');
+    expect(r.eventType).toBe('permission.would_require_approval');
+  });
+
+  it('file.write is consequential allow under auto shadow-as', () => {
+    process.env.REVDEV_PERMISSION_SHADOW_AS = 'auto';
+    const r = evaluateShadow('file.write');
+    expect(r.actionClass).toBe('consequential');
+    expect(r.would).toBe('allow');
+    expect(r.eventType).toBe('permission.would_allow');
+  });
+
+  it('agent.spawn is critical require_approval even under auto shadow-as', () => {
+    process.env.REVDEV_PERMISSION_SHADOW_AS = 'auto';
+    const r = evaluateShadow('agent.spawn');
+    expect(r.actionClass).toBe('critical');
+    expect(r.would).toBe('require_approval');
+  });
+});
+
+describe('owner-countersigned judgment calls', () => {
+  it('git.pull is consequential (not critical)', () => {
+    expect(classifyMethod('git.pull')).toBe('consequential');
+  });
+  it('git.deleteBranch is consequential; git.discardFile is critical', () => {
+    expect(classifyMethod('git.deleteBranch')).toBe('consequential');
+    expect(classifyMethod('git.discardFile')).toBe('critical');
+  });
+  it('agent.input is consequential; agent.stop is routine', () => {
+    expect(classifyMethod('agent.input')).toBe('consequential');
+    expect(classifyMethod('agent.stop')).toBe('routine');
+  });
+  it('memory.store is routine', () => {
+    expect(classifyMethod('memory.store')).toBe('routine');
+  });
+});

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -38,7 +38,7 @@ import './agent.js';
 // Must come AFTER ./agent.js (stubs) so the real implementations overwrite them.
 import './spawn.js';
 import { DAEMON_DEFAULTS } from './config.js';
-import { LicenseConfigError, LicenseExpiredError, LICENSE_TIER_HELP } from './license.js';
+import { LICENSE_TIER_HELP, LicenseConfigError, LicenseExpiredError } from './license.js';
 import { startDaemon } from './server.js';
 
 // Default log path for --detach mode. Use the user's data dir (mode 0700,

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -151,7 +151,10 @@ export interface PermissionShadowResult {
   actionClass: ActionClass;
   would: ShadowWould;
   simulatedMode: 'manual' | 'auto';
-  eventType: 'permission.would_allow' | 'permission.would_require_approval' | 'permission.would_deny';
+  eventType:
+    | 'permission.would_allow'
+    | 'permission.would_require_approval'
+    | 'permission.would_deny';
 }
 
 export function evaluateShadow(

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -1,0 +1,221 @@
+/**
+ * Permission modes — action-class map + shadow gate (GAP-294 Phase 0).
+ *
+ * Spec: `.jv` docs/gap-specs/GAP-294-permission-modes-design.md §5 / §10.
+ *
+ * Phase 0 (this module): classify every RPC and emit `permission.would_*`
+ * audit events. NEVER blocks. Unmapped methods fail closed to `critical`.
+ *
+ * Manual/auto enforcement (pending_approvals, -32004) is Phase 1+.
+ */
+
+import type { PGlite } from '@electric-sql/pglite';
+import { RPC_METHODS } from '@revdev/protocol';
+import { createLogger } from '@revealui/utils/logger';
+
+const log = createLogger({ service: 'revdev-daemon/permission' });
+
+export type ActionClass = 'routine' | 'consequential' | 'critical';
+export type PermissionMode = 'shadow' | 'manual' | 'auto' | 'agent-scoped';
+export type ShadowWould = 'allow' | 'require_approval' | 'deny';
+
+/**
+ * Explicit method → action class. No wildcards. Unmapped → critical (I2).
+ * Authority: GAP-294 design §5 (owner countersigned 2026-07-18).
+ */
+export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
+  // routine
+  ['ping', 'routine'],
+  ['session.register', 'routine'],
+  ['session.attach', 'routine'],
+  ['session.list', 'routine'],
+  ['session.update', 'routine'],
+  ['mail.send', 'routine'],
+  ['mail.broadcast', 'routine'],
+  ['mail.inbox', 'routine'],
+  ['mail.markRead', 'routine'],
+  ['files.reserve', 'routine'],
+  ['files.check', 'routine'],
+  ['files.release', 'routine'],
+  ['files.list', 'routine'],
+  ['tasks.create', 'routine'],
+  ['tasks.claim', 'routine'],
+  ['tasks.complete', 'routine'],
+  ['tasks.release', 'routine'],
+  ['tasks.list', 'routine'],
+  ['events.log', 'routine'],
+  ['events.query', 'routine'],
+  ['memory.store', 'routine'],
+  ['memory.query', 'routine'],
+  ['harness.health', 'routine'],
+  ['inference.status', 'routine'],
+  ['inference.chat', 'routine'],
+  ['inference.generate', 'routine'],
+  ['file.read', 'routine'],
+  ['file.stat', 'routine'],
+  ['git.status', 'routine'],
+  ['git.diffFile', 'routine'],
+  ['git.diffContent', 'routine'],
+  ['git.readBlobAtHead', 'routine'],
+  ['git.readBlobAtIndex', 'routine'],
+  ['git.listBranches', 'routine'],
+  ['git.log', 'routine'],
+  ['worktree.list', 'routine'],
+  ['merge.status', 'routine'],
+  ['merge.list', 'routine'],
+  ['agent.output', 'routine'],
+  ['agent.resize', 'routine'],
+  ['agent.stop', 'routine'],
+  ['agent.list', 'routine'],
+  // consequential
+  ['file.write', 'consequential'],
+  ['file.delete', 'consequential'],
+  ['git.stageFile', 'consequential'],
+  ['git.unstageFile', 'consequential'],
+  ['git.createBranch', 'consequential'],
+  ['git.switchBranch', 'consequential'],
+  ['git.deleteBranch', 'consequential'],
+  ['git.commit', 'consequential'],
+  ['git.pull', 'consequential'],
+  ['worktree.create', 'consequential'],
+  ['agent.input', 'consequential'],
+  ['merge.request', 'consequential'],
+  ['merge.update', 'consequential'],
+  ['agent.remove', 'consequential'],
+  // critical
+  ['agent.spawn', 'critical'],
+  ['git.push', 'critical'],
+  ['git.discardFile', 'critical'],
+  ['project.open', 'critical'],
+  ['project.grant', 'critical'],
+  ['project.revoke', 'critical'],
+  ['worktree.remove', 'critical'],
+  ['harness.prune', 'critical'],
+  ['identity.rotate', 'critical'],
+  ['session.end', 'critical'],
+  ['inference.pull', 'critical'],
+  ['inference.delete', 'critical'],
+  ['inference.start', 'critical'],
+  ['inference.stop', 'critical'],
+  // future gate controls (not registered yet — mapped for enumeration honesty)
+  ['permission.pending', 'routine'],
+  ['permission.decide', 'critical'],
+  ['permission.setMode', 'critical'],
+]);
+
+/** Fail closed: unmapped method is critical (spec §5 / I2). */
+export function classifyMethod(method: string): ActionClass {
+  return METHOD_ACTION_CLASS.get(method) ?? 'critical';
+}
+
+/**
+ * Shadow simulation of **manual** mode (most interesting observation):
+ * routine → allow; consequential/critical → would require approval.
+ * Deny is reserved for auto deny-list (not wired in Phase 0).
+ */
+export function shadowWouldManual(actionClass: ActionClass): ShadowWould {
+  if (actionClass === 'routine') return 'allow';
+  return 'require_approval';
+}
+
+/**
+ * Shadow simulation of **auto** mode (deterministic policy without root probe):
+ * routine → allow; consequential → allow (real root check is handler-side);
+ * critical → require_approval (policy floor).
+ */
+export function shadowWouldAuto(actionClass: ActionClass): ShadowWould {
+  if (actionClass === 'critical') return 'require_approval';
+  return 'allow';
+}
+
+export function resolvePermissionMode(env: NodeJS.ProcessEnv = process.env): PermissionMode {
+  const raw = (env.REVDEV_PERMISSION_MODE ?? '').trim().toLowerCase();
+  if (raw === 'manual' || raw === 'auto' || raw === 'agent-scoped' || raw === 'shadow') {
+    return raw;
+  }
+  // Unset / unknown → shadow (Phase 0 default; never blocks).
+  return 'shadow';
+}
+
+/**
+ * Which mode the shadow *simulates* for would_* rows when running in shadow.
+ * Defaults to manual (highest-friction observation). Override with
+ * REVDEV_PERMISSION_SHADOW_AS=auto.
+ */
+export function resolveShadowAs(env: NodeJS.ProcessEnv = process.env): 'manual' | 'auto' {
+  const raw = (env.REVDEV_PERMISSION_SHADOW_AS ?? 'manual').trim().toLowerCase();
+  return raw === 'auto' ? 'auto' : 'manual';
+}
+
+export interface PermissionShadowResult {
+  actionClass: ActionClass;
+  would: ShadowWould;
+  simulatedMode: 'manual' | 'auto';
+  eventType: 'permission.would_allow' | 'permission.would_require_approval' | 'permission.would_deny';
+}
+
+export function evaluateShadow(
+  method: string,
+  env: NodeJS.ProcessEnv = process.env,
+): PermissionShadowResult {
+  const actionClass = classifyMethod(method);
+  const simulatedMode = resolveShadowAs(env);
+  const would =
+    simulatedMode === 'auto' ? shadowWouldAuto(actionClass) : shadowWouldManual(actionClass);
+  const eventType =
+    would === 'allow'
+      ? 'permission.would_allow'
+      : would === 'deny'
+        ? 'permission.would_deny'
+        : 'permission.would_require_approval';
+  return { actionClass, would, simulatedMode, eventType };
+}
+
+/**
+ * Best-effort audit insert. Never throws into the RPC path.
+ */
+export function emitPermissionShadowEvent(
+  db: PGlite,
+  agentId: string | null,
+  method: string,
+  result: PermissionShadowResult,
+): void {
+  const payload = {
+    method,
+    actionClass: result.actionClass,
+    would: result.would,
+    simulatedMode: result.simulatedMode,
+    gateMode: 'shadow',
+  };
+  void db
+    .query(`INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`, [
+      agentId ?? 'anonymous',
+      result.eventType,
+      JSON.stringify(payload),
+    ])
+    .catch((err: unknown) => {
+      log.warn('permission shadow event write failed', {
+        method,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+}
+
+/**
+ * Methods that MUST appear in METHOD_ACTION_CLASS for the contract test:
+ * every RPC_METHODS value plus dispatch-only extras.
+ */
+export function expectedClassifiedMethods(): string[] {
+  const fromProtocol = Object.values(RPC_METHODS) as string[];
+  // identity.rotate is in RPC_METHODS; permission.* are future.
+  const extras = ['permission.pending', 'permission.decide', 'permission.setMode'];
+  return [...new Set([...fromProtocol, ...extras])].sort();
+}
+
+/** True when the live gate must not block (Phase 0: always, or explicit shadow). */
+export function isShadowOnly(env: NodeJS.ProcessEnv = process.env): boolean {
+  const mode = resolvePermissionMode(env);
+  // Phase 0: even if someone sets manual/auto, we still only shadow until
+  // Phase 1 enforcement ships. Hard-code true for this PR; Phase 1 flips.
+  return mode === 'shadow' || mode === 'manual' || mode === 'auto' || mode === 'agent-scoped';
+}

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -57,6 +57,7 @@ import {
   syncTaskRelease,
 } from './neon.js';
 import { initObservability, onConnect, onDisconnect, trackRpcCall } from './observability.js';
+import { emitPermissionShadowEvent, evaluateShadow } from './permission.js';
 import { revvaultSet } from './revvault-client.js';
 import { initSessionChecks, runSessionChecks } from './session-checks/index.js';
 import { migrate } from './storage/migrate.js';
@@ -2062,6 +2063,19 @@ export async function startDaemon(
             })}\n`,
           );
           continue;
+        }
+
+        // Permission gate (GAP-294 Phase 0 SHADOW). After identity, before
+        // shutdown/dispatch. Classifies the method and emits permission.would_*
+        // events; NEVER blocks. Phase 1+ will refuse with -32004 here.
+        {
+          const shadow = evaluateShadow(req.method);
+          const agentForEvent =
+            ctx.agentId ??
+            (req.params && typeof req.params.actorAgentId === 'string'
+              ? req.params.actorAgentId
+              : null);
+          emitPermissionShadowEvent(db, agentForEvent, req.method, shadow);
         }
 
         // Shutdown gate. close() sets _closing BEFORE the drain so a


### PR DESCRIPTION
## Summary

INIT-002 Phase 2 start / **GAP-294 §10 Phase 0 (SHADOW)**:

- New `packages/daemon/src/permission.ts` with explicit `METHOD_ACTION_CLASS` (owner-countersigned taxonomy)
- Dispatch seam: after identity gate, before shutdown — classify + emit `permission.would_*` to `events`
- **Never blocks** (no -32004 yet)
- `REVDEV_PERMISSION_SHADOW_AS=manual|auto` (default `manual`) controls which policy is simulated
- Unit tests: full `RPC_METHODS` coverage, judgment-call locks, shadow would_* matrix

## Out of scope (next PRs)
- `pending_approvals` table + `-32004` + `permission.pending/decide` (Phase 1)
- Studio approval UI (Phase 2)
- Owner default flip (Phase 3)

## Test plan
- [x] `vitest` permission + rpc-contract (15 pass)
- [ ] CI green
- [ ] After merge: soak on live daemon; query `events` for `permission.would_%`