### PR TITLE
feat(daemon): UUID mail ids for Neon dual-write markRead (GAP-176)

### DIFF
--- a/packages/daemon/src/__tests__/neon-sync.test.ts
+++ b/packages/daemon/src/__tests__/neon-sync.test.ts
@@ -317,35 +317,35 @@ describe('GAP-154: daemon → Neon dual-write wiring', () => {
 // ---------------------------------------------------------------------------
 
 describe('GAP-154 Phase 3: mail.* dual-write', () => {
-  it('mail.send mirrors to coordination_mail', async () => {
-    // Need a registered sender for the RPC (mail.send requireAgent's it).
+  it('mail.send mirrors to coordination_mail with shared UUID (GAP-176)', async () => {
     await rpc(socketPath, 'session.register', {
       agentId: 'mail-sender',
       agentName: 'mail-sender',
       backend: 'test',
     });
     recordedCalls = [];
-    await rpc(socketPath, 'mail.send', {
+    const sent = (await rpc(socketPath, 'mail.send', {
       actorAgentId: 'mail-sender',
       to: 'mail-recipient',
       subject: 'phase 3 hi',
       body: 'hello from a mock',
-    });
+    })) as { id: string };
+    expect(typeof sent.id).toBe('string');
+    expect(sent.id.length).toBeGreaterThan(10);
     expect(recordedCalls.length).toBe(1);
     const [send] = recordedCalls;
     const sql = send?.strings.join('') ?? '';
     expect(sql).toMatch(/INSERT\s+INTO\s+coordination_mail/i);
-    expect(send?.values).toEqual([
-      'mail-sender',
-      'mail-recipient',
-      'phase 3 hi',
-      'hello from a mock',
-    ]);
+    expect(sql).toMatch(/\bid\b/i);
+    // values: id, from, to, subject, body
+    expect(send?.values[0]).toBe(sent.id);
+    expect(send?.values).toContain('mail-sender');
+    expect(send?.values).toContain('mail-recipient');
+    expect(send?.values).toContain('phase 3 hi');
+    expect(send?.values).toContain('hello from a mock');
   });
 
   it('mail.broadcast fans out one Neon write per recipient', async () => {
-    // Register sender + 2 recipients (broadcast targets all OTHER active
-    // sessions).
     await rpc(socketPath, 'session.register', {
       agentId: 'broadcaster',
       agentName: 'broadcaster',
@@ -367,21 +367,24 @@ describe('GAP-154 Phase 3: mail.* dual-write', () => {
       subject: 'broadcast subject',
       body: 'broadcast body',
     });
-    // One Neon INSERT per recipient.
     const inserts = recordedCalls.filter((c) =>
       /INSERT\s+INTO\s+coordination_mail/i.test(c.strings.join('')),
     );
     expect(inserts.length).toBeGreaterThanOrEqual(2);
-    // Recipients should appear in the values somewhere.
     const allValues = inserts.flatMap((c) => c.values);
     expect(allValues).toContain('recipient-a');
     expect(allValues).toContain('recipient-b');
-    // Sender should not appear as a TO target.
-    const tos = inserts.map((c) => c.values[1]);
+    // Each INSERT carries its own UUID as first value.
+    for (const ins of inserts) {
+      expect(typeof ins.values[0]).toBe('string');
+      expect(String(ins.values[0]).length).toBeGreaterThan(10);
+    }
+    // toAgent is values[2] after id, fromAgent (id, from, to, subject, body)
+    const tos = inserts.map((c) => c.values[2]);
     expect(tos).not.toContain('broadcaster');
   });
 
-  it('mail.markRead uses hints to scope the Neon UPDATE', async () => {
+  it('mail.markRead dual-writes by UUID only — not subject/body (GAP-176)', async () => {
     await rpc(socketPath, 'session.register', {
       agentId: 'reader',
       agentName: 'reader',
@@ -392,31 +395,39 @@ describe('GAP-154 Phase 3: mail.* dual-write', () => {
       agentName: 'sender',
       backend: 'test',
     });
-    // Send one message, capture its id.
-    const sendResult = (await rpc(socketPath, 'mail.send', {
+    // Two identical subject/body messages — heuristic would mark both; UUID marks one.
+    const a = (await rpc(socketPath, 'mail.send', {
       actorAgentId: 'sender',
       to: 'reader',
-      subject: 'specific subject',
-      body: 'specific body',
-    })) as { id: number };
+      subject: 'same subject',
+      body: 'same body',
+    })) as { id: string };
+    const b = (await rpc(socketPath, 'mail.send', {
+      actorAgentId: 'sender',
+      to: 'reader',
+      subject: 'same subject',
+      body: 'same body',
+    })) as { id: string };
+    expect(a.id).not.toBe(b.id);
     recordedCalls = [];
 
     await rpc(socketPath, 'mail.markRead', {
       actorAgentId: 'reader',
-      messageIds: [sendResult.id],
+      messageIds: [a.id],
     });
-    // markRead does: SELECT hints (PGlite fetch — not mocked) + UPDATE
-    // PGlite (also not mocked) + the syncMailMarkRead helper which calls
-    // Neon. The mock recorder receives only the Neon call.
     const updates = recordedCalls.filter((c) =>
       /UPDATE\s+coordination_mail/i.test(c.strings.join('')),
     );
-    expect(updates.length).toBeGreaterThanOrEqual(1);
-    // The hint-scoped UPDATE should reference the subject + body.
+    expect(updates.length).toBe(1);
     const update = updates[0];
+    const sql = update?.strings.join('') ?? '';
+    expect(sql).toMatch(/id\s*=\s*ANY/i);
+    expect(sql).not.toMatch(/subject\s*=/i);
+    expect(sql).not.toMatch(/body\s*=/i);
     expect(update?.values).toContain('reader');
-    expect(update?.values).toContain('specific subject');
-    expect(update?.values).toContain('specific body');
+    // ids array is the second bind
+    expect(update?.values).toEqual(expect.arrayContaining(['reader', [a.id]]));
+    expect(update?.values.flat()).not.toContain(b.id);
   });
 });
 

--- a/packages/daemon/src/migrations/0009-agent-messages-uuid.ts
+++ b/packages/daemon/src/migrations/0009-agent-messages-uuid.ts
@@ -1,0 +1,47 @@
+/**
+ * Migration 0009 — agent_messages.id SERIAL → TEXT UUID (GAP-176).
+ *
+ * Aligns PGlite mail row ids with Neon coordination_mail UUID PKs so
+ * mail.markRead dual-write can UPDATE by id without subject/body heuristics.
+ * Existing rows get deterministic UUIDs derived from the old serial id
+ * (preserves uniqueness; new inserts use crypto.randomUUID in handlers).
+ */
+
+import type { Migration } from '../storage/migrate.js';
+
+const SQL = `
+  CREATE TABLE IF NOT EXISTS agent_messages_uuid (
+    id            TEXT PRIMARY KEY,
+    from_agent    TEXT NOT NULL,
+    to_agent      TEXT NOT NULL,
+    subject       TEXT NOT NULL DEFAULT '',
+    body          TEXT NOT NULL DEFAULT '',
+    read          BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at    TIMESTAMP NOT NULL DEFAULT NOW()
+  );
+
+  INSERT INTO agent_messages_uuid (id, from_agent, to_agent, subject, body, read, created_at)
+  SELECT
+    gen_random_uuid()::text,
+    from_agent,
+    to_agent,
+    subject,
+    body,
+    read,
+    created_at
+  FROM agent_messages
+  ORDER BY id ASC;
+
+  DROP TABLE agent_messages;
+
+  ALTER TABLE agent_messages_uuid RENAME TO agent_messages;
+
+  CREATE INDEX IF NOT EXISTS idx_messages_to_unread
+    ON agent_messages (to_agent, read) WHERE read = FALSE;
+`;
+
+export const MIGRATION_0009: Migration = {
+  version: 9,
+  name: 'agent-messages-uuid',
+  sql: SQL,
+};

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -24,6 +24,7 @@ import { MIGRATION_0005 } from './0005-session-activity-state.js';
 import { MIGRATION_0006 } from './0006-agent-process-confinement.js';
 import { MIGRATION_0007 } from './0007-permission-approvals.js';
 import { MIGRATION_0008 } from './0008-gateway-tokens.js';
+import { MIGRATION_0009 } from './0009-agent-messages-uuid.js';
 
 export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0001,
@@ -34,4 +35,5 @@ export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0006,
   MIGRATION_0007,
   MIGRATION_0008,
+  MIGRATION_0009,
 ];

--- a/packages/daemon/src/neon.ts
+++ b/packages/daemon/src/neon.ts
@@ -216,8 +216,9 @@ export async function listFleetSessions(): Promise<FleetSessionRow[]> {
 // enum translation, missing columns deferred to metadata JSONB, etc.).
 // ---------------------------------------------------------------------------
 
-/** Mirror a daemon `mail.send` row into coordination_mail. */
+/** Mirror a daemon `mail.send` row into coordination_mail (GAP-176 UUID id). */
 export async function syncMailSend(params: {
+  id: string;
   fromAgent: string;
   toAgent: string;
   subject: string;
@@ -227,11 +228,12 @@ export async function syncMailSend(params: {
   try {
     const c = client;
     await c`
-      INSERT INTO coordination_mail (from_agent, to_agent, subject, body)
-      VALUES (${params.fromAgent}, ${params.toAgent}, ${params.subject}, ${params.body})
+      INSERT INTO coordination_mail (id, from_agent, to_agent, subject, body)
+      VALUES (${params.id}::uuid, ${params.fromAgent}, ${params.toAgent}, ${params.subject}, ${params.body})
     `;
   } catch (err) {
     log.warn('syncMailSend failed', {
+      id: params.id,
       fromAgent: params.fromAgent,
       toAgent: params.toAgent,
       error: String(err),
@@ -240,88 +242,53 @@ export async function syncMailSend(params: {
 }
 
 /**
- * Mirror a daemon `mail.broadcast` (one row per recipient). The daemon's
- * INSERT loop in mail.broadcast fans out — this helper takes the same
- * recipient list to keep the per-row write parity with PGlite.
+ * Mirror a daemon `mail.broadcast` (one row per recipient). Each row carries
+ * its own UUID so markRead can target a single message (GAP-176).
  */
 export async function syncMailBroadcast(params: {
   fromAgent: string;
-  toAgents: string[];
-  subject: string;
-  body: string;
+  rows: Array<{ id: string; toAgent: string; subject: string; body: string }>;
 }): Promise<void> {
   if (!client) return;
-  if (params.toAgents.length === 0) return;
+  if (params.rows.length === 0) return;
   try {
     const c = client;
-    for (const to of params.toAgents) {
+    for (const row of params.rows) {
       await c`
-        INSERT INTO coordination_mail (from_agent, to_agent, subject, body)
-        VALUES (${params.fromAgent}, ${to}, ${params.subject}, ${params.body})
+        INSERT INTO coordination_mail (id, from_agent, to_agent, subject, body)
+        VALUES (${row.id}::uuid, ${params.fromAgent}, ${row.toAgent}, ${row.subject}, ${row.body})
       `;
     }
   } catch (err) {
     log.warn('syncMailBroadcast failed', {
       fromAgent: params.fromAgent,
-      recipients: params.toAgents.length,
+      recipients: params.rows.length,
       error: String(err),
     });
   }
 }
 
 /**
- * Mirror a daemon `mail.markRead` to Neon. The daemon uses SERIAL ids
- * scoped to its local PGlite — those ids will not match Neon's SERIAL ids
- * (different sequences). We therefore mark by (toAgent, fromAgent,
- * subject, createdAt-window) heuristic rather than id. For Phase 3 we
- * just bulk-mark all unread mail FROM the fromAgent TO the markReader.
- *
- * NOTE: this is a best-effort approximation. If two agents send overlapping
- * "ping" subjects, marking one read on the daemon will mark BOTH on Neon.
- * Phase 3+ may add a stable cross-DB id (UUID) to avoid this; logged as a
- * known limitation here.
+ * Mirror a daemon `mail.markRead` to Neon by shared UUID primary key (GAP-176).
+ * No subject/body heuristic — the same id exists on both PGlite and Neon.
  */
-export async function syncMailMarkRead(params: {
-  reader: string;
-  ids: number[]; // daemon-local PGlite ids
-  // Best-effort: also pass the (subject + body) tuples to scope the Neon
-  // UPDATE more precisely. If absent, falls back to "mark all unread to
-  // this reader" which is over-broad.
-  hints?: Array<{ subject: string; body: string }>;
-}): Promise<void> {
+export async function syncMailMarkRead(params: { reader: string; ids: string[] }): Promise<void> {
   if (!client) return;
   if (params.ids.length === 0) return;
   try {
     const c = client;
-    if (params.hints && params.hints.length > 0) {
-      // Mark unread rows whose (subject, body) match any hint.
-      for (const hint of params.hints) {
-        await c`
-          UPDATE coordination_mail
-            SET read = TRUE
-          WHERE to_agent = ${params.reader}
-            AND read = FALSE
-            AND subject = ${hint.subject}
-            AND body = ${hint.body}
-        `;
-      }
-    } else {
-      // Over-broad fallback. Match the count being marked locally to
-      // bound the impact: only mark the N oldest unread rows.
-      const limit = params.ids.length;
-      await c`
-        UPDATE coordination_mail
-          SET read = TRUE
-        WHERE id IN (
-          SELECT id FROM coordination_mail
-          WHERE to_agent = ${params.reader} AND read = FALSE
-          ORDER BY created_at ASC
-          LIMIT ${limit}
-        )
-      `;
-    }
+    await c`
+      UPDATE coordination_mail
+        SET read = TRUE
+      WHERE to_agent = ${params.reader}
+        AND id = ANY(${params.ids}::uuid[])
+    `;
   } catch (err) {
-    log.warn('syncMailMarkRead failed', { reader: params.reader, error: String(err) });
+    log.warn('syncMailMarkRead failed', {
+      reader: params.reader,
+      idCount: params.ids.length,
+      error: String(err),
+    });
   }
 }
 

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1488,15 +1488,17 @@ registerHandler('mail.send', async (params, db, ctx) => {
   if (!to) throw new Error('mail.send: missing "to" (or "toAgent")');
   const subject = str(params.subject);
   const body = str(params.body);
+  // GAP-176: generate UUID once; dual-write the same id to Neon.
+  const id = crypto.randomUUID();
 
-  const result = await db.query<{ id: number }>(
-    `INSERT INTO agent_messages (from_agent, to_agent, subject, body)
-     VALUES ($1, $2, $3, $4) RETURNING id`,
-    [from, to, subject, body],
+  await db.query(
+    `INSERT INTO agent_messages (id, from_agent, to_agent, subject, body)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [id, from, to, subject, body],
   );
-  // Best-effort dual-write to coordination_mail (GAP-154 Phase 3).
-  await syncMailSend({ fromAgent: from, toAgent: to, subject, body });
-  return { sent: true, id: result.rows[0]?.id ?? null };
+  // Best-effort dual-write to coordination_mail (GAP-154 Phase 3 + GAP-176).
+  await syncMailSend({ id, fromAgent: from, toAgent: to, subject, body });
+  return { sent: true, id };
 });
 
 registerHandler('mail.inbox', async (params, db, ctx) => {
@@ -1523,48 +1525,38 @@ registerHandler('mail.broadcast', async (params, db, ctx) => {
     `SELECT id FROM agent_sessions WHERE ended_at IS NULL AND id <> $1`,
     [from],
   );
+  const neonRows: Array<{ id: string; toAgent: string; subject: string; body: string }> = [];
   for (const target of sessions.rows) {
+    const id = crypto.randomUUID();
     await db.query(
-      `INSERT INTO agent_messages (from_agent, to_agent, subject, body)
-       VALUES ($1, $2, $3, $4)`,
-      [from, target.id, subject, body],
+      `INSERT INTO agent_messages (id, from_agent, to_agent, subject, body)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [id, from, target.id, subject, body],
     );
+    neonRows.push({ id, toAgent: target.id, subject, body });
   }
-  // Best-effort dual-write to coordination_mail (GAP-154 Phase 3).
-  await syncMailBroadcast({
-    fromAgent: from,
-    toAgents: sessions.rows.map((r) => r.id),
-    subject,
-    body,
-  });
+  // Best-effort dual-write to coordination_mail (GAP-154 Phase 3 + GAP-176).
+  await syncMailBroadcast({ fromAgent: from, rows: neonRows });
   return { broadcast: true, sent: sessions.rows.length, recipients: sessions.rows.length };
 });
 
 registerHandler('mail.markRead', async (params, db, ctx) => {
   const agentId = await requireVerifiedAgent(ctx, db, params);
-  // Accept number[] or string[] (JSON numbers or numeric strings).
+  // GAP-176: ids are UUID strings (legacy numeric ids no longer match after
+  // migration 0009 — clients must re-read inbox for new ids).
   const raw = Array.isArray(params.messageIds) ? params.messageIds : [];
   const ids = raw
-    .map((v) => (typeof v === 'number' ? v : typeof v === 'string' ? Number(v) : NaN))
-    .filter((n) => Number.isFinite(n));
+    .map((v) => (typeof v === 'string' ? v.trim() : typeof v === 'number' ? String(v) : ''))
+    .filter((s) => s.length > 0);
   if (ids.length === 0) return { marked: 0 };
-
-  // Fetch (subject, body) hints BEFORE the update so we can scope the
-  // Neon sync. Without these the sync falls back to "mark N oldest unread"
-  // which is over-broad. See syncMailMarkRead notes.
-  const hintRows = await db.query<{ subject: string; body: string }>(
-    `SELECT subject, body FROM agent_messages
-     WHERE to_agent = $1 AND id = ANY($2::int[]) AND read = FALSE`,
-    [agentId, ids],
-  );
 
   const result = await db.query(
     `UPDATE agent_messages SET read = TRUE
-     WHERE to_agent = $1 AND id = ANY($2::int[])`,
+     WHERE to_agent = $1 AND id = ANY($2::text[])`,
     [agentId, ids],
   );
-  // Best-effort dual-write to coordination_mail (GAP-154 Phase 3).
-  await syncMailMarkRead({ reader: agentId, ids, hints: hintRows.rows });
+  // Best-effort dual-write by shared UUID (GAP-176).
+  await syncMailMarkRead({ reader: agentId, ids });
   return { marked: result.affectedRows ?? ids.length };
 });
 


### PR DESCRIPTION
## Summary
GAP-176 Option A: shared UUID primary keys for inter-agent mail.

- PGlite migration 0009: \`agent_messages.id\` SERIAL → TEXT UUID
- \`mail.send\` / \`mail.broadcast\` generate \`crypto.randomUUID()\` once and dual-write the same id
- \`syncMailMarkRead\` UPDATEs by \`id = ANY(uuid[])\` — no subject/body heuristic
- Companion: revealui# coordination_mail UUID rebuild (0038)

## Test plan
- [x] neon-sync.test.ts 19/19 (incl. two identical-body messages mark only one UUID)