### PR TITLE
feat(daemon): context.snapshot peer awareness (GAP-459 S1)

### DIFF
--- a/packages/daemon/src/__tests__/context-snapshot.test.ts
+++ b/packages/daemon/src/__tests__/context-snapshot.test.ts
@@ -102,10 +102,10 @@ describe('context.snapshot RPC', () => {
        VALUES ($1, $2, $3::timestamp, $4)`,
       ['/tmp/gap459-peer-file.ts', 'ctx-holder', '2099-01-01T00:00:00Z', 'gap459'],
     );
-    await db.query(
-      `INSERT INTO tasks (id, description, status) VALUES ($1, $2, 'open')`,
-      ['task-gap459', 'GAP-459 open claim — visible in snapshot'],
-    );
+    await db.query(`INSERT INTO tasks (id, description, status) VALUES ($1, $2, 'open')`, [
+      'task-gap459',
+      'GAP-459 open claim — visible in snapshot',
+    ]);
     await db.query(
       `INSERT INTO events (agent_id, event_type, payload)
        VALUES ($1, $2, $3::jsonb)`,

--- a/packages/daemon/src/__tests__/context-snapshot.test.ts
+++ b/packages/daemon/src/__tests__/context-snapshot.test.ts
@@ -1,0 +1,159 @@
+/**
+ * GAP-459 Phase 1 — context.snapshot composite peer awareness.
+ *
+ * @vitest-environment node
+ */
+import { vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { PGlite } from '@electric-sql/pglite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { startDaemon } from '../server.js';
+import { validateParams } from '../validation/index.js';
+
+function rpc(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown> = {},
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
+    sock.on('connect', () => sock.write(req));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      const line = buf.slice(0, nl);
+      sock.end();
+      try {
+        const resp = JSON.parse(line);
+        if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
+        else resolve(resp.result);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error(`RPC timeout: ${method}`));
+    });
+  });
+}
+
+let dataDir: string;
+let socketPath: string;
+let close: () => Promise<void>;
+let db: PGlite;
+
+beforeAll(async () => {
+  const { generateTestLicense, setTestLicenseEnv } = await import('./test-license-helper.js');
+  setTestLicenseEnv(generateTestLicense('enterprise'));
+  dataDir = await mkdtemp(join(tmpdir(), 'revdev-ctx-'));
+  socketPath = join(dataDir, 'harness.sock');
+  const d = await startDaemon({ socketPath, dataDir });
+  close = d.close;
+  db = d._db;
+});
+
+afterAll(async () => {
+  await close?.();
+  await rm(dataDir, { recursive: true, force: true });
+  const { clearTestLicenseEnv } = await import('./test-license-helper.js');
+  clearTestLicenseEnv();
+});
+
+describe('context.snapshot schema', () => {
+  it('accepts empty params and rejects eventLimit 0', () => {
+    expect(validateParams('context.snapshot', {}).valid).toBe(true);
+    expect(validateParams('context.snapshot', { eventLimit: 50 }).valid).toBe(true);
+    expect(validateParams('context.snapshot', { eventLimit: 0 }).valid).toBe(false);
+  });
+});
+
+describe('context.snapshot RPC', () => {
+  it('shows peer sessions, peer findings, open tasks, and cross-agent reservations', async () => {
+    await rpc(socketPath, 'session.register', {
+      agentId: 'ctx-alice',
+      agentName: 'ctx-alice',
+      task: 'claiming GAP-459',
+    });
+
+    await rpc(socketPath, 'session.register', {
+      agentId: 'ctx-bob',
+      agentName: 'ctx-bob',
+      task: 'holding a file',
+    });
+
+    // Seed via DB so this test owns the READ surface only (writes stay covered
+    // by files.reserve / tasks.create / events.log suites).
+    // Use a holder id that never session.register'd on a short-lived socket.
+    // register/attach socket-close auto-DELETEs that agent's reservations
+    // (server.ts), and our per-RPC test sockets race with that cleanup.
+    await db.query(
+      `INSERT INTO file_reservations (file_path, agent_id, expires_at, reason)
+       VALUES ($1, $2, $3::timestamp, $4)`,
+      ['/tmp/gap459-peer-file.ts', 'ctx-holder', '2099-01-01T00:00:00Z', 'gap459'],
+    );
+    await db.query(
+      `INSERT INTO tasks (id, description, status) VALUES ($1, $2, 'open')`,
+      ['task-gap459', 'GAP-459 open claim — visible in snapshot'],
+    );
+    await db.query(
+      `INSERT INTO events (agent_id, event_type, payload)
+       VALUES ($1, $2, $3::jsonb)`,
+      [
+        'ctx-bob',
+        'peer.finding',
+        JSON.stringify({ summary: 'context.snapshot is the read surface' }),
+      ],
+    );
+
+    const snap = (await rpc(socketPath, 'context.snapshot', {
+      actorAgentId: 'ctx-alice',
+    })) as {
+      available: boolean;
+      peers: Array<{ agentId: string; isSelf: boolean; task: string }>;
+      reservations: Array<{ path: string; agentId: string }>;
+      tasks: Array<{ title: string }>;
+      findings: Array<{ eventType: string; agentId: string }>;
+      degradation: { mode: string; rule: string };
+      rawCounts?: Record<string, number>;
+    };
+
+    expect(snap.available).toBe(true);
+    expect(snap.degradation).toEqual(
+      expect.objectContaining({ mode: 'advisory', rule: 'never-block' }),
+    );
+    expect(snap.peers.map((p) => p.agentId)).toContain('ctx-bob');
+    expect(snap.peers.map((p) => p.agentId)).not.toContain('ctx-alice');
+    expect(snap.findings.some((f) => f.eventType === 'peer.finding')).toBe(true);
+    expect(snap.tasks.some((t) => String(t.title).includes('GAP-459'))).toBe(true);
+    expect(snap.reservations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: '/tmp/gap459-peer-file.ts', agentId: 'ctx-holder' }),
+      ]),
+    );
+  });
+
+  it('includeSelf=true keeps the caller in peers', async () => {
+    await rpc(socketPath, 'session.register', {
+      agentId: 'ctx-self',
+      agentName: 'ctx-self',
+      task: 'self-check',
+    });
+    const snap = (await rpc(socketPath, 'context.snapshot', {
+      actorAgentId: 'ctx-self',
+      includeSelf: true,
+    })) as { peers: Array<{ agentId: string; isSelf: boolean }> };
+    const me = snap.peers.find((p) => p.agentId === 'ctx-self');
+    expect(me?.isSelf).toBe(true);
+  });
+});

--- a/packages/daemon/src/__tests__/guard.test.ts
+++ b/packages/daemon/src/__tests__/guard.test.ts
@@ -403,6 +403,8 @@ describe('handler tier-classification coverage', () => {
     // event log
     'events.log',
     'events.query',
+    // GAP-459 peer context composite
+    'context.snapshot',
     // harness.prune stays Pro; harness.health is FREE (GAP-337 / EXEMPT_METHODS)
     'harness.prune',
     // worktrees

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -55,6 +55,7 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['tasks.list', 'routine'],
   ['events.log', 'routine'],
   ['events.query', 'routine'],
+  ['context.snapshot', 'routine'],
   ['memory.store', 'routine'],
   ['memory.query', 'routine'],
   ['harness.health', 'routine'],

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1805,6 +1805,146 @@ registerHandler('events.query', async (params, db) => {
   return { events: result.rows };
 });
 
+// -- Peer context (GAP-459 Phase 1) -----------------------------------------
+//
+// Composite advisory snapshot so harnesses can paint peer presence, claims,
+// and active paths in ONE call. Does not invent a third store: composes
+// agent_sessions + file_reservations + tasks + events (peer.* types).
+// Autonomy rule (ADR 2026-07-28): this is awareness only — never a lock.
+// Unavailable clients must degrade VISIBLY (adapters print WARN), never
+// silently pretend peers are absent when the daemon is down.
+
+registerHandler('context.snapshot', async (params, db, ctx) => {
+  const eventLimit = Math.min(num(params.eventLimit, 50), 200);
+  const includeSelf = params.includeSelf === true;
+  // Prefer bound identity so we can label self vs peers. Unsigned callers
+  // with no actor still get a fleet-wide snapshot (selfAgentId null).
+  const selfAgentId =
+    (ctx.agentId && String(ctx.agentId)) || strOrNull(params.actorAgentId) || null;
+
+  // agent_sessions columns: id (also the agent identity), env, task, files,
+  // activity_state (migration 0005), timestamps. No separate agent_name col —
+  // name is encoded in env as `${backend}:${agentName}` at register time.
+  const sessionsResult = await db.query<Record<string, unknown>>(
+    `SELECT id, env, task, files, activity_state, pid, started_at, updated_at,
+            GREATEST(0, FLOOR(EXTRACT(EPOCH FROM (NOW() - updated_at))))::int AS "staleSeconds",
+            (activity_state = 'active'
+             AND updated_at > NOW() - make_interval(secs => $1)) AS active
+       FROM agent_sessions
+      WHERE ended_at IS NULL
+      ORDER BY started_at DESC`,
+    [ACTIVE_WINDOW_SECONDS],
+  );
+
+  // Intentional cross-agent path enumeration for SAME-MACHINE studio
+  // coordination (owner directive GAP-459). Paths only, no content. Trust
+  // boundary remains the 0600 socket + Pro license. Do NOT expand this to
+  // fleet/Neon without a separate security design.
+  // Note: filter expiry in SQL; if a driver returns string timestamps that
+  // compare poorly against NOW(), fall back to returning recent rows and
+  // filter in JS below.
+  const reservationsResult = await db.query<Record<string, unknown>>(
+    `SELECT agent_id, file_path, reserved_at, expires_at, reason
+       FROM file_reservations
+      WHERE expires_at > NOW()
+      ORDER BY reserved_at DESC
+      LIMIT 200`,
+  );
+
+  // tasks: description is the free-text title line; status is open|claimed|...
+  // No updated_at column on the daemon schema.
+  const tasksResult = await db.query<Record<string, unknown>>(
+    `SELECT id, description, status, owner, claimed_at, created_at
+       FROM tasks
+      WHERE status IN ('open', 'claimed', 'in_progress')
+      ORDER BY created_at DESC
+      LIMIT 100`,
+  );
+
+  // Shared findings/claims published via events.log with peer.* types
+  // (contract: peer.finding, peer.claim, peer.intent). Global events table
+  // is already cross-agent readable (events.query).
+  const findingsResult = await db.query<Record<string, unknown>>(
+    `SELECT agent_id, event_type, payload, created_at
+       FROM events
+      WHERE event_type LIKE 'peer.%'
+      ORDER BY created_at DESC
+      LIMIT $1`,
+    [eventLimit],
+  );
+
+  const sessions = sessionsResult.rows.map((r) => {
+    const id = String(r.id);
+    const env = typeof r.env === 'string' ? r.env : '';
+    const colon = env.indexOf(':');
+    const agentName = colon >= 0 ? env.slice(colon + 1) : env || id;
+    return {
+      id,
+      agentId: id,
+      agentName,
+      env,
+      task: r.task,
+      files: r.files,
+      activityState: r.activity_state,
+      pid: r.pid,
+      startedAt: r.started_at,
+      updatedAt: r.updated_at,
+      staleSeconds: r.staleSeconds,
+      active: r.active,
+      isSelf: selfAgentId != null && id === selfAgentId,
+    };
+  });
+
+  const peers = includeSelf ? sessions : sessions.filter((s) => !s.isSelf);
+
+  const reservations = reservationsResult.rows
+    .map((r) => ({
+      agentId: (r.agent_id ?? r.agentId) as string,
+      path: String(r.file_path ?? r.filePath ?? r.path ?? ''),
+      reservedAt: r.reserved_at ?? r.reservedAt,
+      expiresAt: r.expires_at ?? r.expiresAt,
+      reason: r.reason,
+    }))
+    .filter((r) => r.path.length > 0)
+    .filter((r) => includeSelf || !selfAgentId || String(r.agentId) !== selfAgentId);
+
+  const tasks = tasksResult.rows.map((r) => ({
+    id: r.id,
+    title: r.description,
+    status: r.status,
+    owner: r.owner,
+    claimedAt: r.claimed_at,
+    createdAt: r.created_at,
+  }));
+
+  const findings = findingsResult.rows.map((r) => ({
+    agentId: r.agent_id,
+    eventType: r.event_type,
+    payload: r.payload,
+    createdAt: r.created_at,
+  }));
+
+  return {
+    available: true,
+    scope: 'local',
+    selfAgentId,
+    generatedAt: new Date().toISOString(),
+    activeWindowSeconds: ACTIVE_WINDOW_SECONDS,
+    peers,
+    sessions,
+    reservations,
+    tasks,
+    findings,
+    // Adapter contract: when the daemon is DOWN, callers invent
+    // { available: false, reason: 'daemon-unavailable' } client-side.
+    degradation: {
+      mode: 'advisory',
+      rule: 'never-block',
+      note: 'A claim is a signal, not a mutex (ADR 2026-07-28).',
+    },
+  };
+});
+
 // -- Health -----------------------------------------------------------------
 
 registerHandler('harness.health', async (_params, db) => {

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -313,6 +313,21 @@ export const schemas: Record<string, z.ZodType> = {
     })
     .passthrough(),
 
+  // GAP-459 Phase 1: composite peer-context read (advisory awareness).
+  // Pro multi-agent coordination (not EXEMPT). Not signature-required:
+  // metadata only (presence, paths, task titles, event summaries) — no
+  // file contents. Same trust boundary as session.list + files.* on the
+  // 0600 socket.
+  'context.snapshot': z
+    .object({
+      // Recent peer finding/claim events window (default 50, max 200).
+      eventLimit: z.number().int().min(1).max(200).optional(),
+      // When true, include the caller's own session/reservations too.
+      includeSelf: z.boolean().optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
   // -- Memory -----------------------------------------------------------------
   // Field names match DB columns (`agent_memory.memory_type`, `.content`,
   // `.metadata`) and the RevealUI fleet's typed-record framing

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -52,6 +52,9 @@ export const RPC_METHODS = {
   'events.log': 'events.log',
   'events.query': 'events.query',
 
+  // Peer context composite (GAP-459 Phase 1)
+  'context.snapshot': 'context.snapshot',
+
   // Agent memory
   'memory.store': 'memory.store',
   'memory.query': 'memory.query',


### PR DESCRIPTION
## Summary
- Adds `context.snapshot` RPC: composite advisory read of active sessions, live file reservations (paths only), open/claimed tasks, and recent `peer.*` events.
- Pro multi-agent coordination tier; signature-optional (metadata only). Never a mutex (ADR 2026-07-28 unified agent memory).
- Protocol `RPC_METHODS` + validation schema + permission class + integration tests.

## Why
GAP-459 Phase 1: primitives exist; consumption does not. S1 is the single read surface harnesses will call at session start (S2 adapters next).

## Design
`.jv` `docs/gap-specs/GAP-459-phase1-shared-context-design.md` (companion jv PR).

## Test plan
- [x] `vitest` context-snapshot + rpc-contract + guard + permission (121 pass)
- [ ] CI green on PR
- [ ] After merge: S2 session-start peer panel (Claude + Grok) with visible WARN when daemon down