### PR TITLE
fix(daemon): warn once when revvault CLI is missing, not per session

### DIFF
--- a/packages/daemon/src/__tests__/revvault-warn-noise.test.ts
+++ b/packages/daemon/src/__tests__/revvault-warn-noise.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Identity vault-mirror warn dedup — the daemon-noise heartbeat fix.
+ *
+ * Session-keyed identities (GAP-311) mint a fresh keypair on every session
+ * registration, and each registration mirrors it to revvault. On a machine
+ * where the revvault CLI is not on the daemon's PATH (the systemd-user unit),
+ * every registration used to emit the same
+ * "revvault private/public key write failed, reason: cli-not-installed" warn
+ * pair — one pair per heartbeat/session cycle, forever.
+ *
+ * `cli-not-installed` is environmental, not per-agent: warn once per daemon
+ * lifetime, then skip further vault-write attempts until restart. Real
+ * `cli-failure` results keep their per-agent warns.
+ *
+ * @vitest-environment node
+ */
+import { vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+// Capture warns without a real logger. Only createLogger is stubbed; every
+// other logger export keeps its real implementation.
+const { warnCalls } = vi.hoisted(() => ({
+  warnCalls: [] as Array<{ msg: string; meta: unknown }>,
+}));
+vi.mock('@revealui/utils/logger', async (importActual) => {
+  const actual = await importActual<typeof import('@revealui/utils/logger')>();
+  const stub = (): Record<string, unknown> => ({
+    debug() {},
+    info() {},
+    error() {},
+    fatal() {},
+    warn(msg: string, meta?: unknown) {
+      warnCalls.push({ msg, meta });
+    },
+    child() {
+      return stub();
+    },
+  });
+  return { ...actual, createLogger: () => stub() };
+});
+
+// Force the environmental failure deterministically (and keep the suite from
+// ever spawning a real `revvault set` on a developer machine).
+const { revvaultSetMock } = vi.hoisted(() => ({
+  revvaultSetMock: vi.fn(async () => ({
+    ok: false as const,
+    reason: 'cli-not-installed' as const,
+  })),
+}));
+vi.mock('../revvault-client.js', async (importActual) => {
+  const actual = await importActual<typeof import('../revvault-client.js')>();
+  return { ...actual, revvaultSet: revvaultSetMock };
+});
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { startDaemon } from '../server.js';
+
+function rpc(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown> = {},
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
+    sock.on('connect', () => sock.write(req));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      const line = buf.slice(0, nl);
+      sock.end();
+      try {
+        const resp = JSON.parse(line);
+        if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
+        else resolve(resp.result);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error(`RPC timeout: ${method}`));
+    });
+  });
+}
+
+let dataDir: string;
+let socketPath: string;
+let close: () => Promise<void>;
+let originalLicenseKey: string | undefined;
+
+beforeAll(async () => {
+  const { generateTestLicense, setTestLicenseEnv } = await import('./test-license-helper.js');
+  originalLicenseKey = process.env.REVEALUI_LICENSE_KEY;
+  setTestLicenseEnv(generateTestLicense('enterprise'));
+  dataDir = await mkdtemp(join(tmpdir(), 'revdev-vaultwarn-'));
+  socketPath = join(dataDir, 'harness.sock');
+  const d = await startDaemon({ socketPath, dataDir });
+  close = d.close;
+});
+
+afterAll(async () => {
+  await close?.();
+  await rm(dataDir, { recursive: true, force: true });
+  if (originalLicenseKey === undefined) {
+    delete process.env.REVEALUI_LICENSE_KEY;
+  } else {
+    process.env.REVEALUI_LICENSE_KEY = originalLicenseKey;
+  }
+  const { clearTestLicenseEnv } = await import('./test-license-helper.js');
+  clearTestLicenseEnv();
+});
+
+describe('revvault cli-not-installed warn dedup', () => {
+  it('warns once across repeated session registrations, then skips vault writes', async () => {
+    await rpc(socketPath, 'session.register', {
+      agentName: 'noisy-one',
+      workDir: '/tmp/noisy-one',
+      backend: 'test',
+    });
+    await rpc(socketPath, 'session.register', {
+      agentName: 'noisy-two',
+      workDir: '/tmp/noisy-two',
+      backend: 'test',
+    });
+    await rpc(socketPath, 'session.register', {
+      agentName: 'noisy-three',
+      workDir: '/tmp/noisy-three',
+      backend: 'test',
+    });
+
+    const vaultWarns = warnCalls.filter((c) => c.msg.includes('revvault'));
+    expect(vaultWarns).toHaveLength(1);
+    expect(vaultWarns[0]?.msg).toContain('suppressing further warnings');
+
+    // First registration attempts the private-key write, hits the missing
+    // CLI, and no further spawn is attempted for it or any later session.
+    expect(revvaultSetMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1024,17 +1024,33 @@ async function registerClientIdentity(
   return { did, publicKeyPem };
 }
 
+// `cli-not-installed` is an environmental condition of the daemon's unit
+// (revvault not on PATH), not a per-agent fault. Session-keyed identities
+// (GAP-311) mint a fresh keypair per session, so without dedup every session
+// registration re-emits the same warn pair for the daemon's whole lifetime.
+// Warn once, then skip further vault writes until restart.
+let revvaultCliMissing = false;
+
 function persistIdentityToRevvault(
   agentId: string,
   privateKeyPem: string,
   publicKeyPem: string,
 ): Promise<void> {
   return (async () => {
+    if (revvaultCliMissing) return;
     const setPriv = await revvaultSet(
       `revdev/agents/${agentId}/identity/ed25519-private`,
       privateKeyPem,
     );
     if (!setPriv.ok) {
+      if (setPriv.reason === 'cli-not-installed') {
+        revvaultCliMissing = true;
+        log.warn(
+          'revvault CLI not installed — agent identity keys will not be mirrored to revvault; suppressing further warnings (restart the daemon after installing revvault)',
+          { agentId },
+        );
+        return;
+      }
       log.warn('revvault private key write failed', { agentId, reason: setPriv.reason });
     }
     const setPub = await revvaultSet(
@@ -1042,6 +1058,14 @@ function persistIdentityToRevvault(
       publicKeyPem,
     );
     if (!setPub.ok) {
+      if (setPub.reason === 'cli-not-installed') {
+        revvaultCliMissing = true;
+        log.warn(
+          'revvault CLI not installed — agent identity keys will not be mirrored to revvault; suppressing further warnings (restart the daemon after installing revvault)',
+          { agentId },
+        );
+        return;
+      }
       log.warn('revvault public key write failed', { agentId, reason: setPub.reason });
     }
   })();


### PR DESCRIPTION
## Summary

Fixes the repeating daemon-log noise pair on the owner unit: `revvault private key write failed` + `revvault public key write failed` (`reason: cli-not-installed`), re-emitted for every session registration.

Since GAP-311 session-keyed identities, each new `agent-system-p<pid>` session mints a fresh keypair and `bootstrapAgentIdentity` mirrors it to revvault. On a unit where the `revvault` CLI is not on PATH (the systemd-user daemon), that mirror fails identically every cycle, so the journal collects the same warn pair every ~30 minutes forever.

`cli-not-installed` is an environmental condition of the daemon's unit, not a per-agent fault:

- warn **once per daemon lifetime**, with an actionable message (restart after installing revvault)
- skip further `revvault set` spawn attempts until restart
- real `cli-failure` results keep their per-agent warns unchanged

## Test plan

- [x] New `revvault-warn-noise.test.ts`: real daemon on a throwaway socket, revvault-client mocked to `cli-not-installed`, 3 registrations → exactly 1 warn, 1 spawn attempt
- [x] Prove-red: against the unfixed `server.ts` the same test fails (6 warns)
- [x] Full daemon suite: 39 files / 730 tests green
- [x] Biome + tsc clean
- [ ] CI
- [ ] After merge: rebuild daemon + restart unit; journal should show one suppression warn at most

🤖 Generated with [Claude Code](https://claude.com/claude-code)