### PR TITLE
fix(daemon): require a signed, ownership-checked ticket for SSE reads

### DIFF
--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -84,6 +84,11 @@ pub fn requires_signature(method: &str) -> bool {
             | "agent.input"
             | "agent.resize"
             | "agent.output"
+            // agent.streamTicket mints the principal for GET /api/stream (GAP-421
+            // guardrail-2 remediation B1): signature-required so the ticket is
+            // bound to the verified signer, mirroring agent.output's ownership
+            // check. MUST mirror server.ts MUTATING_OR_CONTENT_METHODS.
+            | "agent.streamTicket"
             // agent.list returns another-agent-invisible process metadata and
             // agent.remove kills + prunes a process; both are self-scoped to the
             // verified signer. MUST mirror server.ts MUTATING_OR_CONTENT_METHODS.
@@ -104,6 +109,9 @@ pub fn requires_signature(method: &str) -> bool {
             | "permission.decide"
             // Phase 2 — operator mode override.
             | "permission.setMode"
+            // Revokes an HTTP gateway bearer token (GAP-421 guardrail-2
+            // remediation S5). MUST mirror server.ts MUTATING_OR_CONTENT_METHODS.
+            | "gateway.revokeToken"
     )
 }
 
@@ -626,6 +634,7 @@ mod tests {
         assert!(requires_signature("agent.input"));
         assert!(requires_signature("agent.resize"));
         assert!(requires_signature("agent.output"));
+        assert!(requires_signature("agent.streamTicket"));
         assert!(requires_signature("agent.list"));
         assert!(requires_signature("agent.remove"));
         assert!(requires_signature("session.end"));
@@ -633,6 +642,7 @@ mod tests {
         assert!(requires_signature("harness.prune"));
         // GAP-294 Phase 1.
         assert!(requires_signature("permission.decide"));
+        assert!(requires_signature("gateway.revokeToken"));
         assert!(requires_signature("permission.setMode"));
         assert!(!requires_signature("ping"));
         assert!(!requires_signature("session.list"));

--- a/packages/daemon/src/__tests__/guard.test.ts
+++ b/packages/daemon/src/__tests__/guard.test.ts
@@ -369,7 +369,10 @@ describe('handler tier-classification coverage', () => {
     'agent.remove',
     'agent.input',
     'agent.output',
+    'agent.streamTicket',
     'agent.resize',
+    // HTTP gateway token management (GAP-421 guardrail-2 remediation S5)
+    'gateway.revokeToken',
     // merge pipeline
     'merge.request',
     'merge.status',

--- a/packages/daemon/src/__tests__/http-gateway-adversarial.test.ts
+++ b/packages/daemon/src/__tests__/http-gateway-adversarial.test.ts
@@ -1,0 +1,576 @@
+/**
+ * B2 (GAP-421 guardrail-2 remediation): the GAP-353 adversarial suite,
+ * replicated daemon-side. Ported from `@revealui/harnesses`
+ * `server/__tests__/http-gateway.test.ts`, adapted from that package's
+ * `DaemonStore` + injectable `dispatchHttp` stub to this package's raw
+ * `PGlite` + real `dispatchRpc` (there is no pluggable dispatch here — every
+ * authenticated call in this file uses `ping`, the one identity- and
+ * license-exempt method, as the "a valid token grants real access" proof
+ * instead of the harnesses original's stubbed `agent.spawn`/`agent.stop`).
+ *
+ * These cases must exist daemon-side BEFORE `@revealui/harnesses`
+ * `server/http-gateway.ts` is retired — it is currently the only place any
+ * of them are proven.
+ */
+
+import { createHash, createHmac } from 'node:crypto';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGlite } from '@electric-sql/pglite';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { findValidToken, getBootstrapSecretHash } from '../gateway-store.js';
+import { migrate } from '../storage/migrate.js';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+// Mirrors the harnesses original: a hook that lets one test plant a file
+// inside mkdirSync (the create-path EEXIST race), and a persistent-EEXIST
+// simulator for the retry-cap test. Every other test leaves these null/false,
+// so mkdirSync/writeFileSync pass straight through to the real implementation.
+const fsHooks = vi.hoisted(() => ({
+  beforeMkdir: null as (() => void) | null,
+  forceCreateEexist: false,
+  onCreateAttempt: null as (() => void) | null,
+}));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    mkdirSync: ((path: Parameters<typeof actual.mkdirSync>[0], options) => {
+      fsHooks.beforeMkdir?.();
+      return actual.mkdirSync(path, options);
+    }) as typeof actual.mkdirSync,
+    writeFileSync: ((
+      path: Parameters<typeof actual.writeFileSync>[0],
+      data: Parameters<typeof actual.writeFileSync>[1],
+      options?: Parameters<typeof actual.writeFileSync>[2],
+    ) => {
+      const flag = (options as { flag?: string } | undefined)?.flag;
+      if (flag === 'wx') {
+        fsHooks.onCreateAttempt?.();
+        if (fsHooks.forceCreateEexist) {
+          const err = new Error('EEXIST: file already exists') as NodeJS.ErrnoException;
+          err.code = 'EEXIST';
+          throw err;
+        }
+      }
+      return actual.writeFileSync(path, data, options);
+    }) as typeof actual.writeFileSync,
+  };
+});
+
+// Imported after the mock so HttpGateway picks up the mocked node:fs.
+const { HttpGateway } = await import('../http-gateway.js');
+type HttpGatewayInstance = InstanceType<typeof HttpGateway>;
+type AuthTuning = ConstructorParameters<typeof HttpGateway>[0]['authTuning'];
+
+interface Harness {
+  gateway: HttpGatewayInstance;
+  db: PGlite;
+  secretPath: string;
+  base: string;
+  dir: string;
+}
+
+const dirs: string[] = [];
+const gateways: HttpGatewayInstance[] = [];
+const dbs: PGlite[] = [];
+
+async function boot(opts?: {
+  authTuning?: AuthTuning;
+  preSecret?: { contents: string; mode?: number };
+  seedDb?: (db: PGlite) => Promise<void>;
+  dir?: string;
+}): Promise<Harness> {
+  const dir = opts?.dir ?? mkdtempSync(join(tmpdir(), 'gw-authn-'));
+  dirs.push(dir);
+  const secretPath = join(dir, 'pairing-secret');
+  if (opts?.preSecret) {
+    writeFileSync(secretPath, opts.preSecret.contents, { mode: opts.preSecret.mode ?? 0o600 });
+    chmodSync(secretPath, opts.preSecret.mode ?? 0o600);
+  }
+
+  const db = new PGlite();
+  await migrate(db);
+  dbs.push(db);
+  if (opts?.seedDb) await opts.seedDb(db);
+
+  const gateway = new HttpGateway({
+    port: 0,
+    host: '127.0.0.1',
+    db,
+    secretPath,
+    authTuning: opts?.authTuning,
+  });
+  gateways.push(gateway);
+  await gateway.initAuth();
+  await gateway.start();
+
+  return { gateway, db, secretPath, base: `http://127.0.0.1:${gateway.getPort()}`, dir };
+}
+
+/** Run the full challenge-response pairing flow and return the minted bearer token. */
+async function pair(h: Harness, label?: string): Promise<string> {
+  const nonceRes = await fetch(`${h.base}/api/pair`);
+  expect(nonceRes.status).toBe(200);
+  const { nonce } = (await nonceRes.json()) as { nonce: string };
+  const secret = readFileSync(h.secretPath, 'utf8').trim();
+  const hmac = createHmac('sha256', secret).update(nonce).digest('hex');
+  const pairRes = await fetch(`${h.base}/api/pair`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ nonce, hmac, label }),
+  });
+  expect(pairRes.status).toBe(200);
+  const { token } = (await pairRes.json()) as { token: string };
+  return token;
+}
+
+/** `ping` is the one identity- and license-exempt method — used as the "a valid token grants real access" proof. */
+function rpc(base: string, token?: string): Promise<Response> {
+  return fetch(`${base}/rpc`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }),
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(gateways.splice(0).map((g) => g.stop()));
+  await Promise.all(dbs.splice(0).map((d) => d.close()));
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe('HttpGateway fail-closed auth (GAP-353, daemon-side replication)', () => {
+  describe('headline: a never-paired daemon refuses unauthenticated /rpc', () => {
+    it('refuses an unauthenticated /rpc call without reaching dispatch', async () => {
+      const h = await boot();
+      const res = await rpc(h.base);
+      expect(res.status).toBe(401);
+    });
+
+    it('refuses every unauthenticated /api/* route (nothing but pairing is pre-auth)', async () => {
+      const h = await boot();
+      const status = await fetch(`${h.base}/api/status`);
+      expect(status.status).toBe(401);
+      const stream = await fetch(`${h.base}/api/stream/some-process-id`);
+      expect(stream.status).toBe(401);
+    });
+  });
+
+  describe('challenge-response pairing', () => {
+    it('mints a token on correct HMAC and authenticates /rpc with it', async () => {
+      const h = await boot();
+      const token = await pair(h, 'studio-macbook');
+
+      const res = await rpc(h.base, token);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { result?: unknown; error?: unknown };
+      expect(body.error).toBeUndefined();
+      expect(body.result).toBeDefined();
+    });
+
+    it('persists the token hash (never the plaintext) with expiry and label', async () => {
+      const h = await boot();
+      const token = await pair(h, 'studio-macbook');
+      const row = await findValidToken(
+        h.db,
+        // sha256(token) is what must be stored, not the token itself
+        createHash('sha256').update(token).digest('hex'),
+      );
+      expect(row).not.toBeNull();
+      expect(row?.label).toBe('studio-macbook');
+      expect(row?.expires_at).not.toBeNull();
+      expect(await findValidToken(h.db, token)).toBeNull(); // plaintext is not a stored key
+    });
+
+    it('rejects a wrong HMAC with 403', async () => {
+      const h = await boot();
+      const { nonce } = (await (await fetch(`${h.base}/api/pair`)).json()) as { nonce: string };
+      const res = await fetch(`${h.base}/api/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce, hmac: 'deadbeef'.repeat(8) }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('does not accept a consumed nonce a second time', async () => {
+      const h = await boot();
+      const { nonce } = (await (await fetch(`${h.base}/api/pair`)).json()) as { nonce: string };
+      const secret = readFileSync(h.secretPath, 'utf8').trim();
+      const hmac = createHmac('sha256', secret).update(nonce).digest('hex');
+
+      const first = await fetch(`${h.base}/api/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce, hmac }),
+      });
+      expect(first.status).toBe(200);
+
+      const replay = await fetch(`${h.base}/api/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce, hmac }),
+      });
+      expect(replay.status).toBe(403);
+    });
+
+    it('consumes the nonce even on a failed attempt (no retry with a correct HMAC)', async () => {
+      const h = await boot();
+      const { nonce } = (await (await fetch(`${h.base}/api/pair`)).json()) as { nonce: string };
+      const secret = readFileSync(h.secretPath, 'utf8').trim();
+
+      const wrong = await fetch(`${h.base}/api/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce, hmac: '00'.repeat(32) }),
+      });
+      expect(wrong.status).toBe(403);
+
+      const correctHmac = createHmac('sha256', secret).update(nonce).digest('hex');
+      const retry = await fetch(`${h.base}/api/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce, hmac: correctHmac }),
+      });
+      expect(retry.status).toBe(403);
+    });
+
+    it('rejects an expired nonce', async () => {
+      let clock = 1_000_000;
+      const h = await boot({ authTuning: { now: () => clock, nonceTtlMs: 60_000 } });
+      const { nonce } = (await (await fetch(`${h.base}/api/pair`)).json()) as { nonce: string };
+      const secret = readFileSync(h.secretPath, 'utf8').trim();
+      const hmac = createHmac('sha256', secret).update(nonce).digest('hex');
+
+      clock += 60_001; // past the nonce TTL
+      const res = await fetch(`${h.base}/api/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce, hmac }),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('rate limit + lockout (§D5)', () => {
+    it('locks a source out after repeated failures and clears after the window', async () => {
+      let clock = 5_000_000;
+      const h = await boot({
+        authTuning: {
+          now: () => clock,
+          lockoutThreshold: 3,
+          baseLockoutMs: 30_000,
+          globalFailureCeiling: 1000,
+        },
+      });
+      const secret = readFileSync(h.secretPath, 'utf8').trim();
+
+      for (let i = 0; i < 3; i++) {
+        const { nonce } = (await (await fetch(`${h.base}/api/pair`)).json()) as { nonce: string };
+        const res = await fetch(`${h.base}/api/pair`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ nonce, hmac: '11'.repeat(32) }),
+        });
+        expect(res.status).toBe(403);
+      }
+
+      const locked = (await (await fetch(`${h.base}/api/pair`)).json()) as { nonce: string };
+      const goodHmac = createHmac('sha256', secret).update(locked.nonce).digest('hex');
+      const lockedRes = await fetch(`${h.base}/api/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce: locked.nonce, hmac: goodHmac }),
+      });
+      expect(lockedRes.status).toBe(429);
+
+      clock += 30_001;
+      const token = await pair(h);
+      expect(token).toHaveLength(64);
+    });
+  });
+
+  describe('restart durability (§D2)', () => {
+    it('keeps a previously-issued token valid across a new gateway instance', async () => {
+      const h = await boot();
+      const token = await pair(h);
+      await h.gateway.stop();
+
+      // New gateway instance, SAME db + secret file (simulated daemon restart).
+      const gateway2 = new HttpGateway({
+        port: 0,
+        host: '127.0.0.1',
+        db: h.db,
+        secretPath: h.secretPath,
+      });
+      gateways.push(gateway2);
+      await gateway2.initAuth();
+      await gateway2.start();
+      const base2 = `http://127.0.0.1:${gateway2.getPort()}`;
+
+      const authed = await rpc(base2, token);
+      expect(authed.status).toBe(200);
+      const unauth = await rpc(base2);
+      expect(unauth.status).toBe(401);
+    });
+  });
+
+  describe('boot honesty (§D7 / §7 R5)', () => {
+    it('re-hashes an existing secret file into a fresh store (§7 R5)', async () => {
+      const contents = 'a'.repeat(64);
+      const h = await boot({ preSecret: { contents } });
+      const stored = await getBootstrapSecretHash(h.db);
+      const expected = createHash('sha256').update(contents).digest('hex');
+      expect(stored).toBe(expected);
+      const token = await pair(h);
+      expect(token).toHaveLength(64);
+    });
+
+    it('refuses new pairings when the file is gone but a hash is on record; existing tokens still work', async () => {
+      const knownToken = 'f'.repeat(64);
+      const tokenHash = createHash('sha256').update(knownToken).digest('hex');
+      const h = await boot({
+        seedDb: async (db) => {
+          const { putBootstrapSecretHash, insertToken } = await import('../gateway-store.js');
+          await putBootstrapSecretHash(db, 'some-recorded-hash');
+          await insertToken(db, { tokenHash });
+        },
+      });
+
+      // No secret file was created (preSecret omitted) but a hash is on record → refuse pairing.
+      const { nonce } = (await (await fetch(`${h.base}/api/pair`)).json()) as { nonce: string };
+      const pairRes = await fetch(`${h.base}/api/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce, hmac: '22'.repeat(32) }),
+      });
+      expect(pairRes.status).toBe(503);
+
+      const authed = await rpc(h.base, knownToken);
+      expect(authed.status).toBe(200);
+    });
+
+    it('refuses to use a group/other-readable secret file (§D7)', async () => {
+      const h = await boot({ preSecret: { contents: 'b'.repeat(64), mode: 0o644 } });
+      const { nonce } = (await (await fetch(`${h.base}/api/pair`)).json()) as { nonce: string };
+      const secret = readFileSync(h.secretPath, 'utf8').trim();
+      const hmac = createHmac('sha256', secret).update(nonce).digest('hex');
+      const res = await fetch(`${h.base}/api/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce, hmac }),
+      });
+      expect(res.status).toBe(503);
+    });
+
+    it('refuses a group-readable secret file via the fstat mode check (read-path TOCTOU)', async () => {
+      const h = await boot({ preSecret: { contents: 'g'.repeat(64), mode: 0o640 } });
+      const { nonce } = (await (await fetch(`${h.base}/api/pair`)).json()) as { nonce: string };
+      const secret = readFileSync(h.secretPath, 'utf8').trim();
+      const hmac = createHmac('sha256', secret).update(nonce).digest('hex');
+      const res = await fetch(`${h.base}/api/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce, hmac }),
+      });
+      expect(res.status).toBe(503);
+    });
+
+    it('refuses a secret file that is a symlink (read-path O_NOFOLLOW)', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'gw-authn-'));
+      dirs.push(dir);
+      const target = join(dir, 'attacker-secret');
+      const attackerSecret = 'c'.repeat(64);
+      writeFileSync(target, attackerSecret, { mode: 0o600 });
+      const secretPath = join(dir, 'pairing-secret');
+      symlinkSync(target, secretPath);
+
+      const db = new PGlite();
+      await migrate(db);
+      dbs.push(db);
+      const gateway = new HttpGateway({ port: 0, host: '127.0.0.1', db, secretPath });
+      gateways.push(gateway);
+      await gateway.initAuth();
+      await gateway.start();
+      const base = `http://127.0.0.1:${gateway.getPort()}`;
+
+      expect(readFileSync(target, 'utf8')).toBe(attackerSecret);
+      expect(await getBootstrapSecretHash(db)).toBeNull();
+      const { nonce } = (await (await fetch(`${base}/api/pair`)).json()) as { nonce: string };
+      const hmac = createHmac('sha256', attackerSecret).update(nonce).digest('hex');
+      const res = await fetch(`${base}/api/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce, hmac }),
+      });
+      expect(res.status).toBe(503);
+    });
+
+    it('falls back to reading when another process wins the create race (EEXIST)', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'gw-authn-'));
+      dirs.push(dir);
+      const secretPath = join(dir, 'pairing-secret');
+      const winner = 'e'.repeat(64);
+      fsHooks.beforeMkdir = () => {
+        if (!existsSync(secretPath)) writeFileSync(secretPath, winner, { mode: 0o600 });
+      };
+
+      try {
+        const db = new PGlite();
+        await migrate(db);
+        dbs.push(db);
+        const gateway = new HttpGateway({ port: 0, host: '127.0.0.1', db, secretPath });
+        gateways.push(gateway);
+        await gateway.initAuth();
+        await gateway.start();
+        const base = `http://127.0.0.1:${gateway.getPort()}`;
+
+        expect(readFileSync(secretPath, 'utf8')).toBe(winner);
+        expect(await getBootstrapSecretHash(db)).toBe(
+          createHash('sha256').update(winner).digest('hex'),
+        );
+        const { nonce } = (await (await fetch(`${base}/api/pair`)).json()) as { nonce: string };
+        const hmac = createHmac('sha256', winner).update(nonce).digest('hex');
+        const res = await fetch(`${base}/api/pair`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ nonce, hmac }),
+        });
+        expect(res.status).toBe(200);
+      } finally {
+        fsHooks.beforeMkdir = null;
+      }
+    });
+
+    it('bounds the create-path retry loop so a persistent EEXIST race cannot livelock startup (#1975 verdict fast-follow)', async () => {
+      const SAFETY_VALVE = 200;
+      const dir = mkdtempSync(join(tmpdir(), 'gw-authn-'));
+      dirs.push(dir);
+      const secretPath = join(dir, 'pairing-secret');
+      let attempts = 0;
+      fsHooks.forceCreateEexist = true;
+      fsHooks.onCreateAttempt = () => {
+        attempts++;
+        if (attempts >= SAFETY_VALVE) fsHooks.forceCreateEexist = false;
+      };
+
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      try {
+        const db = new PGlite();
+        await migrate(db);
+        dbs.push(db);
+        const gateway = new HttpGateway({ port: 0, host: '127.0.0.1', db, secretPath });
+        gateways.push(gateway);
+        await gateway.initAuth();
+
+        expect(attempts).toBeGreaterThan(0);
+        expect(attempts).toBeLessThan(SAFETY_VALVE);
+
+        await gateway.start();
+        const base = `http://127.0.0.1:${gateway.getPort()}`;
+        const { nonce } = (await (await fetch(`${base}/api/pair`)).json()) as { nonce: string };
+        const res = await fetch(`${base}/api/pair`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ nonce, hmac: '00'.repeat(32) }),
+        });
+        expect(res.status).toBe(503);
+      } finally {
+        stderrSpy.mockRestore();
+        fsHooks.forceCreateEexist = false;
+        fsHooks.onCreateAttempt = null;
+      }
+    });
+  });
+
+  describe('pre-auth allowlist is an explicit constant (§7 R3)', () => {
+    it('contains exactly the two pairing endpoints', async () => {
+      const { PRE_AUTH_ROUTES } = await import('../http-gateway.js');
+      expect(PRE_AUTH_ROUTES).toEqual([
+        { method: 'GET', path: '/api/pair' },
+        { method: 'POST', path: '/api/pair' },
+      ]);
+    });
+
+    it('classifies routes correctly', async () => {
+      const { isPreAuthRoute } = await import('../http-gateway.js');
+      expect(isPreAuthRoute('GET', '/api/pair')).toBe(true);
+      expect(isPreAuthRoute('POST', '/api/pair')).toBe(true);
+      expect(isPreAuthRoute('POST', '/rpc')).toBe(false);
+      expect(isPreAuthRoute('GET', '/api/status')).toBe(false);
+      expect(isPreAuthRoute('GET', '/api/stream/some-process-id')).toBe(false);
+    });
+  });
+});
+
+describe('PairingRateLimiter', () => {
+  it('applies exponential backoff past the threshold, capped at the ceiling', async () => {
+    const { PairingRateLimiter } = await import('../http-gateway.js');
+    const clock = 0;
+    const rl = new PairingRateLimiter({
+      now: () => clock,
+      lockoutThreshold: 3,
+      baseLockoutMs: 1000,
+      maxLockoutMs: 4000,
+      globalCeiling: 1000,
+    });
+    const src = '1.2.3.4';
+    expect(rl.recordFailure(src).lockMs).toBe(0); // 1
+    expect(rl.recordFailure(src).lockMs).toBe(0); // 2
+    expect(rl.recordFailure(src).lockMs).toBe(1000); // 3  -  base
+    expect(rl.recordFailure(src).lockMs).toBe(2000); // 4  -  base*2
+    expect(rl.recordFailure(src).lockMs).toBe(4000); // 5  -  base*4
+    expect(rl.recordFailure(src).lockMs).toBe(4000); // 6  -  capped at ceiling
+  });
+
+  it('reports a source as locked until the window elapses, and clears on success', async () => {
+    const { PairingRateLimiter } = await import('../http-gateway.js');
+    let clock = 0;
+    const rl = new PairingRateLimiter({
+      now: () => clock,
+      lockoutThreshold: 1,
+      baseLockoutMs: 5000,
+      maxLockoutMs: 5000,
+      globalCeiling: 1000,
+    });
+    const src = '9.9.9.9';
+    rl.recordFailure(src);
+    expect(rl.retryAfterMs(src)).toBe(5000);
+    clock += 5000;
+    expect(rl.retryAfterMs(src)).toBe(0);
+
+    rl.recordFailure(src);
+    rl.recordSuccess(src);
+    expect(rl.retryAfterMs(src)).toBe(0);
+  });
+
+  it('trips a global cooldown at the global ceiling across sources', async () => {
+    const { PairingRateLimiter } = await import('../http-gateway.js');
+    const clock = 0;
+    const rl = new PairingRateLimiter({
+      now: () => clock,
+      lockoutThreshold: 1000,
+      baseLockoutMs: 2000,
+      maxLockoutMs: 2000,
+      globalCeiling: 3,
+    });
+    expect(rl.recordFailure('a').globalTripped).toBe(false);
+    expect(rl.recordFailure('b').globalTripped).toBe(false);
+    expect(rl.recordFailure('c').globalTripped).toBe(true);
+    expect(rl.retryAfterMs('z')).toBe(2000);
+  });
+});

--- a/packages/daemon/src/__tests__/http-gateway-stream-auth.test.ts
+++ b/packages/daemon/src/__tests__/http-gateway-stream-auth.test.ts
@@ -1,0 +1,418 @@
+/**
+ * B1 regression suite (GAP-421 guardrail-2 remediation).
+ *
+ * The merged PR #328 shipped `GET /api/stream` gated by ONLY the HTTP
+ * gateway's bearer token — a transport credential that proves nothing about
+ * agent identity or PTY ownership. `agent.output` (the poll-based read of
+ * the exact same content) requires a verified Ed25519 signer AND
+ * `owner_agent === callerAgentId`. This suite reproduces the reviewer's
+ * probe shape (a bearer-token-only client reading another agent's PTY
+ * output over SSE) and proves it is now rejected the same way, via the
+ * signature-required `agent.streamTicket` RPC.
+ *
+ * @vitest-environment node
+ */
+
+import { vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+// ---------------------------------------------------------------------------
+// Mock node-pty BEFORE any module that imports spawn.ts resolves (mirrors
+// spawn.test.ts — these tests exercise ownership/auth, not the OS sandbox).
+// ---------------------------------------------------------------------------
+
+interface MockPty {
+  pid: number;
+  onData: ReturnType<typeof vi.fn>;
+  onExit: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  resize: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+  _fireData: (chunk: string) => void;
+  _fireExit: (code: number) => void;
+}
+
+const ptys = new Map<number, MockPty>();
+let pidCounter = 5000;
+
+function makeMockPty(): MockPty {
+  let dataCallback: ((chunk: string) => void) | null = null;
+  let exitCallback: ((ev: { exitCode: number }) => void) | null = null;
+  const pid = ++pidCounter;
+  const pty: MockPty = {
+    pid,
+    onData: vi.fn((cb: (chunk: string) => void) => {
+      dataCallback = cb;
+      return { dispose: vi.fn() };
+    }),
+    onExit: vi.fn((cb: (ev: { exitCode: number }) => void) => {
+      exitCallback = cb;
+      return { dispose: vi.fn() };
+    }),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    _fireData: (chunk) => dataCallback?.(chunk),
+    _fireExit: (code) => exitCallback?.({ exitCode: code }),
+  };
+  ptys.set(pid, pty);
+  return pty;
+}
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(() => makeMockPty()),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mock declarations)
+// ---------------------------------------------------------------------------
+
+import { execFileSync } from 'node:child_process';
+import { createHmac } from 'node:crypto';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { connect, createServer, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { formatDid } from '@revdev/protocol/did';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  generateNonce,
+  hashParams,
+  serializeEnvelope,
+  signEnvelope,
+} from '../agent-identity-crypto.js';
+import { startDaemon } from '../server.js';
+// Side-effect: registers agent.* (agent.spawn / agent.streamTicket / ...).
+import '../spawn.js';
+import {
+  clearTestLicenseEnv,
+  generateTestLicense,
+  setTestLicenseEnv,
+} from './test-license-helper.js';
+
+// ---------------------------------------------------------------------------
+// Socket-level signed RPC helper (mirrors spawn.test.ts)
+// ---------------------------------------------------------------------------
+
+interface RpcResult {
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+function rpcFrame(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown>,
+  signature?: string,
+): Promise<RpcResult> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req: Record<string, unknown> = { jsonrpc: '2.0', id: 1, method, params };
+    if (signature) req['x-revdev-signature'] = signature;
+    sock.on('connect', () => sock.write(`${JSON.stringify(req)}\n`));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      sock.end();
+      try {
+        resolve(JSON.parse(buf.slice(0, nl)) as RpcResult);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error(`rpc timeout: ${method}`));
+    });
+  });
+}
+
+function makeSigner(agentId: string) {
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid(agentId, fingerprint);
+  const sign = (method: string, params: Record<string, unknown>): string =>
+    serializeEnvelope(
+      signEnvelope(
+        {
+          did,
+          kid: fingerprint,
+          nonce: generateNonce(),
+          ts: Math.floor(Date.now() / 1000),
+          method,
+          paramsHash: hashParams(method, params),
+        },
+        kp.privateKeyPem,
+      ),
+    );
+  return { agentId, fingerprint, did, publicKeyPem: kp.publicKeyPem, sign };
+}
+
+const owner = makeSigner('stream-auth-owner');
+const other = makeSigner('stream-auth-other');
+
+async function signedRpc(
+  socketPath: string,
+  signer: { sign: (m: string, p: Record<string, unknown>) => string },
+  method: string,
+  params: Record<string, unknown> = {},
+): Promise<unknown> {
+  const resp = await rpcFrame(socketPath, method, params, signer.sign(method, params));
+  if (resp.error) throw new Error(`${resp.error.code}: ${resp.error.message}`);
+  return resp.result;
+}
+
+/** Read an SSE response body for `ms` milliseconds, then cancel the stream. */
+async function readSseFor(res: Response, ms: number): Promise<string> {
+  const reader = res.body?.getReader();
+  if (!reader) return '';
+  let collected = '';
+  const decoder = new TextDecoder();
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    const remaining = deadline - Date.now();
+    const result = await Promise.race([
+      reader.read(),
+      new Promise<{ done: true; value: undefined }>((resolve) => {
+        setTimeout(() => resolve({ done: true, value: undefined }), Math.max(remaining, 0));
+      }),
+    ]);
+    if (result.done) break;
+    collected += decoder.decode(result.value, { stream: true });
+  }
+  await reader.cancel().catch(() => {});
+  return collected;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let dataDir: string;
+let socketPath: string;
+let httpPort: number;
+let close: () => Promise<void>;
+let repoRoot: string;
+let otherRoot: string;
+
+function base(): string {
+  return `http://127.0.0.1:${httpPort}`;
+}
+
+/** Pair over HTTP and return a bearer token (the ONLY credential a remote HTTP client normally holds). */
+async function pairForBearerToken(): Promise<string> {
+  const nonceRes = await fetch(`${base()}/api/pair`);
+  const { nonce } = (await nonceRes.json()) as { nonce: string };
+  const secretPath = join(dataDir, 'gateway-pairing-secret');
+  const secret = (await readFile(secretPath, 'utf8')).trim();
+  const hmac = createHmac('sha256', secret).update(nonce).digest('hex');
+  const pairRes = await fetch(`${base()}/api/pair`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ nonce, hmac }),
+  });
+  const { token } = (await pairRes.json()) as { token: string };
+  return token;
+}
+
+beforeAll(async () => {
+  process.env.REVDEV_SPAWN_CONFINEMENT = 'none';
+  setTestLicenseEnv(generateTestLicense('enterprise'));
+  dataDir = await mkdtemp(join(tmpdir(), 'revdev-stream-auth-'));
+  socketPath = join(dataDir, 'harness.sock');
+  const anchor = join(dataDir, 'trusted-client-fingerprint');
+  await writeFile(
+    anchor,
+    `${owner.agentId}:${owner.fingerprint}\n${other.agentId}:${other.fingerprint}\n`,
+  );
+
+  httpPort = await new Promise<number>((resolve, reject) => {
+    const probe = createServer();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const addr = probe.address();
+      const port = addr && typeof addr === 'object' ? addr.port : 0;
+      probe.close(() => resolve(port));
+    });
+  });
+
+  const d = await startDaemon({
+    socketPath,
+    dataDir,
+    httpPort,
+    httpHost: '127.0.0.1',
+    trustedClientFingerprintPath: anchor,
+    trustedAnchorRequireRootOwned: false,
+  });
+  close = d.close;
+
+  for (const s of [owner, other]) {
+    const reg = await rpcFrame(socketPath, 'session.register', {
+      agentId: s.agentId,
+      agentName: s.agentId,
+      backend: 'test',
+      publicKeyPem: s.publicKeyPem,
+    });
+    if (reg.error) throw new Error(`register ${s.agentId} failed: ${reg.error.message}`);
+  }
+
+  repoRoot = await mkdtemp(join(tmpdir(), 'revdev-stream-auth-root-'));
+  otherRoot = await mkdtemp(join(tmpdir(), 'revdev-stream-auth-otherroot-'));
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: otherRoot });
+  await signedRpc(socketPath, owner, 'project.open', { repoPath: repoRoot });
+  await signedRpc(socketPath, other, 'project.open', { repoPath: otherRoot });
+});
+
+afterAll(async () => {
+  await close?.();
+  await rm(dataDir, { recursive: true, force: true });
+  clearTestLicenseEnv();
+  delete process.env.REVDEV_SPAWN_CONFINEMENT;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('B1: GET /api/stream requires a signed, ownership-checked ticket', () => {
+  it('reproduces the reviewer probe: a bearer-token-only client cannot read PTY output without a ticket', async () => {
+    const { processId } = (await signedRpc(socketPath, owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+    })) as { processId: string };
+    const pty = [...ptys.values()].at(-1);
+
+    const token = await pairForBearerToken();
+
+    // Exactly the reviewer's probe: bearer token only, no ticket, no signature.
+    const res = await fetch(`${base()}/api/stream/${processId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(401);
+
+    // Even if the client ignored the 401 and tried to read a body, no PTY
+    // content should ever have been written to this response.
+    pty?._fireData('AWS_SECRET_ACCESS_KEY=leaked-via-sse\r\n');
+    const body = await res.text().catch(() => '');
+    expect(body).not.toContain('leaked-via-sse');
+    pty?._fireExit(0);
+  });
+
+  it('rejects GET /api/stream with no processId in the path (no firehose mode)', async () => {
+    const token = await pairForBearerToken();
+    const res = await fetch(`${base()}/api/stream`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('agent.streamTicket requires a signature', async () => {
+    const resp = await rpcFrame(socketPath, 'agent.streamTicket', { processId: 'anything' });
+    expect(resp.error?.code).toBe(-32003);
+  });
+
+  it("agent.streamTicket rejects a process owned by another agent (mirrors agent.output's check)", async () => {
+    const { processId } = (await signedRpc(socketPath, owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+    })) as { processId: string };
+
+    await expect(signedRpc(socketPath, other, 'agent.streamTicket', { processId })).rejects.toThrow(
+      /not owned by caller/,
+    );
+  });
+
+  it("a minted ticket authorizes the stream and delivers only that process's output", async () => {
+    const { processId: ownerProcessId } = (await signedRpc(socketPath, owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+    })) as { processId: string };
+    const ownerPty = [...ptys.values()].at(-1);
+
+    await signedRpc(socketPath, other, 'agent.spawn', {
+      command: 'bash',
+      repoPath: otherRoot,
+    });
+    const otherPty = [...ptys.values()].at(-1);
+
+    const { ticket } = (await signedRpc(socketPath, owner, 'agent.streamTicket', {
+      processId: ownerProcessId,
+    })) as { ticket: string };
+
+    const token = await pairForBearerToken();
+    const res = await fetch(`${base()}/api/stream/${ownerProcessId}?ticket=${ticket}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+
+    ownerPty?._fireData('owner-process-output\r\n');
+    otherPty?._fireData('other-process-output\r\n');
+
+    const body = await readSseFor(res, 400);
+    expect(body).toContain('owner-process-output');
+    expect(body).not.toContain('other-process-output');
+
+    ownerPty?._fireExit(0);
+    otherPty?._fireExit(0);
+  });
+
+  it('a stream ticket is single-use', async () => {
+    const { processId } = (await signedRpc(socketPath, owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+    })) as { processId: string };
+    const pty = [...ptys.values()].at(-1);
+
+    const { ticket } = (await signedRpc(socketPath, owner, 'agent.streamTicket', {
+      processId,
+    })) as { ticket: string };
+    const token = await pairForBearerToken();
+
+    const first = await fetch(`${base()}/api/stream/${processId}?ticket=${ticket}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(first.status).toBe(200);
+    await first.body?.cancel().catch(() => {});
+
+    const replay = await fetch(`${base()}/api/stream/${processId}?ticket=${ticket}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(replay.status).toBe(401);
+
+    pty?._fireExit(0);
+  });
+
+  it('a ticket minted for one processId cannot be presented for another', async () => {
+    const { processId: procA } = (await signedRpc(socketPath, owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+    })) as { processId: string };
+    const ptyA = [...ptys.values()].at(-1);
+    const { processId: procB } = (await signedRpc(socketPath, owner, 'agent.spawn', {
+      command: 'bash',
+      repoPath: repoRoot,
+    })) as { processId: string };
+    const ptyB = [...ptys.values()].at(-1);
+
+    const { ticket } = (await signedRpc(socketPath, owner, 'agent.streamTicket', {
+      processId: procA,
+    })) as { ticket: string };
+    const token = await pairForBearerToken();
+
+    const res = await fetch(`${base()}/api/stream/${procB}?ticket=${ticket}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(401);
+
+    ptyA?._fireExit(0);
+    ptyB?._fireExit(0);
+  });
+});

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -57,6 +57,9 @@ const SIGNED = [
   'agent.input',
   'agent.resize',
   'agent.output',
+  // agent.streamTicket mints the /api/stream principal (GAP-421 guardrail-2
+  // remediation B1): signature-required, re-runs the owner_agent check.
+  'agent.streamTicket',
   // agent.list returns another-agent-invisible process metadata and agent.remove
   // kills + prunes; both are self-scoped to the verified signer.
   'agent.list',
@@ -71,6 +74,9 @@ const SIGNED = [
   'permission.decide',
   // Phase 2: operator mode override.
   'permission.setMode',
+  // gateway.revokeToken revokes an HTTP gateway bearer token (GAP-421
+  // guardrail-2 remediation S5).
+  'gateway.revokeToken',
 ];
 
 // Only payload-free, repo-agnostic coordination methods stay signature-OPTIONAL.

--- a/packages/daemon/src/agent.ts
+++ b/packages/daemon/src/agent.ts
@@ -56,3 +56,7 @@ registerHandler('agent.resize', async () => {
 registerHandler('agent.output', async () => {
   throw new SpawnSurfaceUnavailableError('agent.output');
 });
+
+registerHandler('agent.streamTicket', async () => {
+  throw new SpawnSurfaceUnavailableError('agent.streamTicket');
+});

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -37,6 +37,8 @@ import './agent.js';
 // Register PTY-backed agent.spawn/stop/input/resize/output handlers.
 // Must come AFTER ./agent.js (stubs) so the real implementations overwrite them.
 import './spawn.js';
+// Register gateway.revokeToken (GAP-421 guardrail-2 remediation S5).
+import './gateway-rpc.js';
 import { DAEMON_DEFAULTS } from './config.js';
 import { LICENSE_TIER_HELP, LicenseConfigError, LicenseExpiredError } from './license.js';
 import { startDaemon } from './server.js';

--- a/packages/daemon/src/gateway-rpc.ts
+++ b/packages/daemon/src/gateway-rpc.ts
@@ -1,0 +1,40 @@
+/**
+ * `gateway.*` RPC handlers — the socket/HTTP-dispatchable operations on the
+ * HTTP gateway's durable state (bearer tokens). Kept in its own module,
+ * separate from `http-gateway.ts`, so it can be imported as a side-effect
+ * from `index.ts`/`cli.ts` the same way `agent.ts`/`spawn.ts`/`vcs.ts` are:
+ * AFTER `server.ts` has fully evaluated. `http-gateway.ts` itself cannot
+ * hold this registration — `server.ts` imports the `HttpGateway` class
+ * directly (to construct it in `startDaemon`), so anything registered at
+ * `http-gateway.ts`'s module top level runs mid-way through `server.ts`'s
+ * own module evaluation, before `server.ts`'s `handlers` map is
+ * initialized (`ReferenceError: Cannot access 'handlers' before
+ * initialization`). This module has no such cycle.
+ */
+
+import { createHash } from 'node:crypto';
+import { revokeToken } from './gateway-store.js';
+import { registerHandler } from './server.js';
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+/**
+ * gateway.revokeToken — makes `revokeToken` (gateway-store.ts) reachable
+ * (GAP-421 guardrail-2 remediation S5). Signature-required so an unsigned
+ * caller cannot revoke another client's session, but note the scope
+ * limitation: `gateway_tokens` rows carry no agent linkage (they are
+ * daemon-wide bearer credentials, not per-agent), so any verified signer
+ * may revoke ANY known token, not only its own. Closing that would need a
+ * schema change binding a token to the agent that minted it; out of scope
+ * for this fix, which only had to make revocation reachable at all.
+ */
+registerHandler('gateway.revokeToken', async (params, db) => {
+  const token = params.token;
+  if (typeof token !== 'string' || token.length === 0) {
+    throw new Error('gateway.revokeToken: missing token');
+  }
+  const revoked = await revokeToken(db, sha256Hex(token));
+  return { revoked };
+});

--- a/packages/daemon/src/http-gateway.ts
+++ b/packages/daemon/src/http-gateway.ts
@@ -22,7 +22,12 @@ import {
   putBootstrapSecretHash,
 } from './gateway-store.js';
 import { dispatchRpc, type RpcRequest, type RpcResponse, type SocketContext } from './server.js';
-import { type AgentExitEvent, type AgentOutputEvent, agentEvents } from './spawn-events.js';
+import {
+  type AgentExitEvent,
+  type AgentOutputEvent,
+  agentEvents,
+  redeemStreamTicket,
+} from './spawn-events.js';
 
 /**
  * HTTP gateway that exposes the RevDev daemon over TCP (GAP-421
@@ -32,17 +37,22 @@ import { type AgentExitEvent, type AgentOutputEvent, agentEvents } from './spawn
  * `pairWithDaemon`) needs no protocol change).
  *
  * Routes:
- *   POST /rpc                -  JSON-RPC 2.0 proxy, through the SAME
- *                                dispatchRpc the Unix socket uses (license
- *                                guard, param validation, signature gate,
- *                                identity gate, permission gate — one
- *                                authorization path, never a parallel one)
- *   GET  /api/pair           -  Issue a single-use pairing nonce (pre-auth)
- *   POST /api/pair           -  Submit an HMAC challenge response, receive a bearer token (pre-auth)
- *   GET  /api/status         -  Daemon status summary (requires a valid token)
- *   GET  /api/stream/:id     -  SSE stream of agent.* PTY output/exit (requires a valid token)
- *   GET  /                   -  Serves Studio static frontend (index.html)
- *   GET  /assets/*           -  Serves static assets
+ *   POST /rpc                        -  JSON-RPC 2.0 proxy, through the SAME
+ *                                        dispatchRpc the Unix socket uses (license
+ *                                        guard, param validation, signature gate,
+ *                                        identity gate, permission gate — one
+ *                                        authorization path, never a parallel one)
+ *   GET  /api/pair                   -  Issue a single-use pairing nonce (pre-auth)
+ *   POST /api/pair                   -  Submit an HMAC challenge response, receive a bearer token (pre-auth)
+ *   GET  /api/status                 -  Daemon status summary (requires a valid token)
+ *   GET  /api/stream/:processId      -  SSE stream of one process's PTY output/exit
+ *                                        (requires a valid bearer token AND a
+ *                                        `?ticket=` minted by the signature-required
+ *                                        RPC `agent.streamTicket` — see "Streaming
+ *                                        authorization" below; no unfiltered/firehose
+ *                                        mode exists)
+ *   GET  /                           -  Serves Studio static frontend (index.html)
+ *   GET  /assets/*                   -  Serves static assets
  *
  * Auth (fail-closed):
  *   Every /rpc and /api/* request EXCEPT the pairing endpoints (see PRE_AUTH_ROUTES)
@@ -56,6 +66,16 @@ import { type AgentExitEvent, type AgentOutputEvent, agentEvents } from './spawn
  *   server verifies against the same file secret with a timing-safe comparison, then mints
  *   a durable bearer token. The stored DB hash (gateway_bootstrap) detects file tampering
  *   or substitution; the file itself is the HMAC key.
+ *
+ * Streaming authorization (GAP-421 guardrail-2 remediation, B1):
+ *   The bearer token above is a TRANSPORT credential — it proves this HTTP client
+ *   paired with the daemon, nothing about which agent it is or what PTY content it
+ *   may read. `agent.output` (the poll-based equivalent) requires a verified Ed25519
+ *   signer AND `owner_agent === callerAgentId`; `/api/stream` enforces the identical
+ *   check via a short-lived, single-use, processId-bound ticket minted by the
+ *   signature-required RPC `agent.streamTicket` (spawn.ts). A bearer token alone
+ *   cannot open a stream, and there is no way to subscribe to more than one
+ *   `processId` per ticket.
  *
  * Off by default: the daemon only constructs this gateway when `httpPort` is
  * configured to a non-zero value (see `startDaemon` in server.ts). No config,
@@ -128,6 +148,14 @@ const MAX_INIT_AUTH_ATTEMPTS = 5;
 const SECRET_BYTES = 32;
 const NONCE_BYTES = 32;
 const TOKEN_BYTES = 32;
+/** Host header values treated as loopback for the Host-validation check (S3). */
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
+/** Cap on concurrent SSE connections (S6) — each holds a 30s keepalive timer. */
+const MAX_SSE_CONNECTIONS = 64;
+/** 1 MiB cap on /rpc bodies, measured in UTF-8 bytes (S1, mirrors server.ts maxLineBytes). */
+const MAX_RPC_BODY_BYTES = 1_048_576;
+/** 1 KiB cap on /api/pair bodies, measured in UTF-8 bytes (S1). */
+const MAX_PAIR_BODY_BYTES = 1024;
 
 /** MIME types for static file serving */
 const MIME_TYPES: Record<string, string> = {
@@ -216,6 +244,8 @@ export class HttpGateway {
   private readonly now: () => number;
   private readonly tokenTtlMs: number;
   private readonly nonceTtlMs: number;
+  /** S6: bounds concurrent SSE connections. */
+  private activeStreamCount = 0;
 
   constructor(config: HttpGatewayConfig) {
     this.config = config;
@@ -387,10 +417,27 @@ export class HttpGateway {
       const path = url.pathname;
       const method = req.method ?? 'GET';
 
-      // CORS headers for mobile browser access
-      res.setHeader('Access-Control-Allow-Origin', '*');
-      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+      // Host validation (S3, DNS-rebinding defense-in-depth). Checked before
+      // anything else, including the pre-auth pairing routes — rebinding
+      // specifically targets those, since they need no bearer token.
+      if (!this.isAllowedHost(req.headers.host)) {
+        res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ error: 'Invalid Host header' }));
+        return;
+      }
+
+      // CORS is withheld from the pairing routes (S3): a page the operator
+      // merely has open can otherwise reach GET/POST /api/pair cross-origin
+      // pre-auth and burn the nonce pool / trip the lockout. It cannot forge
+      // the HMAC without the file secret, so this is a DoS hardening, not an
+      // auth-bypass fix. Every other route still needs a bearer token, which
+      // a cross-origin page does not have.
+      const isPairingPath = path === '/api/pair';
+      if (!isPairingPath) {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+      }
 
       if (method === 'OPTIONS') {
         res.writeHead(204);
@@ -421,8 +468,11 @@ export class HttpGateway {
           return;
         }
         if (path.startsWith('/api/stream') && method === 'GET') {
-          const processFilter = path.split('/')[3] ?? null; // optional processId filter
-          this.handleStream(req, res, processFilter);
+          // Mandatory processId (B1: no wildcard/firehose mode) + the
+          // signature-required ticket minted by agent.streamTicket.
+          const processId = path.split('/')[3] ?? null;
+          const ticket = url.searchParams.get('ticket');
+          this.handleStream(req, res, processId, ticket);
           return;
         }
 
@@ -436,6 +486,28 @@ export class HttpGateway {
       this.logAuth(`request handling error: ${err instanceof Error ? err.message : 'unknown'}`);
       if (!res.headersSent) jsonResponse(res, 500, { error: 'Internal error' });
     }
+  }
+
+  /**
+   * S3: reject requests whose Host header doesn't match the bound interface,
+   * to blunt DNS rebinding against the pre-auth pairing routes. When bound to
+   * loopback (the default), only loopback Host values are accepted. A
+   * non-loopback bind (the operator opted into remote exposure) only
+   * requires a present, parseable Host — a full allowlist would need
+   * operator-supplied config this class does not have.
+   */
+  private isAllowedHost(hostHeader: string | undefined): boolean {
+    if (!hostHeader) return false;
+    let hostname: string;
+    try {
+      hostname = new URL(`http://${hostHeader}`).hostname;
+    } catch {
+      return false;
+    }
+    if (LOOPBACK_HOSTS.has(this.config.host)) {
+      return LOOPBACK_HOSTS.has(hostname);
+    }
+    return hostname.length > 0;
   }
 
   /** Verify `Authorization: Bearer <token>` against the durable token store. */
@@ -502,17 +574,30 @@ export class HttpGateway {
       return;
     }
 
-    let body = '';
+    // S1: accumulate raw Buffers and cap on UTF-8 BYTES, not string length
+    // (which double-counts under UTF-16 for astral characters and can also
+    // undercount multibyte BMP characters against the intended byte budget).
+    // Decoding once at the end also avoids splitting a multibyte character
+    // across a chunk boundary. S2: `rejected` stops a second, already-
+    // buffered chunk from re-entering writeHead after req.destroy().
+    const chunks: Buffer[] = [];
+    let bytes = 0;
+    let rejected = false;
     req.on('data', (chunk: Buffer) => {
-      body += chunk.toString();
-      if (body.length > 1024) {
+      if (rejected) return;
+      bytes += chunk.length;
+      if (bytes > MAX_PAIR_BODY_BYTES) {
+        rejected = true;
         res.writeHead(413);
         res.end();
         req.destroy();
+        return;
       }
+      chunks.push(chunk);
     });
     req.on('end', () => {
-      void this.completePair(res, body, source);
+      if (rejected) return;
+      void this.completePair(res, Buffer.concat(chunks).toString('utf8'), source);
     });
   }
 
@@ -596,18 +681,25 @@ export class HttpGateway {
    * the request body, never a persisted per-connection binding.
    */
   private handleRpc(req: IncomingMessage, res: ServerResponse): void {
-    let body = '';
+    // S1/S2: same byte-accumulation + single-reject pattern as handlePair.
+    const chunks: Buffer[] = [];
+    let bytes = 0;
+    let rejected = false;
     req.on('data', (chunk: Buffer) => {
-      body += chunk.toString();
-      // 1MB limit for RPC payloads
-      if (body.length > 1_048_576) {
+      if (rejected) return;
+      bytes += chunk.length;
+      if (bytes > MAX_RPC_BODY_BYTES) {
+        rejected = true;
         res.writeHead(413);
         res.end();
         req.destroy();
+        return;
       }
+      chunks.push(chunk);
     });
     req.on('end', () => {
-      void this.completeRpc(res, body);
+      if (rejected) return;
+      void this.completeRpc(res, Buffer.concat(chunks).toString('utf8'));
     });
   }
 
@@ -638,12 +730,53 @@ export class HttpGateway {
     jsonResponse(res, 200, response);
   }
 
-  /** GET /api/stream[/:processId]  -  SSE for agent.* PTY output and exit events. */
+  /**
+   * GET /api/stream/:processId?ticket=...  -  SSE for one process's PTY
+   * output and exit events (GAP-421 guardrail-2 remediation, B1).
+   *
+   * The bearer token already checked upstream (checkAuth) is a TRANSPORT
+   * credential: it proves this HTTP client paired with the daemon, nothing
+   * about which agent it is or what it may read. That is not sufficient
+   * here — `agent.output` requires a verified Ed25519 signer AND
+   * `owner_agent === callerAgentId`, and this route must enforce the same.
+   * The `ticket` query param is minted only by the signature-required RPC
+   * `agent.streamTicket` (spawn.ts), which re-runs that exact ownership
+   * check. `redeemStreamTicket` is single-use and processId-bound, so:
+   *   - no ticket, or a ticket for a different processId → 401, no stream.
+   *   - no processId in the path at all → 400 (there is no "stream
+   *     everything" mode; the pre-port harnesses SSE endpoint had no
+   *     Studio consumer, so there is no back-compat contract to preserve
+   *     for an unfiltered subscribe).
+   */
   private handleStream(
     req: IncomingMessage,
     res: ServerResponse,
-    processFilter: string | null,
+    processId: string | null,
+    ticket: string | null,
   ): void {
+    if (!processId) {
+      jsonResponse(res, 400, { error: 'processId is required' });
+      return;
+    }
+    if (!ticket) {
+      jsonResponse(res, 401, { error: 'A stream ticket is required (call agent.streamTicket)' });
+      return;
+    }
+    const redeemed = redeemStreamTicket(ticket, processId);
+    if (!redeemed) {
+      jsonResponse(res, 401, { error: 'Invalid, expired, or already-used stream ticket' });
+      return;
+    }
+
+    // S6: bound concurrent SSE connections. Checked AFTER ticket redemption
+    // (which is itself rate-limited by requiring a fresh signed RPC call
+    // per attempt) so an unauthenticated client cannot exhaust the cap.
+    if (this.activeStreamCount >= MAX_SSE_CONNECTIONS) {
+      jsonResponse(res, 503, { error: 'Too many concurrent streams; try again shortly' });
+      return;
+    }
+    this.activeStreamCount++;
+
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
@@ -653,13 +786,24 @@ export class HttpGateway {
     // Send initial keepalive
     res.write(': connected\n\n');
 
+    // S6: a stalled consumer's kernel socket buffer fills, res.write()
+    // returns false, and Node queues writes in unbounded userspace memory
+    // behind it. Drop further frames for this connection until 'drain'
+    // fires rather than buffering without bound — documented lossy
+    // behavior for a slow reader, not a correctness requirement (SSE has
+    // no delivery guarantee).
+    let backpressured = false;
+    res.on('drain', () => {
+      backpressured = false;
+    });
+
     const onOutput = (evt: AgentOutputEvent): void => {
-      if (processFilter && evt.processId !== processFilter) return;
-      res.write(`event: output\ndata: ${JSON.stringify(evt)}\n\n`);
+      if (evt.processId !== processId || backpressured) return;
+      if (!res.write(`event: output\ndata: ${JSON.stringify(evt)}\n\n`)) backpressured = true;
     };
 
     const onExit = (evt: AgentExitEvent): void => {
-      if (processFilter && evt.processId !== processFilter) return;
+      if (evt.processId !== processId) return;
       res.write(`event: exit\ndata: ${JSON.stringify(evt)}\n\n`);
     };
 
@@ -673,6 +817,7 @@ export class HttpGateway {
 
     // Cleanup on client disconnect
     req.on('close', () => {
+      this.activeStreamCount--;
       clearInterval(keepalive);
       agentEvents.off('output', onOutput);
       agentEvents.off('exit', onExit);
@@ -737,3 +882,6 @@ function jsonResponse(res: ServerResponse, status: number, body: unknown): void 
   });
   res.end(json);
 }
+
+// gateway.revokeToken (S5) is registered in gateway-rpc.ts, not here — see
+// that file's docblock for why it cannot live in this module.

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -61,6 +61,7 @@ import './agent.js';
 // PTY-backed agent.spawn/stop/input/resize/output — overwrites the stubs
 // in agent.js with real implementations. Must follow agent.js in import order.
 import './spawn.js';
+import './gateway-rpc.js';
 
 export { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 export { SCHEMA_SQL } from './storage/schema.js';

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -74,6 +74,7 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['merge.status', 'routine'],
   ['merge.list', 'routine'],
   ['agent.output', 'routine'],
+  ['agent.streamTicket', 'routine'],
   ['agent.resize', 'routine'],
   ['agent.stop', 'routine'],
   ['agent.list', 'routine'],
@@ -111,6 +112,9 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['permission.pending', 'routine'],
   ['permission.decide', 'critical'],
   ['permission.setMode', 'critical'],
+  // Revokes a bearer credential — reversible (a new one can be paired), so
+  // consequential rather than critical (GAP-421 guardrail-2 remediation S5).
+  ['gateway.revokeToken', 'consequential'],
 ]);
 
 /** Fail closed: unmapped method is critical (spec §5 / I2). */

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -237,6 +237,13 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   'agent.input',
   'agent.resize',
   'agent.output',
+  // agent.streamTicket mints the principal for GET /api/stream (GAP-421
+  // guardrail-2 remediation B1): signature-required so the ticket is bound
+  // to the VERIFIED signer, and the handler re-runs agent.output's
+  // owner_agent === callerAgentId check before minting. The gateway's
+  // bearer token alone is a transport credential, never sufficient to read
+  // PTY content.
+  'agent.streamTicket',
   // agent.list returns another-agent-invisible process metadata (command, cwd),
   // and agent.remove kills + prunes a process. Both are signature-required and
   // self-scoped to the verified signer's owner_agent — an unsigned or spoofed
@@ -269,6 +276,10 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   // Phase 2: operator mode overrides are signature-required too.
   'permission.decide',
   'permission.setMode',
+  // gateway.revokeToken revokes an HTTP gateway bearer token (GAP-421
+  // guardrail-2 remediation S5). Signature-required so an unsigned caller
+  // cannot revoke another client's session.
+  'gateway.revokeToken',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/spawn-events.ts
+++ b/packages/daemon/src/spawn-events.ts
@@ -5,15 +5,30 @@
  * — this EventEmitter exists only so the HTTP gateway's SSE endpoint
  * (`GET /api/stream/:processId`) has a live feed to relay, mirroring what
  * `@revealui/harnesses` `server/spawner-service.ts` gave `http-gateway.ts`
- * before the port. No auth surface: SSE access is gated upstream by the
- * gateway's bearer-token check before this module is ever touched.
+ * before the port.
+ *
+ * Authorization (GAP-421 guardrail-2 remediation, B1): the gateway's bearer
+ * token is a TRANSPORT credential (proves "this HTTP client paired with the
+ * daemon"), not a principal. It is NOT sufficient to read PTY output —
+ * `agent.output` requires a verified Ed25519 signer AND
+ * `owner_agent === callerAgentId` (spawn.ts, the 2026-06-29 Part B
+ * cross-agent PTY-hijack fix), and `/api/stream` must enforce the same. A
+ * bearer-token-only client cannot subscribe directly: it must first call the
+ * signature-required RPC `agent.streamTicket` (dispatchRpc — same license
+ * guard, signature gate, identity gate, and `owner_agent` ownership check as
+ * `agent.output`) to mint a short-lived, single-use, processId-bound ticket,
+ * then present that ticket on `/api/stream/:processId?ticket=...`. The
+ * ticket is the resolved principal for the stream; there is no
+ * ticket-free/firehose mode.
  */
 
+import { randomBytes } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 
 export interface AgentOutputEvent {
   processId: string;
-  stream: 'stdout' | 'stderr';
+  /** node-pty merges stdout/stderr into one stream; always 'stdout'. */
+  stream: 'stdout';
   data: string;
 }
 
@@ -33,3 +48,88 @@ class AgentEventBus extends EventEmitter {
 
 /** Process-wide singleton — one daemon process, one PTY registry (spawn.ts). */
 export const agentEvents = new AgentEventBus();
+
+// S6 (guardrail-2 remediation): each SSE connection registers two listeners
+// (output + exit). The HTTP gateway independently caps concurrent SSE
+// connections (MAX_SSE_CONNECTIONS in http-gateway.ts); this only raises
+// Node's default-10 listener-count warning threshold to match that real
+// cap, rather than actually removing a bound.
+agentEvents.setMaxListeners(160);
+
+// ---------------------------------------------------------------------------
+// Stream tickets — the principal-resolution step for /api/stream.
+//
+// Minted only by the signature-required `agent.streamTicket` RPC handler
+// (spawn.ts), which re-runs the exact `owner_agent === callerAgentId` check
+// `agent.output` uses. Single-use and short-lived: redeeming a ticket
+// deletes it, so a captured/logged ticket cannot be replayed to open a
+// second stream once the legitimate client has connected (or once it
+// expires, whichever comes first).
+// ---------------------------------------------------------------------------
+
+const STREAM_TICKET_TTL_MS = 60_000;
+const STREAM_TICKET_BYTES = 32;
+const MAX_PENDING_TICKETS = 256;
+
+interface StreamTicket {
+  agentId: string;
+  processId: string;
+  expiresAt: number;
+}
+
+const tickets = new Map<string, StreamTicket>();
+
+function pruneExpiredTickets(now: number): void {
+  for (const [ticket, entry] of tickets) {
+    if (entry.expiresAt <= now) tickets.delete(ticket);
+  }
+}
+
+/**
+ * Mint a single-use ticket binding (agentId, processId). Called only from
+ * the `agent.streamTicket` handler AFTER it has verified the caller owns
+ * `processId` — this function performs no authorization of its own.
+ */
+export function issueStreamTicket(
+  agentId: string,
+  processId: string,
+  now = Date.now(),
+): { ticket: string; expiresIn: number } {
+  pruneExpiredTickets(now);
+  if (tickets.size >= MAX_PENDING_TICKETS) {
+    // Oldest-first eviction: drop the least-recently-issued ticket rather
+    // than refusing a legitimate mint. Tickets are short-lived, so this
+    // only bites under sustained abuse, and abuse of THIS endpoint already
+    // required a valid signature.
+    const oldest = tickets.keys().next().value;
+    if (oldest !== undefined) tickets.delete(oldest);
+  }
+  const ticket = randomBytes(STREAM_TICKET_BYTES).toString('hex');
+  tickets.set(ticket, { agentId, processId, expiresAt: now + STREAM_TICKET_TTL_MS });
+  return { ticket, expiresIn: Math.floor(STREAM_TICKET_TTL_MS / 1000) };
+}
+
+/**
+ * Redeem a ticket for a specific `processId`. Single-use: the ticket is
+ * deleted whether or not it matches, so a wrong-processId presentation also
+ * burns it rather than leaving it available for a correct guess. Returns
+ * the bound `agentId` on success, or `null` if the ticket is unknown,
+ * expired, or bound to a different `processId`.
+ */
+export function redeemStreamTicket(
+  ticket: string,
+  processId: string,
+  now = Date.now(),
+): { agentId: string } | null {
+  const entry = tickets.get(ticket);
+  tickets.delete(ticket);
+  if (!entry) return null;
+  if (entry.expiresAt <= now) return null;
+  if (entry.processId !== processId) return null;
+  return { agentId: entry.agentId };
+}
+
+/** @internal — test-only seam to assert the pending-ticket count. */
+export function _pendingTicketCountForTest(): number {
+  return tickets.size;
+}

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -43,7 +43,7 @@ import {
 import { onAgentEnded, onDaemonStarted } from './eviction.js';
 import { requireRootAndDir } from './filegit.js';
 import { getDaemonConfig, registerHandler, type SocketContext } from './server.js';
-import { agentEvents } from './spawn-events.js';
+import { agentEvents, issueStreamTicket } from './spawn-events.js';
 import { denyToolAction, evaluateToolAction } from './tool-guard/index.js';
 
 const log = createLogger({ service: 'revdev-daemon/spawn' });
@@ -596,4 +596,34 @@ registerHandler('agent.output', async (params, db, ctx) => {
     cursor: nextCursor,
     status: proc.status,
   };
+});
+
+/**
+ * agent.streamTicket — mint a short-lived, single-use ticket authorizing
+ * `GET /api/stream/:processId` (GAP-421 guardrail-2 remediation, B1).
+ *
+ * The HTTP gateway's bearer token is a transport credential, not a
+ * principal: it does not carry an Ed25519 signature or prove PTY
+ * ownership. This handler re-runs the EXACT same ownership check
+ * `agent.output` uses (`owner_agent === callerAgentId`) before minting a
+ * ticket, so `/api/stream` inherits the same signature + identity +
+ * ownership gates as every other read of this content, just resolved once
+ * at subscribe time instead of per-poll.
+ */
+registerHandler('agent.streamTicket', async (params, db, ctx) => {
+  const callerAgentId = requireAgent(ctx, params);
+  const processId = stringParam(params, 'processId');
+  if (!processId) throw new Error('agent.streamTicket: missing processId');
+
+  const procRow = await db.query<{ owner_agent: string }>(
+    `SELECT owner_agent FROM agent_processes WHERE id = $1`,
+    [processId],
+  );
+  const proc = procRow.rows[0];
+  if (!proc) throw new Error(`agent.streamTicket: unknown processId ${processId}`);
+  if (proc.owner_agent !== callerAgentId) {
+    throw new Error(`agent.streamTicket: process ${processId} is not owned by caller`);
+  }
+
+  return issueStreamTicket(callerAgentId, processId);
 });

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -592,6 +592,14 @@ export const schemas: Record<string, z.ZodType> = {
     })
     .passthrough(),
 
+  // Mints the /api/stream principal ticket (GAP-421 guardrail-2 remediation B1).
+  'agent.streamTicket': z
+    .object({
+      processId: z.string().min(1),
+      actorAgentId,
+    })
+    .passthrough(),
+
   // -- File surface (P0: daemon-owned ext4 I/O) -------------------------------
   // `safePath` already rejects `..` traversal + system roots; the handler
   // additionally realpath-checks every target is a descendant of a registered
@@ -742,6 +750,14 @@ export const schemas: Record<string, z.ZodType> = {
     .object({
       approvalId: z.string().min(1).max(MAX_NAME_LENGTH),
       verdict: z.enum(['approved', 'denied']),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  // -- HTTP gateway token management (GAP-421 guardrail-2 remediation S5) -----
+  'gateway.revokeToken': z
+    .object({
+      token: z.string().min(1),
       actorAgentId,
     })
     .passthrough(),

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -64,6 +64,7 @@ export const RPC_METHODS = {
   'agent.input': 'agent.input',
   'agent.resize': 'agent.resize',
   'agent.output': 'agent.output',
+  'agent.streamTicket': 'agent.streamTicket',
 
   // Inference management
   'inference.status': 'inference.status',
@@ -118,4 +119,7 @@ export const RPC_METHODS = {
   'permission.pending': 'permission.pending',
   'permission.decide': 'permission.decide',
   'permission.setMode': 'permission.setMode',
+
+  // HTTP gateway token management (GAP-421 guardrail-2 remediation S5)
+  'gateway.revokeToken': 'gateway.revokeToken',
 } as const;


### PR DESCRIPTION
## Summary

Remediates the guardrail-2 REQUEST-CHANGES verdict on #328 (already merged
to `test` before the verdict landed):
https://github.com/RevealUIStudio/revdev/pull/328#issuecomment-5080736287

**The gateway must stay unconfigured (`httpPort: 0`, the default) everywhere
until this lands.** Nothing in this PR changes that default; it only closes
the gap in what happens when an operator does turn it on.

This PR is itself a security surface (SSE authorization, a new
signature-required RPC, gateway body-size/CORS/Host handling) and requests a
**fresh, non-author guardrail-2 verdict before merge**.

## B1 (the blocker) — fixed

`GET /api/stream` served every agent's PTY output to any bearer-token
holder, with none of the Ed25519 signature or `owner_agent` ownership check
`agent.output` enforces on the identical content. The port also deleted the
harnesses original's `spawner` null-guard that had kept that route inert.

Fix: a new signature-required RPC `agent.streamTicket`
([spawn.ts](packages/daemon/src/spawn.ts)) re-runs `agent.output`'s exact
ownership check (`owner_agent === callerAgentId`) before minting a
short-lived (60s), single-use, `processId`-bound ticket
([spawn-events.ts](packages/daemon/src/spawn-events.ts)). `GET
/api/stream/:processId?ticket=...` ([http-gateway.ts](packages/daemon/src/http-gateway.ts))
now requires both the bearer token (transport) AND a valid ticket (signed
principal + ownership) — there is no unfiltered/firehose subscribe mode
left; a missing `processId` is a 400, not "everything."

`agent.streamTicket` is wired into every completeness contract the fleet
already enforces: `MUTATING_OR_CONTENT_METHODS` (server.ts), the
`signature-gate.test.ts` exact-set lock, `RPC_METHODS`
(`@revdev/protocol`), `METHOD_ACTION_CLASS` (permission.ts), a validation
schema, and the Rust `signing.rs` cross-language contract (+ its own test,
verified with `cargo test --lib signing` — 10/10 passed).

## B2 (adversarial parity) — fixed

Ported all 19 missing GAP-353 cases the verdict enumerated into
[`http-gateway-adversarial.test.ts`](packages/daemon/src/__tests__/http-gateway-adversarial.test.ts)
(nonce replay x3, rate-limit/lockout x4, the full §D7 boot-honesty block x7,
token-hash-not-plaintext, restart durability, `PRE_AUTH_ROUTES` exact
contents, `isPreAuthRoute` classification, full `/api/*` auth coverage
including `/api/stream`), adapted from the harnesses original's
`DaemonStore`/stubbed-dispatch shape to this package's raw `PGlite` + real
`dispatchRpc` (using `ping`, the one identity- and license-exempt method, as
the "a valid token grants real access" proof in place of the original's
stubbed `agent.spawn`/`agent.stop`). 22 tests total (19 + the 3
`PairingRateLimiter` unit tests already alongside them in the original
file). These now exist daemon-side before the harnesses copy retires.

## Suggestions — fixed

- **S1** (UTF-16-vs-bytes body cap): `/rpc` and `/api/pair` now accumulate
  raw `Buffer`s and cap on `chunk.length` (already bytes), decoding once at
  the end — mirrors the socket path's documented `Buffer.byteLength(...,
  'utf8')` fix and stops a multibyte character from being split across a
  chunk boundary.
- **S2** (double `writeHead` on 413): both handlers now set a local
  `rejected` flag before `req.destroy()`, so an already-buffered second
  chunk can't re-enter and call `writeHead` on an ended response.
- **S3** (CORS + Host): `Access-Control-Allow-*` is withheld on `/api/pair`
  specifically; a new `isAllowedHost` check runs before anything else
  (including the pairing pre-auth allowlist) and rejects a Host header that
  doesn't match the bound loopback interface (or is empty/unparseable on a
  non-loopback bind).
- **S4** (cleartext bearer / TLS): per the dispatch instructions, documented
  rather than built. `index.ts` / `http-gateway.ts` docblocks now say
  plainly that the transport is plaintext and that `httpHost` staying
  loopback is what makes the current default safe; no TLS added, no ADR
  contradicted.
- **S5** (`revokeToken` unreachable): a new signature-required RPC
  `gateway.revokeToken` ([gateway-rpc.ts](packages/daemon/src/gateway-rpc.ts))
  makes it reachable. Documented scope limit: `gateway_tokens` rows carry no
  agent linkage, so any verified signer can revoke any known token, not only
  its own — closing that needs a schema change, out of scope here.
  (Registered in its own module, not `http-gateway.ts` — see below.)
- **S6** (SSE resource bounds): `MAX_SSE_CONNECTIONS = 64` concurrent
  streams (503 beyond it), `agentEvents.setMaxListeners(160)` sized to that
  cap, and a per-connection `backpressured` flag that drops further frames
  (rather than buffering unboundedly) when `res.write()` returns `false`,
  clearing on `drain`.

## A circular-import bug found while wiring S5 (fixed, not shipped)

Registering `gateway.revokeToken` at `http-gateway.ts`'s module top level
crashed every test at import time: `ReferenceError: Cannot access 'handlers'
before initialization`. `server.ts` imports the `HttpGateway` class
directly (to construct it in `startDaemon`), so `http-gateway.ts` evaluates
mid-way through `server.ts`'s own module body — before `server.ts`'s
`handlers` map exists. `agent.ts`/`spawn.ts`/`vcs.ts` avoid this because
they're only ever imported from `index.ts`/`cli.ts`, never from `server.ts`
itself. Moved the registration into a new `gateway-rpc.ts`, imported as a
side-effect from `index.ts` and `cli.ts` (same pattern, same import
points), which has no such cycle. Caught by running the full suite before
committing — not something a reviewer should have to find.

## Tests

- `http-gateway-stream-auth.test.ts` (7 new): the literal reviewer probe (a
  bearer-token-only client reading `/api/stream` — now 401, and confirmed no
  leaked bytes even if the client ignores the rejection and reads the body
  anyway), no-processId rejection, `agent.streamTicket` signature
  requirement, `agent.streamTicket` ownership rejection, a happy-path ticket
  that delivers only its own process's output (cross-tenant isolation
  proven with two concurrently spawned processes), single-use enforcement,
  and processId-mismatch rejection.
- `http-gateway-adversarial.test.ts` (22 new): B2, described above.
- Full daemon suite: **775/775 passed** (746 pre-existing at the tip of
  `test` + 7 + 22 new).

**Red-proof method** (no `git stash`, per instructions): committed the fix
first, then ran `git show origin/test:packages/daemon/src/http-gateway.ts >
packages/daemon/src/http-gateway.ts` and the same for `spawn-events.ts` —
i.e. overwrote the working tree with the exact vulnerable files merged in
#328 — and ran only `http-gateway-stream-auth.test.ts`:

```
✕ reproduces the reviewer probe: a bearer-token-only client cannot read PTY output without a ticket
  AssertionError: expected 200 to be 401
✕ rejects GET /api/stream with no processId in the path (no firehose mode)
  AssertionError: expected 200 to be 400
```

(The other 3 tests in that file failed too, but incidentally —
`issueStreamTicket is not a function` — because I reverted only the two
vulnerable files, not `spawn.ts`, which already calls it; that failure mode
is not itself a finding.) Restored the fix via `git show
HEAD:packages/daemon/src/http-gateway.ts > packages/daemon/src/http-gateway.ts`
(and the same for `spawn-events.ts`), rebuilt, and reran the full suite:
775/775 green, `git status` clean before pushing.

## Verdict items I dispute

None. Every blocker and suggestion is addressed as specified, or
(S4) addressed the way the dispatch instructions redirected it (document,
don't build TLS).

## Request

**Requesting a fresh, non-author guardrail-2 verdict before merge.** The
gateway must remain unconfigured (`httpPort: 0`) in every environment until
that verdict lands.

## Test plan

- [x] `pnpm -r --filter=!studio build` — clean
- [x] `pnpm --filter @revdev/daemon test` — 775/775 passed
- [x] `cargo test --lib signing` (apps/studio/src-tauri) — 10/10 passed
- [x] Red-proof of the B1 fix (see above)
- [ ] Non-author guardrail-2 verdict (blocking merge)
- [ ] Owner merge (`gh pr merge --squash --delete-branch`) after verdict

Generated with Claude Code (https://claude.com/claude-code)
