### PR TITLE
fix(studio): US-origin Inference Snap install catalog only

### DIFF
--- a/apps/studio/src-tauri/src/inference.rs
+++ b/apps/studio/src-tauri/src/inference.rs
@@ -204,12 +204,13 @@ pub struct SnapModel {
     pub installed: bool,
 }
 
-/// Known inference snaps from Canonical.
+/// Product Inference Snaps catalog (US-origin allowlist only).
+/// Lockstep with `@revealui/ai` `US_ORIGIN_INFERENCE_SNAP_IDS`.
 const KNOWN_SNAPS: &[(&str, &str)] = &[
-    ("nemotron-3-nano", "General (reasoning + non-reasoning) — free tier default"),
-    ("gemma3", "General + vision — image understanding, multimodal"),
-    ("deepseek-r1", "Reasoning — complex analysis, chain-of-thought"),
-    ("qwen-vl", "Vision-language — document parsing, visual Q&A"),
+    ("nemotron-3-nano", "NVIDIA (US) — general + tools; product default"),
+    ("nemotron-3-nano-omni", "NVIDIA (US) — multimodal (text/image/video/audio)"),
+    ("gemma4", "Google (US) — general + vision + tools"),
+    ("gemma3", "Google (US) — general + vision (allowlisted)"),
 ];
 
 /// Check if a specific inference snap is installed and running.

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -220,22 +220,22 @@ const MOCK_DATA: Record<string, unknown> = {
   inference_snap_list: [
     {
       name: 'nemotron-3-nano',
-      description: 'General (reasoning + non-reasoning) — free tier default',
+      description: 'NVIDIA (US) — general + tools; product default',
+      installed: false,
+    },
+    {
+      name: 'nemotron-3-nano-omni',
+      description: 'NVIDIA (US) — multimodal (text/image/video/audio)',
+      installed: false,
+    },
+    {
+      name: 'gemma4',
+      description: 'Google (US) — general + vision + tools',
       installed: false,
     },
     {
       name: 'gemma3',
-      description: 'General + vision — image understanding, multimodal',
-      installed: false,
-    },
-    {
-      name: 'deepseek-r1',
-      description: 'Reasoning — complex analysis, chain-of-thought',
-      installed: false,
-    },
-    {
-      name: 'qwen-vl',
-      description: 'Vision-language — document parsing, visual Q&A',
+      description: 'Google (US) — general + vision (allowlisted)',
       installed: false,
     },
   ] satisfies SnapModel[],


### PR DESCRIPTION
## Summary

Studio install/list catalog now matches the product US-origin hardline from `@revealui/ai` (revealui#2132):

- `nemotron-3-nano` (default)
- `nemotron-3-nano-omni`
- `gemma4`
- `gemma3`

Removed `deepseek-r1` and `qwen-vl` from Tauri `KNOWN_SNAPS` and the web mock list so the install UI cannot offer non-allowlisted snaps.

## Companion

revealui residual PR: harnesses `InferenceService` + docs/marketing.

## Test plan

- [x] Diff only catalog constants
- [ ] Studio mock list shows four US snaps
- [ ] `inference_snap_install` rejects unknown names (existing allowlist check)