### PR TITLE
chore(ci): bump backflow-reusable pin to label-applying version

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -27,7 +27,7 @@ jobs:
     # Pinned to an immutable SHA (RevealUIStudio/.github main @ 2026-06-12) so a
     # later push to the shared repo cannot silently change this production gate.
     # Bump via Dependabot (github-actions) like every other pinned ref.
-    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@010a9388aee91d6f6fef8fce5a18f897af42443b # main @ 2026-07-06 (backflow signed-merge — .github#7)
+    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@e895ec57294c24089e3a0c7238d6c34ebb5fdf95 # main @ 2026-07-25 (backflow applies backflow:merge-commit label — .github#12)
     # Scope to ONLY the two secrets the reusable declares (its workflow_call.secrets
     # block documents this exact form) instead of `secrets: inherit`, which would
     # forward every caller secret into it.


### PR DESCRIPTION
Picks up RevealUIStudio/.github#12 (e895ec5): the shared backflow reusable now applies `backflow:merge-commit` on PR open (best-effort; this repo has no merge-method guard, so it just gains the informative label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)