### PR TITLE
fix(daemon): GAP-307 tool-use events.log heartbeats session.list

### DIFF
--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -1097,3 +1097,50 @@ describe('GAP-257: session activity-state', () => {
     expect(row?.blocked_reason).toBeFalsy();
   });
 });
+
+// ---------------------------------------------------------------------------
+// GAP-307: tool-use events.log advances session heartbeat (updated_at)
+// ---------------------------------------------------------------------------
+
+describe('GAP-307: events.log tool-use heartbeats session.list active', () => {
+  it('tool-use with payload.sessionId bumps updated_at and restores active', async () => {
+    await seedIdentity('gap307-hb');
+    await db.query(
+      `UPDATE agent_sessions SET updated_at = NOW() - INTERVAL '500 seconds' WHERE id = $1`,
+      ['gap307-hb'],
+    );
+    let row = (await listLocal()).find((s) => s.id === 'gap307-hb');
+    expect(row?.active).toBe(false);
+
+    // track-tools.js shape: actorAgentId + agentId + eventType tool-use + sessionId
+    await rpc(socketPath, 'events.log', {
+      actorAgentId: 'gap307-hb',
+      agentId: 'gap307-hb',
+      eventType: 'tool-use',
+      payload: { tool: 'Bash', sessionId: 'gap307-hb' },
+    });
+
+    // Allow fire-and-forget UPDATE to land
+    await new Promise((r) => setTimeout(r, 50));
+    row = (await listLocal()).find((s) => s.id === 'gap307-hb');
+    expect(row?.active).toBe(true);
+    expect(row?.staleSeconds).toBeLessThan(30);
+  });
+
+  it('non-tool-use events do not revive a stale session', async () => {
+    await seedIdentity('gap307-other');
+    await db.query(
+      `UPDATE agent_sessions SET updated_at = NOW() - INTERVAL '500 seconds' WHERE id = $1`,
+      ['gap307-other'],
+    );
+    await rpc(socketPath, 'events.log', {
+      actorAgentId: 'gap307-other',
+      agentId: 'gap307-other',
+      eventType: 'custom',
+      payload: { sessionId: 'gap307-other' },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    const row = (await listLocal()).find((s) => s.id === 'gap307-other');
+    expect(row?.active).toBe(false);
+  });
+});

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1602,6 +1602,32 @@ registerHandler('events.log', async (params, db, ctx) => {
     eventType,
     JSON.stringify(payload),
   ]);
+  // GAP-307: fold liveness into the existing high-frequency tool-use path.
+  // track-tools.js already logs tool-use after every tool with
+  // payload.sessionId = daemon session id cache. Bump updated_at so
+  // session.list's server-side `active` window reflects real work without a
+  // new RPC or a new hook process.
+  if (eventType === 'tool-use') {
+    const payloadObj =
+      payload && typeof payload === 'object' && !Array.isArray(payload)
+        ? (payload as Record<string, unknown>)
+        : {};
+    const sessionKey =
+      (typeof payloadObj.sessionId === 'string' && payloadObj.sessionId) ||
+      (agentId !== 'anonymous' ? agentId : null);
+    if (sessionKey) {
+      void db
+        .query(
+          `UPDATE agent_sessions
+              SET updated_at = NOW()
+            WHERE id = $1 AND ended_at IS NULL`,
+          [sessionKey],
+        )
+        .catch(() => {
+          /* non-fatal — liveness is best-effort */
+        });
+    }
+  }
   // Best-effort dual-write to coordination_events (GAP-154 Phase 3).
   await syncEventLog({ agentId, type: eventType, payload });
   return { logged: true };


### PR DESCRIPTION
## Summary

GAP-307 residual: fold session liveness into existing **track-tools → events.log tool-use** path.

- On `eventType: tool-use`, bump `agent_sessions.updated_at` for `payload.sessionId` (or agentId)
- No new RPC / no new hook process
- Tests: `coordination.test.ts` GAP-307 cases (37 total green)

Pairs with claude-config hooks PR (unwrap + prefer daemon session id).

## Test plan

- [x] vitest coordination.test.ts
- [ ] CI
- [ ] After merge: rebuild daemon + restart unit; confirm active sessions after tool use