### PR TITLE
feat(daemon): async gh rollup for sec-review label (GAP-375 optionals)

### DIFF
--- a/packages/daemon/src/__tests__/tool-guard.test.ts
+++ b/packages/daemon/src/__tests__/tool-guard.test.ts
@@ -105,6 +105,40 @@ describe('evaluateToolAction — command', () => {
   });
 });
 
+describe('evaluateToolActionAsync — live rollup (GAP-375 residual)', () => {
+  it('allows label-add when fetchRollup reports all audits SUCCESS', async () => {
+    const { evaluateToolActionAsync } = await import('../tool-guard/index.js');
+    const green = [
+      'Security Gate',
+      'CodeQL',
+      'Secret Scanning (Gitleaks)',
+      'Dependency Review',
+    ].map((name) => ({ name, conclusion: 'SUCCESS', state: 'COMPLETED' }));
+    const v = await evaluateToolActionAsync(
+      { kind: 'command', command: 'gh pr edit 42 --add-label sec-review:approved' },
+      { fetchRollup: async () => green },
+    );
+    expect(v.allowed).toBe(true);
+  });
+
+  it('blocks label-add when fetchRollup reports a failure', async () => {
+    const { evaluateToolActionAsync } = await import('../tool-guard/index.js');
+    const v = await evaluateToolActionAsync(
+      { kind: 'command', command: 'gh pr edit 42 --add-label sec-review:approved' },
+      {
+        fetchRollup: async () => [
+          { name: 'Security Gate', conclusion: 'FAILURE' },
+          { name: 'CodeQL', conclusion: 'SUCCESS' },
+          { name: 'Secret Scanning (Gitleaks)', conclusion: 'SUCCESS' },
+          { name: 'Dependency Review', conclusion: 'SUCCESS' },
+        ],
+      },
+    );
+    expect(v.allowed).toBe(false);
+    expect(v.rule).toBe('sec-review-label-withhold');
+  });
+});
+
 describe('evaluateToolAction — read', () => {
   it('blocks reading a credential file', () => {
     const v = evaluateToolAction({ kind: 'read', path: `${homedir()}/.ssh/id_ed25519` });

--- a/packages/daemon/src/spawn.ts
+++ b/packages/daemon/src/spawn.ts
@@ -44,7 +44,7 @@ import { onAgentEnded, onDaemonStarted } from './eviction.js';
 import { requireRootAndDir } from './filegit.js';
 import { getDaemonConfig, registerHandler, type SocketContext } from './server.js';
 import { agentEvents, issueStreamTicket } from './spawn-events.js';
-import { denyToolAction, evaluateToolAction } from './tool-guard/index.js';
+import { denyToolAction, evaluateToolActionAsync } from './tool-guard/index.js';
 
 const log = createLogger({ service: 'revdev-daemon/spawn' });
 
@@ -256,7 +256,8 @@ registerHandler('agent.spawn', async (params, db, ctx) => {
   // can touch, this refuses a command that matches a dangerous pattern (curl |
   // sh, inline eval, credential reads) before any process is forked.
   const commandLine = args.length > 0 ? `${command} ${args.join(' ')}` : command;
-  const guardVerdict = evaluateToolAction({ kind: 'command', command: commandLine });
+  // GAP-375 residual: async path may allow sec-review:approved when gh reports audit green
+  const guardVerdict = await evaluateToolActionAsync({ kind: 'command', command: commandLine });
   if (!guardVerdict.allowed) {
     throw await denyToolAction(db, 'agent.spawn', ownerAgentId, guardVerdict, {
       command: commandLine,

--- a/packages/daemon/src/tool-guard/governance-gates.ts
+++ b/packages/daemon/src/tool-guard/governance-gates.ts
@@ -269,9 +269,7 @@ export function evaluateSecurityAuditRollup(
       problems.push(`${name}: missing`);
       continue;
     }
-    const bad = entries.find(
-      (c) => FAILING.has(c.conclusion ?? '') || FAILING.has(c.state ?? ''),
-    );
+    const bad = entries.find((c) => FAILING.has(c.conclusion ?? '') || FAILING.has(c.state ?? ''));
     if (bad) {
       problems.push(`${name}: ${bad.conclusion || bad.state || 'failing'}`);
       continue;

--- a/packages/daemon/src/tool-guard/governance-gates.ts
+++ b/packages/daemon/src/tool-guard/governance-gates.ts
@@ -55,6 +55,14 @@ function tokenize(s: string): string[] {
   return parts;
 }
 
+function isAllDigits(s: string): boolean {
+  if (s.length === 0) return false;
+  for (const ch of s) {
+    if (ch < '0' || ch > '9') return false;
+  }
+  return true;
+}
+
 function segmentIsLabelAdd(s: string): boolean {
   if (!s.includes('pr') || !s.includes('edit')) return false;
   const parts = tokenize(s);
@@ -171,5 +179,199 @@ export function evaluateGovernanceCommand(command: string): GovernanceVerdict {
         'sec-review:approved withheld on agent tool path until security audit is verified green (or SEC_REVIEW_AUDIT_OVERRIDE=1). Prefer CI required checks + owner label apply.',
     };
   }
+  return { allowed: true };
+}
+
+// ---------------------------------------------------------------------------
+// Async path: live gh statusCheckRollup for label-add (GAP-375 residual)
+// ---------------------------------------------------------------------------
+
+export interface StatusCheckLike {
+  name?: string | null;
+  conclusion?: string | null;
+  state?: string | null;
+}
+
+const REQUIRED_SECURITY_AUDIT_CHECKS = [
+  'Security Gate',
+  'CodeQL',
+  'Secret Scanning (Gitleaks)',
+  'Dependency Review',
+] as const;
+
+const FAILING = new Set([
+  'FAILURE',
+  'TIMED_OUT',
+  'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
+  'ERROR',
+  'CANCELLED',
+]);
+
+/** Parse PR number + optional -R repo from a gh pr edit command (no authored regex). */
+export function parseGhPrEditTarget(command: string): {
+  pr: string | null;
+  repo: string | null;
+  cwd: string | null;
+} {
+  let repo: string | null = null;
+  let pr: string | null = null;
+  let cwd: string | null = null;
+
+  const parts = tokenize(command);
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i] as string;
+    if (p === 'cd' && parts[i + 1]) {
+      cwd = (parts[i + 1] as string).replace(/^~/, process.env.HOME ?? '');
+    }
+    if ((p === '-R' || p === '--repo') && parts[i + 1]) {
+      repo = parts[i + 1] as string;
+    }
+    if (p.startsWith('--repo=')) {
+      repo = p.slice('--repo='.length);
+    }
+    if (p === 'edit') {
+      for (let j = i + 1; j < parts.length; j++) {
+        const t = parts[j] as string;
+        if (isAllDigits(t)) {
+          pr = t;
+          break;
+        }
+        // pull/N URL fragment
+        const marker = '/pull/';
+        const idx = t.indexOf(marker);
+        if (idx >= 0) {
+          const rest = t.slice(idx + marker.length);
+          let num = '';
+          for (const ch of rest) {
+            if (ch >= '0' && ch <= '9') num += ch;
+            else break;
+          }
+          if (num) {
+            pr = num;
+            break;
+          }
+        }
+      }
+    }
+  }
+  return { pr, repo, cwd };
+}
+
+export function evaluateSecurityAuditRollup(
+  rollup: readonly StatusCheckLike[] | null | undefined,
+): { ok: boolean; problems: string[] } {
+  const problems: string[] = [];
+  const list = rollup ?? [];
+  for (const name of REQUIRED_SECURITY_AUDIT_CHECKS) {
+    const entries = list.filter((c) => c && c.name === name);
+    if (entries.length === 0) {
+      problems.push(`${name}: missing`);
+      continue;
+    }
+    const bad = entries.find(
+      (c) => FAILING.has(c.conclusion ?? '') || FAILING.has(c.state ?? ''),
+    );
+    if (bad) {
+      problems.push(`${name}: ${bad.conclusion || bad.state || 'failing'}`);
+      continue;
+    }
+    const success = entries.some(
+      (c) =>
+        (c.conclusion === 'SUCCESS' || c.state === 'SUCCESS') &&
+        !FAILING.has(c.conclusion ?? '') &&
+        !FAILING.has(c.state ?? ''),
+    );
+    if (!success) problems.push(`${name}: not green`);
+  }
+  return { ok: problems.length === 0, problems };
+}
+
+export type FetchPrStatusRollup = (args: {
+  pr: string;
+  repo: string | null;
+  cwd: string | null;
+}) => Promise<StatusCheckLike[] | null>;
+
+/**
+ * Async governance evaluation. For sec-review:approved label-add, optionally
+ * fetches live statusCheckRollup (default: `gh pr view --json statusCheckRollup`)
+ * and allows the command when audit is green.
+ */
+export async function evaluateGovernanceCommandAsync(
+  command: string,
+  options: {
+    fetchRollup?: FetchPrStatusRollup;
+    override?: boolean;
+  } = {},
+): Promise<GovernanceVerdict> {
+  // Disposition blocks remain sync / unconditional
+  if (isGhPrMergeCommand(command)) {
+    return evaluateGovernanceCommand(command);
+  }
+  if (isSecuritySelfClearCommand(command)) {
+    return evaluateGovernanceCommand(command);
+  }
+
+  if (!isSecReviewApprovedLabelAdd(command)) {
+    return evaluateGovernanceCommand(command);
+  }
+
+  const override = options.override ?? process.env.SEC_REVIEW_AUDIT_OVERRIDE === '1';
+  if (override) {
+    return { allowed: true };
+  }
+
+  const { pr, repo, cwd } = parseGhPrEditTarget(command);
+  if (!pr) {
+    return {
+      allowed: false,
+      rule: 'sec-review-label-withhold',
+      reason:
+        'sec-review audit gate: could not parse PR number from sec-review:approved command. Fail-closed.',
+    };
+  }
+
+  const fetchRollup =
+    options.fetchRollup ??
+    (async ({ pr: prNum, repo: r, cwd: dir }) => {
+      const { execFile } = await import('node:child_process');
+      const { promisify } = await import('node:util');
+      const execFileAsync = promisify(execFile);
+      const args = ['pr', 'view', prNum, '--json', 'statusCheckRollup'];
+      if (r) args.push('-R', r);
+      try {
+        const { stdout } = await execFileAsync('gh', args, {
+          timeout: 8000,
+          cwd: !r && dir ? dir : undefined,
+          maxBuffer: 2 * 1024 * 1024,
+        });
+        const parsed = JSON.parse(stdout) as { statusCheckRollup?: StatusCheckLike[] };
+        return parsed.statusCheckRollup ?? [];
+      } catch {
+        return null;
+      }
+    });
+
+  const rollup = await fetchRollup({ pr, repo, cwd });
+  if (rollup == null) {
+    return {
+      allowed: false,
+      rule: 'sec-review-label-withhold',
+      reason: `sec-review audit gate: could not verify security audit for PR #${pr} (gh unavailable). Fail-closed. Override with SEC_REVIEW_AUDIT_OVERRIDE=1.`,
+    };
+  }
+
+  const { ok, problems } = evaluateSecurityAuditRollup(rollup);
+  if (!ok) {
+    return {
+      allowed: false,
+      rule: 'sec-review-label-withhold',
+      reason:
+        `sec-review audit gate — PR #${pr} security audit is NOT green; label withheld:\n  ` +
+        problems.join('\n  '),
+    };
+  }
+
   return { allowed: true };
 }

--- a/packages/daemon/src/tool-guard/index.ts
+++ b/packages/daemon/src/tool-guard/index.ts
@@ -17,7 +17,11 @@
 import { homedir } from 'node:os';
 import type { PGlite } from '@electric-sql/pglite';
 import { createLogger } from '@revealui/utils/logger';
-import { evaluateGovernanceCommand } from './governance-gates.js';
+import {
+  evaluateGovernanceCommand,
+  evaluateGovernanceCommandAsync,
+  type FetchPrStatusRollup,
+} from './governance-gates.js';
 import {
   evaluateCommand,
   evaluateContentSecrets,
@@ -101,7 +105,7 @@ export function evaluateToolAction(action: ToolAction): GuardVerdict {
       const command = action.command ?? '';
       const hit = evaluateCommand(command, manifest);
       if (hit) return deny('dangerous-command', hit.reason);
-      // GAP-375: provider-agnostic disposition + sec-review label withhold
+      // GAP-375: provider-agnostic disposition + sec-review label withhold (sync fail-closed)
       const gov = evaluateGovernanceCommand(command);
       if (!gov.allowed) {
         return deny(gov.rule ?? 'governance', gov.reason ?? 'blocked by governance gate');
@@ -134,6 +138,33 @@ export function evaluateToolAction(action: ToolAction): GuardVerdict {
     default:
       return ALLOW;
   }
+}
+
+/**
+ * Async tool-action evaluation (GAP-375 residual). For commands, re-checks
+ * governance with optional live `gh` statusCheckRollup so a green audit can
+ * allow `sec-review:approved` without SEC_REVIEW_AUDIT_OVERRIDE.
+ */
+export async function evaluateToolActionAsync(
+  action: ToolAction,
+  options: { fetchRollup?: FetchPrStatusRollup } = {},
+): Promise<GuardVerdict> {
+  // Non-command paths stay pure sync
+  if (action.kind !== 'command') {
+    return evaluateToolAction(action);
+  }
+  const command = action.command ?? '';
+  const { manifest } = loadPatterns();
+  const hit = evaluateCommand(command, manifest);
+  if (hit) return deny('dangerous-command', hit.reason);
+
+  const gov = await evaluateGovernanceCommandAsync(command, {
+    fetchRollup: options.fetchRollup,
+  });
+  if (!gov.allowed) {
+    return deny(gov.rule ?? 'governance', gov.reason ?? 'blocked by governance gate');
+  }
+  return ALLOW;
 }
 
 /** Error thrown by a handler when the guard denies an action. */


### PR DESCRIPTION
## Summary
\`evaluateToolActionAsync\` / \`evaluateGovernanceCommandAsync\`: live \`gh pr view --json statusCheckRollup\` allows \`sec-review:approved\` when audit is green without override. \`agent.spawn\` uses the async path.

## Test plan
- [x] tool-guard.test.ts 45 tests (incl. green/failing rollup fixtures)