### PR TITLE
docs(daemon): drop stale rpc-server.ts reference from schemas provenance comment

### DIFF
--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -7,8 +7,7 @@
  * agent-memory + agent-coordination contracts (see
  * `revealui/packages/contracts/src/agents`,
  * `revealui/packages/db/src/schema/agents.ts`,
- * `revealui/packages/mcp/src/servers/revealui-memory.ts`,
- * `revealui/packages/harnesses/src/server/rpc-server.ts` —
+ * `revealui/packages/mcp/src/servers/revealui-memory.ts` —
  * all use the typed-record framing
  * `memoryType`/`content`/`metadata`, not KV-store `key`/`value`).
  *


### PR DESCRIPTION
Comment-only follow-up flagged by the revealui#2169 guardrail-2 re-review. The daemon schemas provenance comment cited `revealui/packages/harnesses/src/server/rpc-server.ts` as an example of the typed-record framing; that file is deleted by the GAP-421 harnesses coordination-twin removal (revealui#2169). Drops the one dead cross-repo reference; the other three examples (contracts/agents, db/schema/agents, mcp/revealui-memory) still stand.

Comment-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)