### PR TITLE
ci: restore claim-gates source ref to test

### DIFF
--- a/.github/workflows/claim-gates.yml
+++ b/.github/workflows/claim-gates.yml
@@ -37,8 +37,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: RevealUIStudio/revealui
-          # Pin until revealui#2300 (product-readme fleet-attrib off) is on test.
-          ref: a11ad3356ac6234f1ee68e08feb53054914e8546
+          ref: test
           path: revealui
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

`revealui#2300` is on `test`. Restore claim-gates workflow `ref: test` and drop the temporary pin SHA used while hard-fail CI landed ahead of the profile fix.

## Test plan

- [ ] claim-gates job green against revealui@test
