### PR TITLE
fix(daemon): identity-exempt context.snapshot (GAP-459 peers)

### DIFF
--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -137,6 +137,9 @@ const IDENTITY_EXEMPT = new Set([
   'session.register',
   'session.attach',
   'session.list',
+  // GAP-459: peer metadata composite (same class as session.list — no file
+  // content). Optional actorAgentId still labels isSelf when provided.
+  'context.snapshot',
   'harness.health',
   // `harness.prune` was here. It reaches notifyAgentEnded for EVERY matched
   // session, so an identity-exempt, unsigned caller could evict every agent's


### PR DESCRIPTION
## Summary
`context.snapshot` is read-only peer metadata (same class as `session.list`). Making it identity-exempt lets `session peers` work without a prior bind when no `actorAgentId` is passed.

Still Pro-tier. Optional `actorAgentId` still labels `isSelf`.

## Why
Bare `session peers` got `-32002 Not registered … before context.snapshot`, and the harness mis-reported that as "context.snapshot unavailable".

## Companion
revealui: peers CLI uses daemon session cache for actor.