### PR TITLE
feat(studio): dogfood residual + Operate/Build/Configure nav

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -18,7 +18,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/inter-tight": "^5.2.7",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
-    "@revealui/presentation": "^0.9.1",
+    "@revealui/presentation": "^0.12.1",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-shell": "^2.3.5",

--- a/apps/studio/src/__tests__/components/Button.test.tsx
+++ b/apps/studio/src/__tests__/components/Button.test.tsx
@@ -28,7 +28,6 @@ describe('Button', () => {
 
   it('shows spinner when loading', () => {
     render(<Button loading>Submit</Button>);
-    // The spinner SVG should be present
     const button = screen.getByRole('button');
     const svg = button.querySelector('svg');
     expect(svg).not.toBeNull();
@@ -42,53 +41,51 @@ describe('Button', () => {
     expect(svg).toBeNull();
   });
 
-  it('applies primary variant styles', () => {
+  it('maps primary → brand solid (bg-primary)', () => {
     render(<Button variant="primary">Primary</Button>);
     const button = screen.getByRole('button');
     expect(button.className).toContain('bg-primary');
   });
 
-  it('applies secondary variant styles by default', () => {
+  it('maps secondary → neutral solid (bg-secondary) by default', () => {
     render(<Button>Default</Button>);
     const button = screen.getByRole('button');
     expect(button.className).toContain('bg-secondary');
   });
 
-  it('applies ghost variant styles', () => {
+  it('maps ghost → neutral ghost appearance', () => {
     render(<Button variant="ghost">Ghost</Button>);
     const button = screen.getByRole('button');
     expect(button.className).toContain('hover:text-accent-foreground');
   });
 
-  it('applies danger variant styles', () => {
+  it('maps danger → danger solid (bg-destructive)', () => {
     render(<Button variant="danger">Delete</Button>);
     const button = screen.getByRole('button');
     expect(button.className).toContain('bg-destructive');
   });
 
-  it('applies success variant styles', () => {
+  it('maps success → success solid token fill', () => {
     render(<Button variant="success">Save</Button>);
     const button = screen.getByRole('button');
-    expect(button.className).toContain('bg-success');
+    expect(button.className).toContain('bg-[var(--rvui-success-strong)]');
   });
 
-  it('applies a compact size override for size="sm" (h-8, denser than presentation\'s h-10 base)', () => {
+  it('applies a compact size override for size="sm" (h-8, denser than presentation sm)', () => {
     render(<Button size="sm">Small</Button>);
     const button = screen.getByRole('button');
     expect(button.className).toContain('h-8');
-    expect(button.className).not.toContain('h-10');
   });
 
-  it('applies presentation\'s smallest built-in size for size="md" (the default)', () => {
+  it('applies presentation sm (h-10) for size="md" (the default)', () => {
     render(<Button>Default size</Button>);
     expect(screen.getByRole('button').className).toContain('h-10');
   });
 
-  it('applies presentation\'s default size for size="lg"', () => {
+  it('applies presentation default (h-11) for size="lg"', () => {
     render(<Button size="lg">Large</Button>);
     const button = screen.getByRole('button');
     expect(button.className).toContain('h-11');
-    expect(button.className).not.toContain('h-12');
   });
 
   it('has type="button" by default', () => {

--- a/apps/studio/src/__tests__/components/ErrorAlert.test.tsx
+++ b/apps/studio/src/__tests__/components/ErrorAlert.test.tsx
@@ -18,7 +18,7 @@ describe('ErrorAlert', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders error message', () => {
+  it('renders error message with role=alert', () => {
     render(<ErrorAlert message="Something went wrong" />);
     expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong');
   });

--- a/apps/studio/src/__tests__/components/Sidebar.test.tsx
+++ b/apps/studio/src/__tests__/components/Sidebar.test.tsx
@@ -3,15 +3,56 @@ import { describe, expect, it, vi } from 'vitest';
 import Sidebar from '../../components/layout/Sidebar';
 
 describe('Sidebar', () => {
-  it('renders all navigation items', () => {
+  it('renders Operate / Build / Configure group labels', () => {
     render(<Sidebar currentPage="dashboard" onNavigate={vi.fn()} />);
 
+    expect(screen.getByText('Operate')).toBeInTheDocument();
+    expect(screen.getByText('Build')).toBeInTheDocument();
+    expect(screen.getByText('Configure')).toBeInTheDocument();
+  });
+
+  it('opens the group that owns the current page and shows its items', () => {
+    render(<Sidebar currentPage="dashboard" onNavigate={vi.fn()} />);
+
+    // Operate is open (owns dashboard)
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Vault')).toBeInTheDocument();
-    expect(screen.getByText('Infrastructure')).toBeInTheDocument();
-    expect(screen.getByText('Sync')).toBeInTheDocument();
     expect(screen.getByText('Terminal')).toBeInTheDocument();
+
+    // Build / Configure start collapsed — their items are hidden
+    expect(screen.queryByText('Editor')).not.toBeInTheDocument();
+    expect(screen.queryByText('Infrastructure')).not.toBeInTheDocument();
+    expect(screen.queryByText('Setup')).not.toBeInTheDocument();
+  });
+
+  it('expands Build when its header is clicked', () => {
+    render(<Sidebar currentPage="dashboard" onNavigate={vi.fn()} />);
+
+    fireEvent.click(screen.getByText('Build'));
+
+    expect(screen.getByText('Editor')).toBeInTheDocument();
+    expect(screen.getByText('Git')).toBeInTheDocument();
+    expect(screen.getByText('Inference')).toBeInTheDocument();
+    expect(screen.getByText('Sync')).toBeInTheDocument();
+  });
+
+  it('expands Configure when its header is clicked', () => {
+    render(<Sidebar currentPage="dashboard" onNavigate={vi.fn()} />);
+
+    fireEvent.click(screen.getByText('Configure'));
+
+    expect(screen.getByText('Infrastructure')).toBeInTheDocument();
     expect(screen.getByText('Setup')).toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  it('opens Configure when the current page is Setup', () => {
+    render(<Sidebar currentPage="setup" onNavigate={vi.fn()} />);
+
+    expect(screen.getByText('Setup')).toBeInTheDocument();
+    expect(screen.getByText('Infrastructure')).toBeInTheDocument();
+    // Operate items not required to be visible
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
   });
 
   it('renders the brand name', () => {
@@ -45,15 +86,14 @@ describe('Sidebar', () => {
     const dashboardClasses = dashboardButton?.className.split(' ') ?? [];
     expect(dashboardClasses).toContain('text-fg-muted');
     expect(dashboardClasses).not.toContain('bg-surface-3');
-    expect(dashboardClasses).not.toContain('text-fg');
   });
 
-  it('navigates to each page', () => {
+  it('navigates to each page within the open Operate group', () => {
     const onNavigate = vi.fn();
     render(<Sidebar currentPage="dashboard" onNavigate={onNavigate} />);
 
-    const pages = ['Dashboard', 'Vault', 'Infrastructure', 'Sync', 'Terminal', 'Setup'];
-    const pageIds = ['dashboard', 'vault', 'infrastructure', 'sync', 'terminal', 'setup'];
+    const pages = ['Dashboard', 'Vault', 'Terminal'];
+    const pageIds = ['dashboard', 'vault', 'terminal'];
 
     for (let i = 0; i < pages.length; i++) {
       fireEvent.click(screen.getByText(pages[i]));

--- a/apps/studio/src/__tests__/components/StatusDot.test.tsx
+++ b/apps/studio/src/__tests__/components/StatusDot.test.tsx
@@ -10,60 +10,41 @@ describe('StatusDot', () => {
 
   it('applies --rvui-success token for ok status', () => {
     const { container } = render(<StatusDot status="ok" />);
-    expect(container.querySelector('span')?.className).toContain('bg-[var(--rvui-success)]');
+    expect(container.innerHTML).toContain('bg-[var(--rvui-success)]');
   });
 
   it('applies --rvui-warning token for warn status', () => {
     const { container } = render(<StatusDot status="warn" />);
-    expect(container.querySelector('span')?.className).toContain('bg-[var(--rvui-warning)]');
+    expect(container.innerHTML).toContain('bg-[var(--rvui-warning)]');
   });
 
   it('applies --rvui-error token for error status', () => {
     const { container } = render(<StatusDot status="error" />);
-    expect(container.querySelector('span')?.className).toContain('bg-[var(--rvui-error)]');
+    expect(container.innerHTML).toContain('bg-[var(--rvui-error)]');
   });
 
-  it('applies --rvui-text-2 token for off status', () => {
+  it('maps off → presentation idle fill (--rvui-text-2)', () => {
     const { container } = render(<StatusDot status="off" />);
-    expect(container.querySelector('span')?.className).toContain('bg-[var(--rvui-text-2)]');
-  });
-
-  it('defaults to sm size', () => {
-    const { container } = render(<StatusDot status="ok" />);
-    expect(container.querySelector('span')?.className).toContain('size-2');
-  });
-
-  it('applies md size', () => {
-    const { container } = render(<StatusDot status="ok" size="md" />);
-    expect(container.querySelector('span')?.className).toContain('size-2.5');
-  });
-
-  it('applies pulse animation when pulse is true', () => {
-    const { container } = render(<StatusDot status="ok" pulse />);
-    expect(container.querySelector('span')?.className).toContain('animate-pulse');
-  });
-
-  it('does not apply pulse animation by default', () => {
-    const { container } = render(<StatusDot status="ok" />);
-    expect(container.querySelector('span')?.className).not.toContain('animate-pulse');
+    expect(container.innerHTML).toContain('bg-[var(--rvui-text-2)]');
   });
 
   it('exposes status to assistive tech via role="img" + aria-label by default', () => {
     const { container } = render(<StatusDot status="error" />);
-    const span = container.querySelector('span');
-    expect(span?.getAttribute('role')).toBe('img');
+    const span = container.querySelector('span[role="img"]');
+    expect(span).not.toBeNull();
     expect(span?.getAttribute('aria-label')).toBe('Error');
-    expect(span?.getAttribute('aria-hidden')).toBeNull();
   });
 
   it('uses a per-status default label', () => {
     const { container } = render(<StatusDot status="warn" />);
-    expect(container.querySelector('span')?.getAttribute('aria-label')).toBe('Warning');
+    const span = container.querySelector('span[role="img"]');
+    expect(span?.getAttribute('aria-label')).toBe('Warning');
   });
 
   it('honors a custom label override', () => {
     const { container } = render(<StatusDot status="ok" label="Database: healthy" />);
-    expect(container.querySelector('span')?.getAttribute('aria-label')).toBe('Database: healthy');
+    const span = container.querySelector('span[role="img"]');
+    expect(span?.getAttribute('aria-label')).toBe('Database: healthy');
   });
 
   it('is hidden from screen readers when decorative (adjacent text conveys status)', () => {
@@ -76,6 +57,11 @@ describe('StatusDot', () => {
 
   it('applies custom className', () => {
     const { container } = render(<StatusDot status="ok" className="ml-2" />);
-    expect(container.querySelector('span')?.className).toContain('ml-2');
+    expect(container.innerHTML).toContain('ml-2');
+  });
+
+  it('emits a pulse ring when pulse is true (presentation animate-ping)', () => {
+    const { container } = render(<StatusDot status="ok" pulse />);
+    expect(container.innerHTML).toContain('animate-ping');
   });
 });

--- a/apps/studio/src/components/layout/Sidebar.tsx
+++ b/apps/studio/src/components/layout/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react';
 import type { Page } from '../../types';
 
 interface SidebarProps {
@@ -5,22 +6,88 @@ interface SidebarProps {
   onNavigate: (page: Page) => void;
 }
 
-const NAV_ITEMS: { page: Page; label: string; icon: string }[] = [
-  { page: 'dashboard', label: 'Dashboard', icon: 'grid' },
-  { page: 'gallery', label: 'Launcher', icon: 'rocket' },
-  { page: 'vault', label: 'Vault', icon: 'lock' },
-  { page: 'infrastructure', label: 'Infrastructure', icon: 'server' },
-  { page: 'sync', label: 'Sync', icon: 'refresh' },
-  { page: 'terminal', label: 'Terminal', icon: 'terminal' },
-  { page: 'git', label: 'Git', icon: 'git' },
-  { page: 'editor', label: 'Editor', icon: 'editor' },
-  { page: 'agent', label: 'Agent', icon: 'agent' },
-  { page: 'inference', label: 'Inference', icon: 'inference' },
-  { page: 'setup', label: 'Setup', icon: 'settings' },
-  { page: 'settings', label: 'Settings', icon: 'wrench' },
+type NavItem = { page: Page; label: string; icon: string };
+type NavGroupId = 'operate' | 'build' | 'configure';
+
+interface NavGroup {
+  id: NavGroupId;
+  label: string;
+  items: NavItem[];
+}
+
+/**
+ * Frontend-excellence Phase 2 hard rule: 12 destinations → 3 progressive-
+ * disclosure groups (Operate / Build / Configure). Group containing the
+ * current page starts open; others start collapsed.
+ */
+const NAV_GROUPS: NavGroup[] = [
+  {
+    id: 'operate',
+    label: 'Operate',
+    items: [
+      { page: 'dashboard', label: 'Dashboard', icon: 'grid' },
+      { page: 'gallery', label: 'Launcher', icon: 'rocket' },
+      { page: 'agent', label: 'Agent', icon: 'agent' },
+      { page: 'terminal', label: 'Terminal', icon: 'terminal' },
+      { page: 'vault', label: 'Vault', icon: 'lock' },
+    ],
+  },
+  {
+    id: 'build',
+    label: 'Build',
+    items: [
+      { page: 'editor', label: 'Editor', icon: 'editor' },
+      { page: 'git', label: 'Git', icon: 'git' },
+      { page: 'inference', label: 'Inference', icon: 'inference' },
+      { page: 'sync', label: 'Sync', icon: 'refresh' },
+    ],
+  },
+  {
+    id: 'configure',
+    label: 'Configure',
+    items: [
+      { page: 'infrastructure', label: 'Infrastructure', icon: 'server' },
+      { page: 'setup', label: 'Setup', icon: 'settings' },
+      { page: 'settings', label: 'Settings', icon: 'wrench' },
+    ],
+  },
 ];
 
+function groupForPage(page: Page): NavGroupId {
+  for (const group of NAV_GROUPS) {
+    if (group.items.some((item) => item.page === page)) {
+      return group.id;
+    }
+  }
+  // deploy and any future pages: default into Operate so the nav is never empty
+  return 'operate';
+}
+
 export default function Sidebar({ currentPage, onNavigate }: SidebarProps) {
+  const activeGroup = useMemo(() => groupForPage(currentPage), [currentPage]);
+  const [openGroups, setOpenGroups] = useState<Record<NavGroupId, boolean>>(() => ({
+    operate: activeGroup === 'operate',
+    build: activeGroup === 'build',
+    configure: activeGroup === 'configure',
+  }));
+
+  // Keep the group that owns the current page open when navigation lands
+  // from outside the sidebar (e.g. deep-link / intent screen).
+  const effectiveOpen: Record<NavGroupId, boolean> = {
+    operate: openGroups.operate || activeGroup === 'operate',
+    build: openGroups.build || activeGroup === 'build',
+    configure: openGroups.configure || activeGroup === 'configure',
+  };
+
+  function toggleGroup(id: NavGroupId) {
+    setOpenGroups((prev) => ({
+      ...prev,
+      // Do not collapse the group that owns the current page — user would
+      // lose the highlighted item without a way to see where they are.
+      [id]: activeGroup === id ? true : !prev[id],
+    }));
+  }
+
   return (
     <aside className="flex h-full w-56 flex-col border-r border-edge bg-surface-1">
       <div className="flex items-center gap-2 border-b border-edge px-4 py-4">
@@ -29,22 +96,44 @@ export default function Sidebar({ currentPage, onNavigate }: SidebarProps) {
         </div>
         <span className="text-sm font-semibold">RevealUI Studio</span>
       </div>
-      <nav className="flex-1 px-2 py-3">
-        {NAV_ITEMS.map((item) => (
-          <button
-            key={item.page}
-            type="button"
-            onClick={() => onNavigate(item.page)}
-            className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors ${
-              currentPage === item.page
-                ? 'bg-surface-3 text-fg'
-                : 'text-fg-muted hover:bg-surface-3 hover:text-fg'
-            }`}
-          >
-            <NavIcon name={item.icon} />
-            {item.label}
-          </button>
-        ))}
+      <nav className="flex-1 space-y-1 overflow-y-auto px-2 py-3" aria-label="Studio">
+        {NAV_GROUPS.map((group) => {
+          const isOpen = effectiveOpen[group.id];
+          return (
+            <div key={group.id} className="pb-1">
+              <button
+                type="button"
+                onClick={() => toggleGroup(group.id)}
+                aria-expanded={isOpen}
+                className="flex w-full items-center justify-between rounded-md px-3 py-1.5 text-xs font-semibold tracking-wide text-fg-muted uppercase hover:bg-surface-3 hover:text-fg"
+              >
+                <span>{group.label}</span>
+                <span aria-hidden="true" className="text-[10px]">
+                  {isOpen ? '▾' : '▸'}
+                </span>
+              </button>
+              {isOpen && (
+                <div className="mt-0.5 space-y-0.5">
+                  {group.items.map((item) => (
+                    <button
+                      key={item.page}
+                      type="button"
+                      onClick={() => onNavigate(item.page)}
+                      className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors ${
+                        currentPage === item.page
+                          ? 'bg-surface-3 text-fg'
+                          : 'text-fg-muted hover:bg-surface-3 hover:text-fg'
+                      }`}
+                    >
+                      <NavIcon name={item.icon} />
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </nav>
     </aside>
   );

--- a/apps/studio/src/components/ui/Button.tsx
+++ b/apps/studio/src/components/ui/Button.tsx
@@ -1,24 +1,23 @@
-import { ButtonCVA as PresentationButton } from '@revealui/presentation';
+import { Button as PresentationButton } from '@revealui/presentation';
 import type { ButtonHTMLAttributes } from 'react';
 
-const variantMap = {
-  primary: 'primary',
-  secondary: 'secondary',
-  ghost: 'ghost',
-  danger: 'destructive',
-  success: 'secondary',
+/**
+ * Studio consumer variants → presentation (0.12+) axes:
+ * `variant` is colour intent; `appearance` is visual weight.
+ */
+const intentMap = {
+  primary: { variant: 'brand', appearance: 'solid' },
+  secondary: { variant: 'neutral', appearance: 'solid' },
+  ghost: { variant: 'neutral', appearance: 'ghost' },
+  danger: { variant: 'danger', appearance: 'solid' },
+  success: { variant: 'success', appearance: 'solid' },
 } as const;
 
 /**
- * Presentation's CVA size scale (`sm`=h-10/40px, `default`=h-11/44px,
- * `lg`=h-12/48px) runs noticeably taller than Studio's old hand-rolled
- * buttons (~24-36px, compact desktop chrome). Shifted down a step so
- * Studio keeps its density: `md` (Studio's most-used size) takes
- * presentation's smallest built-in size (`sm`); `lg` takes presentation's
- * `default`. Presentation has nothing smaller than `sm`, so Studio's `sm`
- * stays on presentation `sm` and layers a compact `className` override
- * (h-8) on top — `cn()` appends the caller's `className` last, so it wins
- * over the size variant's own `h-10 px-3 py-2`.
+ * Presentation size scale (0.12+): sm=h-10, default=h-11, lg=h-12.
+ * Studio density: md (most-used) takes presentation `sm`; lg takes
+ * presentation `default`. Studio `sm` stays on presentation `sm` with a
+ * compact className override (h-8) so dense chrome survives.
  */
 const sizeMap = {
   sm: 'sm',
@@ -32,7 +31,7 @@ const compactSizeOverride = {
   lg: undefined,
 } as const;
 
-export type ButtonVariant = keyof typeof variantMap;
+export type ButtonVariant = keyof typeof intentMap;
 export type ButtonSize = keyof typeof sizeMap;
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -42,14 +41,10 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 /**
- * Phase 2 remainder (2026-07-18): shimmed to render
- * `@revealui/presentation`'s CVA `Button`. Consumer API (default export,
- * `variant`, `size`, `loading`, `className`) unchanged.
- *
- * `success` has no matching presentation variant, so it renders the
- * `secondary` variant's base classes with a `className` color override —
- * the package's `cn()` appends the caller's `className` last, so it wins
- * over the variant's baked-in `bg-*`/`text-*` classes.
+ * Phase 2 residual (studio-dogfood): re-shimmed for `@revealui/presentation`
+ * 0.12+ Button API (variant × appearance axes, post Catalyst re-authorship).
+ * Consumer API (default export, `variant`, `size`, `loading`, `className`)
+ * unchanged.
  */
 export default function Button({
   variant = 'secondary',
@@ -59,18 +54,14 @@ export default function Button({
   className,
   ...props
 }: ButtonProps) {
-  const overrideClassName = [
-    variant === 'success' && 'bg-success text-fg font-medium hover:brightness-110',
-    compactSizeOverride[size],
-    className,
-  ]
-    .filter(Boolean)
-    .join(' ');
+  const intent = intentMap[variant];
+  const overrideClassName = [compactSizeOverride[size], className].filter(Boolean).join(' ');
 
   return (
     <PresentationButton
       type={type}
-      variant={variantMap[variant]}
+      variant={intent.variant}
+      appearance={intent.appearance}
       size={sizeMap[size]}
       isLoading={loading}
       className={overrideClassName || undefined}

--- a/apps/studio/src/components/ui/ErrorAlert.tsx
+++ b/apps/studio/src/components/ui/ErrorAlert.tsx
@@ -1,17 +1,24 @@
+import { Callout } from '@revealui/presentation';
+
 interface ErrorAlertProps {
   message: string | null | undefined;
   className?: string;
 }
 
+/**
+ * Phase 2 residual (studio-dogfood): shimmed to `@revealui/presentation`
+ * `Callout` (variant=error). Presentation's `Alert` is a modal alertdialog
+ * and is the wrong primitive for inline panel errors.
+ *
+ * Consumer API (default export, `message`, `className`) unchanged.
+ * Empty / null / undefined message still renders nothing.
+ */
 export default function ErrorAlert({ message, className = '' }: ErrorAlertProps) {
   if (!message) return null;
 
   return (
-    <div
-      className={`rounded-md border border-[var(--rvui-error)]/30 bg-[var(--rvui-error-subtle)] px-4 py-3 text-sm text-[var(--rvui-error)] ${className}`}
-      role="alert"
-    >
-      {message}
-    </div>
+    <Callout variant="error" role="alert" className={className} icon={null}>
+      <span className="text-error">{message}</span>
+    </Callout>
   );
 }

--- a/apps/studio/src/components/ui/StatusDot.tsx
+++ b/apps/studio/src/components/ui/StatusDot.tsx
@@ -1,37 +1,34 @@
-/**
- * Studio status indicator — a small decorative colored dot.
- *
- * Phase 2 PR-1 (2026-05-16): status colors migrated from hardcoded
- * Tailwind palette classes (`bg-green-500`, `bg-yellow-500`, `bg-red-500`,
- * `bg-neutral-600`) to `--rvui-success/warning/error/text-2` design tokens
- * defined in `@revealui/presentation/tokens.css`. Consumer API
- * (default export, `status`, `size`, `pulse`, `className`) unchanged.
- *
- * StatusDot itself has no `@revealui/presentation` equivalent yet
- * (presentation has `Badge` for text content, but no pure decorative dot
- * primitive). It is named as a future promotion candidate. For Phase 2
- * PR-1, the dot is token-backed but still lives in Studio.
- *
- * Sequencing tracked in the internal Studio dogfood lane plan;
- * design rule codified in the internal fleet RevealUI-native
- * compliance ADR.
- */
+import {
+  StatusDot as PresentationStatusDot,
+  type StatusDotStatus as PresentationStatus,
+} from '@revealui/presentation';
 
-const statusMeta = {
-  ok: { color: 'bg-[var(--rvui-success)]', label: 'OK' },
-  warn: { color: 'bg-[var(--rvui-warning)]', label: 'Warning' },
-  error: { color: 'bg-[var(--rvui-error)]', label: 'Error' },
-  off: { color: 'bg-[var(--rvui-text-2)]', label: 'Off' },
+const statusMap = {
+  ok: 'ok',
+  warn: 'warn',
+  error: 'error',
+  /** Studio legacy name; presentation uses `idle`. */
+  off: 'idle',
+} as const satisfies Record<string, PresentationStatus>;
+
+const defaultLabel = {
+  ok: 'OK',
+  warn: 'Warning',
+  error: 'Error',
+  off: 'Off',
 } as const;
 
-const sizeMap = {
-  sm: 'size-2',
-  md: 'size-2.5',
-} as const;
+export type StatusDotStatus = keyof typeof statusMap;
+export type StatusDotSize = 'sm' | 'md';
 
 interface StatusDotProps {
-  status: keyof typeof statusMeta;
-  size?: keyof typeof sizeMap;
+  status: StatusDotStatus;
+  /**
+   * Accepted for API compatibility. Presentation renders a single size
+   * (`size-2.5`); this prop does not change the visual size (same narrowing
+   * as the Badge shim).
+   */
+  size?: StatusDotSize;
   pulse?: boolean;
   className?: string;
   /**
@@ -43,32 +40,53 @@ interface StatusDotProps {
   /**
    * Set when an adjacent VISIBLE text label already conveys the status (e.g.
    * HealthCard renders "Degraded" next to the dot). The dot is then hidden from
-   * screen readers to avoid a redundant double-announcement. Defaults to false,
-   * so a bare dot announces its status via `role="img"` + `aria-label`.
+   * screen readers to avoid a redundant double-announcement. Defaults to false.
    */
   decorative?: boolean;
 }
 
+/**
+ * Phase 2 residual (studio-dogfood): shimmed to `@revealui/presentation`
+ * `StatusDot` (requires presentation ≥0.12.0 / Phase-3 quartet publish).
+ *
+ * Consumer API (default export, `status`, `size`, `pulse`, `label`,
+ * `decorative`, `className`) preserved. Studio `off` maps to presentation
+ * `idle`. When `decorative` is true, a local token-backed span is used because
+ * presentation always exposes `role="img"` + `aria-label`.
+ */
 export default function StatusDot({
   status,
-  size = 'sm',
   pulse = false,
   className = '',
   label,
   decorative = false,
 }: StatusDotProps) {
-  const meta = statusMeta[status];
-  // Color alone is not an accessible status cue (color-only fails WCAG 1.4.1 and
-  // is ambiguous for colorblind users). A bare dot therefore exposes its status
-  // as text to assistive tech; a dot paired with a visible label opts out.
-  const a11y = decorative
-    ? ({ 'aria-hidden': true } as const)
-    : ({ role: 'img', 'aria-label': label ?? meta.label } as const);
+  const fill =
+    status === 'ok'
+      ? 'bg-[var(--rvui-success)]'
+      : status === 'warn'
+        ? 'bg-[var(--rvui-warning)]'
+        : status === 'error'
+          ? 'bg-[var(--rvui-error)]'
+          : 'bg-[var(--rvui-text-2)]';
+
+  if (decorative) {
+    return (
+      <span
+        aria-hidden="true"
+        className={['relative inline-flex size-2.5 shrink-0 rounded-full', fill, className]
+          .filter(Boolean)
+          .join(' ')}
+      />
+    );
+  }
 
   return (
-    <span
-      className={`inline-block shrink-0 rounded-full ${meta.color} ${sizeMap[size]} ${pulse ? 'animate-pulse' : ''} ${className}`}
-      {...a11y}
+    <PresentationStatusDot
+      status={statusMap[status]}
+      pulse={pulse}
+      label={label ?? defaultLabel[status]}
+      className={className || undefined}
     />
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@revealui/presentation':
-        specifier: ^0.9.1
-        version: 0.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^0.12.1
+        version: 0.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@tauri-apps/api':
         specifier: ^2.11.1
         version: 2.11.1
@@ -430,11 +430,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -810,6 +810,16 @@ packages:
       drizzle-zod:
         optional: true
 
+  '@revealui/contracts@0.8.1':
+    resolution: {integrity: sha512-bQY4HFibIsffTty6OxEclnueqWxk5q70d/m9mtNC3a5vdjMh7K3V4XADnvDNqayrzG6fYLkjz4Eq98ccDuYk0Q==}
+    engines: {node: '>=24.13.0'}
+    peerDependencies:
+      drizzle-zod: ^0.8.3
+      typescript: '>=6.0.0'
+    peerDependenciesMeta:
+      drizzle-zod:
+        optional: true
+
   '@revealui/contracts@1.4.0':
     resolution: {integrity: sha512-84jp/fzhI1GpMUZ3WnLUQLlQqE3f74nK/TGQE+xdqx11G1WcIxSLG1v8IjiGRJO16R7rTeoPKhFHvTj2xXm1DQ==}
     engines: {node: '>=24.13.0'}
@@ -827,8 +837,8 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@revealui/presentation@0.9.1':
-    resolution: {integrity: sha512-w+qIqj6wxg6PcRe90LW8dX3GAJDxod4iGgyQamDTg6Gp43izFFIB3NJOeFHi8aHvRojdyuAPHviHWxgBSRNR1g==}
+  '@revealui/presentation@0.12.1':
+    resolution: {integrity: sha512-bHzMaetE7VjF/Jp5g+7/NMTrUomUm4bYw1J0FbFys1a5KGMijArx+dAv4qP8rzkl8QC1XBNj+7U68E6Jtiz/aw==}
     engines: {node: '>=24.13.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -842,8 +852,8 @@ packages:
     resolution: {integrity: sha512-Gl0YLjh5JmE4Cpat0djARZWuXZ5FuEwXuk1Jr3E/uq+hKD2XiUxPP133KqkIj95PadGiCpLMz8DYc1pgQFLlVg==}
     engines: {node: '>=24.13.0'}
 
-  '@revealui/tokens@0.2.0':
-    resolution: {integrity: sha512-dLU9Svi65SigQr9eFa5OMtEjBZfqxSd6Yw/ANx3vaDhOUtZaMMT3FFDQsKAXEV21eHOsXLePOoCCfc5HyKKFeQ==}
+  '@revealui/tokens@0.3.0':
+    resolution: {integrity: sha512-ETlCSoEdJXXieWowcnZE577MpFcED8KSUPvGhgBfK7GThuH7QFtAmq0nvD2jEAf0uvP1v+iraCTUmtSH/ZEDYQ==}
     engines: {node: '>=24.13.0'}
 
   '@revealui/utils@0.3.5':
@@ -3302,6 +3312,11 @@ snapshots:
       typescript: 6.0.3
       zod: 4.4.3
 
+  '@revealui/contracts@0.8.1(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+      zod: 4.4.3
+
   '@revealui/contracts@1.4.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
@@ -3341,12 +3356,16 @@ snapshots:
       - pg-native
       - typescript
 
-  '@revealui/presentation@0.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@revealui/presentation@0.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
-      '@revealui/tokens': 0.2.0
+      '@revealui/contracts': 0.8.1(typescript@6.0.3)
+      '@revealui/tokens': 0.3.0
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       tailwind-merge: 3.6.0
+    transitivePeerDependencies:
+      - drizzle-zod
+      - typescript
 
   '@revealui/resilience@0.2.4': {}
 
@@ -3360,7 +3379,7 @@ snapshots:
       - drizzle-zod
       - typescript
 
-  '@revealui/tokens@0.2.0': {}
+  '@revealui/tokens@0.3.0': {}
 
   '@revealui/utils@0.3.5':
     dependencies:


### PR DESCRIPTION
## Summary

Closes the remaining **studio-dogfood** Phase 2 residuals and the **frontend-excellence** Phase 2 nav hard rule for Studio.

- Bump `@revealui/presentation` to `^0.12.1` so Studio can use published `StatusDot` and Callout `role`
- **ErrorAlert** → presentation `Callout` (`variant=error`, `role=alert`). Presentation `Alert` is a modal alertdialog and is the wrong primitive for inline panel errors
- **StatusDot** → presentation `StatusDot` (`off` → `idle`). Decorative dots stay a local token-backed span (presentation always announces)
- **Button** re-shim for 0.12+ `variant` × `appearance` axes
- **Sidebar** regroup: flat 12 items → Operate / Build / Configure progressive disclosure (group that owns current page starts open)

## Lanes / initiative

- INIT-004 product-frontend-ves
- studio-dogfood (Phase 2 residual; Phase 4 delete-shadow still next)
- frontend-excellence Phase 2 nav

## Test plan

- [x] `pnpm --filter studio` vitest: ErrorAlert, StatusDot, Sidebar, Button + other ui shims (87 tests)
- [x] Full studio suite: 516 tests pass (protocol build required for invoke.test)
- [ ] CI `studio-release.yml` green on PR
- [ ] Visual: open Studio, confirm groups expand/collapse and brand/button density still looks right

## Residual (not this PR)

- Phase 4: delete `components/ui/` + Biome `noRestrictedImports` after consumer imports move to presentation (or allowed compositions only)
- ConfirmDialog remains a Studio composition over Modal (intentional)
- GAP-300 journey walkthrough acceptance (owner / separate surface)