### PR TITLE
docs: refresh MASTER_* entry dates for W3 truth pass

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,7 +1,7 @@
 ---
 type: repo-doc-index
 repo: revdev
-updated: 2026-06-11
+updated: 2026-07-23
 ---
 
 # RevDev — Documentation Index

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -1,14 +1,14 @@
 ---
 type: master-plan
 repo: revdev
-last-updated: 2026-06-11
+last-updated: 2026-07-23
 owner: RevealUI Studio
 staleness-status: FRESH
 ---
 
 # RevDev — Master Plan
 
-**Last Updated:** 2026-06-11
+**Last Updated:** 2026-07-23
 **Status:** Pre-1.0 — Studio + Console + harness daemon all buildable; no public releases yet
 **Owner:** RevealUI Studio (`founder@revealui.com`)
 **Repo:** [RevealUIStudio/revdev](https://github.com/RevealUIStudio/revdev)

--- a/docs/MASTER_SPEC.md
+++ b/docs/MASTER_SPEC.md
@@ -1,14 +1,14 @@
 ---
 type: master-spec
 repo: revdev
-last-updated: 2026-06-11
+last-updated: 2026-07-23
 owner: RevealUI Studio
 staleness-status: FRESH
 ---
 
 # RevDev — Master Spec
 
-**Last Updated:** 2026-06-11
+**Last Updated:** 2026-07-23
 **Status:** Pre-1.0 — daemon production-grade for internal use; Studio + Console builds clean; no public releases
 **Repo:** [RevealUIStudio/revdev](https://github.com/RevealUIStudio/revdev)
 


### PR DESCRIPTION
GAP-407 W3 / **revdev**. Peer-safe (no open revdev PRs; disjoint from revealui VES/fleet-redundancy).

Light DOC-DRIFT: master entry dates. Authoritative detail remains `docs/PLAN.md` (2026-07-21).

Owner: `gh pr merge <N> --repo RevealUIStudio/revdev --squash`