### PR TITLE
feat(bridge): GAP-294 MCP permission pending/decide/setMode

### DIFF
--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -466,6 +466,62 @@ server.tool(
   },
 );
 
+// -- Permission modes (GAP-294) ---------------------------------------------
+// Headless decision surface (design: permission.pending / decide / setMode).
+// decide + setMode are signature-required; operator must use a trusted signed
+// identity (not the requester session). Studio has the same RPCs via Tauri.
+
+server.tool(
+  'permission_pending',
+  'List pending permission approvals (GAP-294). Optional agentId filter.',
+  {
+    agentId: z
+      .string()
+      .optional()
+      .describe('When set, only list pending approvals for this agent session'),
+  },
+  async ({ agentId }) => {
+    const result = await daemon.call(RPC_METHODS['permission.pending'], agentId ? { agentId } : {});
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
+server.tool(
+  'permission_decide',
+  'Approve or deny a pending permission approval (signed operator only; self-approval rejected)',
+  {
+    approvalId: z.string().describe('Pending approval id from permission_pending'),
+    verdict: z.enum(['approved', 'denied']).describe('Decision for the requester'),
+  },
+  async ({ approvalId, verdict }) => {
+    daemon.requireSigned('permission.decide');
+    const result = await daemon.call(RPC_METHODS['permission.decide'], {
+      approvalId,
+      verdict,
+    });
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
+server.tool(
+  'permission_set_mode',
+  'Set per-session permission mode override for another agent (signed operator only)',
+  {
+    agentId: z.string().describe('Target agent session id (cannot be the operator itself)'),
+    mode: z
+      .enum(['manual', 'auto', 'agent-scoped', 'shadow', 'default'])
+      .describe("Mode override, or 'default' to clear and use daemon REVDEV_PERMISSION_MODE"),
+  },
+  async ({ agentId, mode }) => {
+    daemon.requireSigned('permission.setMode');
+    const result = await daemon.call(RPC_METHODS['permission.setMode'], {
+      agentId,
+      mode: mode === 'default' ? null : mode,
+    });
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Start
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -86,6 +86,8 @@ Environment:
   REVDEV_DAEMON_MAX_LINE_BYTES  Max bytes per JSON-RPC frame (default: ${DAEMON_DEFAULTS.maxLineBytes}, ~1 MiB)
   REVDEV_DAEMON_GIT_TIMEOUT_MS  Max wall-clock per git spawn (default: ${DAEMON_DEFAULTS.gitTimeoutMs} ms = ${DAEMON_DEFAULTS.gitTimeoutMs / 1000} s)
   REVDEV_DAEMON_SHUTDOWN_GRACE_MS  Max wait for in-flight handlers during close() (default: ${DAEMON_DEFAULTS.shutdownGracePeriodMs} ms = ${DAEMON_DEFAULTS.shutdownGracePeriodMs / 1000} s)
+  REVDEV_PERMISSION_MODE       GAP-294 mode: shadow (default) | manual | auto | agent-scoped
+                               shadow = would_* events only (no block). Flip only after soak review.
 
 ${LICENSE_TIER_HELP}
 `);


### PR DESCRIPTION
## Summary
GAP-294 residual after Phase 0–2 on `test` (#303/#306/#307):

- **Bridge MCP tools:** `permission_pending`, `permission_decide`, `permission_set_mode`
  (headless decision surface from design; Studio already has ApprovalQueue)
- **Daemon `--help`:** document `REVDEV_PERMISSION_MODE` (default remains `shadow`)

Phase 3 install default flip remains **owner-gated** (soak review).

## Test plan
- [x] `@revdev/bridge` typecheck after daemon build
- [ ] CI green
- [ ] Optional: with signed bridge + live daemon, list pending / decide

## Residual
- Agent-scoped grant model (still demotes to manual)
- Owner soak → optional `REVDEV_PERMISSION_MODE=auto` dogfood → Phase 3 default