### PR TITLE
feat(daemon): GAP-294 Phase 1 manual/auto permission queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+### Added
+
+- **GAP-294 Phase 0 permission shadow gate.** Every RPC is classified
+  (`routine` / `consequential` / `critical` per owner-countersigned map) and
+  emits `permission.would_allow` / `permission.would_require_approval` events
+  without blocking. Simulated mode via `REVDEV_PERMISSION_SHADOW_AS=manual|auto`
+  (default manual). Enforcement (-32004 queue) is Phase 1.
+
 ### Fixed
 
 - **CLI / free-mode license help honesty.** Tier help is sourced from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ Dates are ISO 8601 (UTC).
   (`routine` / `consequential` / `critical` per owner-countersigned map) and
   emits `permission.would_allow` / `permission.would_require_approval` events
   without blocking. Simulated mode via `REVDEV_PERMISSION_SHADOW_AS=manual|auto`
-  (default manual). Enforcement (-32004 queue) is Phase 1.
+  (default manual).
+- **GAP-294 Phase 1 manual/auto enforce (headless).** With
+  `REVDEV_PERMISSION_MODE=manual|auto`, consequential/critical calls get
+  reject-with-receipt (`-32004`, `pending_approvals` queue). `permission.pending`
+  + signed `permission.decide` (no self-approval). Migration 0007. Default remains
+  shadow until the operator sets the env.
 
 ### Fixed
 

--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -100,6 +100,8 @@ pub fn requires_signature(method: &str) -> bool {
             // (`staleDays: 0` selects `started_at < NOW()`). GAP-312.
             // MUST mirror server.ts MUTATING_OR_CONTENT_METHODS.
             | "harness.prune"
+            // GAP-294 Phase 1 — approval decisions are signature-required.
+            | "permission.decide"
     )
 }
 
@@ -627,10 +629,13 @@ mod tests {
         assert!(requires_signature("session.end"));
         // GAP-312: same eviction primitive as session.end, fleet-wide fan-out.
         assert!(requires_signature("harness.prune"));
+        // GAP-294 Phase 1.
+        assert!(requires_signature("permission.decide"));
         assert!(!requires_signature("ping"));
         assert!(!requires_signature("session.list"));
         // harness.health is a read; it stays unsigned. Guards against a
         // copy-paste that gates the wrong half of the harness.* surface.
         assert!(!requires_signature("harness.health"));
+        assert!(!requires_signature("permission.pending"));
     }
 }

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -380,7 +380,9 @@ server.tool(
   {
     repoPath: z
       .string()
-      .describe('Absolute path of a root opened via project.open that this agent owns or was granted'),
+      .describe(
+        'Absolute path of a root opened via project.open that this agent owns or was granted',
+      ),
     branch: z.string().describe('Branch name for the worktree'),
     baseBranch: z.string().optional().describe('Base branch (default: main)'),
   },

--- a/packages/daemon/src/__tests__/permission.test.ts
+++ b/packages/daemon/src/__tests__/permission.test.ts
@@ -5,6 +5,7 @@ import { RPC_METHODS } from '@revdev/protocol';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   classifyMethod,
+  decideEnforcement,
   evaluateShadow,
   expectedClassifiedMethods,
   METHOD_ACTION_CLASS,
@@ -102,5 +103,32 @@ describe('owner-countersigned judgment calls', () => {
   });
   it('memory.store is routine', () => {
     expect(classifyMethod('memory.store')).toBe('routine');
+  });
+});
+
+describe('decideEnforcement (Phase 1)', () => {
+  afterEach(() => {
+    delete process.env.REVDEV_PERMISSION_MODE;
+    delete process.env.REVDEV_PERMISSION_DENY_METHODS;
+  });
+
+  it('shadow mode is not used by decideEnforcement callers for block', () => {
+    // decideEnforcement under manual requires approval for critical
+    const d = decideEnforcement('git.push', 'manual');
+    expect(d.action).toBe('require_approval');
+  });
+
+  it('manual allows routine', () => {
+    expect(decideEnforcement('ping', 'manual').action).toBe('allow');
+  });
+
+  it('auto allows consequential and requires approval for critical', () => {
+    expect(decideEnforcement('file.write', 'auto').action).toBe('allow');
+    expect(decideEnforcement('agent.spawn', 'auto').action).toBe('require_approval');
+  });
+
+  it('deny-list absorbs', () => {
+    process.env.REVDEV_PERMISSION_DENY_METHODS = 'git.pull,file.write';
+    expect(decideEnforcement('git.pull', 'auto').action).toBe('deny');
   });
 });

--- a/packages/daemon/src/__tests__/permission.test.ts
+++ b/packages/daemon/src/__tests__/permission.test.ts
@@ -1,0 +1,106 @@
+/**
+ * GAP-294 Phase 0 — action-class map + shadow evaluation.
+ */
+import { RPC_METHODS } from '@revdev/protocol';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  classifyMethod,
+  evaluateShadow,
+  expectedClassifiedMethods,
+  METHOD_ACTION_CLASS,
+  shadowWouldAuto,
+  shadowWouldManual,
+} from '../permission.js';
+
+describe('METHOD_ACTION_CLASS coverage', () => {
+  it('classifies every RPC_METHODS value', () => {
+    for (const method of Object.values(RPC_METHODS)) {
+      expect(
+        METHOD_ACTION_CLASS.has(method),
+        `RPC method ${method} missing from METHOD_ACTION_CLASS`,
+      ).toBe(true);
+    }
+  });
+
+  it('classifies expectedClassifiedMethods without gaps for protocol set', () => {
+    const expected = new Set(expectedClassifiedMethods());
+    for (const method of Object.values(RPC_METHODS)) {
+      expect(expected.has(method)).toBe(true);
+    }
+  });
+
+  it('unmapped method fails closed to critical', () => {
+    expect(classifyMethod('totally.unknown.method')).toBe('critical');
+  });
+});
+
+describe('shadow would (manual simulation)', () => {
+  it('routine allows', () => {
+    expect(shadowWouldManual('routine')).toBe('allow');
+  });
+  it('consequential and critical require approval', () => {
+    expect(shadowWouldManual('consequential')).toBe('require_approval');
+    expect(shadowWouldManual('critical')).toBe('require_approval');
+  });
+});
+
+describe('shadow would (auto simulation)', () => {
+  it('routine and consequential allow; critical requires approval', () => {
+    expect(shadowWouldAuto('routine')).toBe('allow');
+    expect(shadowWouldAuto('consequential')).toBe('allow');
+    expect(shadowWouldAuto('critical')).toBe('require_approval');
+  });
+});
+
+describe('evaluateShadow', () => {
+  afterEach(() => {
+    delete process.env.REVDEV_PERMISSION_SHADOW_AS;
+  });
+
+  it('ping is routine would_allow under default manual shadow-as', () => {
+    const r = evaluateShadow('ping');
+    expect(r.actionClass).toBe('routine');
+    expect(r.would).toBe('allow');
+    expect(r.eventType).toBe('permission.would_allow');
+  });
+
+  it('git.push is critical would_require_approval under manual shadow-as', () => {
+    process.env.REVDEV_PERMISSION_SHADOW_AS = 'manual';
+    const r = evaluateShadow('git.push');
+    expect(r.actionClass).toBe('critical');
+    expect(r.would).toBe('require_approval');
+    expect(r.eventType).toBe('permission.would_require_approval');
+  });
+
+  it('file.write is consequential allow under auto shadow-as', () => {
+    process.env.REVDEV_PERMISSION_SHADOW_AS = 'auto';
+    const r = evaluateShadow('file.write');
+    expect(r.actionClass).toBe('consequential');
+    expect(r.would).toBe('allow');
+    expect(r.eventType).toBe('permission.would_allow');
+  });
+
+  it('agent.spawn is critical require_approval even under auto shadow-as', () => {
+    process.env.REVDEV_PERMISSION_SHADOW_AS = 'auto';
+    const r = evaluateShadow('agent.spawn');
+    expect(r.actionClass).toBe('critical');
+    expect(r.would).toBe('require_approval');
+  });
+});
+
+describe('owner-countersigned judgment calls', () => {
+  it('git.pull is consequential (not critical)', () => {
+    expect(classifyMethod('git.pull')).toBe('consequential');
+  });
+  it('git.deleteBranch is consequential; git.discardFile is critical', () => {
+    expect(classifyMethod('git.deleteBranch')).toBe('consequential');
+    expect(classifyMethod('git.discardFile')).toBe('critical');
+  });
+  it('agent.input is consequential; agent.stop is routine', () => {
+    expect(classifyMethod('agent.input')).toBe('consequential');
+    expect(classifyMethod('agent.stop')).toBe('routine');
+  });
+  it('memory.store is routine', () => {
+    expect(classifyMethod('memory.store')).toBe('routine');
+  });
+});

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -67,6 +67,8 @@ const SIGNED = [
   // harness.prune reaches the same eviction primitive as session.end but fans
   // it across every matched session. Was unsigned + identity-exempt (GAP-312).
   'harness.prune',
+  // GAP-294 Phase 1: approval decisions are signature-required mutations.
+  'permission.decide',
 ];
 
 // Only payload-free, repo-agnostic coordination methods stay signature-OPTIONAL.

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -38,7 +38,7 @@ import './agent.js';
 // Must come AFTER ./agent.js (stubs) so the real implementations overwrite them.
 import './spawn.js';
 import { DAEMON_DEFAULTS } from './config.js';
-import { LicenseConfigError, LicenseExpiredError, LICENSE_TIER_HELP } from './license.js';
+import { LICENSE_TIER_HELP, LicenseConfigError, LicenseExpiredError } from './license.js';
 import { startDaemon } from './server.js';
 
 // Default log path for --detach mode. Use the user's data dir (mode 0700,

--- a/packages/daemon/src/migrations/0007-permission-approvals.ts
+++ b/packages/daemon/src/migrations/0007-permission-approvals.ts
@@ -1,0 +1,38 @@
+/**
+ * Migration 0007 — permission modes Phase 1 (GAP-294).
+ *
+ * - pending_approvals queue for reject-with-receipt manual mode
+ * - optional per-session permission_mode override on agent_sessions
+ */
+
+import type { Migration } from '../storage/migrate.js';
+
+const SQL = `
+  CREATE TABLE IF NOT EXISTS pending_approvals (
+    id            TEXT PRIMARY KEY,
+    agent_id      TEXT NOT NULL,
+    method        TEXT NOT NULL,
+    params_hash   TEXT NOT NULL,
+    summary       TEXT NOT NULL DEFAULT '',
+    requested_at  TIMESTAMP NOT NULL DEFAULT NOW(),
+    expires_at    TIMESTAMP NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'pending',
+    decided_by    TEXT,
+    decided_at    TIMESTAMP
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_pending_approvals_agent_status
+    ON pending_approvals (agent_id, status, expires_at);
+
+  CREATE INDEX IF NOT EXISTS idx_pending_approvals_consume
+    ON pending_approvals (agent_id, method, params_hash, status);
+
+  ALTER TABLE agent_sessions
+    ADD COLUMN IF NOT EXISTS permission_mode TEXT;
+`;
+
+export const MIGRATION_0007: Migration = {
+  version: 7,
+  name: 'permission-approvals',
+  sql: SQL,
+};

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -22,6 +22,7 @@ import { MIGRATION_0003 } from './0003-project-roots.js';
 import { MIGRATION_0004 } from './0004-agent-processes.js';
 import { MIGRATION_0005 } from './0005-session-activity-state.js';
 import { MIGRATION_0006 } from './0006-agent-process-confinement.js';
+import { MIGRATION_0007 } from './0007-permission-approvals.js';
 
 export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0001,
@@ -30,4 +31,5 @@ export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0004,
   MIGRATION_0005,
   MIGRATION_0006,
+  MIGRATION_0007,
 ];

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -1,19 +1,29 @@
 /**
- * Permission modes — action-class map + shadow gate (GAP-294 Phase 0).
+ * Permission modes — action-class map + shadow/enforce gate (GAP-294).
  *
- * Spec: `.jv` docs/gap-specs/GAP-294-permission-modes-design.md §5 / §10.
+ * Spec: `.jv` docs/gap-specs/GAP-294-permission-modes-design.md §5–§10.
  *
- * Phase 0 (this module): classify every RPC and emit `permission.would_*`
- * audit events. NEVER blocks. Unmapped methods fail closed to `critical`.
- *
- * Manual/auto enforcement (pending_approvals, -32004) is Phase 1+.
+ * Phase 0: classify + `permission.would_*` events (never blocks when mode=shadow).
+ * Phase 1: manual/auto enforcement with pending_approvals + -32004 reject-with-receipt.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { PGlite } from '@electric-sql/pglite';
 import { RPC_METHODS } from '@revdev/protocol';
 import { createLogger } from '@revealui/utils/logger';
+import { hashParams } from './agent-identity-crypto.js';
 
 const log = createLogger({ service: 'revdev-daemon/permission' });
+
+/** Spec §6 — approval-required (shares code with untrusted-client; data.kind distinguishes). */
+export const APPROVAL_REQUIRED_CODE = -32004;
+
+/** Pending request TTL (ms). */
+export const PENDING_TTL_MS = 30 * 60 * 1000;
+/** Approved-but-unconsumed TTL (ms). */
+export const APPROVAL_CONSUME_TTL_MS = 5 * 60 * 1000;
+/** Max pending rows per agent. */
+export const MAX_PENDING_PER_AGENT = 10;
 
 export type ActionClass = 'routine' | 'consequential' | 'critical';
 export type PermissionMode = 'shadow' | 'manual' | 'auto' | 'agent-scoped';
@@ -215,10 +225,292 @@ export function expectedClassifiedMethods(): string[] {
   return [...new Set([...fromProtocol, ...extras])].sort();
 }
 
-/** True when the live gate must not block (Phase 0: always, or explicit shadow). */
+/** True when the gate only observes (would_*) and never blocks. */
 export function isShadowOnly(env: NodeJS.ProcessEnv = process.env): boolean {
-  const mode = resolvePermissionMode(env);
-  // Phase 0: even if someone sets manual/auto, we still only shadow until
-  // Phase 1 enforcement ships. Hard-code true for this PR; Phase 1 flips.
-  return mode === 'shadow' || mode === 'manual' || mode === 'auto' || mode === 'agent-scoped';
+  return resolvePermissionMode(env) === 'shadow';
+}
+
+export type EnforceDecision =
+  | { action: 'allow'; reason: 'routine' | 'auto_consequential' | 'consumed_approval' }
+  | { action: 'require_approval'; reason: 'manual' | 'auto_critical' | 'auto_other' }
+  | { action: 'deny'; reason: 'deny_list' };
+
+/**
+ * Live policy for manual/auto (Phase 1). Agent-scoped falls back to manual
+ * until grants ship (spec §9 deferred).
+ */
+export function decideEnforcement(
+  method: string,
+  mode: PermissionMode,
+  env: NodeJS.ProcessEnv = process.env,
+): EnforceDecision {
+  const actionClass = classifyMethod(method);
+  const effective: PermissionMode =
+    mode === 'agent-scoped' ? 'manual' : mode === 'shadow' ? 'shadow' : mode;
+
+  if (effective === 'shadow') {
+    return { action: 'allow', reason: 'routine' };
+  }
+
+  // Deny-list (auto + manual): comma-separated method names in env.
+  const denyRaw = (env.REVDEV_PERMISSION_DENY_METHODS ?? '').trim();
+  if (denyRaw.length > 0) {
+    const deny = new Set(
+      denyRaw
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+    if (deny.has(method)) {
+      return { action: 'deny', reason: 'deny_list' };
+    }
+  }
+
+  if (effective === 'auto') {
+    if (actionClass === 'critical') {
+      return { action: 'require_approval', reason: 'auto_critical' };
+    }
+    if (actionClass === 'consequential') {
+      // Handler-side requireRoot is the real root check; auto allows here.
+      return { action: 'allow', reason: 'auto_consequential' };
+    }
+    return { action: 'allow', reason: 'routine' };
+  }
+
+  // manual
+  if (actionClass === 'routine') {
+    return { action: 'allow', reason: 'routine' };
+  }
+  return { action: 'require_approval', reason: 'manual' };
+}
+
+export function summarizeParams(
+  method: string,
+  params: Record<string, unknown> | undefined,
+): string {
+  if (!params) return method;
+  const pathish =
+    (typeof params.filePath === 'string' && params.filePath) ||
+    (typeof params.repoPath === 'string' && params.repoPath) ||
+    (typeof params.command === 'string' && params.command) ||
+    '';
+  const branch =
+    (typeof params.branch === 'string' && params.branch) ||
+    (typeof params.name === 'string' && params.name) ||
+    '';
+  const bits = [method];
+  if (pathish) bits.push(pathish.slice(0, 120));
+  if (branch) bits.push(branch.slice(0, 64));
+  return bits.join(' ').slice(0, 240);
+}
+
+export class ApprovalRequiredError extends Error {
+  readonly code = APPROVAL_REQUIRED_CODE;
+  readonly data: {
+    kind: 'approval-required';
+    approvalId: string;
+    method: string;
+    expiresAt: string;
+  };
+  constructor(approvalId: string, method: string, expiresAt: Date) {
+    super(`Approval required for ${method}`);
+    this.name = 'ApprovalRequiredError';
+    this.data = {
+      kind: 'approval-required',
+      approvalId,
+      method,
+      expiresAt: expiresAt.toISOString(),
+    };
+  }
+}
+
+/**
+ * Try to consume a matching approved row. Returns true if consumed (caller may proceed).
+ */
+export async function tryConsumeApproval(
+  db: PGlite,
+  agentId: string,
+  method: string,
+  params: Record<string, unknown> | undefined,
+): Promise<boolean> {
+  const paramsHash = hashParams(method, params ?? {});
+  const found = await db.query<{ id: string }>(
+    `SELECT id FROM pending_approvals
+     WHERE agent_id = $1 AND method = $2 AND params_hash = $3
+       AND status = 'approved' AND expires_at > NOW()
+     ORDER BY decided_at DESC NULLS LAST
+     LIMIT 1`,
+    [agentId, method, paramsHash],
+  );
+  const row = found.rows[0];
+  if (!row) return false;
+  const updated = await db.query(
+    `UPDATE pending_approvals SET status = 'consumed'
+     WHERE id = $1 AND status = 'approved'`,
+    [row.id],
+  );
+  // PGlite may not expose rowCount; re-check.
+  const check = await db.query<{ status: string }>(
+    `SELECT status FROM pending_approvals WHERE id = $1`,
+    [row.id],
+  );
+  if (check.rows[0]?.status !== 'consumed') return false;
+  void db.query(`INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`, [
+    agentId,
+    'permission.consumed',
+    JSON.stringify({ approvalId: row.id, method, paramsHash }),
+  ]);
+  void updated;
+  return true;
+}
+
+/**
+ * Queue a pending approval (or refuse if at flood cap). Throws ApprovalRequiredError.
+ */
+export async function queueApprovalRequired(
+  db: PGlite,
+  agentId: string,
+  method: string,
+  params: Record<string, unknown> | undefined,
+): Promise<never> {
+  const pendingCount = await db.query<{ n: string }>(
+    `SELECT COUNT(*)::text AS n FROM pending_approvals
+     WHERE agent_id = $1 AND status = 'pending' AND expires_at > NOW()`,
+    [agentId],
+  );
+  const n = Number(pendingCount.rows[0]?.n ?? '0');
+  if (n >= MAX_PENDING_PER_AGENT) {
+    throw new ApprovalRequiredError('flood-cap', method, new Date(Date.now() + PENDING_TTL_MS));
+  }
+
+  const id = randomUUID();
+  const paramsHash = hashParams(method, params ?? {});
+  const summary = summarizeParams(method, params);
+  const expiresAt = new Date(Date.now() + PENDING_TTL_MS);
+
+  await db.query(
+    `INSERT INTO pending_approvals (id, agent_id, method, params_hash, summary, expires_at, status)
+     VALUES ($1, $2, $3, $4, $5, $6, 'pending')`,
+    [id, agentId, method, paramsHash, summary, expiresAt.toISOString()],
+  );
+
+  // Mark session blocked (best-effort; self-scoped activity).
+  await db.query(
+    `UPDATE agent_sessions
+     SET activity_state = 'blocked', blocked_reason = 'permission', blocked_since = NOW(), updated_at = NOW()
+     WHERE id = $1 AND ended_at IS NULL`,
+    [agentId],
+  );
+
+  void db.query(`INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`, [
+    agentId,
+    'permission.requested',
+    JSON.stringify({ approvalId: id, method, paramsHash, summary }),
+  ]);
+
+  throw new ApprovalRequiredError(id, method, expiresAt);
+}
+
+export async function listPendingApprovals(
+  db: PGlite,
+  agentIdFilter?: string | null,
+): Promise<
+  Array<{
+    id: string;
+    agentId: string;
+    method: string;
+    paramsHash: string;
+    summary: string;
+    requestedAt: string;
+    expiresAt: string;
+    status: string;
+  }>
+> {
+  // Expire stale pending rows opportunistically.
+  await db.query(
+    `UPDATE pending_approvals SET status = 'expired'
+     WHERE status = 'pending' AND expires_at <= NOW()`,
+  );
+
+  const sql = agentIdFilter
+    ? `SELECT id, agent_id, method, params_hash, summary, requested_at, expires_at, status
+       FROM pending_approvals
+       WHERE status = 'pending' AND expires_at > NOW() AND agent_id = $1
+       ORDER BY requested_at ASC`
+    : `SELECT id, agent_id, method, params_hash, summary, requested_at, expires_at, status
+       FROM pending_approvals
+       WHERE status = 'pending' AND expires_at > NOW()
+       ORDER BY requested_at ASC`;
+  const r = await db.query<{
+    id: string;
+    agent_id: string;
+    method: string;
+    params_hash: string;
+    summary: string;
+    requested_at: string;
+    expires_at: string;
+    status: string;
+  }>(sql, agentIdFilter ? [agentIdFilter] : []);
+
+  return r.rows.map((row) => ({
+    id: row.id,
+    agentId: row.agent_id,
+    method: row.method,
+    paramsHash: row.params_hash,
+    summary: row.summary,
+    requestedAt: row.requested_at,
+    expiresAt: row.expires_at,
+    status: row.status,
+  }));
+}
+
+export async function decideApproval(
+  db: PGlite,
+  approvalId: string,
+  verdict: 'approved' | 'denied',
+  deciderAgentId: string,
+): Promise<{ id: string; status: string }> {
+  const row = await db.query<{
+    id: string;
+    agent_id: string;
+    method: string;
+    status: string;
+  }>(`SELECT id, agent_id, method, status FROM pending_approvals WHERE id = $1`, [approvalId]);
+  const found = row.rows[0];
+  if (!found) {
+    throw new Error(`permission.decide: unknown approvalId ${approvalId}`);
+  }
+  if (found.status !== 'pending') {
+    throw new Error(`permission.decide: approval ${approvalId} is ${found.status}, not pending`);
+  }
+  // I4: self-decision structurally impossible.
+  if (deciderAgentId === found.agent_id) {
+    throw new Error('permission.decide: self-approval is not allowed');
+  }
+
+  const consumeExpires = new Date(Date.now() + APPROVAL_CONSUME_TTL_MS);
+  const status = verdict === 'approved' ? 'approved' : 'denied';
+  await db.query(
+    `UPDATE pending_approvals
+     SET status = $2, decided_by = $3, decided_at = NOW(),
+         expires_at = CASE WHEN $2 = 'approved' THEN $4 ELSE expires_at END
+     WHERE id = $1`,
+    [approvalId, status, deciderAgentId, consumeExpires.toISOString()],
+  );
+
+  // Clear blocked state on requester when decided.
+  await db.query(
+    `UPDATE agent_sessions
+     SET activity_state = 'active', blocked_reason = NULL, blocked_since = NULL, updated_at = NOW()
+     WHERE id = $1 AND activity_state = 'blocked' AND blocked_reason = 'permission'`,
+    [found.agent_id],
+  );
+
+  void db.query(`INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`, [
+    found.agent_id,
+    verdict === 'approved' ? 'permission.approved' : 'permission.denied',
+    JSON.stringify({ approvalId, method: found.method, decidedBy: deciderAgentId }),
+  ]);
+
+  return { id: approvalId, status };
 }

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -151,7 +151,10 @@ export interface PermissionShadowResult {
   actionClass: ActionClass;
   would: ShadowWould;
   simulatedMode: 'manual' | 'auto';
-  eventType: 'permission.would_allow' | 'permission.would_require_approval' | 'permission.would_deny';
+  eventType:
+    | 'permission.would_allow'
+    | 'permission.would_require_approval'
+    | 'permission.would_deny';
 }
 
 export function evaluateShadow(

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -1,0 +1,221 @@
+/**
+ * Permission modes — action-class map + shadow gate (GAP-294 Phase 0).
+ *
+ * Spec: `.jv` docs/gap-specs/GAP-294-permission-modes-design.md §5 / §10.
+ *
+ * Phase 0 (this module): classify every RPC and emit `permission.would_*`
+ * audit events. NEVER blocks. Unmapped methods fail closed to `critical`.
+ *
+ * Manual/auto enforcement (pending_approvals, -32004) is Phase 1+.
+ */
+
+import type { PGlite } from '@electric-sql/pglite';
+import { RPC_METHODS } from '@revdev/protocol';
+import { createLogger } from '@revealui/utils/logger';
+
+const log = createLogger({ service: 'revdev-daemon/permission' });
+
+export type ActionClass = 'routine' | 'consequential' | 'critical';
+export type PermissionMode = 'shadow' | 'manual' | 'auto' | 'agent-scoped';
+export type ShadowWould = 'allow' | 'require_approval' | 'deny';
+
+/**
+ * Explicit method → action class. No wildcards. Unmapped → critical (I2).
+ * Authority: GAP-294 design §5 (owner countersigned 2026-07-18).
+ */
+export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
+  // routine
+  ['ping', 'routine'],
+  ['session.register', 'routine'],
+  ['session.attach', 'routine'],
+  ['session.list', 'routine'],
+  ['session.update', 'routine'],
+  ['mail.send', 'routine'],
+  ['mail.broadcast', 'routine'],
+  ['mail.inbox', 'routine'],
+  ['mail.markRead', 'routine'],
+  ['files.reserve', 'routine'],
+  ['files.check', 'routine'],
+  ['files.release', 'routine'],
+  ['files.list', 'routine'],
+  ['tasks.create', 'routine'],
+  ['tasks.claim', 'routine'],
+  ['tasks.complete', 'routine'],
+  ['tasks.release', 'routine'],
+  ['tasks.list', 'routine'],
+  ['events.log', 'routine'],
+  ['events.query', 'routine'],
+  ['memory.store', 'routine'],
+  ['memory.query', 'routine'],
+  ['harness.health', 'routine'],
+  ['inference.status', 'routine'],
+  ['inference.chat', 'routine'],
+  ['inference.generate', 'routine'],
+  ['file.read', 'routine'],
+  ['file.stat', 'routine'],
+  ['git.status', 'routine'],
+  ['git.diffFile', 'routine'],
+  ['git.diffContent', 'routine'],
+  ['git.readBlobAtHead', 'routine'],
+  ['git.readBlobAtIndex', 'routine'],
+  ['git.listBranches', 'routine'],
+  ['git.log', 'routine'],
+  ['worktree.list', 'routine'],
+  ['merge.status', 'routine'],
+  ['merge.list', 'routine'],
+  ['agent.output', 'routine'],
+  ['agent.resize', 'routine'],
+  ['agent.stop', 'routine'],
+  ['agent.list', 'routine'],
+  // consequential
+  ['file.write', 'consequential'],
+  ['file.delete', 'consequential'],
+  ['git.stageFile', 'consequential'],
+  ['git.unstageFile', 'consequential'],
+  ['git.createBranch', 'consequential'],
+  ['git.switchBranch', 'consequential'],
+  ['git.deleteBranch', 'consequential'],
+  ['git.commit', 'consequential'],
+  ['git.pull', 'consequential'],
+  ['worktree.create', 'consequential'],
+  ['agent.input', 'consequential'],
+  ['merge.request', 'consequential'],
+  ['merge.update', 'consequential'],
+  ['agent.remove', 'consequential'],
+  // critical
+  ['agent.spawn', 'critical'],
+  ['git.push', 'critical'],
+  ['git.discardFile', 'critical'],
+  ['project.open', 'critical'],
+  ['project.grant', 'critical'],
+  ['project.revoke', 'critical'],
+  ['worktree.remove', 'critical'],
+  ['harness.prune', 'critical'],
+  ['identity.rotate', 'critical'],
+  ['session.end', 'critical'],
+  ['inference.pull', 'critical'],
+  ['inference.delete', 'critical'],
+  ['inference.start', 'critical'],
+  ['inference.stop', 'critical'],
+  // future gate controls (not registered yet — mapped for enumeration honesty)
+  ['permission.pending', 'routine'],
+  ['permission.decide', 'critical'],
+  ['permission.setMode', 'critical'],
+]);
+
+/** Fail closed: unmapped method is critical (spec §5 / I2). */
+export function classifyMethod(method: string): ActionClass {
+  return METHOD_ACTION_CLASS.get(method) ?? 'critical';
+}
+
+/**
+ * Shadow simulation of **manual** mode (most interesting observation):
+ * routine → allow; consequential/critical → would require approval.
+ * Deny is reserved for auto deny-list (not wired in Phase 0).
+ */
+export function shadowWouldManual(actionClass: ActionClass): ShadowWould {
+  if (actionClass === 'routine') return 'allow';
+  return 'require_approval';
+}
+
+/**
+ * Shadow simulation of **auto** mode (deterministic policy without root probe):
+ * routine → allow; consequential → allow (real root check is handler-side);
+ * critical → require_approval (policy floor).
+ */
+export function shadowWouldAuto(actionClass: ActionClass): ShadowWould {
+  if (actionClass === 'critical') return 'require_approval';
+  return 'allow';
+}
+
+export function resolvePermissionMode(env: NodeJS.ProcessEnv = process.env): PermissionMode {
+  const raw = (env.REVDEV_PERMISSION_MODE ?? '').trim().toLowerCase();
+  if (raw === 'manual' || raw === 'auto' || raw === 'agent-scoped' || raw === 'shadow') {
+    return raw;
+  }
+  // Unset / unknown → shadow (Phase 0 default; never blocks).
+  return 'shadow';
+}
+
+/**
+ * Which mode the shadow *simulates* for would_* rows when running in shadow.
+ * Defaults to manual (highest-friction observation). Override with
+ * REVDEV_PERMISSION_SHADOW_AS=auto.
+ */
+export function resolveShadowAs(env: NodeJS.ProcessEnv = process.env): 'manual' | 'auto' {
+  const raw = (env.REVDEV_PERMISSION_SHADOW_AS ?? 'manual').trim().toLowerCase();
+  return raw === 'auto' ? 'auto' : 'manual';
+}
+
+export interface PermissionShadowResult {
+  actionClass: ActionClass;
+  would: ShadowWould;
+  simulatedMode: 'manual' | 'auto';
+  eventType: 'permission.would_allow' | 'permission.would_require_approval' | 'permission.would_deny';
+}
+
+export function evaluateShadow(
+  method: string,
+  env: NodeJS.ProcessEnv = process.env,
+): PermissionShadowResult {
+  const actionClass = classifyMethod(method);
+  const simulatedMode = resolveShadowAs(env);
+  const would =
+    simulatedMode === 'auto' ? shadowWouldAuto(actionClass) : shadowWouldManual(actionClass);
+  const eventType =
+    would === 'allow'
+      ? 'permission.would_allow'
+      : would === 'deny'
+        ? 'permission.would_deny'
+        : 'permission.would_require_approval';
+  return { actionClass, would, simulatedMode, eventType };
+}
+
+/**
+ * Best-effort audit insert. Never throws into the RPC path.
+ */
+export function emitPermissionShadowEvent(
+  db: PGlite,
+  agentId: string | null,
+  method: string,
+  result: PermissionShadowResult,
+): void {
+  const payload = {
+    method,
+    actionClass: result.actionClass,
+    would: result.would,
+    simulatedMode: result.simulatedMode,
+    gateMode: 'shadow',
+  };
+  void db
+    .query(`INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`, [
+      agentId ?? 'anonymous',
+      result.eventType,
+      JSON.stringify(payload),
+    ])
+    .catch((err: unknown) => {
+      log.warn('permission shadow event write failed', {
+        method,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+}
+
+/**
+ * Methods that MUST appear in METHOD_ACTION_CLASS for the contract test:
+ * every RPC_METHODS value plus dispatch-only extras.
+ */
+export function expectedClassifiedMethods(): string[] {
+  const fromProtocol = Object.values(RPC_METHODS) as string[];
+  // identity.rotate is in RPC_METHODS; permission.* are future.
+  const extras = ['permission.pending', 'permission.decide', 'permission.setMode'];
+  return [...new Set([...fromProtocol, ...extras])].sort();
+}
+
+/** True when the live gate must not block (Phase 0: always, or explicit shadow). */
+export function isShadowOnly(env: NodeJS.ProcessEnv = process.env): boolean {
+  const mode = resolvePermissionMode(env);
+  // Phase 0: even if someone sets manual/auto, we still only shadow until
+  // Phase 1 enforcement ships. Hard-code true for this PR; Phase 1 flips.
+  return mode === 'shadow' || mode === 'manual' || mode === 'auto' || mode === 'agent-scoped';
+}

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -57,7 +57,18 @@ import {
   syncTaskRelease,
 } from './neon.js';
 import { initObservability, onConnect, onDisconnect, trackRpcCall } from './observability.js';
-import { emitPermissionShadowEvent, evaluateShadow } from './permission.js';
+import {
+  ApprovalRequiredError,
+  decideApproval,
+  decideEnforcement,
+  emitPermissionShadowEvent,
+  evaluateShadow,
+  isShadowOnly,
+  listPendingApprovals,
+  queueApprovalRequired,
+  resolvePermissionMode,
+  tryConsumeApproval,
+} from './permission.js';
 import { revvaultSet } from './revvault-client.js';
 import { initSessionChecks, runSessionChecks } from './session-checks/index.js';
 import { migrate } from './storage/migrate.js';
@@ -244,6 +255,9 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   // Cross-language contract: signing.rs requires_signature() must mark this too.
   // GAP-312. Sibling of the session.end fix (GAP-288, revdev#261).
   'harness.prune',
+  // GAP-294 Phase 1: approval decisions are signature-required mutations.
+  // permission.setMode lands with Studio UI (Phase 2).
+  'permission.decide',
 ]);
 
 // ---------------------------------------------------------------------------
@@ -1686,6 +1700,28 @@ registerHandler('harness.prune', async (params, db, ctx) => {
   };
 });
 
+// -- Permission (GAP-294) ----------------------------------------------------
+
+registerHandler('permission.pending', async (params, db, ctx) => {
+  // Read surface: list pending approvals. Optional agentId filter.
+  // Operator tools typically list all; agents may filter to self.
+  const filter =
+    strOrNull(params.agentId) ?? (ctx.agentId && params.scope === 'self' ? ctx.agentId : null);
+  const approvals = await listPendingApprovals(db, filter);
+  return { approvals };
+});
+
+registerHandler('permission.decide', async (params, db, ctx) => {
+  // Signature-required (MUTATING). Self-approval rejected in decideApproval.
+  const decider = await requireVerifiedAgent(ctx, db, params);
+  const approvalId = str(params.approvalId);
+  const verdictRaw = str(params.verdict).toLowerCase();
+  if (verdictRaw !== 'approved' && verdictRaw !== 'denied') {
+    throw new Error("permission.decide: verdict must be 'approved' or 'denied'");
+  }
+  return decideApproval(db, approvalId, verdictRaw, decider);
+});
+
 // -- Memory -----------------------------------------------------------------
 
 registerHandler('memory.store', async (params, db, ctx) => {
@@ -2065,17 +2101,82 @@ export async function startDaemon(
           continue;
         }
 
-        // Permission gate (GAP-294 Phase 0 SHADOW). After identity, before
-        // shutdown/dispatch. Classifies the method and emits permission.would_*
-        // events; NEVER blocks. Phase 1+ will refuse with -32004 here.
+        // Permission gate (GAP-294). After identity, before shutdown/dispatch.
+        // Shadow (default): would_* events only. manual/auto: enforce with
+        // reject-with-receipt (-32004) + pending_approvals queue.
         {
-          const shadow = evaluateShadow(req.method);
           const agentForEvent =
             ctx.agentId ??
             (req.params && typeof req.params.actorAgentId === 'string'
               ? req.params.actorAgentId
               : null);
-          emitPermissionShadowEvent(db, agentForEvent, req.method, shadow);
+          const mode = resolvePermissionMode();
+          if (isShadowOnly()) {
+            emitPermissionShadowEvent(db, agentForEvent, req.method, evaluateShadow(req.method));
+          } else {
+            // Still emit would_* for soak continuity under enforce modes.
+            emitPermissionShadowEvent(db, agentForEvent, req.method, evaluateShadow(req.method));
+            const decision = decideEnforcement(req.method, mode);
+            if (decision.action === 'deny') {
+              socket.write(
+                `${JSON.stringify({
+                  jsonrpc: '2.0',
+                  id: req.id,
+                  error: {
+                    code: -32004,
+                    message: `Permission denied for ${req.method}`,
+                    data: {
+                      kind: 'permission-denied',
+                      method: req.method,
+                      reason: decision.reason,
+                    },
+                  },
+                })}\n`,
+              );
+              continue;
+            }
+            if (decision.action === 'require_approval') {
+              if (!agentForEvent) {
+                socket.write(
+                  `${JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: req.id,
+                    error: {
+                      code: -32002,
+                      message: `Not registered: call session.register before ${req.method}`,
+                    },
+                  })}\n`,
+                );
+                continue;
+              }
+              const paramsObj =
+                req.params && typeof req.params === 'object' && !Array.isArray(req.params)
+                  ? (req.params as Record<string, unknown>)
+                  : {};
+              try {
+                const consumed = await tryConsumeApproval(db, agentForEvent, req.method, paramsObj);
+                if (!consumed) {
+                  await queueApprovalRequired(db, agentForEvent, req.method, paramsObj);
+                }
+              } catch (permErr) {
+                if (permErr instanceof ApprovalRequiredError) {
+                  socket.write(
+                    `${JSON.stringify({
+                      jsonrpc: '2.0',
+                      id: req.id,
+                      error: {
+                        code: permErr.code,
+                        message: permErr.message,
+                        data: permErr.data,
+                      },
+                    })}\n`,
+                  );
+                  continue;
+                }
+                throw permErr;
+              }
+            }
+          }
         }
 
         // Shutdown gate. close() sets _closing BEFORE the drain so a
@@ -2109,6 +2210,7 @@ export async function startDaemon(
           // the JSON-RPC `code` field — those fall back to the generic -32000.
           const rawCode = (err as { code?: unknown }).code;
           const code = typeof rawCode === 'number' ? rawCode : -32000;
+          const data = (err as { data?: unknown }).data;
           socket.write(
             `${JSON.stringify({
               jsonrpc: '2.0',
@@ -2116,6 +2218,7 @@ export async function startDaemon(
               error: {
                 code,
                 message: err instanceof Error ? err.message : 'Internal error',
+                ...(data !== undefined ? { data } : {}),
               },
             })}\n`,
           );

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -57,6 +57,7 @@ import {
   syncTaskRelease,
 } from './neon.js';
 import { initObservability, onConnect, onDisconnect, trackRpcCall } from './observability.js';
+import { emitPermissionShadowEvent, evaluateShadow } from './permission.js';
 import { revvaultSet } from './revvault-client.js';
 import { initSessionChecks, runSessionChecks } from './session-checks/index.js';
 import { migrate } from './storage/migrate.js';
@@ -2062,6 +2063,19 @@ export async function startDaemon(
             })}\n`,
           );
           continue;
+        }
+
+        // Permission gate (GAP-294 Phase 0 SHADOW). After identity, before
+        // shutdown/dispatch. Classifies the method and emits permission.would_*
+        // events; NEVER blocks. Phase 1+ will refuse with -32004 here.
+        {
+          const shadow = evaluateShadow(req.method);
+          const agentForEvent =
+            ctx.agentId ??
+            (req.params && typeof req.params.actorAgentId === 'string'
+              ? req.params.actorAgentId
+              : null);
+          emitPermissionShadowEvent(db, agentForEvent, req.method, shadow);
         }
 
         // Shutdown gate. close() sets _closing BEFORE the drain so a

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -728,4 +728,21 @@ export const schemas: Record<string, z.ZodType> = {
   'git.readBlobAtIndex': z
     .object({ repoPath: safePath, filePath: safePath, actorAgentId })
     .passthrough(),
+
+  // -- Permission (GAP-294) ---------------------------------------------------
+  'permission.pending': z
+    .object({
+      agentId: z.string().max(MAX_NAME_LENGTH).optional(),
+      scope: z.enum(['self', 'all']).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'permission.decide': z
+    .object({
+      approvalId: z.string().min(1).max(MAX_NAME_LENGTH),
+      verdict: z.enum(['approved', 'denied']),
+      actorAgentId,
+    })
+    .passthrough(),
 };

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -113,4 +113,8 @@ export const RPC_METHODS = {
   'merge.status': 'merge.status',
   'merge.list': 'merge.list',
   'merge.update': 'merge.update',
+
+  // Permission modes (GAP-294 Phase 1 — pending/decide; setMode is Phase 2)
+  'permission.pending': 'permission.pending',
+  'permission.decide': 'permission.decide',
 } as const;


### PR DESCRIPTION
## Summary

Stacks on **#303** (Phase 0 shadow). Headless Phase 1 of GAP-294:

| Piece | Detail |
|-------|--------|
| Default | Still **shadow** (no friction until env set) |
| Enforce | `REVDEV_PERMISSION_MODE=manual` or `auto` |
| Manual | routine allow; consequential+critical → `-32004` + queue |
| Auto | critical → queue; consequential allow; deny-list via `REVDEV_PERMISSION_DENY_METHODS` |
| RPCs | `permission.pending`, `permission.decide` (signed, no self-approve) |
| Schema | migration **0007** `pending_approvals` + `agent_sessions.permission_mode` |

## Operator try

```bash
# After merge + restart:
systemctl --user edit revdev-daemon   # or drop-in
# Environment=REVDEV_PERMISSION_MODE=manual
systemctl --user restart revdev-daemon
```

## Test plan
- [x] permission + rpc-contract + signature-gate (58)
- [ ] CI green
- [ ] Security review (guardrail-2) — authz surface

## Not in this PR
- Studio approval UI (`permission.setMode`) — Phase 2
- Owner default flip — Phase 3