### PR TITLE
feat(claude): materialize revfleet rules via revcon copy-mode (GAP-372)

### DIFF
--- a/.claude/.revcon-manifest.json
+++ b/.claude/.revcon-manifest.json
@@ -25,7 +25,7 @@
     },
     "rules/git.md": {
       "source": "profiles/revfleet/claude/rules/git.md",
-      "sha256": "59fdde78476f102a1b65f88ec4a874471f5178e6ee9c1cdbe68f53f532221694"
+      "sha256": "a8c582428a148f5c3d8f07a96256b157606a5244d2e9d8e3d2ae81aef230dbd3"
     },
     "rules/model-allocation.md": {
       "source": "profiles/revfleet/claude/rules/model-allocation.md",
@@ -41,7 +41,7 @@
     },
     "rules/planning.md": {
       "source": "profiles/revfleet/claude/rules/planning.md",
-      "sha256": "731ed2f7a2df810224a6436bfefae96972d869fbb64a54e1055e3ebf6726d769"
+      "sha256": "b489fbf16bb2513d37a540474653ab70fe45f7fe704d69d7306dfde3128fd7fd"
     },
     "rules/secrets.md": {
       "source": "profiles/revfleet/claude/rules/secrets.md",

--- a/.claude/.revcon-manifest.json
+++ b/.claude/.revcon-manifest.json
@@ -1,0 +1,59 @@
+{
+  "mode": "copy",
+  "editor": "claude",
+  "profiles": ["revfleet"],
+  "files": {
+    "rules/code-over-docs.md": {
+      "source": "profiles/revfleet/claude/rules/code-over-docs.md",
+      "sha256": "fcc9af90a0fc31a1c04202891099a5e6e0f13502649011fd7a9cfe59bf6b5500"
+    },
+    "rules/control-layer.md": {
+      "source": "profiles/revfleet/claude/rules/control-layer.md",
+      "sha256": "289388f1038de4f372f5eeea5a61ee583fbea93042d01801b6c90b01d878c9f9"
+    },
+    "rules/disposition-actions.md": {
+      "source": "profiles/revfleet/claude/rules/disposition-actions.md",
+      "sha256": "cf3f1aa1f927dfac43494127590f6334239c3bc0619956e78a1b26e05b9e07b8"
+    },
+    "rules/durable-solutions.md": {
+      "source": "profiles/revfleet/claude/rules/durable-solutions.md",
+      "sha256": "1d9ab978b70bf67f68b65c4b9e06f1065730d1b212fb51d71c42bffc26de1e63"
+    },
+    "rules/extend-before-create.md": {
+      "source": "profiles/revfleet/claude/rules/extend-before-create.md",
+      "sha256": "eda319933321d2d69db659dfd6d441640d25d69b8c51b2ae026ca0974e0f430c"
+    },
+    "rules/git.md": {
+      "source": "profiles/revfleet/claude/rules/git.md",
+      "sha256": "59fdde78476f102a1b65f88ec4a874471f5178e6ee9c1cdbe68f53f532221694"
+    },
+    "rules/model-allocation.md": {
+      "source": "profiles/revfleet/claude/rules/model-allocation.md",
+      "sha256": "d71bb65d9315523e29b927ae47c7a3e9e35e763c7c30602d04c3043f92413c9b"
+    },
+    "rules/no-em-dashes.md": {
+      "source": "profiles/revfleet/claude/rules/no-em-dashes.md",
+      "sha256": "18b1cfe5218fd816837c13a2e6cd08786befad19a292f1fa85874a3ad0b5f22e"
+    },
+    "rules/opensrc.md": {
+      "source": "profiles/revfleet/claude/rules/opensrc.md",
+      "sha256": "c8d0eef53fda278bf2f077e4c7dbf843c8e0b07023b546429a2d209a1620ac55"
+    },
+    "rules/planning.md": {
+      "source": "profiles/revfleet/claude/rules/planning.md",
+      "sha256": "731ed2f7a2df810224a6436bfefae96972d869fbb64a54e1055e3ebf6726d769"
+    },
+    "rules/secrets.md": {
+      "source": "profiles/revfleet/claude/rules/secrets.md",
+      "sha256": "79d09010deb767f582cbd0a28f12d6bf3a36cc44e2f4260a7fbaddd709318d68"
+    },
+    "rules/temp-scripts.md": {
+      "source": "profiles/revfleet/claude/rules/temp-scripts.md",
+      "sha256": "66a574826b46352275606d88a9854a0e63c39433a97a55c75f50ccc0f4862a15"
+    },
+    "rules/token-economy.md": {
+      "source": "profiles/revfleet/claude/rules/token-economy.md",
+      "sha256": "b30a830e9dd333b05085bc5ce3994c477ac66390aabe4cf41741a64ccd12ef57"
+    }
+  }
+}

--- a/.claude/rules/code-over-docs.md
+++ b/.claude/rules/code-over-docs.md
@@ -1,0 +1,40 @@
+# Code Over Docs — Source of Truth Is Always the Source Code
+
+**Status:** convention. Applies to every repo and every session.
+
+## The rule
+
+The source code is the single source of truth. Documentation (READMEs, specs,
+plans, handoffs, ADRs, comments, backlog items, memory) *describes* the
+system; the code *defines* it. When a doc and the code disagree, the code is
+correct and the doc is stale. Full stop.
+
+## How to apply
+
+1. **Verify against code before acting.** Never implement, review, plan, or
+   report from a doc claim alone. Every load-bearing claim gets grounded to
+   `file:line` in the actual source before it drives a decision.
+2. **On disagreement: trust code, then fix the doc.** A doc-vs-code conflict
+   is a doc bug. Act on what the code does; queue or commit the doc
+   correction so the drift dies instead of propagating. Never "fix" working
+   code to match a stale doc without an explicit decision that the doc's
+   description was the intended behavior.
+3. **Doc-tier authority is subordinate.** Whatever authority hierarchy your
+   team uses for doc-vs-doc conflicts (roadmap over handoff over working
+   notes, or similar) resolves doc-vs-doc conflicts only. Code outranks every
+   tier on any factual claim about system behavior.
+4. **Prioritize code work over doc work.** When triaging a backlog, changes
+   that make the code correct outrank changes that make the prose about the
+   code nicer. Doc sweeps ride behind, never ahead of, the code fixes they
+   describe.
+5. **Comments are docs too.** A stale comment (for example, a header
+   describing a retired format) is drift. Fix it when touching the file, but
+   trust the code path below it, not the comment above it.
+
+## Why
+
+Docs rot by default. Shipped code pivots that never propagate to prose are
+the single biggest source of stale documentation, and requests to "do this"
+often turn out to already be done in code, just not yet reflected in the docs
+someone read first. Reading docs without grounding claims in code produces
+duplicate work and phantom bugs.

--- a/.claude/rules/control-layer.md
+++ b/.claude/rules/control-layer.md
@@ -1,0 +1,43 @@
+# Control Layer, Not Mirrors
+
+**Status:** convention. States the architecture shared workflow capabilities
+should follow.
+
+## The rule
+
+1. **A shared control layer authors workflow capabilities**: hardline rules,
+   registries, session-boundary checks, coordination tools. It's the one
+   place these are defined.
+2. **Harness homes are thin adapters.** Whatever editor or agent CLI a
+   session runs in (Claude Code, Grok, Cursor, OpenCode, VS Code, or a
+   product's own agents) loads or invokes the control layer's content and
+   may run thin hooks that call into it. No harness home owns a second full
+   implementation of the same capability.
+3. **Bootstrapping under one harness home is transitional, not a fork.** A
+   capability may land first under a single tool's config directory for
+   dogfooding. Its durable destination is the control layer, and that
+   harness config cuts over once the control layer supports it. This is
+   tracked as a conversion, never as a permanent "native twin."
+4. **Forbidden:** dual-home rules that re-author the same policy in two
+   places; full-copy rule bodies kept as a second source of truth instead of
+   as pointers or adapters; any setup that keeps one harness as "the real
+   product" and another as its copy.
+
+## Why
+
+A project's value is in native, provider-agnostic infrastructure, not in
+whichever editor happens to be open. Dual homes re-author the same rule
+twice and drift silently, the same failure class as any other unmaintained
+copy. The product is the control plane; harness homes consume it rather than
+compete with it.
+
+## How to apply
+
+- Shipping a workflow capability? Author it in the control layer first when
+  possible. If it has to bootstrap under a single harness's config directory
+  for dogfooding, record the control-layer cutover as a tracked follow-up in
+  the same change, not as a separate "native twin" ask.
+- When rules content needs to travel to multiple harnesses or multiple
+  consumer projects, add a lockstep check between the copies rather than
+  trusting hand-syncing to hold. See the extend-before-create convention for
+  the broader reuse discipline this sits under.

--- a/.claude/rules/disposition-actions.md
+++ b/.claude/rules/disposition-actions.md
@@ -1,0 +1,52 @@
+# Disposition Actions — Propose, Don't Dispose
+
+**Status:** convention. Applies to every agent working in this fleet.
+
+## The boundary
+
+Agent work is proposal-shaped by default. A proposal produces an artifact
+someone else can act on; a disposition consummates an outcome. Proposals
+never need special authorization; dispositions always do.
+
+**Always safe (proposal-shaped):**
+- Reading, grepping, auditing; empirical tests in a scratch environment.
+- Posting review or verdict comments on PRs.
+- Creating worktrees, committing to fresh branches, pushing feature branches.
+- Opening PRs, filing issues, authoring specs and plan docs.
+
+**Disposition-shaped (requires named, in-session authorization from the
+project owner, or a standing settings allow-rule):**
+- Merging any PR the agent authored this session, in any repo.
+- Merging any PR whose subject matter is security-sensitive, even when a
+  docs-self-merge convention would otherwise cover it.
+- Applying gate-clearing labels (approval labels and siblings).
+- Deleting remote branches.
+- Mutating repo settings, rulesets, required checks, CI variables or
+  secrets, webhooks, environments.
+- Force pushes, history rewrites, removing another session's worktree.
+
+A blanket preference recorded in memory ("merge green PRs") does not cover
+the security-classed items above; only named in-session words or a settings
+rule do.
+
+## Never bundle a disposition with anything else
+
+One disposition action per command, alone. Permission classifiers typically
+evaluate per command, so a mid-bundle block leaves the bundle half-executed
+(for example: a merge lands, but the follow-up branch delete is blocked,
+leaving state someone has to go verify by hand). A lone command either fully
+lands or cleanly does not.
+
+## When work is ready and no authorization exists
+
+Stop at the open PR. List it under owner actions with the exact one-line
+command that clears it. Do not re-send a blocked command, do not reword it,
+and do not accomplish it through another tool.
+
+## Reducing friction the sanctioned way
+
+- The project owner names dispositions in the prompt when delegating them.
+- The owner adds targeted permission allow-rules for command classes that
+  should never prompt.
+- Widening this boundary (letting agents self-merge a class of change)
+  happens by the owner editing the rule, not by an agent inferring it.

--- a/.claude/rules/durable-solutions.md
+++ b/.claude/rules/durable-solutions.md
@@ -1,0 +1,52 @@
+# Durable Solutions — Long-Term First, Hotfixes Are Debt
+
+**Status:** convention. Applies to every session, product and internal work
+alike. No "just this once" carve-out.
+
+## The rule
+
+1. **Prefer long-term durable solutions.** Fix root causes in the owning
+   layer (shared lib, env bootstrap, policy, product primitive) so the
+   failure class cannot recur. Session-local patches, ad hoc edits to
+   generated or environment files, one-off shell recipes, and "works on my
+   machine" overrides are not acceptable unless the project owner explicitly
+   accepts a registered hotfix.
+2. **Hotfixes are allowed only as registered debt.** If something needs to be
+   unblocked right now, a narrow hotfix may ship, but it must be registered
+   the same session. Unregistered hotfixes are policy violations, the same
+   class of problem as orphaned temp scripts.
+3. **Every hotfix has a durable destination.** Registration records: symptom,
+   temporary shape, durable target, owning path/repo, and what counts as
+   "converted." Pending hotfixes should surface at session boundaries until
+   resolved.
+4. **Extend before create still wins.** Durable does not mean greenfield.
+   Prefer hardening the existing primitive (a seed script, a hook, a
+   package, a gate) over standing up a parallel one-off.
+
+## What counts as non-durable (must register or refuse)
+
+| Shape | Examples |
+|-------|----------|
+| Env / machine only | Editing a gitignored local env file without fixing the loader; an env-var override treated as the permanent recipe |
+| Session-only | Scratch scripts left for someone else to run; undocumented escape-hatch flags |
+| Symptom patch | Catch-and-ignore without a root fix; copying credentials into chat or docs |
+| Parallel path | A second seed script or a second resolver "just for this one case" |
+| Silent demotion | "We'll harden this later" with no registry entry and no tracked follow-up |
+
+## What counts as durable
+
+- A shared module, rule, hook, or CI gate that fails closed for the whole
+  class of problem, not just the instance in front of you.
+- Documented escape hatches with explicit, named override flags.
+- A design doc or ticket when the durable fix needs multi-session design.
+- Tests that lock the durable behavior in place (prove red, then green).
+
+## Relationship to other conventions
+
+- Extend-before-create: durable means extending the real primitive, not
+  building a second one beside it.
+- Temp-scripts lifecycle: one-shot helper scripts are a related but separate
+  lifecycle (register, confirm, clean up) from hotfix debt.
+- Disposition boundary: registering a hotfix is proposal-shaped; shipping the
+  durable fix to production still needs the same authorization any
+  disposition needs.

--- a/.claude/rules/extend-before-create.md
+++ b/.claude/rules/extend-before-create.md
@@ -1,0 +1,33 @@
+# Extend Before Create — Obligatory Reuse and Consolidation
+
+**Status:** convention. Applies before building anything new.
+
+## The rule
+
+1. **Never create what you can extend.** Before building anything new
+   (package, script, hook, API, component, doc, workflow), find the existing
+   implementation and enhance or extend it. Creating something net-new
+   requires that an audit has shown nothing extensible exists, and the
+   PR or spec should say so explicitly ("extends X" or "nothing to extend
+   because Y").
+2. **Consolidate on contact.** Duplication, redundancy, and incomplete
+   wiring or consumption discovered during any task get flagged, even when
+   out of scope, and folded in when the fix is cheap. A half-adopted part
+   that's built but never wired up counts as drift the same as a literal
+   copy.
+3. **Converge on one implementation, many consumers.** When a project has a
+   shared library or native primitive for something, call that one
+   implementation everywhere rather than growing bespoke one-offs beside it.
+   Third-party or hand-rolled alternatives need the same carve-out
+   discipline: durable, documented exceptions only.
+4. **Intentional duplication survives.** Decoupling, avoiding circular
+   dependencies, and test isolation are legitimate reasons to duplicate on
+   purpose. Classify before consolidating: only accidental duplication is
+   debt.
+
+## Where discovered redundancy goes
+
+Track fleet-wide or project-wide consolidation work as its own backlog item,
+separate from the task that discovered it, so cleanup work doesn't silently
+block or get lost inside an unrelated PR. Per-discovery items go to whatever
+backlog or issue tracker the project uses.

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -39,5 +39,5 @@ Grok worktrees: use `rfg … --worktree=…` (injects `--ref test`) or pass
 - One PR can close multiple issues: `Closes #1, Closes #2`
 
 ## Identity
-- Professional repos (RevealUIStudio): RevealUI Studio <43050008+joshua-v-dev@users.noreply.github.com>
-- Amended 2026-07-10: never "restore" founder@revealui.com. It belongs to the org account, so SSH-signed commits carrying it render Unverified and required-signatures rulesets silently block the merge. Full rationale in the fleet-level `~/.claude/rules/git.md`.
+- Professional repos (RevealUIStudio): display name `RevealUI Studio` plus the **signing account's** verified GitHub noreply address (shape `id+login@users.noreply.github.com` on the account that holds the SSH signing key). Do not paste a personal login into public rule copies; resolve the real address from the machine git config / fleet hardline when committing.
+- Amended 2026-07-10: never "restore" founder@revealui.com. It belongs to the org account, so SSH-signed commits carrying it render Unverified and required_signatures rulesets silently block the merge. Full rationale in the fleet-level Studio git hardline (not re-copied here).

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -1,0 +1,43 @@
+# Git Conventions
+
+## Commit Messages
+- Use conventional commits: `type(scope): description`
+- Types: feat, fix, refactor, docs, test, chore, ci, perf
+- Scope is optional, use package name for monorepos (e.g., `feat(core): add parser`)
+- Description in imperative mood, lowercase, no period
+- Keep subject line under 72 characters
+
+## Branch Naming
+- Feature: `feat/<short-description>` or `feat/<issue#>-<short-description>`
+- Bugfix: `fix/<short-description>` or `fix/<issue#>-<short-description>`
+- Chore: `chore/<short-description>` or `chore/<issue#>-<short-description>`
+- When fixing a GitHub issue, include the issue number in the branch name
+
+## Branch Flow (test → main)
+- Feature/fix/chore branches base on **`test`**, never `main`. Open the PR against `test`.
+- `main` only ever receives changes via a promotion PR whose head is `test` (enforced by `promotion-gate.yml`). Never push directly to `main` or `test`, and never open a feature PR directly against `main`.
+- Merge manually after review — no auto-merge.
+
+### HARDLINE: never branch off a feature branch (owner 2026-07-21)
+
+Always cut new branches from **`origin/test`** (or `origin/main` when the
+repo has no `test`). Never from an existing `feat/*` / `fix/*` / `chore/*` tip.
+
+```bash
+git fetch origin test
+git switch -c fix/<name> origin/test
+```
+
+Grok worktrees: use `rfg … --worktree=…` (injects `--ref test`) or pass
+`--ref test` explicitly. Architecture: ADR
+`2026-07-21-harness-policy-runtime-launch-planes` (policy / runtime / launch).
+
+## Issue → PR → Close Workflow
+- PRs that fix a GitHub issue MUST include `Closes #N` in the PR description
+- Place `Closes #N` at the top of the PR body (the template prompts for it)
+- GitHub auto-closes the issue when the change reaches `main`. Because feature PRs merge to `test` first, the linked issue closes at the `test` → `main` promotion, not at the feature-PR merge
+- One PR can close multiple issues: `Closes #1, Closes #2`
+
+## Identity
+- Professional repos (RevealUIStudio): RevealUI Studio <43050008+joshua-v-dev@users.noreply.github.com>
+- Amended 2026-07-10: never "restore" founder@revealui.com. It belongs to the org account, so SSH-signed commits carrying it render Unverified and required-signatures rulesets silently block the merge. Full rationale in the fleet-level `~/.claude/rules/git.md`.

--- a/.claude/rules/model-allocation.md
+++ b/.claude/rules/model-allocation.md
@@ -1,0 +1,71 @@
+# Model Allocation — Work Class First, Provider Second
+
+**Status:** convention. Routes which kind of work goes to which kind of model
+or agent.
+
+## Principle
+
+1. **Work class** describes the *task* (Design, Build, Verify, Deploy).
+2. **Provider profile** describes *who runs the weights* (a frontier model
+   family, an implementer-tier model, a local/open model). Profiles are a
+   peer senior band with different strengths, not a strict power ranking.
+3. **The product's control layer** (if the project has one) is where policy,
+   routing, execution, and audit for governed AI work live. Harness-specific
+   configs (an editor's agent config, a CLI's rule files) stay thin adapters
+   on top of it, not a second implementation of the same policy.
+4. **Owner disposition** (merging security-sensitive PRs, gating labels,
+   money, legal) is never allocated to a model.
+
+Same result, right capability bar, lowest cost and lowest external exposure
+where it matters.
+
+## Work classes
+
+| Class | Question | Typical output |
+|-------|----------|-----------------|
+| **Design** | What should be true? Which trade-offs bind? | Spec, decision doc, open-question rulings, acceptance criteria |
+| **Build** | Make the design real | Branch from the integration ref, PRs, tests (prove red, then green) |
+| **Verify** | True, safe, and not self-checked by the author? | CI, independent review, probes, claim gates |
+| **Deploy** | Runs where users live? | Promote to the production branch, env, seed, worker, smoke test |
+
+### Class rules
+
+1. Ambiguous or security-sensitive work gets Design before Build.
+2. Crown-jewel surfaces (auth, license, entitlements, tenant boundaries,
+   webhooks, signing, agent spawning): Verify must not be the same session
+   that authored the Build. Any senior profile may Verify; the rule is about
+   process integrity, not brand.
+3. Deploy means promote plus runtime honesty, not just "CI is green on a
+   feature branch."
+4. Mechanical polish is light Build or automated Verify, not a fifth class.
+5. Escalate on ambiguity rather than improvising architecture during Build.
+
+### Lifecycle
+
+```text
+Design → Build → Verify → Deploy
+   ↑        │        │
+   │        └── rebuild on verify fail
+   └────────── redesign when verify/deploy finds a design hole
+```
+
+## Provider profiles
+
+| Family | Route here when |
+|--------|------------------|
+| Senior frontier model | Long structured Build; security Design; dense review |
+| A second senior frontier model (if available) | Multi-repo synthesis, combined Design+Build sessions, Verify peer |
+| Implementer-tier model | Low-ambiguity Build once Design is fixed |
+| Local / open-weight model | Cheap draft or classify work where local capability is proven sufficient |
+
+Prefer the cheapest model that is actually capable of the work class, not the
+most powerful model available. Frontier is opt-in by route decision, not a
+default for every task.
+
+## Security surfaces
+
+Anything on a sensitive-path list (auth, licensing, tenant boundaries,
+signing, agent spawning) gets a Design pass and a non-author Verify pass, not
+"must be a specific brand of model." Implementation is Build against a
+countersigned design. The project owner still disposes of merges and gating
+labels.

--- a/.claude/rules/no-em-dashes.md
+++ b/.claude/rules/no-em-dashes.md
@@ -1,0 +1,24 @@
+# No Em Dashes in Copy
+
+**Status:** convention. Applies to all customer-facing or public-facing text.
+
+## The rule
+
+Never use an em dash in copy: marketing site copy, UI strings, product
+surfaces, docs prose, blog posts, emails, README headlines, pricing pages,
+onboarding text, and anything a customer or prospect reads.
+
+## Replacement
+
+Remove the dash and separate the clauses with a plain space, a period, or let
+a layout's line break do the separation. Do not substitute a colon or
+semicolon for an em dash by default; if a plain space would garble the
+meaning on a single line, restructure the sentence instead.
+
+## How to apply
+
+- When a sweep or edit touches existing copy that contains em dashes, remove
+  them as part of the change.
+- Internal writing (chat, commit messages, internal docs) is a style
+  preference, not a hard rule: avoid em dashes going forward, but don't
+  bulk-rewrite historical internal docs just to remove them.

--- a/.claude/rules/opensrc.md
+++ b/.claude/rules/opensrc.md
@@ -1,0 +1,41 @@
+# opensrc — Package Source Context
+
+## What It Is
+
+`opensrc` fetches full source code for npm packages into a local `opensrc/` directory. This gives agents access to actual implementations, not just types or docs.
+
+## When to Use
+
+- When you need to understand how a dependency works internally (not just its API)
+- When types alone are insufficient (e.g., understanding Drizzle query builders, Hono middleware internals, Stripe SDK behavior)
+- When debugging integration issues with a third-party package
+
+## Usage
+
+```bash
+# Fetch a package (auto-detects version from lockfile)
+opensrc zod --cwd ~/revfleet/revealui
+
+# Fetch specific version
+opensrc stripe@17.0.0 --cwd ~/revfleet/revealui
+
+# Fetch multiple packages
+opensrc drizzle-orm hono @neondatabase/serverless --cwd ~/revfleet/revealui
+
+# Fetch from GitHub repo
+opensrc vercel/ai --cwd ~/revfleet/revealui
+
+# List fetched sources
+opensrc list --cwd ~/revfleet/revealui
+
+# Remove a fetched package
+opensrc rm zod --cwd ~/revfleet/revealui
+```
+
+## Conventions
+
+- Always pass `--cwd ~/revfleet/revealui` (opensrc writes to cwd)
+- The `opensrc/` directory is gitignored — fetch on demand, don't hoard
+- After fetching, read files directly from `opensrc/<package>/` with the Read tool
+- Clean up when done if the source is no longer needed: `opensrc rm <package>`
+- Prefer fetching over guessing when you're unsure how a dependency behaves

--- a/.claude/rules/planning.md
+++ b/.claude/rules/planning.md
@@ -1,16 +1,40 @@
 # Planning Convention
 
-## Per-repo planning
+## Fleet plan (canonical cross-product)
 
-Where a repo still carries a `docs/MASTER_PLAN.md`, it is a **retired pointer
-stub**, not a plan (the public-snapshot model was retired 2026-07-16; a
-pre-tool-use hook blocks edits to rogue plan copies). Planning is not tracked
-in public repos.
-
-Fleet-level cross-cutting plans, lane state, and roadmap tracking live in the
-internal coordination hub (the agent dev environment), not in a public repo (see
-this repo's `docs/INDEX.md` "Fleet coordination"). Per-endeavor, multi-session
-work is tracked as a lane in that hub, not as a loose plan file.
+Fleet-level cross-cutting plans, lanes, gaps, and free surfaces live in the
+internal coordination hub (private). Day-to-day free surfaces: hub
+`docs/TRACKER.md`. Do not invent a second fleet plan inside a public product
+repo.
 
 Session plan files in `~/.claude/plans/` are ephemeral scratch — do not treat as
 durable, and do not promote them into a repo's `docs/`.
+
+## Per-product plans
+
+Fleet product repos may keep a **product-scoped** plan at
+`docs/MASTER_PLAN.md` (roadmap and residuals for that product only). Those
+files are real and editable under the pre-tool-use holster allowlist (GAP-336).
+
+Sanctioned product plan paths:
+
+```text
+~/revfleet/{revealui,revdev,revvault,revcon,revkit,revskills,revforge,agency}/docs/MASTER_PLAN.md
+```
+
+Notes:
+
+- **revealui** keeps a **retired public stub** at that path (2026-07-16). The
+  stub is still editable so it stays an honest pointer; it is not the plan of
+  record. Fleet planning for RevealUI lives in the hub.
+- **Other product repos** (revvault, revkit, revcon, …) keep live product-scoped
+  plans. Edit them when product reality changes; do not fork fleet TRACKER work
+  into them.
+- **Stray** `MASTER_PLAN.md` files outside the allowlist are blocked by the
+  pre-tool-use holster (rogue-copy guard).
+
+## What not to do
+
+- Do not create ACTION_PLAN.md / STATUS.md / TODO.md planning siblings.
+- Do not treat session plans as durable.
+- Do not track fleet free surfaces only in a product plan.

--- a/.claude/rules/planning.md
+++ b/.claude/rules/planning.md
@@ -1,0 +1,16 @@
+# Planning Convention
+
+## Per-repo planning
+
+Where a repo still carries a `docs/MASTER_PLAN.md`, it is a **retired pointer
+stub**, not a plan (the public-snapshot model was retired 2026-07-16; a
+pre-tool-use hook blocks edits to rogue plan copies). Planning is not tracked
+in public repos.
+
+Fleet-level cross-cutting plans, lane state, and roadmap tracking live in the
+internal coordination hub (the agent dev environment), not in a public repo (see
+this repo's `docs/INDEX.md` "Fleet coordination"). Per-endeavor, multi-session
+work is tracked as a lane in that hub, not as a loose plan file.
+
+Session plan files in `~/.claude/plans/` are ephemeral scratch — do not treat as
+durable, and do not promote them into a repo's `docs/`.

--- a/.claude/rules/secrets.md
+++ b/.claude/rules/secrets.md
@@ -1,0 +1,83 @@
+# Secrets and Key Management — One Vault Is the Source of Truth
+
+## The rule
+
+Every secret a project depends on lives in one vault. Full stop.
+
+- **Every secret** — API keys, database URLs, webhook secrets, JWT or
+  session secrets, signing keys, license keys, hosting tokens, OAuth client
+  secrets, SSH keys, anything else.
+- **Lives in the vault** — not in `.env` files, not in `.env.local`, not in
+  committed config, not in CI secrets UIs as the primary store (CI secrets
+  are a downstream mirror, never the source).
+
+## Why this is a hard rule, not a preference
+
+- One encryption boundary gates every secret in the project. No per-system
+  credential sprawl.
+- Secrets never land on disk in plaintext outside a controlled, ephemeral
+  restore path.
+- Rotating a secret updates one store, and every downstream system
+  (including CI) re-reads from that same source.
+- The trust story for customers and reviewers is one sentence: "secrets live
+  in a vault, encrypted by a key that doesn't leave the developer's machine."
+  That sentence is only true if the rule is actually enforced everywhere.
+
+## Canonical path conventions
+
+Group secret paths by project, then by subsystem, lower-kebab:
+
+```
+<project>/<subsystem>/<name>
+```
+
+Examples: `myapp/dev/database/url`, `myapp/prod/stripe/secret-key`,
+`myapp/prod/stripe/webhook-secret`, `credentials/github/token`.
+
+## How to apply
+
+1. **Assume the vault first.** Use the project's vault CLI or helper as the
+   primary lookup, whatever that is for this stack.
+2. **Fall back to env vars** only when the vault isn't available (for
+   example, CI running in a hosted runner). The env-var value in CI must
+   itself be mirrored from the vault by a publish step, never hand-typed.
+3. **Fail fast if a secret is missing.** Never silently continue with a
+   default. "Missing" should be a loud error naming the exact vault path to
+   set.
+4. **Never log or echo a secret value.** Debug logs can reference a path,
+   never a value.
+
+## What this rules out
+
+- `.env` and `.env.local` files as a source of truth. They can exist as a
+  local-dev convenience if they're populated from the vault at session
+  start, but the vault entries are authoritative.
+- Pasting secrets into a chat, an agent session, or any agent tool. Agents
+  should invoke the vault directly rather than being handed a value.
+- Committing any file that contains a credential-shaped value, even a "test"
+  value. Use obvious placeholder patterns instead.
+- Storing credentials in password managers as the primary copy. Password
+  managers are fine for human-memorable entries (an unlock passphrase), not
+  for the secrets themselves.
+
+## When adding a new secret
+
+1. Write it into the vault.
+2. Add the path to the project's secrets index doc.
+3. Update the code that consumes it to pull from the vault.
+4. If the secret needs to be mirrored to CI, document the mirror step in
+   that index, never as a one-off manual add.
+
+## When rotating a secret
+
+1. Write the new value to the vault.
+2. Rebuild or redeploy any long-lived consumer so it picks up the new value.
+3. Log the rotation in the project's security log, if one exists.
+
+## Escape hatch
+
+None. Exceptions break the one-sentence trust story and create
+single-secret-in-two-places drift. If a case genuinely can't work with the
+vault (for example, a secret that must be embedded in a signed binary at
+build time), flag it in a design doc, get it reviewed, and document the
+exception as a known, deliberate deviation.

--- a/.claude/rules/temp-scripts.md
+++ b/.claude/rules/temp-scripts.md
@@ -1,0 +1,39 @@
+# Temp Scripts — Registered Lifecycle, No Orphans
+
+**Status:** convention.
+
+## The rule
+
+Any one-shot helper file written outside a session's private scratch
+directory, meant for later execution by a human (installers, verifiers,
+migration helpers, repro scripts), needs a clear lifecycle: registered when
+created, and confirmed plus cleaned up once it has served its purpose.
+Orphaned helper files left in a home directory or a repo root are drift, the
+same as any other dead code.
+
+## Workflow
+
+1. **Register at creation.** Note the file's path, its purpose, and a command
+   that proves it worked, wherever the project tracks this (a lightweight
+   manifest file, an issue, a checklist item). The point is that the file
+   is not invisible the moment it's written.
+2. **Confirm after use.** Once the script has been run and its outcome
+   verified, run the validation command, then delete the file.
+3. **Sweep periodically.** Any session can list pending temp scripts and
+   clean up anything that's expired or was never confirmed.
+
+## Why this needs enforcement, not just good intentions
+
+A model asked to "write a quick script to check X" will happily do so and
+then move on, leaving the file behind. Session-scoped scratch directories are
+exempt from this lifecycle by construction (they're isolated and cleaned up
+automatically); anything a human has to run by hand is not scratch, and
+should be registered instead of left to rot next to real project files.
+
+## Enforcement
+
+Wire a lightweight check into session-start and session-end hooks (or
+whatever automation boundary the project has) that surfaces pending,
+unconfirmed temp scripts every time. Warn-only is fine for the "session end"
+side (a stop hook usually can't block); the point is that pending debt is
+never silently forgotten between sessions.

--- a/.claude/rules/token-economy.md
+++ b/.claude/rules/token-economy.md
@@ -1,0 +1,56 @@
+# Token Economy — Spend Tokens Only Where They Buy Value
+
+**Status:** convention, owner directive 2026-07-16. Governs the *amount of work*
+sent to any model, tool, loop, or automation (the companion to model routing,
+which picks the cheapest *capable* model).
+
+## The principle
+
+Every token spent must buy proportional value. Tokens are a real cost — to you
+now and to anyone running this fleet later — so the default is the smallest
+amount of work that reaches a correct, verified result. Thoroughness is not the
+enemy: a deep audit that prevents a wrong merge is worth thousands of tokens.
+Waste is spend that changes nothing — polling that a notification would have
+delivered for free, a re-read of a file you just wrote, a subagent whose answer
+you already had. Cut the second kind, never the first.
+
+## Loops, wakeups, and polling (the biggest avoidable drain)
+
+- **Never poll for background work the harness already tracks.** Background
+  agents and long-running commands re-invoke you automatically on completion.
+  Scheduling a wakeup or loop tick to "check on" them spends tokens to learn
+  what you'd have been told for free. Wait for the notification.
+- **Never schedule wakeups to keep a prompt cache warm.** The session cache
+  already covers the allowed delay range; extra wakeups are pure waste.
+- **Match any real loop's cadence to what it waits on.** An ~8-minute CI run
+  gets one ~480s check, not eight 60s ones. Idle heartbeats default to
+  1200–1800s.
+- **Stop a loop the moment it stops advancing work.** Three consecutive
+  "nothing actionable" ticks means scale back to one quick check and stop. If a
+  loop is only polling auto-notified work, stop it entirely. When in doubt,
+  pause rather than keep ticking — it can always be resumed.
+- **Surface and stop, don't silently burn.** If an automation is spending
+  tokens for no forward progress, end it and say so in one line.
+
+## Tools, skills, subagents, workflows
+
+- **Invoke for a result you don't already have, not for form's sake.** Don't run
+  a search whose answer is in context; don't re-read a file you just wrote;
+  don't re-derive a fact the transcript already established.
+- **One broad delegation beats many narrow calls.** Send one well-scoped
+  agent/search and keep the conclusion, rather than dozens of round-trips whose
+  intermediate output you don't need.
+- **Don't double-run delegated work.** Once a subagent owns a search or build,
+  don't also do it yourself — wait for its result.
+- **Reserve fan-out for proportional payoff.** Dozens of agents are right for a
+  genuine audit or migration; waste for a task one context can hold.
+- **Batch and cache external calls.** Make independent calls in one turn so they
+  run in parallel; don't refetch a URL/result already in context.
+
+## Verification is proportional, not skipped
+
+Right-sizing spend never means skipping verification on risky changes. Prove
+tests red before claiming a fix, drive the real flow on product changes, run the
+gate before a push. The economy is in not re-verifying what's already proven and
+not re-reading what can't have changed — never in cutting the check that catches
+a real bug. Correctness and authorization always outrank economy.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,17 @@ permissions:
   contents: read
 
 jobs:
+  # GAP-372: materialized .claude rules must match .revcon-manifest.json
+  copy-lockstep:
+    name: Copy lockstep
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Verify copy-mode lockstep
+        run: bash scripts/verify-copy-lockstep.sh --target "$GITHUB_WORKSPACE"
+
   quality:
     name: Quality
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,10 @@ coverage/
 
 # opensrc context (fetched on demand)
 opensrc/
-.claude/
+# Local Claude/agent state ignored; materialized rules/agents/skills tracked (GAP-372 copy-mode).
+.claude/*
+!.claude/rules/
+!.claude/agents/
+!.claude/skills/
+!.claude/.revcon-manifest.json
 .agents/

--- a/scripts/verify-copy-lockstep.sh
+++ b/scripts/verify-copy-lockstep.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# verify-copy-lockstep.sh — shared CI/local gate for revcon copy-mode materialization
+#
+# GAP-372 design (shared gate, not per-repo ports of revealui rules-lockstep.ts):
+#   One script, many consumers. Each fleet repo that materializes
+#   .claude/{rules,agents,skills} via `link.sh --mode copy` runs this gate in
+#   CI so hand-edits and stray tracked files fail the build.
+#
+# Self-consistency only (no sibling revcon profile checkout required):
+#   1. .claude/.revcon-manifest.json present, mode=copy
+#   2. Every manifest entry exists as a real file (not a symlink) with matching sha256
+#   3. Every git-tracked file under .claude/{rules,agents,skills} appears in the manifest
+#
+# Profile-source freshness (stale vs current profiles) remains an operator
+# concern via status.sh (needs the revcon checkout). CI only needs the
+# tracked tree to match its own manifest.
+#
+# Usage:
+#   bash scripts/verify-copy-lockstep.sh --target /path/to/repo
+#   bash scripts/verify-copy-lockstep.sh --target . --dot .claude
+#
+# Exit: 0 ok · 1 drift / missing manifest · 2 usage error
+
+set -euo pipefail
+
+TARGET=""
+DOT=".claude"
+MATERIALIZED_SUBDIRS=(rules agents skills)
+
+usage() {
+  cat <<'EOF'
+Usage: verify-copy-lockstep.sh --target DIR [--dot .claude]
+
+Options:
+  --target DIR   Repo root that owns the materialized editor dir (required)
+  --dot NAME     Dot-dir under target (default: .claude)
+  -h, --help     Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGET="$2"; shift 2 ;;
+    --dot)    DOT="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$TARGET" ]]; then
+  echo "error: --target is required" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -d "$TARGET" ]]; then
+  echo "error: target is not a directory: $TARGET" >&2
+  exit 2
+fi
+
+TARGET="$(cd "$TARGET" && pwd)"
+MANIFEST="$TARGET/$DOT/.revcon-manifest.json"
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "✗ missing $DOT/.revcon-manifest.json" >&2
+  echo "  Materialize with revcon:" >&2
+  echo "    bash ~/revfleet/revcon/link.sh --target $TARGET --profile revfleet --editor claude --mode copy" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 2
+fi
+
+mode="$(jq -r '.mode // empty' "$MANIFEST")"
+if [[ "$mode" != "copy" ]]; then
+  echo "✗ $DOT/.revcon-manifest.json mode is '${mode:-missing}' (expected copy)" >&2
+  exit 1
+fi
+
+if ! jq -e '.files | type == "object"' "$MANIFEST" >/dev/null 2>&1; then
+  echo "✗ $DOT/.revcon-manifest.json missing files map" >&2
+  exit 1
+fi
+
+hash_file() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+problems=0
+count=0
+declare -A manifest_paths=()
+
+while IFS=$'\t' read -r rel src want; do
+  [[ -n "$rel" ]] || continue
+  count=$((count + 1))
+  file_rel="$DOT/$rel"
+  manifest_paths["$file_rel"]=1
+  abs="$TARGET/$DOT/$rel"
+  if [[ ! -e "$abs" ]]; then
+    echo "  $file_rel — missing on disk (manifest source: $src)" >&2
+    problems=$((problems + 1))
+    continue
+  fi
+  if [[ -L "$abs" ]]; then
+    echo "  $file_rel — still a symlink; re-materialize with link.sh --mode copy" >&2
+    problems=$((problems + 1))
+    continue
+  fi
+  if [[ ! -f "$abs" ]]; then
+    echo "  $file_rel — not a regular file" >&2
+    problems=$((problems + 1))
+    continue
+  fi
+  have="$(hash_file "$abs")"
+  if [[ "$have" != "$want" ]]; then
+    echo "  $file_rel — content differs from the manifest (locally edited?)." >&2
+    echo "    Edit the revcon profile ($src), then re-run link.sh --mode copy." >&2
+    problems=$((problems + 1))
+  fi
+done < <(jq -r '.files | to_entries[] | [.key, .value.source, .value.sha256] | @tsv' "$MANIFEST")
+
+# Strays: git-tracked under materialized dirs but not in the manifest
+if git -C "$TARGET" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  pathspecs=()
+  for sub in "${MATERIALIZED_SUBDIRS[@]}"; do
+    pathspecs+=("$DOT/$sub")
+  done
+  while IFS= read -r tracked; do
+    [[ -n "$tracked" ]] || continue
+    if [[ -z "${manifest_paths[$tracked]+x}" ]]; then
+      echo "  $tracked — tracked but not in the manifest (hand-added?)." >&2
+      echo "    Add it to the revcon profile and re-run link.sh --mode copy, or untrack it." >&2
+      problems=$((problems + 1))
+    fi
+  done < <(git -C "$TARGET" ls-files -- "${pathspecs[@]}" 2>/dev/null || true)
+else
+  echo "  (warn) not a git work tree — skipping stray-file check" >&2
+fi
+
+profiles="$(jq -r '.profiles | join(", ")' "$MANIFEST" 2>/dev/null || echo "?")"
+
+if (( problems > 0 )); then
+  echo "✗ copy-lockstep: $problems violation(s) ($count manifest entr(y/ies), profiles: $profiles)" >&2
+  echo "  Re-apply: bash ~/revfleet/revcon/link.sh --target $TARGET --editor claude --mode copy --profile …" >&2
+  exit 1
+fi
+
+echo "✓ copy-lockstep: $count materialized file(s) match the manifest (profiles: $profiles); no strays"
+exit 0


### PR DESCRIPTION
## Summary

- **Pilot for GAP-372:** revdev is the first non-revealui fleet repo on copy-mode
- Materialize `revfleet` profile into tracked `.claude/rules/` + `.revcon-manifest.json`
- `.gitignore`: `.claude/*` with negations (local state stays ignored)
- CI job **Copy lockstep** runs `scripts/verify-copy-lockstep.sh` (shared gate; SSOT [revcon#110](https://github.com/RevealUIStudio/revcon/pull/110))

## Why

Symlinks into revcon were invisible to fresh clones / CI / worktrees and made \"edit the repo rules\" write into the revcon tree. Same class of problem copy-mode solved for revealui.

## Test plan

- [x] `bash scripts/verify-copy-lockstep.sh --target .` exit 0
- [x] no symlinks under `.claude/rules`
- [ ] CI Copy lockstep green on this PR

## Related

- revcon shared gate: #110
- revkit bootstrap `:copy` for revdev: sibling PR