### PR TITLE
fix(daemon): accept idmap-squashed root for the client trust anchor on WSL systemd-user

### DIFF
--- a/packages/daemon/src/__tests__/trust-anchor-idmap.test.ts
+++ b/packages/daemon/src/__tests__/trust-anchor-idmap.test.ts
@@ -1,0 +1,121 @@
+/**
+ * GAP-409 item 2 (D7-D9): the trust-anchor root-owned check must accept
+ * uid 65534 ONLY under the proven WSL systemd-user idmap squash (the same
+ * predicate revdev#304 shipped for bwrap), and must stay fail-closed for
+ * every other non-root owner.
+ *
+ * node:fs and node:fs/promises are fully mocked so uid scenarios that cannot
+ * be fabricated as a non-root test user (root-owned trees, idmap-squashed
+ * trees) are deterministic. confinement.ts touches the real fs only at call
+ * time, so mocking here never races module init.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = {
+  /** uid reported for /usr/bin/true — 0 = no squash, 65534 = squash proven */
+  systemProbeUid: 0,
+  /** uid reported for every anchor ancestor dir and the anchor file */
+  anchorUid: 0,
+};
+
+function dirStat(uid: number) {
+  return {
+    isSymbolicLink: () => false,
+    isDirectory: () => true,
+    uid,
+    mode: 0o40755,
+  };
+}
+
+function fileStat(uid: number) {
+  return {
+    isFile: () => true,
+    uid,
+    mode: 0o100644,
+  };
+}
+
+vi.mock('node:fs', async (importOriginal) => {
+  const real = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...real,
+    statSync: vi.fn((p: unknown): { isFile: () => boolean; uid: number } => {
+      if (p === '/usr/bin/true') {
+        return { isFile: () => true, uid: state.systemProbeUid };
+      }
+      return real.statSync(p as string);
+    }),
+  };
+});
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const real = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...real,
+    lstat: vi.fn(async () => dirStat(state.anchorUid)),
+    open: vi.fn(async () => ({
+      stat: async () => fileStat(state.anchorUid),
+      readFile: async () => 'agent-a:fp-a\n',
+      close: async () => undefined,
+    })),
+  };
+});
+
+import { isTrustedRootOwner, readRootOwnedFile } from '../confinement.js';
+
+beforeEach(() => {
+  state.systemProbeUid = 0;
+  state.anchorUid = 0;
+});
+
+describe('isTrustedRootOwner (GAP-409 D7)', () => {
+  it('trusts uid 0 unconditionally', () => {
+    state.systemProbeUid = 0;
+    expect(isTrustedRootOwner({ uid: 0 })).toBe(true);
+    state.systemProbeUid = 65534;
+    expect(isTrustedRootOwner({ uid: 0 })).toBe(true);
+  });
+
+  it('trusts uid 65534 only when the system-wide squash is proven', () => {
+    state.systemProbeUid = 65534;
+    expect(isTrustedRootOwner({ uid: 65534 })).toBe(true);
+    state.systemProbeUid = 0;
+    expect(isTrustedRootOwner({ uid: 65534 })).toBe(false);
+  });
+
+  it('never trusts an ordinary user uid, squash or not (D8)', () => {
+    state.systemProbeUid = 65534;
+    expect(isTrustedRootOwner({ uid: 1000 })).toBe(false);
+    state.systemProbeUid = 0;
+    expect(isTrustedRootOwner({ uid: 1000 })).toBe(false);
+  });
+});
+
+describe('readRootOwnedFile under idmap squash (GAP-409 D7-D9)', () => {
+  it('reads a root-owned anchor (uid 0 everywhere) — the pre-existing path', async () => {
+    state.anchorUid = 0;
+    await expect(readRootOwnedFile('/etc/revdev/trusted-clients')).resolves.toBe('agent-a:fp-a\n');
+  });
+
+  it('reads a 65534-owned anchor when the squash is proven (the WSL systemd-user fix)', async () => {
+    state.systemProbeUid = 65534;
+    state.anchorUid = 65534;
+    await expect(readRootOwnedFile('/etc/revdev/trusted-clients')).resolves.toBe('agent-a:fp-a\n');
+  });
+
+  it('rejects a 65534-owned anchor when the squash is NOT proven (fail-closed, D8)', async () => {
+    state.systemProbeUid = 0;
+    state.anchorUid = 65534;
+    await expect(readRootOwnedFile('/etc/revdev/trusted-clients')).rejects.toThrow(
+      'not root-owned',
+    );
+  });
+
+  it('rejects a user-owned anchor even when the squash IS active (D8)', async () => {
+    state.systemProbeUid = 65534;
+    state.anchorUid = 1000;
+    await expect(readRootOwnedFile('/etc/revdev/trusted-clients')).rejects.toThrow(
+      'not root-owned',
+    );
+  });
+});

--- a/packages/daemon/src/confinement.ts
+++ b/packages/daemon/src/confinement.ts
@@ -21,9 +21,9 @@
  */
 
 import { createHash } from 'node:crypto';
-import { existsSync, realpathSync, statSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
-import { join, sep } from 'node:path';
+import { constants as fsConstants, existsSync, realpathSync, statSync } from 'node:fs';
+import { lstat, mkdir, open as fsOpen, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve, sep } from 'node:path';
 import { createLogger } from '@revealui/utils/logger';
 
 const log = createLogger({ service: 'revdev-daemon/confinement' });
@@ -106,15 +106,68 @@ export function systemRootUidIsSquashedToNobody(): boolean {
 }
 
 /**
- * True when the stat result is an acceptable owner for the bwrap binary.
+ * True when the stat result is an acceptable ROOT owner for a trust-critical
+ * filesystem entry (the bwrap binary, the client trust anchor and its
+ * ancestors):
  * - Normal: uid 0 (root)
  * - WSL systemd-user idmap: uid 65534 only if the whole system root→nobody
  *   squash is observed on `/usr/bin/true` as well
+ *
+ * A genuinely nobody-owned file on a non-squashed system never passes
+ * (fail-closed, GAP-409 D8).
  */
-export function isTrustedBwrapOwner(st: { uid: number }): boolean {
+export function isTrustedRootOwner(st: { uid: number }): boolean {
   if (st.uid === 0) return true;
   if (st.uid === 65534 && systemRootUidIsSquashedToNobody()) return true;
   return false;
+}
+
+/**
+ * True when the stat result is an acceptable owner for the bwrap binary.
+ * Same semantics as `isTrustedRootOwner` — kept as a named alias because the
+ * bwrap call sites and tests predate the shared predicate (revdev#304).
+ */
+export function isTrustedBwrapOwner(st: { uid: number }): boolean {
+  return isTrustedRootOwner(st);
+}
+
+/**
+ * Read a file that MUST be root-owned and tamper-resistant: every ancestor
+ * directory must be a root-owned, non-symlink directory with no group/other
+ * write bit, and the file itself is opened O_NOFOLLOW then fstat-checked
+ * (regular file, trusted-root-owned, not group/other-writable). Throws
+ * otherwise.
+ *
+ * "Root-owned" is `isTrustedRootOwner`: uid 0 always; uid 65534 only under
+ * the proven WSL systemd-user idmap squash (GAP-409 D7). Every other
+ * property — non-symlink ancestors, write-bit checks, O_NOFOLLOW + fstat —
+ * is unchanged from the strict form.
+ */
+export async function readRootOwnedFile(filePath: string): Promise<string> {
+  let dir = dirname(resolve(filePath));
+  for (;;) {
+    const dstat = await lstat(dir);
+    if (dstat.isSymbolicLink()) throw new Error(`anchor ancestor is a symlink: ${dir}`);
+    if (!dstat.isDirectory()) throw new Error(`anchor ancestor is not a directory: ${dir}`);
+    if (!isTrustedRootOwner(dstat))
+      throw new Error(`anchor ancestor not root-owned (uid ${dstat.uid}): ${dir}`);
+    if ((dstat.mode & 0o022) !== 0) throw new Error(`anchor ancestor group/other-writable: ${dir}`);
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached the filesystem root
+    dir = parent;
+  }
+  const handle = await fsOpen(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const fstat = await handle.stat();
+    if (!fstat.isFile()) throw new Error(`trust anchor is not a regular file: ${filePath}`);
+    if (!isTrustedRootOwner(fstat))
+      throw new Error(`trust anchor not root-owned (uid ${fstat.uid}): ${filePath}`);
+    if ((fstat.mode & 0o022) !== 0)
+      throw new Error(`trust anchor group/other-writable: ${filePath}`);
+    return await handle.readFile('utf8');
+  } finally {
+    await handle.close();
+  }
 }
 
 /**

--- a/packages/daemon/src/confinement.ts
+++ b/packages/daemon/src/confinement.ts
@@ -21,8 +21,8 @@
  */
 
 import { createHash } from 'node:crypto';
-import { constants as fsConstants, existsSync, realpathSync, statSync } from 'node:fs';
-import { lstat, mkdir, open as fsOpen, writeFile } from 'node:fs/promises';
+import { existsSync, constants as fsConstants, realpathSync, statSync } from 'node:fs';
+import { open as fsOpen, lstat, mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve, sep } from 'node:path';
 import { createLogger } from '@revealui/utils/logger';
 

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -15,10 +15,9 @@
  *   `session.register` are rejected with -32002.
  */
 
-import { constants as fsConstants } from 'node:fs';
-import { open as fsOpen, lstat, mkdir, readFile } from 'node:fs/promises';
+import { mkdir, readFile } from 'node:fs/promises';
 import { createServer, type Socket } from 'node:net';
-import { dirname, resolve } from 'node:path';
+import { dirname } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import { formatDid, parseDid } from '@revdev/protocol/did';
 import { createLogger } from '@revealui/utils/logger';
@@ -31,6 +30,7 @@ import {
   verifyEnvelope,
 } from './agent-identity-crypto.js';
 import { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
+import { readRootOwnedFile } from './confinement.js';
 import { notifyAgentEnded, notifyDaemonStarted } from './eviction.js';
 import {
   guardRpcMethod,
@@ -890,8 +890,10 @@ class UntrustedClientKeyError extends Error {
  * A missing / unreadable / UNTRUSTED file yields an EMPTY set — enrollment then
  * fails closed. When `requireRootOwned` (production, review B-2), the file AND
  * every ancestor directory must be a root-owned, non-symlink entry with no
- * group/other write bit, and the file is opened O_NOFOLLOW + fstat-checked — so
- * a WSL-user attacker cannot point the daemon at a file they control, even via
+ * group/other write bit, and the file is opened O_NOFOLLOW + fstat-checked
+ * ("root-owned" = confinement's `isTrustedRootOwner`: uid 0, or uid 65534 only
+ * under the proven WSL systemd-user idmap squash — GAP-409 D7). So a WSL-user
+ * attacker cannot point the daemon at a file they control, even via
  * a systemd-user `Environment=REVDEV_DAEMON_TRUSTED_CLIENT_FP=...` override
  * (their path is not root-owned, so it is rejected). The disable lives ONLY in
  * the programmatic startDaemon config (tests), never in an env var an attacker
@@ -924,39 +926,6 @@ async function loadTrustedClientEntries(
     out.add(`${trimmed.slice(0, idx)}:${trimmed.slice(idx + 1)}`);
   }
   return out;
-}
-
-/**
- * Read a file that MUST be root-owned and tamper-resistant: every ancestor
- * directory must be a root-owned, non-symlink directory with no group/other
- * write bit, and the file itself is opened O_NOFOLLOW then fstat-checked
- * (regular file, uid 0, not group/other-writable). Throws otherwise.
- */
-async function readRootOwnedFile(filePath: string): Promise<string> {
-  let dir = dirname(resolve(filePath));
-  for (;;) {
-    const dstat = await lstat(dir);
-    if (dstat.isSymbolicLink()) throw new Error(`anchor ancestor is a symlink: ${dir}`);
-    if (!dstat.isDirectory()) throw new Error(`anchor ancestor is not a directory: ${dir}`);
-    if (dstat.uid !== 0)
-      throw new Error(`anchor ancestor not root-owned (uid ${dstat.uid}): ${dir}`);
-    if ((dstat.mode & 0o022) !== 0) throw new Error(`anchor ancestor group/other-writable: ${dir}`);
-    const parent = dirname(dir);
-    if (parent === dir) break; // reached the filesystem root
-    dir = parent;
-  }
-  const handle = await fsOpen(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
-  try {
-    const fstat = await handle.stat();
-    if (!fstat.isFile()) throw new Error(`trust anchor is not a regular file: ${filePath}`);
-    if (fstat.uid !== 0)
-      throw new Error(`trust anchor not root-owned (uid ${fstat.uid}): ${filePath}`);
-    if ((fstat.mode & 0o022) !== 0)
-      throw new Error(`trust anchor group/other-writable: ${filePath}`);
-    return await handle.readFile('utf8');
-  } finally {
-    await handle.close();
-  }
 }
 
 /**


### PR DESCRIPTION
## Problem

Under WSL systemd-user, root-owned files in `/etc/revdev` stat as uid 65534 (`nobody`) through the user-namespace uid_map. The trust-anchor gate (`readRootOwnedFile`) required literal uid 0 on the anchor file and every ancestor, so signed client-owned enroll against the production socket always failed closed on WSL — dogfood only worked via a temp daemon with `trustedAnchorRequireRootOwned: false` (GAP-409 item 2; the grok INIT-002 exit-note residual).

## Fix (extend #304, no second implementation)

- `confinement.ts` exports `isTrustedRootOwner`: uid 0 always trusted; uid 65534 trusted **only** when the system-wide root→nobody squash is proven on `/usr/bin/true` — the exact predicate #304 shipped for bwrap. `isTrustedBwrapOwner` now delegates to it.
- `readRootOwnedFile` moves from `server.ts` into `confinement.ts` (making it unit-testable without the daemon module graph) and uses the shared predicate for the ancestor + file owner checks. **Everything else is unchanged:** non-symlink ancestors, group/other write-bit rejection, O_NOFOLLOW open + fstat.
- Fail-closed preserved: uid 65534 without the proven squash still rejects; ordinary user uids still reject; no env-var override added.

## Proof

- New `trust-anchor-idmap.test.ts` (deterministic, fs mocked): squash-proven 65534 anchor reads; unproven 65534 rejects; user-owned rejects even under active squash; predicate unit rows.
- **Prove-red:** with the owner checks temporarily restored to strict `uid !== 0`, exactly the squash-accept test fails; all fail-closed tests stay green in both forms.
- Full daemon suite: 40 files / 737 tests pass; `tsc --noEmit` clean.

Identity/signing surface: needs a guardrail-2 non-author recorded verdict before merge; owner disposes label + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)