### PR TITLE
fix(daemon): free-tier harness.health (GAP-337)

### DIFF
--- a/apps/studio/src-tauri/tests/harness_integration.rs
+++ b/apps/studio/src-tauri/tests/harness_integration.rs
@@ -203,17 +203,15 @@ async fn full_rpc_round_trip_against_real_daemon() {
         "ended session {agent_id} still listed as active: {after}"
     );
 
-    // The daemon runs unlicensed (free tier) here, and harness.health is
-    // LICENSE-gated (the license-exempt set is only ping + session.* —
-    // narrower than the identity-exempt set). Assert the gate end to end
-    // through the Rust client: a clean RPC-level "License required", not
-    // a transport error.
-    let gated = harness::rpc_call("harness.health", serde_json::json!({}))
+    // GAP-337: harness.health is free-tier exempt (monitoring without Pro).
+    // Assert healthy payload end to end through the Rust client — not a license error.
+    let health = harness::rpc_call("harness.health", serde_json::json!({}))
         .await
-        .expect_err("harness.health must be license-gated on a free-tier daemon");
-    assert!(
-        gated.contains("License required"),
-        "expected the license gate, got: {gated}"
+        .expect("harness.health succeeds on a free-tier daemon (GAP-337)");
+    assert_eq!(
+        health.get("status").and_then(|v| v.as_str()),
+        Some("healthy"),
+        "expected healthy status, got: {health}"
     );
 }
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -35,7 +35,7 @@ Returns a pong response to verify daemon connectivity.
 ---
 
 ### `harness.health`
-**Tier**: Pro
+**Tier**: Free (GAP-337 — monitoring without a Pro license; `harness.prune` remains Pro)
 
 Returns daemon health status, active session/task counts, prune state, and client-identity anchor consistency. Takes no params (any passed are ignored).
 

--- a/packages/daemon/src/__tests__/guard.test.ts
+++ b/packages/daemon/src/__tests__/guard.test.ts
@@ -51,6 +51,8 @@ describe('guardRpcMethod', () => {
       'inference.status',
       'inference.chat',
       'inference.generate',
+      // GAP-337: monitoring without a Pro license
+      'harness.health',
     ];
 
     for (const method of exemptMethods) {
@@ -158,7 +160,7 @@ describe('guardRpcMethod', () => {
       'files.release',
       'events.log',
       'events.query',
-      'harness.health',
+      // harness.health is FREE (GAP-337); prune stays Pro coordination
       'harness.prune',
       'worktree.create',
     ];
@@ -167,6 +169,10 @@ describe('guardRpcMethod', () => {
         expect(guardRpcMethod(method).allowed).toBe(true);
       });
     }
+
+    it('allows harness.health on free and pro (GAP-337)', () => {
+      expect(guardRpcMethod('harness.health').allowed).toBe(true);
+    });
   });
 
   describe('max/enterprise licenses', () => {
@@ -397,8 +403,7 @@ describe('handler tier-classification coverage', () => {
     // event log
     'events.log',
     'events.query',
-    // harness housekeeping
-    'harness.health',
+    // harness.prune stays Pro; harness.health is FREE (GAP-337 / EXEMPT_METHODS)
     'harness.prune',
     // worktrees
     'worktree.create',

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -115,6 +115,9 @@ const EXEMPT_METHODS = new Set([
   'permission.pending',
   'permission.decide',
   'permission.setMode',
+  // GAP-337: health/monitoring must answer without a Pro license (same class
+  // as ping). Multi-agent harness.prune stays Pro.
+  'harness.health',
 ]);
 
 /**
@@ -151,7 +154,7 @@ export const METHOD_MIN_TIER = new Map<string, LicenseTier>([
  * free-file/git claims so help cannot re-drift (INIT-002 Phase 0).
  */
 export const LICENSE_TIER_HELP = `License tiers (method gate; source: EXEMPT_METHODS + METHOD_MIN_TIER):
-  free         Sessions, single-repo file/git, local inference run (status/chat/generate)
+  free         Sessions, single-repo file/git, local inference run, harness.health
   pro          Multi-agent coordination (mail, tasks, files.*, agent.*, merge.*, worktree, events, harness.prune, …)
   max          + full AI memory (memory.*) and local-model management (inference.pull/delete/start/stop)
   enterprise   Same method surface as max today; commercial terms differ`;


### PR DESCRIPTION
## Summary

**GAP-337:** add `harness.health` to `EXEMPT_METHODS` so Free/degraded daemons can answer health checks. `harness.prune` remains Pro.

## Test plan

- [ ] `pnpm --filter @revdev/daemon test -- guard.test.ts`