### PR TITLE
docs(daemon): intentional memory/merge Neon non-sync (GAP-174)

### DIFF
--- a/packages/daemon/src/neon.ts
+++ b/packages/daemon/src/neon.ts
@@ -25,6 +25,16 @@
  *
  * When `POSTGRES_URL` is unset, all helpers are no-ops. The daemon runs
  * fine single-machine; sync is purely additive.
+ *
+ * Intentional non-sync (GAP-174, closed 2026-08-05 — not an audit miss):
+ *   - `memory.*` (agent_memory in PGlite) and `merge.*` (merge_requests in
+ *     PGlite) have NO Neon `coordination_*` counterparts. The Neon schema
+ *     (`@revealui/db` coordination.ts) covers agents, sessions, file claims,
+ *     events, work items, mail, and queue items only. Dual-write for
+ *     memory/merge would need new tables + migrations; that is multi-machine
+ *     scope and rides GAP-154 Phase 5 (cross-machine discovery/gateway) if
+ *     and when fleet-wide agent memory or merge-request lifecycle must
+ *     reconcile across daemons. Until then they stay local-only by design.
  */
 
 import { type NeonQueryFunction, neon } from '@neondatabase/serverless';


### PR DESCRIPTION
## Summary
Code-over-docs for GAP-174: Neon `coordination_*` has no memory or merge tables. Dual-write omission is intentional local-only, not a Phase 3 miss. Header documents the carve-out; future multi-machine needs rides GAP-154 Phase 5.

## Test plan
- [x] docs-only header comment