### PR TITLE
feat(daemon): heartbeat prune arm for abandoned sessions (GAP-459)

### DIFF
--- a/.changeset/gap459-heartbeat-prune.md
+++ b/.changeset/gap459-heartbeat-prune.md
@@ -1,0 +1,5 @@
+---
+"@revdev/daemon": minor
+---
+
+GAP-459: harness.prune heartbeat arm (reap idle agent_sessions by updated_at)

--- a/packages/daemon/src/__tests__/coordination.test.ts
+++ b/packages/daemon/src/__tests__/coordination.test.ts
@@ -387,6 +387,41 @@ describe('GAP-153: stale-session prune', () => {
     expect(after.sessions.find((s) => s.id === 'stale-test')).toBeUndefined();
   });
 
+  it('ages out a heartbeat-idle session via heartbeatStaleSeconds (GAP-459)', async () => {
+    await rpc(socketPath, 'session.register', {
+      agentId: 'heartbeat-idle',
+      agentName: 'heartbeat-idle',
+      backend: 'test',
+    });
+    // Started recently but no tool activity for >1h (updated_at aged).
+    await db.query(
+      "UPDATE agent_sessions SET updated_at = NOW() - INTERVAL '2 hours' WHERE id = $1",
+      ['heartbeat-idle'],
+    );
+
+    const pruner = await seedIdentity('pruner-heartbeat');
+    const result = (await signedRpc(
+      socketPath,
+      'harness.prune',
+      // staleDays huge so only the heartbeat arm selects this row
+      { staleDays: 365, hardDeleteDays: 365, heartbeatStaleSeconds: 3600 },
+      { did: pruner.did, fingerprint: pruner.fingerprint, privateKeyPem: pruner.privateKeyPem },
+    )) as { aged: number; heartbeatStaleSeconds: number };
+    expect(result.heartbeatStaleSeconds).toBe(3600);
+    expect(result.aged).toBeGreaterThanOrEqual(1);
+
+    const after = (await rpc(socketPath, 'session.list')) as {
+      sessions: Array<{ id: string }>;
+    };
+    expect(after.sessions.find((s) => s.id === 'heartbeat-idle')).toBeUndefined();
+
+    const row = await db.query<{ exit_summary: string }>(
+      'SELECT exit_summary FROM agent_sessions WHERE id = $1',
+      ['heartbeat-idle'],
+    );
+    expect(row.rows[0]?.exit_summary).toBe('pruned-heartbeat');
+  });
+
   it('hard-deletes a session ended longer than hardDeleteDays', async () => {
     await rpc(socketPath, 'session.register', {
       agentId: 'hard-delete-test',

--- a/packages/daemon/src/__tests__/validation.test.ts
+++ b/packages/daemon/src/__tests__/validation.test.ts
@@ -366,6 +366,16 @@ describe('harness.prune validation', () => {
     expect(validateParams('harness.prune', { staleDays: 0 }).valid).toBe(false);
   });
 
+  it('accepts heartbeatStaleSeconds at the 1h floor (GAP-459)', () => {
+    expect(validateParams('harness.prune', { heartbeatStaleSeconds: 3600 }).valid).toBe(true);
+    expect(validateParams('harness.prune', { heartbeatStaleSeconds: 7200 }).valid).toBe(true);
+  });
+
+  it('REJECTS heartbeatStaleSeconds below 1h (GAP-459 / GAP-312 class)', () => {
+    expect(validateParams('harness.prune', { heartbeatStaleSeconds: 300 }).valid).toBe(false);
+    expect(validateParams('harness.prune', { heartbeatStaleSeconds: 0 }).valid).toBe(false);
+  });
+
   it('REJECTS negative days (GAP-312 floor; no clamp-to-zero)', () => {
     // Previously accepted on the theory that the handler's Math.max(0, ...) was
     // "the safety net". A zero floor is not a net: it is the fleet-wide

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -319,11 +319,20 @@ const pruneState: PruneState = {
  * invoke on demand via the `harness.prune` RPC for ops use, in addition to
  * the periodic timer set up in `startDaemon`.
  */
+/**
+ * Minimum heartbeat-idle seconds accepted on the RPC path (GAP-459 reaper).
+ * Floor prevents a misconfigured client from wiping every live session the way
+ * staleDays:0 once did (GAP-312). Periodic auto-prune keeps this at 0
+ * (start-age path only).
+ */
+export const MIN_HEARTBEAT_STALE_SECONDS = 3600;
+
 async function runPrune(
   db: PGlite,
   staleDays: number,
   hardDeleteDays: number,
-): Promise<{ aged: number; deleted: number }> {
+  heartbeatStaleSeconds = 0,
+): Promise<{ aged: number; deleted: number; heartbeatStaleSeconds: number }> {
   // Floor at ONE DAY, not zero. The previous Math.max(0, ...) let a caller pass
   // staleDays: 0 (or any negative, which clamped to 0), turning the WHERE
   // clause into `started_at < NOW()`, every live session, and fanning
@@ -335,16 +344,37 @@ async function runPrune(
   // GAP-312.
   const stale = Number.isFinite(staleDays) ? Math.max(1, staleDays) : 7;
   const hard = Number.isFinite(hardDeleteDays) ? Math.max(1, hardDeleteDays) : 30;
+  // heartbeatStaleSeconds: 0 disables the updated_at arm (periodic default).
+  // Positive values are floored at MIN_HEARTBEAT_STALE_SECONDS on the RPC path.
+  const heartbeat =
+    Number.isFinite(heartbeatStaleSeconds) && heartbeatStaleSeconds > 0
+      ? Math.max(MIN_HEARTBEAT_STALE_SECONDS, Math.floor(heartbeatStaleSeconds))
+      : 0;
 
-  // Parameterized interval avoids SQL injection on the days value.
+  // Parameterized intervals avoid SQL injection on the thresholds.
+  // Arm A: classic start-age (sessions that never ended and began long ago).
+  // Arm B: heartbeat-idle (GAP-459) — no updated_at activity for $2 seconds.
+  // Either arm alone is enough; exit_summary distinguishes for forensics.
   const aged = await db.query<{ id: string }>(
     `UPDATE agent_sessions
         SET ended_at = NOW(),
-            exit_summary = COALESCE(exit_summary, 'pruned-stale')
+            exit_summary = COALESCE(
+              exit_summary,
+              CASE
+                WHEN started_at < NOW() - INTERVAL '1 day' * $1 THEN 'pruned-stale'
+                ELSE 'pruned-heartbeat'
+              END
+            )
       WHERE ended_at IS NULL
-        AND started_at < NOW() - INTERVAL '1 day' * $1
+        AND (
+          started_at < NOW() - INTERVAL '1 day' * $1
+          OR (
+            $2::int > 0
+            AND updated_at < NOW() - make_interval(secs => $2)
+          )
+        )
       RETURNING id`,
-    [stale],
+    [stale, heartbeat],
   );
   // Evict filesystem roots for every stale-terminated agent (B6 item 10).
   for (const { id } of aged.rows) notifyAgentEnded(id, db);
@@ -376,9 +406,14 @@ async function runPrune(
       deleted: pruneState.lastDeletedCount,
       staleDays: stale,
       hardDeleteDays: hard,
+      heartbeatStaleSeconds: heartbeat,
     });
   }
-  return { aged: pruneState.lastAgedCount, deleted: pruneState.lastDeletedCount };
+  return {
+    aged: pruneState.lastAgedCount,
+    deleted: pruneState.lastDeletedCount,
+    heartbeatStaleSeconds: heartbeat,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -2021,13 +2056,19 @@ registerHandler('harness.prune', async (params, db, ctx) => {
   // regression cannot hand runPrune a fleet-wide selector.
   const staleDays = Math.max(1, num(params.staleDays, DAEMON_DEFAULTS.staleSessionDays));
   const hardDeleteDays = Math.max(1, num(params.hardDeleteDays, DAEMON_DEFAULTS.hardDeleteDays));
-  const result = await runPrune(db, staleDays, hardDeleteDays);
+  // Optional GAP-459 heartbeat arm. Omitted/0 = start-age only (backward compatible).
+  // Positive values re-floored at MIN_HEARTBEAT_STALE_SECONDS inside runPrune.
+  const heartbeatRaw = num(params.heartbeatStaleSeconds, 0);
+  const heartbeatStaleSeconds =
+    heartbeatRaw > 0 ? Math.max(MIN_HEARTBEAT_STALE_SECONDS, heartbeatRaw) : 0;
+  const result = await runPrune(db, staleDays, hardDeleteDays, heartbeatStaleSeconds);
   return {
     aged: result.aged,
     deleted: result.deleted,
     runAt: pruneState.lastRunAt?.toISOString() ?? null,
     staleDays,
     hardDeleteDays,
+    heartbeatStaleSeconds: result.heartbeatStaleSeconds,
   };
 });
 

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -389,6 +389,10 @@ export const schemas: Record<string, z.ZodType> = {
     .object({
       staleDays: z.number().min(1).optional(),
       hardDeleteDays: z.number().min(1).optional(),
+      // GAP-459: also end sessions with no updated_at activity for this many
+      // seconds. Floor 3600s (1h) when provided — 0/omit disables the arm.
+      // Not .int()-only: fractional seconds are harmless; floor is the property.
+      heartbeatStaleSeconds: z.number().min(3600).optional(),
       actorAgentId,
     })
     .passthrough(),


### PR DESCRIPTION
## Summary
- `harness.prune` accepts optional `heartbeatStaleSeconds` (floor **3600s**)
- Ends sessions with no `updated_at` activity (not only old `started_at`)
- `exit_summary`: `pruned-heartbeat` vs `pruned-stale`
- Periodic auto-prune unchanged (heartbeat arm off by default)

## Companion
revealui `session reap` CLI (archives candidates then signed prune).

## Test plan
- [x] validation tests for floor
- [x] coordination test heartbeat reaper
- [ ] CI green