### PR TITLE
feat(daemon): Neon file-claim TTL dual-write + sweep (GAP-175)

### DIFF
--- a/packages/daemon/src/__tests__/neon-sync.test.ts
+++ b/packages/daemon/src/__tests__/neon-sync.test.ts
@@ -26,7 +26,7 @@ import {
   serializeEnvelope,
   signEnvelope,
 } from '../agent-identity-crypto.js';
-import { _resetForTesting, setNeonClientForTesting } from '../neon.js';
+import { _resetForTesting, setNeonClientForTesting, sweepExpiredFileClaims } from '../neon.js';
 import { startDaemon } from '../server.js';
 
 /**
@@ -428,6 +428,7 @@ describe('GAP-154 Phase 3: files.* dual-write', () => {
       backend: 'test',
     });
     recordedCalls = [];
+    const before = Date.now();
     await rpc(socketPath, 'files.reserve', {
       actorAgentId: 'file-reserver',
       paths: ['src/a.ts', 'src/b.ts'],
@@ -442,6 +443,16 @@ describe('GAP-154 Phase 3: files.* dual-write', () => {
     expect(allValues).toContain('src/a.ts');
     expect(allValues).toContain('src/b.ts');
     expect(allValues).toContain('file-reserver');
+    // GAP-175: each INSERT carries expires_at (~ now + ttlSeconds)
+    const sql = inserts[0]?.strings.join('') ?? '';
+    expect(sql).toMatch(/expires_at/i);
+    const isoExpiry = allValues.find(
+      (v) => typeof v === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(v),
+    ) as string | undefined;
+    expect(isoExpiry).toBeTruthy();
+    const expMs = Date.parse(isoExpiry ?? '');
+    expect(expMs).toBeGreaterThanOrEqual(before + 590_000);
+    expect(expMs).toBeLessThanOrEqual(Date.now() + 610_000);
   });
 
   it('files.release with paths DELETEs scoped to (sessionId, paths)', async () => {
@@ -490,6 +501,20 @@ describe('GAP-154 Phase 3: files.* dual-write', () => {
     const sql = deletes[0]?.strings.join('') ?? '';
     expect(sql).not.toMatch(/file_path/i); // no path filter
     expect(deletes[0]?.values).toEqual(['file-releaser-all']);
+  });
+
+  it('sweepExpiredFileClaims DELETEs Neon rows past expires_at (GAP-175)', async () => {
+    recordedCalls = [];
+    nextResult = [{ file_path: 'src/expired.ts' }];
+    const r = await sweepExpiredFileClaims();
+    expect(r.deleted).toBe(1);
+    const deletes = recordedCalls.filter((c) =>
+      /DELETE\s+FROM\s+coordination_file_claims/i.test(c.strings.join('')),
+    );
+    expect(deletes.length).toBe(1);
+    const sql = deletes[0]?.strings.join('') ?? '';
+    expect(sql).toMatch(/expires_at\s+IS\s+NOT\s+NULL/i);
+    expect(sql).toMatch(/expires_at\s*<\s*NOW\(\)/i);
   });
 });
 

--- a/packages/daemon/src/neon.ts
+++ b/packages/daemon/src/neon.ts
@@ -327,25 +327,29 @@ export async function syncMailMarkRead(params: {
 
 /**
  * Mirror a daemon `files.reserve` row(s) into coordination_file_claims.
- * Schema divergence: daemon has TTL + reason; Neon has only (file_path,
- * session_id, claimed_at) composite PK. We sync only the subset; TTL
- * expiry on the daemon side does NOT propagate to Neon (a future cleanup
- * pass needs to handle that). For Phase 3 this is a known limitation.
+ * GAP-175: write `expires_at` (ISO / Date) so Neon can drop expired claims
+ * via `sweepExpiredFileClaims` (piggybacked on the daemon prune timer).
+ * `reason` stays PGlite-only (no Neon column).
  */
 export async function syncFilesReserve(params: {
   sessionId: string;
   paths: string[];
+  /** Absolute expiry for this reservation batch (daemon TTL). */
+  expiresAt: Date | string;
 }): Promise<void> {
   if (!client) return;
   if (params.paths.length === 0) return;
+  const expiresAt =
+    params.expiresAt instanceof Date ? params.expiresAt.toISOString() : params.expiresAt;
   try {
     const c = client;
     for (const p of params.paths) {
       await c`
-        INSERT INTO coordination_file_claims (file_path, session_id)
-        VALUES (${p}, ${params.sessionId})
+        INSERT INTO coordination_file_claims (file_path, session_id, expires_at)
+        VALUES (${p}, ${params.sessionId}, ${expiresAt}::timestamptz)
         ON CONFLICT (file_path, session_id) DO UPDATE
-          SET claimed_at = NOW()
+          SET claimed_at = NOW(),
+              expires_at = EXCLUDED.expires_at
       `;
     }
   } catch (err) {
@@ -354,6 +358,32 @@ export async function syncFilesReserve(params: {
       pathCount: params.paths.length,
       error: String(err),
     });
+  }
+}
+
+/**
+ * Delete Neon file claims past their TTL (GAP-175). Best-effort; no-op without
+ * POSTGRES_URL. Safe to call from the periodic prune timer.
+ */
+export async function sweepExpiredFileClaims(): Promise<{ deleted: number }> {
+  if (!client) return { deleted: 0 };
+  try {
+    const c = client;
+    // Neon serverless returns row metadata inconsistently; count via RETURNING.
+    const rows = await c`
+      DELETE FROM coordination_file_claims
+      WHERE expires_at IS NOT NULL
+        AND expires_at < NOW()
+      RETURNING file_path
+    `;
+    const deleted = Array.isArray(rows) ? rows.length : 0;
+    if (deleted > 0) {
+      log.info('sweepExpiredFileClaims', { deleted });
+    }
+    return { deleted };
+  } catch (err) {
+    log.warn('sweepExpiredFileClaims failed', { error: String(err) });
+    return { deleted: 0 };
   }
 }
 

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -43,6 +43,7 @@ import {
   initNeonSync,
   isNeonSyncActive,
   listFleetSessions,
+  sweepExpiredFileClaims,
   syncEventLog,
   syncFilesRelease,
   syncFilesReserve,
@@ -399,6 +400,20 @@ async function runPrune(
   );
   if (prunedTelemetry.rows.length > 0) {
     log.debug('pruned signature telemetry events', { count: prunedTelemetry.rows.length });
+  }
+  // Local file_reservations: drop rows past TTL (queries already filter
+  // expires_at > NOW(); without this, PGlite grows unbounded).
+  const expiredLocal = await db.query<{ file_path: string }>(
+    `DELETE FROM file_reservations WHERE expires_at <= NOW() RETURNING file_path`,
+  );
+  // Neon coordination_file_claims: same TTL semantics (GAP-175). Best-effort
+  // dual-write mirror; no-op when POSTGRES_URL is unset.
+  const neonClaims = await sweepExpiredFileClaims();
+  if (expiredLocal.rows.length > 0 || neonClaims.deleted > 0) {
+    log.info('file claim TTL sweep', {
+      localDeleted: expiredLocal.rows.length,
+      neonDeleted: neonClaims.deleted,
+    });
   }
   pruneState.lastRunAt = new Date();
   pruneState.lastAgedCount = aged.rows.length;
@@ -1591,12 +1606,12 @@ registerHandler('files.reserve', async (params, db, ctx) => {
     reserved.push(p);
   }
 
-  // Best-effort dual-write to coordination_file_claims (GAP-154 Phase 3).
-  // Only sync the paths we actually reserved (not conflicts). The TTL +
-  // reason fields don't exist on the Neon side; PGlite remains the source
-  // of truth for expiry. See syncFilesReserve notes.
+  // Best-effort dual-write to coordination_file_claims (GAP-154 Phase 3 +
+  // GAP-175 expires_at). Only sync paths actually reserved (not conflicts).
+  // reason stays PGlite-only; Neon TTL is swept by sweepExpiredFileClaims.
   if (reserved.length > 0) {
-    await syncFilesReserve({ sessionId: agentId, paths: reserved });
+    const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+    await syncFilesReserve({ sessionId: agentId, paths: reserved, expiresAt });
   }
   return {
     success: conflicts.length === 0,


### PR DESCRIPTION
## Summary
GAP-175: stop unbounded Neon `coordination_file_claims` growth.

- `syncFilesReserve` writes `expires_at` (ISO from daemon TTL)
- `sweepExpiredFileClaims` deletes Neon rows past TTL
- Piggybacked on `runPrune` + local PGlite `file_reservations` DELETE of expired rows
- Companion: revealui schema migration `0037_gap175_file_claims_expires_at`

## Test plan
- [x] neon-sync.test.ts 19/19 (expires_at on INSERT + sweep SQL)