### PR TITLE
feat(daemon): port harness HTTP gateway into revdev daemon

### DIFF
--- a/apps/studio/src/components/settings/SettingsPanel.tsx
+++ b/apps/studio/src/components/settings/SettingsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { Theme } from '../../hooks/use-settings';
 import { useSettingsContext } from '../../hooks/use-settings';
+import { getDaemonUrl, pairWithDaemon, setDaemonToken, setDaemonUrl } from '../../lib/invoke';
 import Card from '../ui/Card';
 import PanelHeader from '../ui/PanelHeader';
 
@@ -166,6 +167,8 @@ export default function SettingsPanel() {
         </Card>
       )}
 
+      {activeTab === 'connection' && <RemoteDaemonPairing />}
+
       {activeTab === 'about' && (
         <Card header={<h2 className="text-sm font-semibold text-fg">About</h2>}>
           <div className="flex flex-col gap-4">
@@ -198,5 +201,112 @@ export default function SettingsPanel() {
         </Card>
       )}
     </div>
+  );
+}
+
+/**
+ * Remote-daemon pairing (GAP-421 daemon-ownership ADR, wire path §5). Pairing
+ * is an explicit operator action only — the daemon URL and pairing secret are
+ * never submitted automatically; nothing is sent until "Pair" is clicked.
+ */
+function RemoteDaemonPairing() {
+  const [daemonUrl, setDaemonUrlInput] = useState('');
+  const [secret, setSecret] = useState('');
+  const [pairedUrl, setPairedUrl] = useState<string | null>(() => getDaemonUrl());
+  const [status, setStatus] = useState<{
+    kind: 'idle' | 'pairing' | 'error' | 'success';
+    message?: string;
+  }>({
+    kind: 'idle',
+  });
+
+  async function handlePair() {
+    if (!daemonUrl.trim() || !secret.trim()) {
+      setStatus({ kind: 'error', message: 'Daemon URL and pairing secret are both required.' });
+      return;
+    }
+    setStatus({ kind: 'pairing' });
+    try {
+      await pairWithDaemon({ daemonUrl: daemonUrl.trim(), secret: secret.trim(), label: 'studio' });
+      setPairedUrl(daemonUrl.trim());
+      setSecret('');
+      setStatus({
+        kind: 'success',
+        message: 'Paired. This daemon is now the active remote connection.',
+      });
+    } catch (err) {
+      setStatus({ kind: 'error', message: err instanceof Error ? err.message : 'Pairing failed.' });
+    }
+  }
+
+  function handleForget() {
+    setDaemonUrl(null);
+    setDaemonToken(null);
+    setPairedUrl(null);
+    setStatus({ kind: 'idle' });
+  }
+
+  return (
+    <Card header={<h2 className="text-sm font-semibold text-fg">Remote daemon</h2>}>
+      <div className="flex flex-col gap-4">
+        {pairedUrl && (
+          <div className="flex items-center justify-between rounded-md bg-surface-2 px-3 py-2">
+            <span className="text-sm text-fg-muted">
+              Paired with <span className="text-fg">{pairedUrl}</span>
+            </span>
+            <button
+              type="button"
+              onClick={handleForget}
+              className="text-sm text-fg-subtle hover:text-fg-muted transition-colors"
+            >
+              Forget
+            </button>
+          </div>
+        )}
+        <div className="flex flex-col gap-1">
+          <label htmlFor="daemon-pair-url" className="text-sm text-fg-muted">
+            Daemon URL
+          </label>
+          <input
+            id="daemon-pair-url"
+            type="text"
+            placeholder="http://127.0.0.1:7890"
+            value={daemonUrl}
+            onChange={(e) => setDaemonUrlInput(e.target.value)}
+            className="rounded-md border border-edge bg-surface-2 px-3 py-2 text-sm text-fg-muted focus:border-edge focus:outline-none"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="daemon-pair-secret" className="text-sm text-fg-muted">
+            Pairing secret
+          </label>
+          <input
+            id="daemon-pair-secret"
+            type="password"
+            placeholder="contents of the daemon's gateway-pairing-secret file"
+            value={secret}
+            onChange={(e) => setSecret(e.target.value)}
+            className="rounded-md border border-edge bg-surface-2 px-3 py-2 text-sm text-fg-muted focus:border-edge focus:outline-none"
+          />
+          <span className="text-xs text-fg-subtle">
+            Read from the 0600 secret file the daemon printed at boot. Never sent on the wire — used
+            only to sign the pairing challenge locally.
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => void handlePair()}
+          disabled={status.kind === 'pairing'}
+          className="self-start rounded-md bg-brand px-4 py-2 text-sm text-on-brand transition-colors disabled:opacity-60"
+        >
+          {status.kind === 'pairing' ? 'Pairing…' : 'Pair'}
+        </button>
+        {status.message && (
+          <span className={`text-xs ${status.kind === 'error' ? 'text-error' : 'text-fg-subtle'}`}>
+            {status.message}
+          </span>
+        )}
+      </div>
+    </Card>
   );
 }

--- a/packages/daemon/src/__tests__/http-gateway.test.ts
+++ b/packages/daemon/src/__tests__/http-gateway.test.ts
@@ -1,0 +1,228 @@
+/**
+ * HTTP gateway (GAP-421 daemon-ownership ADR wire path). Proves:
+ *   (a) an unpaired/unsigned HTTP request is rejected by the SAME gate that
+ *       rejects the identical request on the Unix socket — one authorization
+ *       path, never a parallel one (dispatchRpc, server.ts).
+ *   (b) the pairing round trip (GET /api/pair -> POST /api/pair -> Bearer
+ *       token) works end to end and the token then authorizes /rpc.
+ *   (c) the gateway never binds a listener unless httpPort is configured —
+ *       default OFF.
+ */
+
+import { createHmac } from 'node:crypto';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { connect, createServer, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { startDaemon } from '../server.js';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+/** Find a currently-free TCP port by binding to port 0 and reading it back. */
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const addr = probe.address();
+      const port = addr && typeof addr === 'object' ? addr.port : 0;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+/** Send one newline-delimited JSON-RPC request over the Unix socket and read one response line. */
+function socketRpc(
+  socketPath: string,
+  request: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buffer = '';
+    sock.on('connect', () => {
+      sock.write(`${JSON.stringify(request)}\n`);
+    });
+    sock.on('data', (chunk) => {
+      buffer += chunk.toString();
+      const nl = buffer.indexOf('\n');
+      if (nl === -1) return;
+      const line = buffer.slice(0, nl);
+      sock.destroy();
+      try {
+        resolve(JSON.parse(line));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    sock.on('error', reject);
+  });
+}
+
+describe('HttpGateway — off by default', () => {
+  let dataDir: string;
+  let socketPath: string;
+  let originalLicenseKey: string | undefined;
+  let originalPublicKey: string | undefined;
+
+  beforeEach(async () => {
+    const { generateTestLicense, setTestLicenseEnv } = await import('./test-license-helper.js');
+    originalLicenseKey = process.env.REVEALUI_LICENSE_KEY;
+    originalPublicKey = process.env.REVDEV_LICENSE_PUBLIC_KEY;
+    setTestLicenseEnv(generateTestLicense('enterprise'));
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-http-gateway-off-'));
+    socketPath = join(dataDir, 'harness.sock');
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+    const { clearTestLicenseEnv } = await import('./test-license-helper.js');
+    clearTestLicenseEnv();
+    if (originalLicenseKey) process.env.REVEALUI_LICENSE_KEY = originalLicenseKey;
+    if (originalPublicKey) process.env.REVDEV_LICENSE_PUBLIC_KEY = originalPublicKey;
+  });
+
+  it('never constructs a listener when httpPort is left at its default (0)', async () => {
+    const d = await startDaemon({ socketPath, dataDir });
+    try {
+      expect(d._httpGateway).toBeNull();
+    } finally {
+      await d.close();
+    }
+  });
+
+  it('never constructs a listener when httpPort is explicitly 0', async () => {
+    const d = await startDaemon({ socketPath, dataDir, httpPort: 0 });
+    try {
+      expect(d._httpGateway).toBeNull();
+    } finally {
+      await d.close();
+    }
+  });
+});
+
+describe('HttpGateway — pairing + shared authorization path', () => {
+  let dataDir: string;
+  let socketPath: string;
+  let httpPort: number;
+  let close: () => Promise<void>;
+  let originalLicenseKey: string | undefined;
+  let originalPublicKey: string | undefined;
+
+  beforeEach(async () => {
+    const { generateTestLicense, setTestLicenseEnv } = await import('./test-license-helper.js');
+    originalLicenseKey = process.env.REVEALUI_LICENSE_KEY;
+    originalPublicKey = process.env.REVDEV_LICENSE_PUBLIC_KEY;
+    setTestLicenseEnv(generateTestLicense('enterprise'));
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-http-gateway-on-'));
+    socketPath = join(dataDir, 'harness.sock');
+    httpPort = await getFreePort();
+    const d = await startDaemon({ socketPath, dataDir, httpPort, httpHost: '127.0.0.1' });
+    close = d.close;
+    expect(d._httpGateway).not.toBeNull();
+  });
+
+  afterEach(async () => {
+    await close?.();
+    await rm(dataDir, { recursive: true, force: true });
+    const { clearTestLicenseEnv } = await import('./test-license-helper.js');
+    clearTestLicenseEnv();
+    if (originalLicenseKey) process.env.REVEALUI_LICENSE_KEY = originalLicenseKey;
+    if (originalPublicKey) process.env.REVDEV_LICENSE_PUBLIC_KEY = originalPublicKey;
+  });
+
+  const base = () => `http://127.0.0.1:${httpPort}`;
+
+  it('refuses /rpc with no Authorization header', async () => {
+    const res = await fetch(`${base()}/rpc`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('refuses /api/status with no Authorization header', async () => {
+    const res = await fetch(`${base()}/api/status`);
+    expect(res.status).toBe(401);
+  });
+
+  it('completes the pairing round trip and the minted token then authorizes /rpc', async () => {
+    const nonceRes = await fetch(`${base()}/api/pair`);
+    expect(nonceRes.status).toBe(200);
+    const { nonce } = (await nonceRes.json()) as { nonce: string };
+    expect(typeof nonce).toBe('string');
+
+    const secretPath = join(dataDir, 'gateway-pairing-secret');
+    const secret = (await readFile(secretPath, 'utf8')).trim();
+    const hmac = createHmac('sha256', secret).update(nonce).digest('hex');
+
+    const pairRes = await fetch(`${base()}/api/pair`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nonce, hmac, label: 'test' }),
+    });
+    expect(pairRes.status).toBe(200);
+    const { token } = (await pairRes.json()) as { token: string };
+    expect(typeof token).toBe('string');
+    expect(token.length).toBeGreaterThan(0);
+
+    const rpcRes = await fetch(`${base()}/rpc`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }),
+    });
+    expect(rpcRes.status).toBe(200);
+    const body = (await rpcRes.json()) as { result?: unknown; error?: unknown };
+    expect(body.error).toBeUndefined();
+    expect(body.result).toBeDefined();
+  });
+
+  it('rejects a bad HMAC pairing response and does not mint a token', async () => {
+    const nonceRes = await fetch(`${base()}/api/pair`);
+    const { nonce } = (await nonceRes.json()) as { nonce: string };
+
+    const pairRes = await fetch(`${base()}/api/pair`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nonce, hmac: '00'.repeat(32) }),
+    });
+    expect(pairRes.status).toBe(403);
+  });
+
+  it('rejects an unsigned MUTATING_OR_CONTENT_METHODS call over HTTP with the SAME code the socket returns', async () => {
+    // Pair first to obtain a valid bearer token.
+    const nonceRes = await fetch(`${base()}/api/pair`);
+    const { nonce } = (await nonceRes.json()) as { nonce: string };
+    const secretPath = join(dataDir, 'gateway-pairing-secret');
+    const secret = (await readFile(secretPath, 'utf8')).trim();
+    const hmac = createHmac('sha256', secret).update(nonce).digest('hex');
+    const pairRes = await fetch(`${base()}/api/pair`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nonce, hmac }),
+    });
+    const { token } = (await pairRes.json()) as { token: string };
+
+    // session.end is signature-required (MUTATING_OR_CONTENT_METHODS) and is
+    // registered directly in server.ts (no side-effect module import needed),
+    // so this exercises the gate itself rather than handler wiring.
+    const request = { jsonrpc: '2.0', id: 1, method: 'session.end', params: {} };
+
+    const httpRes = await fetch(`${base()}/rpc`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify(request),
+    });
+    expect(httpRes.status).toBe(200); // JSON-RPC errors are 200 with an error body
+    const httpBody = (await httpRes.json()) as { error?: { code: number } };
+    expect(httpBody.error?.code).toBe(-32003);
+
+    // Identical unsigned request over the Unix socket must be rejected with
+    // the exact same JSON-RPC code — proving one shared authorization path
+    // (dispatchRpc), not a weaker parallel one for remote traffic.
+    const socketBody = await socketRpc(socketPath, request);
+    const socketError = socketBody.error as { code: number } | undefined;
+    expect(socketError?.code).toBe(-32003);
+  });
+});

--- a/packages/daemon/src/gateway-store.ts
+++ b/packages/daemon/src/gateway-store.ts
@@ -1,0 +1,99 @@
+/**
+ * HTTP gateway authn substrate — bootstrap secret hash + hashed bearer
+ * tokens (migration 0008). Ported from `@revealui/harnesses`
+ * `storage/daemon-store.ts` gateway methods, adapted to this package's plain
+ * function-over-`db: PGlite` convention (see permission.ts) rather than a
+ * store class, since the daemon has no `DaemonStore` abstraction.
+ */
+
+import type { PGlite } from '@electric-sql/pglite';
+
+export interface GatewayBootstrapRow {
+  id: number;
+  secret_hash: string;
+  created_at: string;
+}
+
+export interface GatewayTokenRow {
+  token_hash: string;
+  issued_at: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+  label: string | null;
+}
+
+/**
+ * Persist the SHA-256 hash of the bootstrap pairing secret (singleton row).
+ * Upserts so a fresh data dir can re-adopt an existing on-disk secret file.
+ */
+export async function putBootstrapSecretHash(
+  db: PGlite,
+  secretHash: string,
+): Promise<GatewayBootstrapRow> {
+  const result = await db.query<GatewayBootstrapRow>(
+    `INSERT INTO gateway_bootstrap (id, secret_hash)
+     VALUES (1, $1)
+     ON CONFLICT (id) DO UPDATE SET secret_hash = EXCLUDED.secret_hash
+     RETURNING *`,
+    [secretHash],
+  );
+  // RETURNING * always produces a row for INSERT ... ON CONFLICT DO UPDATE
+  return result.rows[0] as GatewayBootstrapRow;
+}
+
+/** Get the persisted bootstrap secret hash, or null if never set. */
+export async function getBootstrapSecretHash(db: PGlite): Promise<string | null> {
+  const result = await db.query<GatewayBootstrapRow>(
+    'SELECT * FROM gateway_bootstrap WHERE id = 1',
+  );
+  return result.rows[0]?.secret_hash ?? null;
+}
+
+/** Insert a hashed bearer token with optional expiry and label. */
+export async function insertToken(
+  db: PGlite,
+  token: { tokenHash: string; expiresAt?: string | null; label?: string | null },
+): Promise<GatewayTokenRow> {
+  const result = await db.query<GatewayTokenRow>(
+    `INSERT INTO gateway_tokens (token_hash, expires_at, label)
+     VALUES ($1, $2, $3)
+     RETURNING *`,
+    [token.tokenHash, token.expiresAt ?? null, token.label ?? null],
+  );
+  // RETURNING * always produces a row for a plain INSERT
+  return result.rows[0] as GatewayTokenRow;
+}
+
+/** Find a token by hash that is neither revoked nor expired. */
+export async function findValidToken(
+  db: PGlite,
+  tokenHash: string,
+): Promise<GatewayTokenRow | null> {
+  const result = await db.query<GatewayTokenRow>(
+    `SELECT * FROM gateway_tokens
+     WHERE token_hash = $1
+       AND revoked_at IS NULL
+       AND (expires_at IS NULL OR expires_at > NOW())`,
+    [tokenHash],
+  );
+  return result.rows[0] ?? null;
+}
+
+/** Revoke a token by hash. Returns true if a non-revoked token was revoked. */
+export async function revokeToken(db: PGlite, tokenHash: string): Promise<boolean> {
+  const result = await db.query(
+    `UPDATE gateway_tokens SET revoked_at = NOW()
+     WHERE token_hash = $1 AND revoked_at IS NULL
+     RETURNING token_hash`,
+    [tokenHash],
+  );
+  return (result.rows?.length ?? 0) > 0;
+}
+
+/** Delete tokens whose expiry has passed. Returns the number removed. */
+export async function pruneExpiredTokens(db: PGlite): Promise<number> {
+  const result = await db.query(
+    'DELETE FROM gateway_tokens WHERE expires_at IS NOT NULL AND expires_at < NOW()',
+  );
+  return result.affectedRows ?? 0;
+}

--- a/packages/daemon/src/http-gateway.ts
+++ b/packages/daemon/src/http-gateway.ts
@@ -1,0 +1,739 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import {
+  closeSync,
+  constants,
+  createReadStream,
+  existsSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { dirname, extname, join, normalize } from 'node:path';
+import type { PGlite } from '@electric-sql/pglite';
+import {
+  findValidToken,
+  getBootstrapSecretHash,
+  insertToken,
+  pruneExpiredTokens,
+  putBootstrapSecretHash,
+} from './gateway-store.js';
+import { dispatchRpc, type RpcRequest, type RpcResponse, type SocketContext } from './server.js';
+import { type AgentExitEvent, type AgentOutputEvent, agentEvents } from './spawn-events.js';
+
+/**
+ * HTTP gateway that exposes the RevDev daemon over TCP (GAP-421
+ * daemon-ownership ADR — ported from `@revealui/harnesses`
+ * `server/http-gateway.ts`, preserving the on-the-wire contract byte for
+ * byte so the Studio pairing client (`apps/studio/src/lib/invoke.ts`
+ * `pairWithDaemon`) needs no protocol change).
+ *
+ * Routes:
+ *   POST /rpc                -  JSON-RPC 2.0 proxy, through the SAME
+ *                                dispatchRpc the Unix socket uses (license
+ *                                guard, param validation, signature gate,
+ *                                identity gate, permission gate — one
+ *                                authorization path, never a parallel one)
+ *   GET  /api/pair           -  Issue a single-use pairing nonce (pre-auth)
+ *   POST /api/pair           -  Submit an HMAC challenge response, receive a bearer token (pre-auth)
+ *   GET  /api/status         -  Daemon status summary (requires a valid token)
+ *   GET  /api/stream/:id     -  SSE stream of agent.* PTY output/exit (requires a valid token)
+ *   GET  /                   -  Serves Studio static frontend (index.html)
+ *   GET  /assets/*           -  Serves static assets
+ *
+ * Auth (fail-closed):
+ *   Every /rpc and /api/* request EXCEPT the pairing endpoints (see PRE_AUTH_ROUTES)
+ *   requires `Authorization: Bearer <token>`, where the token's SHA-256 hash matches a
+ *   durable, unexpired, unrevoked row in `gateway_tokens`. There is no pre-pairing
+ *   bypass: a never-paired daemon refuses every RPC (including agent.spawn / agent.stop).
+ *
+ * Pairing (challenge-response, secret never crosses the wire):
+ *   GET /api/pair returns a nonce; the operator computes HMAC-SHA256(secret, nonce) with
+ *   the 32-byte secret from the 0600 file in the daemon data dir and POSTs it back. The
+ *   server verifies against the same file secret with a timing-safe comparison, then mints
+ *   a durable bearer token. The stored DB hash (gateway_bootstrap) detects file tampering
+ *   or substitution; the file itself is the HMAC key.
+ *
+ * Off by default: the daemon only constructs this gateway when `httpPort` is
+ * configured to a non-zero value (see `startDaemon` in server.ts). No config,
+ * no listener.
+ */
+
+/** Tunable auth parameters (defaults applied in the constructor). */
+export interface AuthTuning {
+  /** Bearer-token lifetime in ms (default: 90 days). */
+  tokenTtlMs?: number;
+  /** Pairing-nonce lifetime in ms (default: 2 minutes). */
+  nonceTtlMs?: number;
+  /** Failed pairing attempts per source before lockout kicks in (default: 5). */
+  lockoutThreshold?: number;
+  /** Base lockout duration in ms; doubles per failure past the threshold (default: 60s). */
+  baseLockoutMs?: number;
+  /** Ceiling on lockout duration in ms (default: 1 hour). */
+  maxLockoutMs?: number;
+  /** Global failed-attempt ceiling before a fleet-wide cooldown (default: 100). */
+  globalFailureCeiling?: number;
+  /** Clock source (default: Date.now); injectable for deterministic tests. */
+  now?: () => number;
+}
+
+export interface HttpGatewayConfig {
+  /** TCP port to listen on (0 = disabled; the daemon never constructs this class in that case) */
+  port: number;
+  /** Bind address */
+  host: string;
+  /** Path to Studio static build directory (optional  -  disables static serving if absent) */
+  staticDir?: string | null;
+  /** The daemon's PGlite handle — dispatchRpc and the gateway-store both read/write it */
+  db: PGlite;
+  /** Absolute path to the 0600 bootstrap pairing secret file */
+  secretPath: string;
+  /** Optional auth tuning (TTLs, lockout, clock) */
+  authTuning?: AuthTuning;
+}
+
+/**
+ * The EXACT set of routes served before authentication. Everything else under
+ * `/rpc` and `/api/*` requires a valid bearer token. Exported so the allowlist is a
+ * verifiable constant rather than emergent routing behavior (spec §7 R3).
+ */
+export const PRE_AUTH_ROUTES: ReadonlyArray<{ readonly method: string; readonly path: string }> = [
+  { method: 'GET', path: '/api/pair' },
+  { method: 'POST', path: '/api/pair' },
+];
+
+/** Whether a (method, path) pair is served without authentication. */
+export function isPreAuthRoute(method: string, path: string): boolean {
+  for (const route of PRE_AUTH_ROUTES) {
+    if (route.method === method && route.path === path) return true;
+  }
+  return false;
+}
+
+const DEFAULT_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+const DEFAULT_NONCE_TTL_MS = 2 * 60 * 1000;
+const DEFAULT_LOCKOUT_THRESHOLD = 5;
+const DEFAULT_BASE_LOCKOUT_MS = 60 * 1000;
+const DEFAULT_MAX_LOCKOUT_MS = 60 * 60 * 1000;
+const DEFAULT_GLOBAL_FAILURE_CEILING = 100;
+const MAX_PENDING_NONCES = 256;
+// Ported from the harnesses gateway's #1975 guardrail-2 verdict: bounded so a
+// persistent create/delete race on the secret file cannot livelock startup.
+// DoS-only concern (O_EXCL + O_NOFOLLOW still hold, so no secret can be
+// substituted); defense-in-depth, not a new attack surface.
+const MAX_INIT_AUTH_ATTEMPTS = 5;
+const SECRET_BYTES = 32;
+const NONCE_BYTES = 32;
+const TOKEN_BYTES = 32;
+
+/** MIME types for static file serving */
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.wasm': 'application/wasm',
+};
+
+interface RateLimiterConfig {
+  now: () => number;
+  lockoutThreshold: number;
+  baseLockoutMs: number;
+  maxLockoutMs: number;
+  globalCeiling: number;
+}
+
+/**
+ * Per-source failed-attempt tracker for the pairing endpoint: exponential backoff
+ * with a lockout ceiling, plus a coarse global cooldown. In-memory only (a pairing
+ * flood is transient and pre-auth); state resets on restart per spec §D5/§7 R6.
+ */
+export class PairingRateLimiter {
+  private readonly perSource = new Map<string, { failures: number; lockedUntil: number }>();
+  private globalFailures = 0;
+  private globalLockedUntil = 0;
+
+  constructor(private readonly cfg: RateLimiterConfig) {}
+
+  /** Milliseconds until this source (or the whole gateway) may attempt again; 0 if clear. */
+  retryAfterMs(source: string): number {
+    const now = this.cfg.now();
+    if (now < this.globalLockedUntil) return this.globalLockedUntil - now;
+    const rec = this.perSource.get(source);
+    if (rec && now < rec.lockedUntil) return rec.lockedUntil - now;
+    return 0;
+  }
+
+  /** Clear a source's failure history after a successful pairing. */
+  recordSuccess(source: string): void {
+    this.perSource.delete(source);
+  }
+
+  /** Record a failed attempt; returns the resulting lockout for this source and the global state. */
+  recordFailure(source: string): { failures: number; lockMs: number; globalTripped: boolean } {
+    const now = this.cfg.now();
+    const rec = this.perSource.get(source) ?? { failures: 0, lockedUntil: 0 };
+    rec.failures += 1;
+    let lockMs = 0;
+    if (rec.failures >= this.cfg.lockoutThreshold) {
+      const over = rec.failures - this.cfg.lockoutThreshold;
+      lockMs = Math.min(this.cfg.baseLockoutMs * 2 ** over, this.cfg.maxLockoutMs);
+      rec.lockedUntil = now + lockMs;
+    }
+    this.perSource.set(source, rec);
+
+    this.globalFailures += 1;
+    let globalTripped = false;
+    if (this.globalFailures >= this.cfg.globalCeiling) {
+      this.globalLockedUntil = now + this.cfg.baseLockoutMs;
+      this.globalFailures = 0;
+      globalTripped = true;
+    }
+    return { failures: rec.failures, lockMs, globalTripped };
+  }
+}
+
+export class HttpGateway {
+  private server: Server;
+  private readonly config: HttpGatewayConfig;
+
+  /** The 32-byte file secret (hex string) used to key pairing HMACs; null when unusable. */
+  private bootstrapSecret: string | null = null;
+  /** Outstanding single-use pairing nonces → expiry (ms epoch). */
+  private readonly nonces = new Map<string, number>();
+  private readonly rateLimiter: PairingRateLimiter;
+  private readonly now: () => number;
+  private readonly tokenTtlMs: number;
+  private readonly nonceTtlMs: number;
+
+  constructor(config: HttpGatewayConfig) {
+    this.config = config;
+    const t = config.authTuning ?? {};
+    this.now = t.now ?? (() => Date.now());
+    this.tokenTtlMs = t.tokenTtlMs ?? DEFAULT_TOKEN_TTL_MS;
+    this.nonceTtlMs = t.nonceTtlMs ?? DEFAULT_NONCE_TTL_MS;
+    this.rateLimiter = new PairingRateLimiter({
+      now: this.now,
+      lockoutThreshold: t.lockoutThreshold ?? DEFAULT_LOCKOUT_THRESHOLD,
+      baseLockoutMs: t.baseLockoutMs ?? DEFAULT_BASE_LOCKOUT_MS,
+      maxLockoutMs: t.maxLockoutMs ?? DEFAULT_MAX_LOCKOUT_MS,
+      globalCeiling: t.globalFailureCeiling ?? DEFAULT_GLOBAL_FAILURE_CEILING,
+    });
+    this.server = createServer((req, res) => {
+      void this.handleRequest(req, res);
+    });
+  }
+
+  /** Absolute path to the bootstrap pairing secret file (never its value). */
+  getSecretPath(): string {
+    return this.config.secretPath;
+  }
+
+  /**
+   * Prepare fail-closed auth state. Must run before start() serves requests.
+   *
+   * Reconciles the 0600 secret file with the persisted hash (gateway_bootstrap):
+   *   - fresh (no file, no hash): generate a 32-byte 0600 secret and persist its hash.
+   *   - fresh DB + existing file (§7 R5): re-hash the file into the new store.
+   *   - file + matching hash: adopt the file secret as the HMAC key.
+   *   - file present, hash mismatch (§D7): possible substitution  -  refuse new pairings.
+   *   - file missing, hash on record (§D7): file removed  -  refuse new pairings (tokens still work).
+   *   - permissive mode (§D7): group/other-readable  -  refuse to use it.
+   */
+  async initAuth(): Promise<void> {
+    const secretPath = this.config.secretPath;
+    const db = this.config.db;
+
+    // Looped so a create-path race that loses to another process (EEXIST) falls
+    // back to reading the winner's file rather than failing the daemon. Bounded
+    // at MAX_INIT_AUTH_ATTEMPTS so a persistent create/delete race cannot
+    // livelock startup.
+    for (let attempt = 1; attempt <= MAX_INIT_AUTH_ATTEMPTS; attempt++) {
+      const dbHash = await getBootstrapSecretHash(db);
+
+      // Read path: open ONE fd with O_NOFOLLOW, then fstat + read that same fd.
+      // No path is resolved twice, so a symlink or file swap after the open
+      // cannot substitute an attacker-controlled key past the permission gate.
+      let fd: number;
+      try {
+        fd = openSync(secretPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'ENOENT') {
+          // File genuinely absent: fall through to the missing/create paths.
+        } else {
+          this.bootstrapSecret = null;
+          if (code === 'ELOOP') {
+            this.logAuth(
+              `bootstrap secret at ${secretPath} is a symlink; refusing to follow it (possible substitution)`,
+            );
+          } else {
+            this.logAuth(
+              `cannot open bootstrap secret at ${secretPath} (${code ?? 'unknown error'}); refusing new pairings`,
+            );
+          }
+          return;
+        }
+
+        // ENOENT: file missing.
+        if (dbHash !== null) {
+          this.bootstrapSecret = null;
+          this.logAuth(
+            `bootstrap secret file ${secretPath} is missing but a hash is on record; refusing new pairings (existing tokens still work). Regenerate the file to re-enable pairing.`,
+          );
+          return;
+        }
+
+        // Truly fresh: exclusively create the fail-closed bootstrap secret. The
+        // 'wx' flag (O_EXCL) refuses a pre-planted file or symlink, and mode
+        // 0600 is applied atomically on creation.
+        mkdirSync(dirname(secretPath), { recursive: true });
+        const secret = randomBytes(SECRET_BYTES).toString('hex');
+        try {
+          writeFileSync(secretPath, secret, { flag: 'wx', mode: 0o600 });
+        } catch (createErr) {
+          if ((createErr as NodeJS.ErrnoException).code === 'EEXIST') {
+            // Another process created the file between our open and write; loop
+            // back to read it rather than failing.
+            continue;
+          }
+          throw createErr;
+        }
+        await putBootstrapSecretHash(db, sha256Hex(secret));
+        this.bootstrapSecret = secret;
+        this.logAuth(`generated a new bootstrap pairing secret at ${secretPath} (mode 0600)`);
+        return;
+      }
+
+      try {
+        const stat = fstatSync(fd);
+        if (!stat.isFile()) {
+          this.bootstrapSecret = null;
+          this.logAuth(
+            `bootstrap secret at ${secretPath} is not a regular file; refusing to use it`,
+          );
+          return;
+        }
+        const mode = stat.mode & 0o777;
+        if ((mode & 0o077) !== 0) {
+          this.bootstrapSecret = null;
+          this.logAuth(
+            `bootstrap secret at ${secretPath} is group/other-accessible (mode ${mode.toString(8)}); refusing to use it  -  run: chmod 600 ${secretPath}`,
+          );
+          return;
+        }
+        const contents = readFileSync(fd, 'utf8').trim();
+        if (contents.length === 0) {
+          this.bootstrapSecret = null;
+          this.logAuth(`bootstrap secret file at ${secretPath} is empty; refusing new pairings`);
+          return;
+        }
+        const fileHash = sha256Hex(contents);
+        if (dbHash === null) {
+          await putBootstrapSecretHash(db, fileHash);
+          this.bootstrapSecret = contents;
+          this.logAuth('adopted an existing bootstrap secret file into a fresh store');
+        } else if (dbHash === fileHash) {
+          this.bootstrapSecret = contents;
+        } else {
+          this.bootstrapSecret = null;
+          this.logAuth(
+            `bootstrap secret at ${secretPath} does not match the recorded hash (possible substitution); refusing new pairings until it is regenerated`,
+          );
+        }
+        return;
+      } finally {
+        closeSync(fd);
+      }
+    }
+
+    this.bootstrapSecret = null;
+    this.logAuth(
+      `bootstrap secret initialization at ${secretPath} did not converge after ${MAX_INIT_AUTH_ATTEMPTS} attempts (persistent create/delete race); refusing new pairings`,
+    );
+  }
+
+  async start(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server.listen(this.config.port, this.config.host, () => resolve());
+      this.server.once('error', reject);
+    });
+  }
+
+  async stop(): Promise<void> {
+    return new Promise((resolve) => this.server.close(() => resolve()));
+  }
+
+  /** The bound TCP port (useful when constructed with port 0). */
+  getPort(): number {
+    const addr = this.server.address();
+    return addr && typeof addr === 'object' ? addr.port : this.config.port;
+  }
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+      const path = url.pathname;
+      const method = req.method ?? 'GET';
+
+      // CORS headers for mobile browser access
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+      if (method === 'OPTIONS') {
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+
+      // API / RPC namespace  -  fail-closed except the explicit pairing allowlist.
+      if (path === '/rpc' || path.startsWith('/api/')) {
+        if (!(isPreAuthRoute(method, path) || (await this.checkAuth(req, res)))) {
+          return;
+        }
+
+        if (path === '/api/pair' && method === 'GET') {
+          this.handleIssueNonce(res);
+          return;
+        }
+        if (path === '/api/pair' && method === 'POST') {
+          this.handlePair(req, res);
+          return;
+        }
+        if (path === '/rpc' && method === 'POST') {
+          this.handleRpc(req, res);
+          return;
+        }
+        if (path === '/api/status') {
+          this.handleStatus(res);
+          return;
+        }
+        if (path.startsWith('/api/stream') && method === 'GET') {
+          const processFilter = path.split('/')[3] ?? null; // optional processId filter
+          this.handleStream(req, res, processFilter);
+          return;
+        }
+
+        jsonResponse(res, 404, { error: 'Not found' });
+        return;
+      }
+
+      // Static file serving (Studio SPA shell  -  carries no data without a token).
+      this.handleStatic(path, res);
+    } catch (err) {
+      this.logAuth(`request handling error: ${err instanceof Error ? err.message : 'unknown'}`);
+      if (!res.headersSent) jsonResponse(res, 500, { error: 'Internal error' });
+    }
+  }
+
+  /** Verify `Authorization: Bearer <token>` against the durable token store. */
+  private async checkAuth(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
+    const authHeader = req.headers.authorization ?? '';
+    if (!authHeader.startsWith('Bearer ')) {
+      jsonResponse(res, 401, { error: 'Authorization required' });
+      return false;
+    }
+
+    const presented = authHeader.slice(7);
+    if (presented.length === 0) {
+      jsonResponse(res, 401, { error: 'Authorization required' });
+      return false;
+    }
+
+    const presentedHash = sha256Hex(presented);
+    const row = await findValidToken(this.config.db, presentedHash);
+    if (!row) {
+      jsonResponse(res, 401, { error: 'Invalid or expired token' });
+      return false;
+    }
+
+    // The store matched on hash equality; a constant-time re-check keeps token
+    // verification timing-independent even if that predicate ever loosens.
+    const a = Buffer.from(presentedHash, 'hex');
+    const b = Buffer.from(row.token_hash, 'hex');
+    if (a.length !== b.length || !timingSafeEqual(a, b)) {
+      jsonResponse(res, 401, { error: 'Invalid or expired token' });
+      return false;
+    }
+
+    return true;
+  }
+
+  /** GET /api/pair  -  issue a single-use, short-lived pairing nonce. */
+  private handleIssueNonce(res: ServerResponse): void {
+    this.pruneNonces();
+    if (this.nonces.size >= MAX_PENDING_NONCES) {
+      jsonResponse(res, 503, { error: 'Too many pending pairings; try again shortly' });
+      return;
+    }
+    const nonce = randomBytes(NONCE_BYTES).toString('hex');
+    this.nonces.set(nonce, this.now() + this.nonceTtlMs);
+    jsonResponse(res, 200, { nonce, expiresIn: Math.floor(this.nonceTtlMs / 1000) });
+  }
+
+  private pruneNonces(): void {
+    const now = this.now();
+    for (const [nonce, expiresAt] of this.nonces) {
+      if (expiresAt <= now) this.nonces.delete(nonce);
+    }
+  }
+
+  /** POST /api/pair  -  verify an HMAC challenge response and mint a durable token. */
+  private handlePair(req: IncomingMessage, res: ServerResponse): void {
+    const source = req.socket.remoteAddress ?? 'unknown';
+    const wait = this.rateLimiter.retryAfterMs(source);
+    if (wait > 0) {
+      this.logAuth(
+        `pairing attempt from a locked-out source; ${Math.ceil(wait / 1000)}s remaining`,
+      );
+      jsonResponse(res, 429, { error: 'Too many attempts', retryAfter: Math.ceil(wait / 1000) });
+      return;
+    }
+
+    let body = '';
+    req.on('data', (chunk: Buffer) => {
+      body += chunk.toString();
+      if (body.length > 1024) {
+        res.writeHead(413);
+        res.end();
+        req.destroy();
+      }
+    });
+    req.on('end', () => {
+      void this.completePair(res, body, source);
+    });
+  }
+
+  private async completePair(res: ServerResponse, body: string, source: string): Promise<void> {
+    if (this.bootstrapSecret === null) {
+      // §D7 refusal state  -  a server condition, not the client's fault; do not penalize the source.
+      this.logAuth('pairing requested but the bootstrap secret is unavailable; refusing');
+      jsonResponse(res, 503, { error: 'Pairing is disabled' });
+      return;
+    }
+
+    let nonce: string;
+    let hmac: string;
+    let label: string | null = null;
+    try {
+      const parsed = JSON.parse(body) as { nonce?: unknown; hmac?: unknown; label?: unknown };
+      if (typeof parsed.nonce !== 'string' || typeof parsed.hmac !== 'string') {
+        jsonResponse(res, 400, { error: 'nonce and hmac are required' });
+        return;
+      }
+      nonce = parsed.nonce;
+      hmac = parsed.hmac;
+      if (typeof parsed.label === 'string') label = parsed.label.slice(0, 128);
+    } catch {
+      jsonResponse(res, 400, { error: 'Invalid JSON' });
+      return;
+    }
+
+    // Consume the nonce (single-use): remove it before verifying so it cannot be replayed,
+    // whether the attempt succeeds or fails.
+    const nonceExpiry = this.nonces.get(nonce);
+    this.nonces.delete(nonce);
+    if (nonceExpiry === undefined || nonceExpiry <= this.now()) {
+      this.registerPairFailure(source, 'unknown or expired nonce');
+      jsonResponse(res, 403, { error: 'Invalid or expired nonce' });
+      return;
+    }
+
+    const expected = createHmac('sha256', this.bootstrapSecret).update(nonce).digest();
+    const presented = Buffer.from(hmac, 'hex');
+    const ok = expected.length === presented.length && timingSafeEqual(expected, presented);
+    if (!ok) {
+      this.registerPairFailure(source, 'incorrect pairing response');
+      jsonResponse(res, 403, { error: 'Invalid pairing response' });
+      return;
+    }
+
+    this.rateLimiter.recordSuccess(source);
+
+    const token = randomBytes(TOKEN_BYTES).toString('hex');
+    const expiresAt = new Date(this.now() + this.tokenTtlMs).toISOString();
+    await insertToken(this.config.db, { tokenHash: sha256Hex(token), expiresAt, label });
+    await pruneExpiredTokens(this.config.db);
+    this.logAuth('issued a new bearer token via successful pairing');
+    jsonResponse(res, 200, { token, expiresAt });
+  }
+
+  private registerPairFailure(source: string, reason: string): void {
+    const { failures, lockMs, globalTripped } = this.rateLimiter.recordFailure(source);
+    const lockNote = lockMs > 0 ? `; locked out ${Math.ceil(lockMs / 1000)}s` : '';
+    this.logAuth(`pairing failure from ${source} (${reason}); failures=${failures}${lockNote}`);
+    if (globalTripped) {
+      this.logAuth('global pairing-failure ceiling reached; applying a global cooldown');
+    }
+  }
+
+  /** GET /api/status  -  daemon status summary (auth required). */
+  private handleStatus(res: ServerResponse): void {
+    jsonResponse(res, 200, {
+      daemon: 'revdev-daemon',
+      pid: process.pid,
+      uptime: process.uptime(),
+    });
+  }
+
+  /**
+   * POST /rpc  -  proxy JSON-RPC through dispatchRpc, the SAME authorization
+   * path the Unix socket uses (GAP-421 wire path §1). Each HTTP request gets
+   * a fresh SocketContext: HTTP is stateless, so per-call identity comes from
+   * an embedded `x-revdev-signature` envelope or `params.actorAgentId` inside
+   * the request body, never a persisted per-connection binding.
+   */
+  private handleRpc(req: IncomingMessage, res: ServerResponse): void {
+    let body = '';
+    req.on('data', (chunk: Buffer) => {
+      body += chunk.toString();
+      // 1MB limit for RPC payloads
+      if (body.length > 1_048_576) {
+        res.writeHead(413);
+        res.end();
+        req.destroy();
+      }
+    });
+    req.on('end', () => {
+      void this.completeRpc(res, body);
+    });
+  }
+
+  private async completeRpc(res: ServerResponse, body: string): Promise<void> {
+    let parsed: RpcRequest;
+    try {
+      parsed = JSON.parse(body) as RpcRequest;
+    } catch {
+      jsonResponse(res, 200, {
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32700, message: 'Parse error' },
+      } satisfies RpcResponse);
+      return;
+    }
+
+    const ctx: SocketContext = {
+      agentId: null,
+      agentName: null,
+      boundVia: null,
+      keyOrigin: null,
+      verifiedSignature: null,
+      preSignatureAgentId: null,
+      preSignatureAgentName: null,
+      preSignatureBoundVia: null,
+    };
+    const response = await dispatchRpc(parsed, this.config.db, ctx);
+    jsonResponse(res, 200, response);
+  }
+
+  /** GET /api/stream[/:processId]  -  SSE for agent.* PTY output and exit events. */
+  private handleStream(
+    req: IncomingMessage,
+    res: ServerResponse,
+    processFilter: string | null,
+  ): void {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+
+    // Send initial keepalive
+    res.write(': connected\n\n');
+
+    const onOutput = (evt: AgentOutputEvent): void => {
+      if (processFilter && evt.processId !== processFilter) return;
+      res.write(`event: output\ndata: ${JSON.stringify(evt)}\n\n`);
+    };
+
+    const onExit = (evt: AgentExitEvent): void => {
+      if (processFilter && evt.processId !== processFilter) return;
+      res.write(`event: exit\ndata: ${JSON.stringify(evt)}\n\n`);
+    };
+
+    agentEvents.on('output', onOutput);
+    agentEvents.on('exit', onExit);
+
+    // Keepalive every 30s to prevent proxy/firewall timeouts
+    const keepalive = setInterval(() => {
+      res.write(': keepalive\n\n');
+    }, 30_000);
+
+    // Cleanup on client disconnect
+    req.on('close', () => {
+      clearInterval(keepalive);
+      agentEvents.off('output', onOutput);
+      agentEvents.off('exit', onExit);
+    });
+  }
+
+  /** Serve static files from the Studio build directory */
+  private handleStatic(urlPath: string, res: ServerResponse): void {
+    if (!this.config.staticDir) {
+      jsonResponse(res, 404, { error: 'Static serving not configured' });
+      return;
+    }
+
+    // Default to index.html for SPA routing
+    const filePath = urlPath === '/' ? '/index.html' : urlPath;
+
+    // Security: prevent directory traversal
+    const normalized = normalize(filePath);
+    if (normalized.includes('..')) {
+      res.writeHead(400);
+      res.end('Bad request');
+      return;
+    }
+
+    const fullPath = join(this.config.staticDir, normalized);
+
+    // If file doesn't exist, serve index.html (SPA fallback)
+    const targetPath =
+      existsSync(fullPath) && statSync(fullPath).isFile()
+        ? fullPath
+        : join(this.config.staticDir, 'index.html');
+
+    if (!existsSync(targetPath)) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+
+    const ext = extname(targetPath);
+    const contentType = MIME_TYPES[ext] ?? 'application/octet-stream';
+
+    res.writeHead(200, { 'Content-Type': contentType });
+    createReadStream(targetPath).pipe(res);
+  }
+
+  private logAuth(message: string): void {
+    process.stderr.write(`[http-gateway auth] ${message}\n`);
+  }
+}
+
+/** SHA-256 hex digest of a string. */
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+/** Helper to send a JSON response */
+function jsonResponse(res: ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body);
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(json),
+  });
+  res.end(json);
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -7,9 +7,12 @@
  *
  * Transport:
  *   - Local: Unix socket (~/.local/share/revealui/harness.sock)
- *   - Remote (optional): the @revealui/harnesses HTTP gateway with
- *     fail-closed challenge-response pairing (GET/POST /api/pair) — not
- *     served by this package; Studio pairs against that gateway when remote.
+ *   - Remote (optional, off by default): an in-process HTTP gateway with
+ *     fail-closed challenge-response pairing (GET/POST /api/pair). Ported
+ *     from `@revealui/harnesses` `server/http-gateway.ts` into this package
+ *     (GAP-421 daemon-ownership ADR) — every /rpc and /api/* request runs
+ *     through the same `dispatchRpc` authorization path as the socket.
+ *     Configure `httpPort` (0 = disabled, the default) to enable it.
  *   - Protocol: JSON-RPC 2.0 over newline-delimited JSON
  *
  * License: FSL-1.1-MIT (converts to MIT after 2 years)
@@ -25,8 +28,21 @@ export {
   type RpcGuardResult,
   refreshLicense,
 } from './guard.js';
+export {
+  HttpGateway,
+  type HttpGatewayConfig,
+  isPreAuthRoute,
+  PRE_AUTH_ROUTES,
+} from './http-gateway.js';
 export { checkLicense, LICENSE_TIERS, type LicenseTier } from './license.js';
-export { listRegisteredMethods, registerHandler, startDaemon } from './server.js';
+export {
+  dispatchRpc,
+  listRegisteredMethods,
+  type RpcRequest,
+  type RpcResponse,
+  registerHandler,
+  startDaemon,
+} from './server.js';
 export {
   evaluateToolAction,
   type GuardVerdict,

--- a/packages/daemon/src/migrations/0008-gateway-tokens.ts
+++ b/packages/daemon/src/migrations/0008-gateway-tokens.ts
@@ -1,0 +1,34 @@
+/**
+ * Migration 0008 — HTTP gateway pairing tokens (GAP-421 daemon-ownership ADR).
+ *
+ * Ported from `@revealui/harnesses` `storage/schema.ts` (`gateway_bootstrap` +
+ * `gateway_tokens`), byte-identical column shape so the on-the-wire pairing
+ * contract (GET/POST /api/pair, Bearer auth on /rpc and /api/*) needs no
+ * protocol change. `gateway_bootstrap` is a singleton row recording the
+ * SHA-256 hash of the 0600 bootstrap pairing-secret file; `gateway_tokens`
+ * holds hashed durable bearer tokens minted on successful pairing.
+ */
+
+import type { Migration } from '../storage/migrate.js';
+
+const SQL = `
+  CREATE TABLE IF NOT EXISTS gateway_bootstrap (
+    id            INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    secret_hash   TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  );
+
+  CREATE TABLE IF NOT EXISTS gateway_tokens (
+    token_hash    TEXT PRIMARY KEY,
+    issued_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at    TIMESTAMPTZ,
+    revoked_at    TIMESTAMPTZ,
+    label         TEXT
+  );
+`;
+
+export const MIGRATION_0008: Migration = {
+  version: 8,
+  name: 'gateway-tokens',
+  sql: SQL,
+};

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -23,6 +23,7 @@ import { MIGRATION_0004 } from './0004-agent-processes.js';
 import { MIGRATION_0005 } from './0005-session-activity-state.js';
 import { MIGRATION_0006 } from './0006-agent-process-confinement.js';
 import { MIGRATION_0007 } from './0007-permission-approvals.js';
+import { MIGRATION_0008 } from './0008-gateway-tokens.js';
 
 export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0001,
@@ -32,4 +33,5 @@ export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0005,
   MIGRATION_0006,
   MIGRATION_0007,
+  MIGRATION_0008,
 ];

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -17,7 +17,7 @@
 
 import { mkdir, readFile } from 'node:fs/promises';
 import { createServer, type Socket } from 'node:net';
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import { formatDid, parseDid } from '@revdev/protocol/did';
 import { createLogger } from '@revealui/utils/logger';
@@ -38,6 +38,7 @@ import {
   licenseErrorResponse,
   runtimeLicenseRecheck,
 } from './guard.js';
+import { HttpGateway } from './http-gateway.js';
 import {
   initNeonSync,
   isNeonSyncActive,
@@ -82,12 +83,20 @@ const log = createLogger({ service: 'revdev-daemon' });
 // Types
 // ---------------------------------------------------------------------------
 
-interface RpcRequest {
+export interface RpcRequest {
   jsonrpc: '2.0';
   id: number | string | null;
   method: string;
   params?: Record<string, unknown>;
   'x-revdev-signature'?: string;
+}
+
+/** A fully-formed JSON-RPC 2.0 response, as returned by {@link dispatchRpc}. */
+export interface RpcResponse {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
 }
 
 /** Per-connection state. Populated on session.register or session.attach. */
@@ -709,6 +718,200 @@ async function verifyOrWarn(
   ctx.boundVia = 'signature';
   ctx.verifiedSignature = { kid: parsed.payload.kid, nonce: parsed.payload.nonce };
   return 'verified';
+}
+
+/**
+ * Dispatch one already-parsed JSON-RPC request through the daemon's full
+ * authorization pipeline — license guard, param validation, handler lookup,
+ * Ed25519 signature gate, identity gate, permission gate, shutdown gate —
+ * and run the matched handler.
+ *
+ * This is the single authorization path (GAP-421 daemon-ownership ADR, wire
+ * path §1): both the Unix-socket loop (below, in `startDaemon`) and the HTTP
+ * gateway (`http-gateway.ts`) call this exact function. Remote (HTTP) traffic
+ * inherits the same license guard, typed param validation, Ed25519 signature
+ * requirement on `MUTATING_OR_CONTENT_METHODS`, and permission queue as local
+ * (socket) traffic — there is no parallel, weaker auth path for the network
+ * surface. `ctx` is per-connection state; the socket loop reuses one `ctx`
+ * across a connection's lifetime, while the HTTP gateway constructs a fresh
+ * `ctx` per request (HTTP is stateless — identity for a given call comes from
+ * an embedded `x-revdev-signature` envelope or a `params.actorAgentId`, never
+ * from a persisted per-connection binding).
+ */
+export async function dispatchRpc(
+  req: RpcRequest,
+  db: PGlite,
+  ctx: SocketContext,
+): Promise<RpcResponse> {
+  // License guard
+  const guard = guardRpcMethod(req.method);
+  if (!guard.allowed) {
+    return JSON.parse(licenseErrorResponse(req.id, guard)) as RpcResponse;
+  }
+
+  // Validate params
+  const validation = validateParams(req.method, req.params);
+  if (!validation.valid) {
+    return JSON.parse(
+      invalidParamsResponse(req.id, validation.error ?? 'Invalid params'),
+    ) as RpcResponse;
+  }
+
+  // Dispatch
+  const handler = handlers.get(req.method);
+  if (!handler) {
+    return {
+      jsonrpc: '2.0',
+      id: req.id,
+      error: { code: -32601, message: `Method not found: ${req.method}` },
+    };
+  }
+
+  // Signature gate. Attempts to bind ctx.agentId from a verified Ed25519
+  // envelope. For coordination methods this is accept-if-present (invalid
+  // or missing signatures fall through to the identity gate below). For
+  // MUTATING_OR_CONTENT_METHODS the signature is REQUIRED — anything other
+  // than a fully-verified envelope is rejected with -32003 before the
+  // handler runs, mirroring the license-guard block above.
+  const verification = await verifyOrWarn(req, db, ctx);
+  // P2 telemetry (ADR 2026-05-16 §Q5). Record the per-RPC signature status
+  // for every non-exempt method BEFORE any accept/reject below, so the
+  // 'none'/'invalid' coverage rate is measured across ALL non-exempt
+  // traffic (the P3 flip gate). Best-effort — never blocks or fails the RPC.
+  emitSignatureTelemetry(req, db, ctx, verification);
+  if (MUTATING_OR_CONTENT_METHODS.has(req.method) && verification !== 'verified') {
+    return {
+      jsonrpc: '2.0',
+      id: req.id,
+      error: {
+        code: -32003,
+        message: 'Signature required',
+        data: {
+          method: req.method,
+          reason:
+            verification === 'none' ? 'missing Ed25519 signature' : 'invalid Ed25519 signature',
+        },
+      },
+    };
+  }
+
+  // Identity gate: most coordination calls need a registered agent.
+  // Fallback: accept `actorAgentId` in params; requireVerifiedAgent
+  // enforces the verified principal (signature, or daemon-minted bind).
+  if (
+    !IDENTITY_EXEMPT.has(req.method) &&
+    !ctx.agentId &&
+    !(req.params && typeof req.params.actorAgentId === 'string')
+  ) {
+    return {
+      jsonrpc: '2.0',
+      id: req.id,
+      error: {
+        code: -32002,
+        message: `Not registered: call session.register or session.attach before ${req.method}`,
+      },
+    };
+  }
+
+  // Permission gate (GAP-294). After identity, before shutdown/dispatch.
+  // Shadow (default): would_* events only. manual/auto: enforce with
+  // reject-with-receipt (-32004) + pending_approvals queue.
+  {
+    const agentForEvent =
+      ctx.agentId ??
+      (req.params && typeof req.params.actorAgentId === 'string' ? req.params.actorAgentId : null);
+    // Spec §3: per-session override ?? daemon default (env).
+    const mode = await resolveEffectiveMode(db, agentForEvent);
+    // Shadow only when *effective* mode is shadow (session override can
+    // promote a session out of daemon-default shadow for dogfood).
+    if (mode === 'shadow') {
+      emitPermissionShadowEvent(db, agentForEvent, req.method, evaluateShadow(req.method));
+    } else {
+      // Still emit would_* for soak continuity under enforce modes.
+      emitPermissionShadowEvent(db, agentForEvent, req.method, evaluateShadow(req.method));
+      const decision = decideEnforcement(req.method, mode);
+      if (decision.action === 'deny') {
+        return {
+          jsonrpc: '2.0',
+          id: req.id,
+          error: {
+            code: -32004,
+            message: `Permission denied for ${req.method}`,
+            data: { kind: 'permission-denied', method: req.method, reason: decision.reason },
+          },
+        };
+      }
+      if (decision.action === 'require_approval') {
+        if (!agentForEvent) {
+          return {
+            jsonrpc: '2.0',
+            id: req.id,
+            error: {
+              code: -32002,
+              message: `Not registered: call session.register before ${req.method}`,
+            },
+          };
+        }
+        const paramsObj =
+          req.params && typeof req.params === 'object' && !Array.isArray(req.params)
+            ? (req.params as Record<string, unknown>)
+            : {};
+        try {
+          const consumed = await tryConsumeApproval(db, agentForEvent, req.method, paramsObj);
+          if (!consumed) {
+            await queueApprovalRequired(db, agentForEvent, req.method, paramsObj);
+          }
+        } catch (permErr) {
+          if (permErr instanceof ApprovalRequiredError) {
+            return {
+              jsonrpc: '2.0',
+              id: req.id,
+              error: { code: permErr.code, message: permErr.message, data: permErr.data },
+            };
+          }
+          throw permErr;
+        }
+      }
+    }
+  }
+
+  // Shutdown gate. A request arriving after shutdown started must not run
+  // against a closing/closed PGlite.
+  if (_closing) {
+    return {
+      jsonrpc: '2.0',
+      id: req.id,
+      error: { code: -32099, message: 'Server is shutting down' },
+    };
+  }
+
+  const startMs = Date.now();
+  _activeHandlerCount++;
+  try {
+    const result = await handler(req.params ?? {}, db, ctx);
+    trackRpcCall(req.method, 'ok', Date.now() - startMs);
+    return { jsonrpc: '2.0', id: req.id, result };
+  } catch (err) {
+    trackRpcCall(req.method, 'error', Date.now() - startMs);
+    // A handler may carry an explicit numeric JSON-RPC code (e.g.
+    // UntrustedClientKeyError → -32004). Guard on `typeof === 'number'`
+    // so Node's string error codes (ENOENT, EACCES, …) don't leak into
+    // the JSON-RPC `code` field — those fall back to the generic -32000.
+    const rawCode = (err as { code?: unknown }).code;
+    const code = typeof rawCode === 'number' ? rawCode : -32000;
+    const data = (err as { data?: unknown }).data;
+    return {
+      jsonrpc: '2.0',
+      id: req.id,
+      error: {
+        code,
+        message: err instanceof Error ? err.message : 'Internal error',
+        ...(data !== undefined ? { data } : {}),
+      },
+    };
+  } finally {
+    _activeHandlerCount--;
+  }
 }
 
 /** Accept either `paths: string[]` or `filePath: string` — normalize to array. */
@@ -1778,7 +1981,7 @@ registerHandler('memory.query', async (params, db, ctx) => {
 
 export async function startDaemon(
   config: Partial<DaemonConfig> = {},
-): Promise<{ close: () => Promise<void>; _db: PGlite }> {
+): Promise<{ close: () => Promise<void>; _db: PGlite; _httpGateway: HttpGateway | null }> {
   const cfg = { ...DAEMON_DEFAULTS, ...config };
   // Publish the effective config so handlers in other modules (filegit.ts)
   // can read limits like maxInlineReadBytes without a cfg parameter.
@@ -2019,214 +2222,12 @@ export async function startDaemon(
           continue;
         }
 
-        // License guard
-        const guard = guardRpcMethod(req.method);
-        if (!guard.allowed) {
-          socket.write(`${licenseErrorResponse(req.id, guard)}\n`);
-          continue;
-        }
-
-        // Validate params
-        const validation = validateParams(req.method, req.params);
-        if (!validation.valid) {
-          socket.write(`${invalidParamsResponse(req.id, validation.error ?? 'Invalid params')}\n`);
-          continue;
-        }
-
-        // Dispatch
-        const handler = handlers.get(req.method);
-        if (!handler) {
-          socket.write(
-            `${JSON.stringify({
-              jsonrpc: '2.0',
-              id: req.id,
-              error: { code: -32601, message: `Method not found: ${req.method}` },
-            })}\n`,
-          );
-          continue;
-        }
-
-        // Signature gate. Attempts to bind ctx.agentId from a verified Ed25519
-        // envelope. For coordination methods this is accept-if-present (invalid
-        // or missing signatures fall through to the identity gate below). For
-        // MUTATING_OR_CONTENT_METHODS the signature is REQUIRED — anything other
-        // than a fully-verified envelope is rejected with -32003 before the
-        // handler runs, mirroring the license-guard block above.
-        const verification = await verifyOrWarn(req, db, ctx);
-        // P2 telemetry (ADR 2026-05-16 §Q5). Record the per-RPC signature status
-        // for every non-exempt method BEFORE any accept/reject below, so the
-        // 'none'/'invalid' coverage rate is measured across ALL non-exempt
-        // traffic (the P3 flip gate). Best-effort — never blocks or fails the RPC.
-        emitSignatureTelemetry(req, db, ctx, verification);
-        if (MUTATING_OR_CONTENT_METHODS.has(req.method) && verification !== 'verified') {
-          socket.write(
-            `${JSON.stringify({
-              jsonrpc: '2.0',
-              id: req.id,
-              error: {
-                code: -32003,
-                message: 'Signature required',
-                data: {
-                  method: req.method,
-                  reason:
-                    verification === 'none'
-                      ? 'missing Ed25519 signature'
-                      : 'invalid Ed25519 signature',
-                },
-              },
-            })}\n`,
-          );
-          continue;
-        }
-
-        // Identity gate: most coordination calls need a registered agent.
-        // Fallback: accept `actorAgentId` in params; requireVerifiedAgent
-        // enforces the verified principal (signature, or daemon-minted bind).
-        if (
-          !IDENTITY_EXEMPT.has(req.method) &&
-          !ctx.agentId &&
-          !(req.params && typeof req.params.actorAgentId === 'string')
-        ) {
-          socket.write(
-            `${JSON.stringify({
-              jsonrpc: '2.0',
-              id: req.id,
-              error: {
-                code: -32002,
-                message: `Not registered: call session.register or session.attach before ${req.method}`,
-              },
-            })}\n`,
-          );
-          continue;
-        }
-
-        // Permission gate (GAP-294). After identity, before shutdown/dispatch.
-        // Shadow (default): would_* events only. manual/auto: enforce with
-        // reject-with-receipt (-32004) + pending_approvals queue.
-        {
-          const agentForEvent =
-            ctx.agentId ??
-            (req.params && typeof req.params.actorAgentId === 'string'
-              ? req.params.actorAgentId
-              : null);
-          // Spec §3: per-session override ?? daemon default (env).
-          const mode = await resolveEffectiveMode(db, agentForEvent);
-          // Shadow only when *effective* mode is shadow (session override can
-          // promote a session out of daemon-default shadow for dogfood).
-          if (mode === 'shadow') {
-            emitPermissionShadowEvent(db, agentForEvent, req.method, evaluateShadow(req.method));
-          } else {
-            // Still emit would_* for soak continuity under enforce modes.
-            emitPermissionShadowEvent(db, agentForEvent, req.method, evaluateShadow(req.method));
-            const decision = decideEnforcement(req.method, mode);
-            if (decision.action === 'deny') {
-              socket.write(
-                `${JSON.stringify({
-                  jsonrpc: '2.0',
-                  id: req.id,
-                  error: {
-                    code: -32004,
-                    message: `Permission denied for ${req.method}`,
-                    data: {
-                      kind: 'permission-denied',
-                      method: req.method,
-                      reason: decision.reason,
-                    },
-                  },
-                })}\n`,
-              );
-              continue;
-            }
-            if (decision.action === 'require_approval') {
-              if (!agentForEvent) {
-                socket.write(
-                  `${JSON.stringify({
-                    jsonrpc: '2.0',
-                    id: req.id,
-                    error: {
-                      code: -32002,
-                      message: `Not registered: call session.register before ${req.method}`,
-                    },
-                  })}\n`,
-                );
-                continue;
-              }
-              const paramsObj =
-                req.params && typeof req.params === 'object' && !Array.isArray(req.params)
-                  ? (req.params as Record<string, unknown>)
-                  : {};
-              try {
-                const consumed = await tryConsumeApproval(db, agentForEvent, req.method, paramsObj);
-                if (!consumed) {
-                  await queueApprovalRequired(db, agentForEvent, req.method, paramsObj);
-                }
-              } catch (permErr) {
-                if (permErr instanceof ApprovalRequiredError) {
-                  socket.write(
-                    `${JSON.stringify({
-                      jsonrpc: '2.0',
-                      id: req.id,
-                      error: {
-                        code: permErr.code,
-                        message: permErr.message,
-                        data: permErr.data,
-                      },
-                    })}\n`,
-                  );
-                  continue;
-                }
-                throw permErr;
-              }
-            }
-          }
-        }
-
-        // Shutdown gate. close() sets _closing BEFORE the drain so a
-        // request arriving on an already-connected socket after shutdown
-        // started cannot increment the counter past the drain observation
-        // window and run against a closing/closed PGlite. We respond with
-        // JSON-RPC -32099 ("Server is shutting down") and bail before the
-        // counter increment.
-        if (_closing) {
-          socket.write(
-            `${JSON.stringify({
-              jsonrpc: '2.0',
-              id: req.id,
-              error: { code: -32099, message: 'Server is shutting down' },
-            })}\n`,
-          );
-          continue;
-        }
-
-        const startMs = Date.now();
-        _activeHandlerCount++;
-        try {
-          const result = await handler(req.params ?? {}, db, ctx);
-          trackRpcCall(req.method, 'ok', Date.now() - startMs);
-          socket.write(`${JSON.stringify({ jsonrpc: '2.0', id: req.id, result })}\n`);
-        } catch (err) {
-          trackRpcCall(req.method, 'error', Date.now() - startMs);
-          // A handler may carry an explicit numeric JSON-RPC code (e.g.
-          // UntrustedClientKeyError → -32004). Guard on `typeof === 'number'`
-          // so Node's string error codes (ENOENT, EACCES, …) don't leak into
-          // the JSON-RPC `code` field — those fall back to the generic -32000.
-          const rawCode = (err as { code?: unknown }).code;
-          const code = typeof rawCode === 'number' ? rawCode : -32000;
-          const data = (err as { data?: unknown }).data;
-          socket.write(
-            `${JSON.stringify({
-              jsonrpc: '2.0',
-              id: req.id,
-              error: {
-                code,
-                message: err instanceof Error ? err.message : 'Internal error',
-                ...(data !== undefined ? { data } : {}),
-              },
-            })}\n`,
-          );
-        } finally {
-          _activeHandlerCount--;
-        }
+        // Every gate (license, param validation, signature, identity,
+        // permission, shutdown) plus handler execution lives in dispatchRpc
+        // so the socket and HTTP gateway transports share one authorization
+        // path (GAP-421 daemon-ownership ADR, wire path §1).
+        const response = await dispatchRpc(req, db, ctx);
+        socket.write(`${JSON.stringify(response)}\n`);
       }
     });
 
@@ -2291,8 +2292,36 @@ export async function startDaemon(
       log.info('listening', { socketPath: cfg.socketPath, mode: '0600' });
       log.info('ready for connections');
 
+      // Optional HTTP gateway (GAP-421 daemon-ownership ADR wire path §3).
+      // Default OFF: httpPort defaults to 0, and this daemon only ever
+      // constructs a listener when the operator sets it explicitly. Every
+      // /rpc and /api/* request runs through the exact same dispatchRpc as
+      // the Unix socket (see http-gateway.ts).
+      let httpGateway: HttpGateway | null = null;
+      if (cfg.httpPort) {
+        httpGateway = new HttpGateway({
+          port: cfg.httpPort,
+          host: cfg.httpHost,
+          staticDir: cfg.httpStaticDir,
+          db,
+          secretPath: join(cfg.dataDir, 'gateway-pairing-secret'),
+        });
+        try {
+          await httpGateway.initAuth();
+          await httpGateway.start();
+          log.info('http gateway listening', {
+            host: cfg.httpHost,
+            port: httpGateway.getPort(),
+          });
+        } catch (err) {
+          reject(err);
+          return;
+        }
+      }
+
       resolve({
         _db: db,
+        _httpGateway: httpGateway,
         close: async () => {
           // Sequence:
           //   1. Set _closing FIRST so any RPC arriving on an existing
@@ -2318,6 +2347,7 @@ export async function startDaemon(
           if (pruneTimer) clearInterval(pruneTimer);
           clearInterval(nonceSweepTimer);
           clearInterval(licenseRecheckTimer);
+          if (httpGateway) await httpGateway.stop();
           server.close();
           for (const s of openSockets) {
             s.destroy();

--- a/packages/daemon/src/spawn-events.ts
+++ b/packages/daemon/src/spawn-events.ts
@@ -1,0 +1,35 @@
+/**
+ * Push feed for `agent.*` PTY output/exit, additive to the poll-based
+ * `agent.output` RPC (see spawn.ts). `spawn.ts` is the storage of record —
+ * every chunk still lands in `agent_process_output` for poll-based catch-up
+ * — this EventEmitter exists only so the HTTP gateway's SSE endpoint
+ * (`GET /api/stream/:processId`) has a live feed to relay, mirroring what
+ * `@revealui/harnesses` `server/spawner-service.ts` gave `http-gateway.ts`
+ * before the port. No auth surface: SSE access is gated upstream by the
+ * gateway's bearer-token check before this module is ever touched.
+ */
+
+import { EventEmitter } from 'node:events';
+
+export interface AgentOutputEvent {
+  processId: string;
+  stream: 'stdout' | 'stderr';
+  data: string;
+}
+
+export interface AgentExitEvent {
+  processId: string;
+  code: number | null;
+}
+
+class AgentEventBus extends EventEmitter {
+  emitOutput(evt: AgentOutputEvent): void {
+    this.emit('output', evt);
+  }
+  emitExit(evt: AgentExitEvent): void {
+    this.emit('exit', evt);
+  }
+}
+
+/** Process-wide singleton — one daemon process, one PTY registry (spawn.ts). */
+export const agentEvents = new AgentEventBus();

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -43,6 +43,7 @@ import {
 import { onAgentEnded, onDaemonStarted } from './eviction.js';
 import { requireRootAndDir } from './filegit.js';
 import { getDaemonConfig, registerHandler, type SocketContext } from './server.js';
+import { agentEvents } from './spawn-events.js';
 import { denyToolAction, evaluateToolAction } from './tool-guard/index.js';
 
 const log = createLogger({ service: 'revdev-daemon/spawn' });
@@ -103,6 +104,10 @@ function bufferOutput(db: PGlite, processId: string, chunk: string): void {
   ).catch((err: unknown) => {
     log.warn('output buffer write failed', { processId, seq, error: String(err) });
   });
+  // Push feed for the HTTP gateway's SSE endpoint (GAP-421 wire path §4).
+  // The DB row above remains the source of truth for poll-based agent.output;
+  // this is purely additive.
+  agentEvents.emitOutput({ processId, stream: 'stdout', data: chunk });
 }
 
 /**
@@ -119,6 +124,7 @@ function markExited(db: PGlite, processId: string, exitCode: number | null): voi
   ).catch((err: unknown) => {
     log.warn('process exit DB update failed', { processId, error: String(err) });
   });
+  agentEvents.emitExit({ processId, code: exitCode });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Executes step 6 of the GAP-421 routing per the **daemon-ownership ADR**
(`docs/decisions/2026-07-25-harness-daemon-ownership.md`, ratified by owner
directive 2026-07-25): ports the harness HTTP gateway into `@revdev/daemon`
so remote/pairing traffic runs through the daemon's real security layers
(license guard, Ed25519 signature gate, permission modes) instead of the
unreachable `@revealui/harnesses` server.

This PR is a **security surface** (remote access, pairing tokens,
Ed25519-gated dispatch) and explicitly requests a **non-author guardrail-2
verdict before merge**, per the ADR and the owner's dispatch instructions.

## What changed

- **`dispatchRpc` extraction** ([server.ts](packages/daemon/src/server.ts)) —
  the socket loop's inline license guard -> param validation -> handler lookup
  -> signature gate -> identity gate -> permission gate -> shutdown gate ->
  handler-exec sequence is now a single exported `dispatchRpc(req, db, ctx)`.
  Both the Unix socket loop and the new HTTP gateway call this exact
  function — one authorization path, never a parallel one.
- **Migration `0008-gateway-tokens.ts`** — `gateway_bootstrap` +
  `gateway_tokens` tables, byte-identical column shape to the harnesses
  schema (`storage/schema.ts:170`) so the wire contract needs no protocol
  change.
- **`gateway-store.ts`** — plain `db: PGlite` functions (daemon's existing
  convention, e.g. `permission.ts`) mirroring the harnesses `DaemonStore`
  gateway methods.
- **`http-gateway.ts`** — ported from
  `revealui/packages/harnesses/src/server/http-gateway.ts` (701 LOC),
  preserving the on-the-wire contract (GET/POST `/api/pair`, `POST /rpc`,
  bearer auth) so `apps/studio/src/lib/invoke.ts:786` `pairWithDaemon` needs
  no changes. `rpcDispatch: RpcServer` -> calls `dispatchRpc` directly;
  `DaemonStore` -> `gateway-store.ts` functions; `SpawnerService` -> the new
  `spawn-events.ts` push feed (see mismatch note below).
- **`config.ts` `httpPort`/`httpHost`/`httpStaticDir` get their first
  reader** — `startDaemon` only constructs `HttpGateway` when
  `cfg.httpPort` is truthy. Default stays `0` — **no config, no listener**.
- **SSE remap** — `spawn-events.ts` adds a small `EventEmitter` fed from the
  same points `spawn.ts`'s poll-based `agent_process_output` buffer is
  written (`bufferOutput`, the PTY exit callback), keyed by `processId`
  (the daemon's PTY registry key) rather than harnesses' `sessionId`. Purely
  additive — the DB buffer remains the source of truth for
  `agent.output` polling.
- **`index.ts` docblock corrected** — no longer claims the HTTP gateway is
  "not served by this package."
- **Studio wiring** — `SettingsPanel.tsx` Connection tab gets a "Remote
  daemon" pairing form (daemon URL + pairing secret) that calls
  `pairWithDaemon` only on an explicit "Pair" button click. No auto-pairing.

## Spec mismatch (flagged, not silently patched)

The ADR's wire path Section 4 says the SSE handler "binds to the daemon's
`agent.*` handlers and `spawn.ts` instead of the harnesses `SpawnerService`."
The harnesses `SpawnerService` is push-based (`EventEmitter`); the daemon's
`spawn.ts` is **poll-based** (`agent_process_output` buffer +
`agent.output` RPC) — there is no push primitive to bind to as written.
This is an implementation-detail gap in the ADR text, not a contract
mismatch with the auth model, so I did not stop: I added a minimal
additive `EventEmitter` (`spawn-events.ts`) fed from the existing
`bufferOutput`/exit call sites, with no change to authorization. Flagging
this explicitly for the guardrail-2 reviewer per the "no improvisation on
the auth model" instruction — the auth model itself is unchanged; only the
event-delivery mechanism for SSE is new.

## Contract parity

- `PRE_AUTH_ROUTES`, HMAC pairing flow, token TTL/lockout defaults, static
  file serving: unchanged from
  `revealui/packages/harnesses/src/server/http-gateway.ts` (that copy is not
  modified by this PR — a later step retires it after this port is
  verdicted).
- New shared gate: `server.ts` `dispatchRpc` is called both from the socket
  loop and from `HttpGateway.completeRpc` (`http-gateway.ts`).

## Tests

7 new tests in `packages/daemon/src/__tests__/http-gateway.test.ts`:

- **(a)** `rejects an unsigned MUTATING_OR_CONTENT_METHODS call over HTTP
  with the SAME code the socket returns` — sends the identical unsigned
  `session.end` request over HTTP (paired, valid bearer) and over the raw
  Unix socket, asserts both return `-32003` (Signature required).
- **(b)** pairing round trip (`GET /api/pair` -> `POST /api/pair` -> bearer
  token -> authorized `/rpc` call succeeds), plus a bad-HMAC rejection test.
- **(c)** `never constructs a listener when httpPort is left at its default
  (0)` and `...explicitly 0` — asserts `_httpGateway === null`.
- Plus 401-without-Authorization tests for `/rpc` and `/api/status`.

Full daemon suite: **744/744 passed** (737 pre-existing + 7 new).

**Red-proof method:** temporarily short-circuited the signature-required
branch in `dispatchRpc` (`if (false && MUTATING_OR_CONTENT_METHODS.has(...))`)
and reran `http-gateway.test.ts` — the parity test failed
(`expected -32002 to be -32003`), proving the test catches a regression in
the exact gate it exists to verify. Reverted before commit (clean diff on
that line before commit — no `git stash pop` used).

## Request

**Requesting a non-author guardrail-2 verdict before merge**, per the
daemon-ownership ADR and dispatch instructions — this PR touches the
Ed25519 signature gate's dispatch path and adds a network-reachable RPC
proxy.

## Test plan

- [x] `pnpm -r --filter=!studio build` — clean
- [x] `pnpm --filter @revdev/daemon test` — 744/744 passed
- [x] Red-proof of the new parity test (see above)
- [ ] Non-author guardrail-2 verdict (blocking merge)
- [ ] Owner merge (`gh pr merge --squash --delete-branch`) after verdict

Generated with Claude Code (https://claude.com/claude-code)
