### PR TITLE
fix(ci): wire prove-red label exemption + skip promotion PRs (GAP-393)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,11 @@ jobs:
     name: Prove-Red (TypeScript changed tests must fail against base)
     runs-on: ubuntu-latest
     needs: quality
-    # PR-only: a merge-base is meaningless on a direct push to test/main.
-    if: github.event_name == 'pull_request'
+    # PR-only: a merge-base is meaningless on a direct push to test/main. Also
+    # skip test -> main promotion PRs (GAP-393): a promotion diff carries a
+    # feature's fix and test together, so the test passes against main's base —
+    # the red-first proof already happened on the constituent feature PR.
+    if: github.event_name == 'pull_request' && !(github.head_ref == 'test' && github.base_ref == 'main')
     steps:
       # Check out the PR head (not the synthetic merge commit) with full history
       # so scripts/ci/prove-red.mjs can compute the merge base and revert the
@@ -150,14 +153,18 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.sha }}
           PROVE_RED_LANGS: typescript
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: node scripts/ci/prove-red.mjs
 
   prove-red-go:
     name: Prove-Red (Go changed tests must fail against base)
     runs-on: ubuntu-latest
     needs: quality
-    # PR-only: a merge-base is meaningless on a direct push to test/main.
-    if: github.event_name == 'pull_request'
+    # PR-only: a merge-base is meaningless on a direct push to test/main. Also
+    # skip test -> main promotion PRs (GAP-393): a promotion diff carries a
+    # feature's fix and test together, so the test passes against main's base —
+    # the red-first proof already happened on the constituent feature PR.
+    if: github.event_name == 'pull_request' && !(github.head_ref == 'test' && github.base_ref == 'main')
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -179,6 +186,7 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.sha }}
           PROVE_RED_LANGS: go
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: node scripts/ci/prove-red.mjs
 
   build:

--- a/.github/workflows/studio-rust-tests.yml
+++ b/.github/workflows/studio-rust-tests.yml
@@ -120,8 +120,11 @@ jobs:
   prove-red-rust:
     name: Prove-Red (Rust changed tests must fail against base)
     runs-on: ubuntu-latest
-    # PR-only: a merge-base is meaningless on a direct push to test/main.
-    if: github.event_name == 'pull_request'
+    # PR-only: a merge-base is meaningless on a direct push to test/main. Also
+    # skip test -> main promotion PRs (GAP-393): a promotion diff carries a
+    # feature's fix and test together, so the test passes against main's base —
+    # the red-first proof already happened on the constituent feature PR.
+    if: github.event_name == 'pull_request' && !(github.head_ref == 'test' && github.base_ref == 'main')
     steps:
       # PR head + full history so prove-red.mjs can compute the merge base.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -173,4 +176,5 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.sha }}
           PROVE_RED_LANGS: rust
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: node scripts/ci/prove-red.mjs

--- a/scripts/ci/prove-red.mjs
+++ b/scripts/ci/prove-red.mjs
@@ -41,6 +41,20 @@
 //
 // Zero authored regex (fleet rule): path classification is suffix/substring
 // membership only.
+//
+// Two exemption paths (GAP-393):
+//   - Promotion skip: a test -> main promotion PR carries both a feature's fix
+//     and its test together, so the test passes against main's base — the
+//     red-first proof already happened on the constituent feature PR. The
+//     workflow `if:` conditions skip these jobs entirely (no checkout); the
+//     early-exit below is defense-in-depth for any invocation that reaches
+//     this script anyway.
+//   - Label exemption: a genuine behavior-preserving change (e.g. a
+//     config/test-infra refactor) has no failing-first test by construction.
+//     The `verify:no-behavior-change` label, applied by a non-author
+//     reviewer (convention-enforced until identity separation exists — the
+//     fleet currently runs a solo GitHub account), records that judgment and
+//     clears the gate.
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
@@ -303,6 +317,25 @@ const LANGS = {
 const baseRef = process.env.BASE_REF || process.env.BASE_SHA;
 if (!baseRef) fail('BASE_REF is not set (pass the PR base sha).');
 
+// --- promotion skip (GAP-393) -----------------------------------------------
+// GITHUB_HEAD_REF / GITHUB_BASE_REF are branch names GitHub Actions sets for
+// every pull_request-triggered job; no extra wiring needed.
+if (process.env.GITHUB_HEAD_REF === 'test' && process.env.GITHUB_BASE_REF === 'main') {
+  skip('promotion PR (test -> main) — red-first proofs happened on constituent feature PRs');
+}
+
+// --- label exemption (GAP-393) ----------------------------------------------
+const prLabels = (process.env.PR_LABELS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+if (prLabels.includes('verify:no-behavior-change')) {
+  skip(
+    "PR carries the 'verify:no-behavior-change' label — recorded non-author exemption " +
+      'for a behavior-preserving change',
+  );
+}
+
 const ALL_LANGS = Object.keys(LANGS);
 const requested = (process.env.PROVE_RED_LANGS || ALL_LANGS.join(','))
   .split(',')
@@ -392,8 +425,11 @@ for (const a of active) {
       `\n✗ prove-red [${a.id}]: NONE of the changed ${a.id} tests fail against the base. This PR\n` +
         `changes ${a.id} product source but carries no failing-first test that depends on the\n` +
         'change. Add a test that is red without the fix, or, for a genuine\n' +
-        'behavior-preserving refactor, carry the recorded verify:no-behavior-change\n' +
-        'label (applied by a non-author, per the verification-enforcement lane).',
+        'behavior-preserving refactor, ask a non-author reviewer to apply the\n' +
+        "'verify:no-behavior-change' label and re-run this check (convention-enforced\n" +
+        'until identity separation exists). test -> main promotion PRs are\n' +
+        'auto-skipped; the red-first proof already happened on the constituent\n' +
+        'feature PR.',
     );
   } else {
     console.log(


### PR DESCRIPTION
## Summary

Wires the Prove-Red gate's documented-but-unwired exemption path and stops its false positives on promotion PRs. The tracked gap is GAP-393 in the internal coordination hub.

- **Label exemption (previously dead):** `scripts/ci/prove-red.mjs`'s failure message has told authors since the gate shipped to "carry the recorded verify:no-behavior-change label" — but the label did not exist in this repo and the script contained no label-reading code at all. The label now exists (`verify:no-behavior-change`, created via `gh label create`), the three prove-red jobs (TS in `ci.yml`, Go in `ci.yml`, Rust in `studio-rust-tests.yml`) pass the PR's labels into the script via `PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}`, and the script exits 0 with a clearly-logged exemption notice when the label is present. Non-author application is convention-enforced (not code-enforced) until identity separation exists, given the fleet's current solo-GitHub-account topology.
- **Promotion-PR false positive:** every test -> main promotion PR was going red on Prove-Red because a promoted diff carries a feature's fix and its test together, so the test passes against `main`'s base — the red-first proof already happened on the constituent feature PR. Precedent: revdev#321 (41 promoted commits) went red on Prove-Red (Rust) for exactly this reason. All three prove-red jobs now skip entirely at the workflow `if:` level when `github.head_ref == 'test' && github.base_ref == 'main'` (cheapest — no checkout at all), and `prove-red.mjs` carries a matching early-exit against `GITHUB_HEAD_REF` / `GITHUB_BASE_REF` (GitHub Actions' own auto-set branch-name env vars) as defense-in-depth for any invocation that reaches the script anyway.
- **Failure message:** rewritten to describe the now-real path (ask a non-author reviewer to apply `verify:no-behavior-change` and re-run, or add a red-first test) and to mention that promotion PRs auto-skip.

None of the three prove-red jobs are required checks today, so this PR does not change merge gating by itself — it makes the documented exemption path real and removes a recurring false positive precedent-set by revdev#298 (the vitest.config.ts scoping PR that hit the same unwired-label wall and only merged because Prove-Red isn't required there).

## Why this needs non-author review before merge

This PR changes CI gate behavior (a verification-enforcement surface). Per the fleet's verification-enforcement lane conventions, gate-behavior changes want a non-author review before merge, not a self-clear.

## Test plan

- [x] `node --check scripts/ci/prove-red.mjs` — syntax clean
- [x] `npx biome check scripts/ci/prove-red.mjs` — clean (formatting fixed)
- [x] YAML syntax of both edited workflow files validated with `yaml.safe_load`
- [x] Confirmed via `gh pr view 321 --json headRefName,baseRefName` that promotion PRs are shaped `head=test, base=main` exactly as the skip condition expects
- [x] No existing test harness covers `scripts/ci/prove-red.mjs` (verified — no `prove-red*.test.*` files); not adding one here to keep the diff proportional to the fix
- [ ] Owner/reviewer: confirm the workflow `if:` skip actually fires SKIPPED (not run) on the next real promotion PR, and that a PR carrying the new label clears Prove-Red with the logged exemption notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)