### PR TITLE
fix(daemon): remove the daemon-minted revvault identity mirror

### DIFF
--- a/packages/daemon/src/__tests__/registration-no-vault-write.test.ts
+++ b/packages/daemon/src/__tests__/registration-no-vault-write.test.ts
@@ -1,16 +1,17 @@
 /**
- * Identity vault-mirror warn dedup — the daemon-noise heartbeat fix.
+ * Registration performs ZERO revvault writes — GAP-409 D1 regression guard.
  *
- * Session-keyed identities (GAP-311) mint a fresh keypair on every session
- * registration, and each registration mirrors it to revvault. On a machine
- * where the revvault CLI is not on the daemon's PATH (the systemd-user unit),
- * every registration used to emit the same
- * "revvault private/public key write failed, reason: cli-not-installed" warn
- * pair — one pair per heartbeat/session cycle, forever.
+ * The daemon-minted identity path used to mirror every fresh keypair into
+ * revvault (`revdev/agents/<id>/identity/*`). Session-keyed identities
+ * (GAP-311) made that mirror inverted — ephemeral per-session keys
+ * accumulating in a durable vault — and any test or dogfood run on a shell
+ * with the revvault CLI on PATH polluted the PRODUCTION secret store (the
+ * ~33 stray `revdev/agents/*` entries found at the GAP-409 D6 sweep).
  *
- * `cli-not-installed` is environmental, not per-agent: warn once per daemon
- * lifetime, then skip further vault-write attempts until restart. Real
- * `cli-failure` results keep their per-agent warns.
+ * The write path is deleted, not made quieter (this file previously guarded
+ * the revdev#318 warn-once dedup of that path's missing-CLI noise). This
+ * guard asserts the daemon never calls revvaultSet — and never logs a vault
+ * warn — across repeated session registrations.
  *
  * @vitest-environment node
  */
@@ -40,8 +41,9 @@ vi.mock('@revealui/utils/logger', async (importActual) => {
   return { ...actual, createLogger: () => stub() };
 });
 
-// Force the environmental failure deterministically (and keep the suite from
-// ever spawning a real `revvault set` on a developer machine).
+// Spy on the vault write entry point. Post GAP-409 D1 it must NEVER be
+// called from the daemon; the mock both proves that and keeps any regression
+// from spawning a real `revvault set` against the production store.
 const { revvaultSetMock } = vi.hoisted(() => ({
   revvaultSetMock: vi.fn(async () => ({
     ok: false as const,
@@ -119,30 +121,31 @@ afterAll(async () => {
   clearTestLicenseEnv();
 });
 
-describe('revvault cli-not-installed warn dedup', () => {
-  it('warns once across repeated session registrations, then skips vault writes', async () => {
+describe('registration performs zero revvault writes (GAP-409 D1)', () => {
+  it('never calls revvaultSet and never logs a vault warn across registrations', async () => {
+    const one = (await rpc(socketPath, 'session.register', {
+      agentName: 'novault-one',
+      workDir: '/tmp/novault-one',
+      backend: 'test',
+    })) as { privateKeyPem?: string };
     await rpc(socketPath, 'session.register', {
-      agentName: 'noisy-one',
-      workDir: '/tmp/noisy-one',
+      agentName: 'novault-two',
+      workDir: '/tmp/novault-two',
       backend: 'test',
     });
     await rpc(socketPath, 'session.register', {
-      agentName: 'noisy-two',
-      workDir: '/tmp/noisy-two',
-      backend: 'test',
-    });
-    await rpc(socketPath, 'session.register', {
-      agentName: 'noisy-three',
-      workDir: '/tmp/noisy-three',
+      agentName: 'novault-three',
+      workDir: '/tmp/novault-three',
       backend: 'test',
     });
 
+    // The one-shot key still comes back on first mint — removal of the
+    // mirror must not touch the client contract (D2).
+    expect(one.privateKeyPem).toContain('PRIVATE KEY');
+
+    // The mirror is gone: no vault write attempt, no vault warn, ever.
+    expect(revvaultSetMock).not.toHaveBeenCalled();
     const vaultWarns = warnCalls.filter((c) => c.msg.includes('revvault'));
-    expect(vaultWarns).toHaveLength(1);
-    expect(vaultWarns[0]?.msg).toContain('suppressing further warnings');
-
-    // First registration attempts the private-key write, hits the missing
-    // CLI, and no further spawn is attempted for it or any later session.
-    expect(revvaultSetMock).toHaveBeenCalledTimes(1);
+    expect(vaultWarns).toHaveLength(0);
   });
 });

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -71,7 +71,6 @@ import {
   setSessionPermissionMode,
   tryConsumeApproval,
 } from './permission.js';
-import { revvaultSet } from './revvault-client.js';
 import { initSessionChecks, runSessionChecks } from './session-checks/index.js';
 import { migrate } from './storage/migrate.js';
 import { initToolGuard } from './tool-guard/index.js';
@@ -783,7 +782,9 @@ registerHandler('session.register', async (params, db, ctx) => {
   //     the real barrier behind the relay — a host process without the key
   //     cannot sign a mutation/content read (see MUTATING_OR_CONTENT_METHODS).
   //   - DAEMON-MINTED (headless hooks): no key supplied, so the daemon
-  //     generates the keypair and mirrors it to revvault, as before.
+  //     generates the keypair and returns it once in the register response.
+  //     No vault mirror (GAP-409 D1) — the one-shot response and the
+  //     client's local cache are the only key holders.
   const clientPublicKeyPem = strOrNull(params.publicKeyPem);
   const identity = clientPublicKeyPem
     ? await registerClientIdentity(db, id, clientPublicKeyPem)
@@ -805,8 +806,8 @@ registerHandler('session.register', async (params, db, ctx) => {
   // Grok dual-harness hooks, Ubuntu Inference Snap / Ollama agents registered
   // from Studio, and the MCP bridge — not Claude/Grok alone. Client-owned
   // enroll never returns a private key (Studio UI keeps it). Re-register of
-  // an existing identity never re-emits the private key — load from cache or
-  // revvault (`revdev/agents/<id>/identity/ed25519-private`).
+  // an existing identity never re-emits the private key — clients load it
+  // from their local cache (there is no vault mirror; GAP-409 D1-D3).
   return {
     sessionId: id,
     agentId: id,
@@ -857,11 +858,12 @@ async function bootstrapAgentIdentity(db: PGlite, agentId: string): Promise<Iden
     [fingerprint, agentId, kp.publicKeyPem],
   );
 
-  // Await vault mirror so hooks can fall back to revvault get if the one-shot
-  // privateKeyPem response is lost (INIT-002 Phase 1). Still best-effort: vault
-  // failures log and do not fail registration.
-  await persistIdentityToRevvault(agentId, kp.privateKeyPem, kp.publicKeyPem);
-
+  // No vault mirror (GAP-409 D1): the one-shot privateKeyPem response and the
+  // client's local cache are the ONLY key holders. Session-keyed identities
+  // are ephemeral; mirroring them into revvault only accumulated dead
+  // per-session entries (and polluted the production store from test runs).
+  // Lost-both recovery is deliberately absent (D3/D4): re-register a fresh
+  // session identity instead.
   return { did, publicKeyPem: kp.publicKeyPem, privateKeyPem: kp.privateKeyPem };
 }
 
@@ -1022,53 +1024,6 @@ async function registerClientIdentity(
   // else: same fingerprint already registered — idempotent no-op.
 
   return { did, publicKeyPem };
-}
-
-// `cli-not-installed` is an environmental condition of the daemon's unit
-// (revvault not on PATH), not a per-agent fault. Session-keyed identities
-// (GAP-311) mint a fresh keypair per session, so without dedup every session
-// registration re-emits the same warn pair for the daemon's whole lifetime.
-// Warn once, then skip further vault writes until restart.
-let revvaultCliMissing = false;
-
-function persistIdentityToRevvault(
-  agentId: string,
-  privateKeyPem: string,
-  publicKeyPem: string,
-): Promise<void> {
-  return (async () => {
-    if (revvaultCliMissing) return;
-    const setPriv = await revvaultSet(
-      `revdev/agents/${agentId}/identity/ed25519-private`,
-      privateKeyPem,
-    );
-    if (!setPriv.ok) {
-      if (setPriv.reason === 'cli-not-installed') {
-        revvaultCliMissing = true;
-        log.warn(
-          'revvault CLI not installed — agent identity keys will not be mirrored to revvault; suppressing further warnings (restart the daemon after installing revvault)',
-          { agentId },
-        );
-        return;
-      }
-      log.warn('revvault private key write failed', { agentId, reason: setPriv.reason });
-    }
-    const setPub = await revvaultSet(
-      `revdev/agents/${agentId}/identity/ed25519-public`,
-      publicKeyPem,
-    );
-    if (!setPub.ok) {
-      if (setPub.reason === 'cli-not-installed') {
-        revvaultCliMissing = true;
-        log.warn(
-          'revvault CLI not installed — agent identity keys will not be mirrored to revvault; suppressing further warnings (restart the daemon after installing revvault)',
-          { agentId },
-        );
-        return;
-      }
-      log.warn('revvault public key write failed', { agentId, reason: setPub.reason });
-    }
-  })();
 }
 
 registerHandler('session.attach', async (params, db, ctx) => {


### PR DESCRIPTION
## What

GAP-409 item 1 (D1–D5): `bootstrapAgentIdentity` no longer mirrors freshly minted keypairs into revvault (`revdev/agents/<id>/identity/*`). The one-shot `privateKeyPem` register response and the client's local cache are now the only key holders. `persistIdentityToRevvault`, its warn-dedup state (#318), and the `revvaultSet` import are deleted. `revvault-client.ts` stays — `revvaultGet` has other consumers.

## Why

- Session-keyed identities (GAP-311) are ephemeral per-session material; mirroring them into a durable vault only accumulates dead entries.
- **The mirror was actively polluting the production secret store:** test suites register sessions against an in-process daemon with no revvault mock, so any run on a shell with the CLI on PATH wrote real vault entries (~33 strays found under `revdev/agents/` at the D6 sweep — e2e/sync/identity-test ids).
- Lost-both recovery is deliberately absent (D3, owner-countersigned): re-register a fresh session identity. No re-mint/recovery RPC is added (D4 — it would reopen the B-2/B-3 self-enrollment/key-takeover holes).

## Proof

- `registration-no-vault-write.test.ts` (retargeted from the #318 warn-dedup test): asserts `revvaultSet` is never called and no vault warn logs across three registrations, while the one-shot key still returns on first mint (D2 contract intact).
- **Prove-red:** with base `server.ts` restored, the test fails (`revvaultSet` called). Restored, green.
- **Zero real CLI spawns, empirically:** full daemon suite (730 tests, all pass) run with a sentinel `revvault` shim first on PATH that logs every invocation — the log stayed empty; the shim itself verified live.

Lockstep consumer-side removal (the hook read tier) rides the paired claude-config PR. The D6 vault sweep of existing strays should run AFTER this merges (deleting first just re-accumulates on the next test run of the old code).

Identity/signing surface: needs a guardrail-2 non-author recorded verdict before merge; owner disposes label + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)