### PR TITLE
feat(daemon): GAP-294 §9 agent-scoped permission grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Dates are ISO 8601 (UTC).
 
 ### Added
 
+- **GAP-294 §9 agent-scoped grants.** Operator-issued scope grants
+  (`permission.grant` / `listGrants` / `revokeGrant`, migration 0009) cover
+  sessions in `agent-scoped` mode: consequential by class or method; critical
+  only by explicit method name. Unmatched calls still escalate to the pending
+  approval queue. Bridge MCP tools + Studio signing parity included.
 - **GAP-294 Phase 0 permission shadow gate.** Every RPC is classified
   (`routine` / `consequential` / `critical` per owner-countersigned map) and
   emits `permission.would_allow` / `permission.would_require_approval` events

--- a/apps/studio/src-tauri/src/signing.rs
+++ b/apps/studio/src-tauri/src/signing.rs
@@ -109,6 +109,9 @@ pub fn requires_signature(method: &str) -> bool {
             | "permission.decide"
             // Phase 2 — operator mode override.
             | "permission.setMode"
+            // §9 — agent-scope grant issue/revoke. MUST mirror server.ts.
+            | "permission.grant"
+            | "permission.revokeGrant"
             // Revokes an HTTP gateway bearer token (GAP-421 guardrail-2
             // remediation S5). MUST mirror server.ts MUTATING_OR_CONTENT_METHODS.
             | "gateway.revokeToken"
@@ -640,15 +643,18 @@ mod tests {
         assert!(requires_signature("session.end"));
         // GAP-312: same eviction primitive as session.end, fleet-wide fan-out.
         assert!(requires_signature("harness.prune"));
-        // GAP-294 Phase 1.
+        // GAP-294 Phase 1 / Phase 2 / §9 grants.
         assert!(requires_signature("permission.decide"));
         assert!(requires_signature("gateway.revokeToken"));
         assert!(requires_signature("permission.setMode"));
+        assert!(requires_signature("permission.grant"));
+        assert!(requires_signature("permission.revokeGrant"));
         assert!(!requires_signature("ping"));
         assert!(!requires_signature("session.list"));
         // harness.health is a read; it stays unsigned. Guards against a
         // copy-paste that gates the wrong half of the harness.* surface.
         assert!(!requires_signature("harness.health"));
         assert!(!requires_signature("permission.pending"));
+        assert!(!requires_signature("permission.listGrants"));
     }
 }

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -522,6 +522,80 @@ server.tool(
   },
 );
 
+server.tool(
+  'permission_list_grants',
+  'List agent-scope permission grants (GAP-294 §9). Optional grantee filter.',
+  {
+    granteeAgentId: z
+      .string()
+      .optional()
+      .describe('When set, only list grants for this grantee agent'),
+    includeInactive: z
+      .boolean()
+      .optional()
+      .describe('Include revoked/expired/exhausted grants (default false)'),
+  },
+  async ({ granteeAgentId, includeInactive }) => {
+    const result = await daemon.call(RPC_METHODS['permission.listGrants'], {
+      ...(granteeAgentId ? { granteeAgentId } : {}),
+      ...(includeInactive ? { includeInactive: true } : {}),
+    });
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
+server.tool(
+  'permission_grant',
+  'Issue an agent-scope grant (signed operator only; cannot self-grant). Critical methods must be named explicitly.',
+  {
+    granteeAgentId: z.string().describe('Agent session that receives the grant'),
+    classes: z
+      .array(z.enum(['consequential']))
+      .optional()
+      .describe('Action classes covered (critical is never by class)'),
+    methods: z
+      .array(z.string())
+      .optional()
+      .describe('Explicit RPC method names (required to cover critical)'),
+    rootScope: z
+      .string()
+      .optional()
+      .describe('Optional filesystem root prefix the grant is limited to'),
+    expiresAt: z.string().optional().describe('ISO expiry; default 24h from issue'),
+    maxUses: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe('Optional use cap; omit for unlimited within TTL'),
+  },
+  async ({ granteeAgentId, classes, methods, rootScope, expiresAt, maxUses }) => {
+    daemon.requireSigned('permission.grant');
+    const result = await daemon.call(RPC_METHODS['permission.grant'], {
+      granteeAgentId,
+      ...(classes ? { classes } : {}),
+      ...(methods ? { methods } : {}),
+      ...(rootScope ? { rootScope } : {}),
+      ...(expiresAt ? { expiresAt } : {}),
+      ...(maxUses !== undefined ? { maxUses } : {}),
+    });
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
+server.tool(
+  'permission_revoke_grant',
+  'Revoke an active agent-scope grant (signed operator only)',
+  {
+    grantId: z.string().describe('Grant id from permission_list_grants or permission_grant'),
+  },
+  async ({ grantId }) => {
+    daemon.requireSigned('permission.revokeGrant');
+    const result = await daemon.call(RPC_METHODS['permission.revokeGrant'], { grantId });
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Start
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/__tests__/permission.test.ts
+++ b/packages/daemon/src/__tests__/permission.test.ts
@@ -184,14 +184,14 @@ describe('grantCoversMethod (GAP-294 §9)', () => {
 
 describe('grantRootMatches', () => {
   it('null root always matches', () => {
-    expect(grantRootMatches(null, { filePath: '/etc/passwd' })).toBe(true);
+    expect(grantRootMatches(null, { filePath: '/var/tmp/x' })).toBe(true);
   });
   it('prefix matches under root', () => {
-    expect(grantRootMatches('/home/proj', { filePath: '/home/proj/src/a.ts' })).toBe(true);
-    expect(grantRootMatches('/home/proj', { filePath: '/home/other/x' })).toBe(false);
+    expect(grantRootMatches('/tmp/proj', { filePath: '/tmp/proj/src/a.ts' })).toBe(true);
+    expect(grantRootMatches('/tmp/proj', { filePath: '/tmp/other/x' })).toBe(false);
   });
   it('no pathish in params does not reject', () => {
-    expect(grantRootMatches('/home/proj', { branch: 'main' })).toBe(true);
+    expect(grantRootMatches('/tmp/proj', { branch: 'main' })).toBe(true);
   });
 });
 

--- a/packages/daemon/src/__tests__/permission.test.ts
+++ b/packages/daemon/src/__tests__/permission.test.ts
@@ -1,18 +1,31 @@
 /**
  * GAP-294 Phase 0 — action-class map + shadow evaluation.
+ * §9 agent-scope grant unit + PGlite issue/consume/revoke.
  */
+
+import { PGlite } from '@electric-sql/pglite';
 import { RPC_METHODS } from '@revdev/protocol';
 import { afterEach, describe, expect, it } from 'vitest';
+import { MIGRATIONS } from '../migrations/index.js';
 import {
   classifyMethod,
   decideEnforcement,
   evaluateShadow,
   expectedClassifiedMethods,
+  grantCoversMethod,
+  grantRootMatches,
+  issueGrant,
+  listGrants,
   METHOD_ACTION_CLASS,
   parseSessionPermissionMode,
+  revokeGrant,
   shadowWouldAuto,
   shadowWouldManual,
+  tryConsumeGrant,
 } from '../permission.js';
+import { migrate } from '../storage/migrate.js';
+
+const DB_TEST_TIMEOUT = 60_000;
 
 describe('METHOD_ACTION_CLASS coverage', () => {
   it('classifies every RPC_METHODS value', () => {
@@ -132,6 +145,54 @@ describe('decideEnforcement (Phase 1)', () => {
     process.env.REVDEV_PERMISSION_DENY_METHODS = 'git.pull,file.write';
     expect(decideEnforcement('git.pull', 'auto').action).toBe('deny');
   });
+
+  it('agent-scoped allows routine and requires approval until grant is consulted', () => {
+    expect(decideEnforcement('ping', 'agent-scoped').action).toBe('allow');
+    const c = decideEnforcement('file.write', 'agent-scoped');
+    expect(c.action).toBe('require_approval');
+    if (c.action === 'require_approval') {
+      expect(c.reason).toBe('agent_scoped');
+    }
+    const k = decideEnforcement('git.push', 'agent-scoped');
+    expect(k.action).toBe('require_approval');
+    if (k.action === 'require_approval') {
+      expect(k.reason).toBe('agent_scoped');
+    }
+  });
+});
+
+describe('grantCoversMethod (GAP-294 §9)', () => {
+  it('consequential class covers file.write but not git.push', () => {
+    const g = { classes: ['consequential'], methods: [] as string[] };
+    expect(grantCoversMethod(g, 'file.write', 'consequential')).toBe(true);
+    expect(grantCoversMethod(g, 'git.push', 'critical')).toBe(false);
+  });
+
+  it('critical only by explicit method name', () => {
+    const byClass = { classes: ['consequential'], methods: [] as string[] };
+    expect(grantCoversMethod(byClass, 'agent.spawn', 'critical')).toBe(false);
+    const byMethod = { classes: [] as string[], methods: ['agent.spawn'] };
+    expect(grantCoversMethod(byMethod, 'agent.spawn', 'critical')).toBe(true);
+    expect(grantCoversMethod(byMethod, 'git.push', 'critical')).toBe(false);
+  });
+
+  it('explicit method covers consequential even without class', () => {
+    const g = { classes: [] as string[], methods: ['file.write'] };
+    expect(grantCoversMethod(g, 'file.write', 'consequential')).toBe(true);
+  });
+});
+
+describe('grantRootMatches', () => {
+  it('null root always matches', () => {
+    expect(grantRootMatches(null, { filePath: '/etc/passwd' })).toBe(true);
+  });
+  it('prefix matches under root', () => {
+    expect(grantRootMatches('/home/proj', { filePath: '/home/proj/src/a.ts' })).toBe(true);
+    expect(grantRootMatches('/home/proj', { filePath: '/home/other/x' })).toBe(false);
+  });
+  it('no pathish in params does not reject', () => {
+    expect(grantRootMatches('/home/proj', { branch: 'main' })).toBe(true);
+  });
 });
 
 describe('parseSessionPermissionMode (Phase 2)', () => {
@@ -152,4 +213,79 @@ describe('parseSessionPermissionMode (Phase 2)', () => {
   it('permission.setMode is critical', () => {
     expect(classifyMethod('permission.setMode')).toBe('critical');
   });
+  it('permission.grant and revokeGrant are critical; listGrants is routine', () => {
+    expect(classifyMethod('permission.grant')).toBe('critical');
+    expect(classifyMethod('permission.revokeGrant')).toBe('critical');
+    expect(classifyMethod('permission.listGrants')).toBe('routine');
+  });
+});
+
+describe('permission grants PGlite (GAP-294 §9)', () => {
+  let db: PGlite;
+
+  afterEach(async () => {
+    await db?.close().catch(() => {});
+  });
+
+  it(
+    'issues, covers consequential by class, exhausts maxUses, revokes',
+    async () => {
+      db = new PGlite();
+      await migrate(db, [...MIGRATIONS]);
+
+      await expect(
+        issueGrant(db, {
+          granteeAgentId: 'agent-a',
+          classes: ['consequential'],
+          issuedBy: 'agent-a',
+        }),
+      ).rejects.toThrow(/cannot issue a grant to itself/);
+
+      await expect(
+        issueGrant(db, {
+          granteeAgentId: 'agent-a',
+          classes: ['critical'],
+          issuedBy: 'op-1',
+        }),
+      ).rejects.toThrow(/critical cannot be granted by class/);
+
+      const grant = await issueGrant(db, {
+        granteeAgentId: 'agent-a',
+        classes: ['consequential'],
+        methods: ['agent.spawn'],
+        maxUses: 1,
+        issuedBy: 'op-1',
+      });
+      expect(grant.status).toBe('active');
+      expect(grant.usesRemaining).toBe(1);
+
+      const hit = await tryConsumeGrant(db, 'agent-a', 'file.write', {
+        filePath: '/tmp/x',
+      });
+      expect(hit?.grantId).toBe(grant.id);
+
+      // maxUses=1 → exhausted; second consequential call needs another grant
+      const miss = await tryConsumeGrant(db, 'agent-a', 'file.delete', {});
+      expect(miss).toBe(null);
+
+      const spawnGrant = await issueGrant(db, {
+        granteeAgentId: 'agent-a',
+        methods: ['agent.spawn'],
+        issuedBy: 'op-1',
+      });
+      const spawnHit = await tryConsumeGrant(db, 'agent-a', 'agent.spawn', {});
+      expect(spawnHit?.grantId).toBe(spawnGrant.id);
+
+      // git.push not named → no cover
+      expect(await tryConsumeGrant(db, 'agent-a', 'git.push', {})).toBe(null);
+
+      await revokeGrant(db, spawnGrant.id, 'op-1');
+      expect(await tryConsumeGrant(db, 'agent-a', 'agent.spawn', {})).toBe(null);
+
+      const listed = await listGrants(db, 'agent-a', true);
+      expect(listed.length).toBeGreaterThanOrEqual(2);
+      expect(listed.some((g) => g.status === 'revoked')).toBe(true);
+    },
+    DB_TEST_TIMEOUT,
+  );
 });

--- a/packages/daemon/src/__tests__/signature-gate.test.ts
+++ b/packages/daemon/src/__tests__/signature-gate.test.ts
@@ -74,6 +74,9 @@ const SIGNED = [
   'permission.decide',
   // Phase 2: operator mode override.
   'permission.setMode',
+  // §9: agent-scope grant issue/revoke.
+  'permission.grant',
+  'permission.revokeGrant',
   // gateway.revokeToken revokes an HTTP gateway bearer token (GAP-421
   // guardrail-2 remediation S5).
   'gateway.revokeToken',

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -109,12 +109,16 @@ const EXEMPT_METHODS = new Set([
   'inference.status',
   'inference.chat',
   'inference.generate',
-  // GAP-294 permission queue: free so FREE-tier daily-driver file/git still
-  // has a path to list/decide approvals when REVDEV_PERMISSION_MODE=manual.
-  // (Decide is still signature-gated; self-approval is rejected.)
+  // GAP-294 permission queue + agent-scope grants: free so FREE-tier
+  // daily-driver file/git still has a path to list/decide approvals and
+  // manage grants when REVDEV_PERMISSION_MODE is enforce.
+  // (Decide/grant/revoke are still signature-gated; self-issue rejected.)
   'permission.pending',
   'permission.decide',
   'permission.setMode',
+  'permission.listGrants',
+  'permission.grant',
+  'permission.revokeGrant',
   // GAP-337: health/monitoring must answer without a Pro license (same class
   // as ping). Multi-agent harness.prune stays Pro.
   'harness.health',

--- a/packages/daemon/src/migrations/0009-permission-grants.ts
+++ b/packages/daemon/src/migrations/0009-permission-grants.ts
@@ -1,0 +1,34 @@
+/**
+ * Migration 0009 — agent-scoped permission grants (GAP-294 §9).
+ *
+ * Operator-issued scope grants for sessions in agent-scoped mode.
+ * A grant may cover consequential by class; critical only by explicit method.
+ */
+
+import type { Migration } from '../storage/migrate.js';
+
+const SQL = `
+  CREATE TABLE IF NOT EXISTS permission_grants (
+    id                 TEXT PRIMARY KEY,
+    grantee_agent_id   TEXT NOT NULL,
+    classes            JSONB NOT NULL DEFAULT '[]'::jsonb,
+    methods            JSONB NOT NULL DEFAULT '[]'::jsonb,
+    root_scope         TEXT,
+    expires_at         TIMESTAMP NOT NULL,
+    max_uses           INTEGER,
+    uses_remaining     INTEGER,
+    issued_by          TEXT NOT NULL,
+    issued_at          TIMESTAMP NOT NULL DEFAULT NOW(),
+    revoked_at         TIMESTAMP,
+    status             TEXT NOT NULL DEFAULT 'active'
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_permission_grants_grantee_status
+    ON permission_grants (grantee_agent_id, status, expires_at);
+`;
+
+export const MIGRATION_0009: Migration = {
+  version: 9,
+  name: 'permission-grants',
+  sql: SQL,
+};

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -24,6 +24,7 @@ import { MIGRATION_0005 } from './0005-session-activity-state.js';
 import { MIGRATION_0006 } from './0006-agent-process-confinement.js';
 import { MIGRATION_0007 } from './0007-permission-approvals.js';
 import { MIGRATION_0008 } from './0008-gateway-tokens.js';
+import { MIGRATION_0009 } from './0009-permission-grants.js';
 
 export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0001,
@@ -34,4 +35,5 @@ export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0006,
   MIGRATION_0007,
   MIGRATION_0008,
+  MIGRATION_0009,
 ];

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -5,6 +5,7 @@
  *
  * Phase 0: classify + `permission.would_*` events (never blocks when mode=shadow).
  * Phase 1: manual/auto enforcement with pending_approvals + -32004 reject-with-receipt.
+ * Phase agent-grants (§9): operator-issued scope grants for agent-scoped mode.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -109,10 +110,13 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['inference.delete', 'critical'],
   ['inference.start', 'critical'],
   ['inference.stop', 'critical'],
-  // future gate controls (not registered yet — mapped for enumeration honesty)
+  // gate controls (enumeration honesty + live handlers)
   ['permission.pending', 'routine'],
   ['permission.decide', 'critical'],
   ['permission.setMode', 'critical'],
+  ['permission.listGrants', 'routine'],
+  ['permission.grant', 'critical'],
+  ['permission.revokeGrant', 'critical'],
   // Revokes a bearer credential — reversible (a new one can be paired), so
   // consequential rather than critical (GAP-421 guardrail-2 remediation S5).
   ['gateway.revokeToken', 'consequential'],
@@ -225,8 +229,14 @@ export function emitPermissionShadowEvent(
  */
 export function expectedClassifiedMethods(): string[] {
   const fromProtocol = Object.values(RPC_METHODS) as string[];
-  // identity.rotate is in RPC_METHODS; permission.* are future.
-  const extras = ['permission.pending', 'permission.decide', 'permission.setMode'];
+  const extras = [
+    'permission.pending',
+    'permission.decide',
+    'permission.setMode',
+    'permission.listGrants',
+    'permission.grant',
+    'permission.revokeGrant',
+  ];
   return [...new Set([...fromProtocol, ...extras])].sort();
 }
 
@@ -236,13 +246,22 @@ export function isShadowOnly(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 export type EnforceDecision =
-  | { action: 'allow'; reason: 'routine' | 'auto_consequential' | 'consumed_approval' }
-  | { action: 'require_approval'; reason: 'manual' | 'auto_critical' | 'auto_other' }
+  | {
+      action: 'allow';
+      reason: 'routine' | 'auto_consequential' | 'consumed_approval' | 'agent_grant';
+    }
+  | {
+      action: 'require_approval';
+      reason: 'manual' | 'auto_critical' | 'auto_other' | 'agent_scoped';
+    }
   | { action: 'deny'; reason: 'deny_list' };
 
 /**
- * Live policy for manual/auto (Phase 1). Agent-scoped falls back to manual
- * until grants ship (spec §9 deferred).
+ * Live policy for manual / auto / agent-scoped (spec §4 + §9).
+ *
+ * Agent-scoped: routine allows; consequential/critical return require_approval
+ * so the gate can try matching an operator grant before queueing (§9).
+ * Critical coverage requires an explicit method name on the grant (never class).
  */
 export function decideEnforcement(
   method: string,
@@ -250,14 +269,13 @@ export function decideEnforcement(
   env: NodeJS.ProcessEnv = process.env,
 ): EnforceDecision {
   const actionClass = classifyMethod(method);
-  const effective: PermissionMode =
-    mode === 'agent-scoped' ? 'manual' : mode === 'shadow' ? 'shadow' : mode;
+  const effective: PermissionMode = mode === 'shadow' ? 'shadow' : mode;
 
   if (effective === 'shadow') {
     return { action: 'allow', reason: 'routine' };
   }
 
-  // Deny-list (auto + manual): comma-separated method names in env.
+  // Deny-list (all enforce modes): comma-separated method names in env.
   const denyRaw = (env.REVDEV_PERMISSION_DENY_METHODS ?? '').trim();
   if (denyRaw.length > 0) {
     const deny = new Set(
@@ -282,11 +300,375 @@ export function decideEnforcement(
     return { action: 'allow', reason: 'routine' };
   }
 
+  if (effective === 'agent-scoped') {
+    if (actionClass === 'routine') {
+      return { action: 'allow', reason: 'routine' };
+    }
+    // Caller consults permission_grants; unmatched → manual-style queue.
+    return { action: 'require_approval', reason: 'agent_scoped' };
+  }
+
   // manual
   if (actionClass === 'routine') {
     return { action: 'allow', reason: 'routine' };
   }
   return { action: 'require_approval', reason: 'manual' };
+}
+
+/** Grant may name these action classes (critical never by class — methods only). */
+export const GRANTABLE_CLASSES = ['consequential'] as const;
+export type GrantableClass = (typeof GRANTABLE_CLASSES)[number];
+
+/** Default grant TTL when operator omits expiresAt (24h). */
+export const GRANT_DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface PermissionGrantRow {
+  id: string;
+  granteeAgentId: string;
+  classes: string[];
+  methods: string[];
+  rootScope: string | null;
+  expiresAt: string;
+  maxUses: number | null;
+  usesRemaining: number | null;
+  issuedBy: string;
+  issuedAt: string;
+  revokedAt: string | null;
+  status: string;
+}
+
+function parseJsonStringArray(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((x): x is string => typeof x === 'string');
+  }
+  if (typeof raw === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((x): x is string => typeof x === 'string');
+      }
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+/**
+ * Whether a grant covers this method for the given action class (spec §9).
+ * - critical: only if methods[] names the method (never by class)
+ * - consequential: classes includes 'consequential' OR methods names the method
+ * - routine: always covered without a grant (not called for routine)
+ */
+export function grantCoversMethod(
+  grant: { classes: string[]; methods: string[] },
+  method: string,
+  actionClass: ActionClass,
+): boolean {
+  if (actionClass === 'critical') {
+    return grant.methods.includes(method);
+  }
+  if (actionClass === 'consequential') {
+    return grant.classes.includes('consequential') || grant.methods.includes(method);
+  }
+  return true;
+}
+
+/**
+ * Optional root_scope prefix check when the call params carry a path.
+ * If the grant has no root_scope, or params have no pathish field, match is ok
+ * (confinement / requireRoot remain senior — I3).
+ */
+export function grantRootMatches(
+  rootScope: string | null | undefined,
+  params: Record<string, unknown> | undefined,
+): boolean {
+  if (!rootScope) return true;
+  if (!params) return true;
+  const pathish =
+    (typeof params.filePath === 'string' && params.filePath) ||
+    (typeof params.repoPath === 'string' && params.repoPath) ||
+    (typeof params.path === 'string' && params.path) ||
+    (typeof params.cwd === 'string' && params.cwd) ||
+    '';
+  if (!pathish) return true;
+  const root = rootScope.endsWith('/') ? rootScope : `${rootScope}/`;
+  return pathish === rootScope || pathish.startsWith(root);
+}
+
+/**
+ * Find an active grant covering (agent, method), optionally consume one use.
+ * Returns grant id when allowed; null when no grant covers the call.
+ */
+export async function tryConsumeGrant(
+  db: PGlite,
+  granteeAgentId: string,
+  method: string,
+  params: Record<string, unknown> | undefined,
+): Promise<{ grantId: string } | null> {
+  const actionClass = classifyMethod(method);
+
+  // Expire stale active grants opportunistically.
+  await db.query(
+    `UPDATE permission_grants SET status = 'expired'
+     WHERE status = 'active' AND expires_at <= NOW()`,
+  );
+
+  const r = await db.query<{
+    id: string;
+    classes: unknown;
+    methods: unknown;
+    root_scope: string | null;
+    uses_remaining: number | null;
+  }>(
+    `SELECT id, classes, methods, root_scope, uses_remaining
+     FROM permission_grants
+     WHERE grantee_agent_id = $1 AND status = 'active' AND expires_at > NOW()
+       AND (uses_remaining IS NULL OR uses_remaining > 0)
+     ORDER BY issued_at ASC`,
+    [granteeAgentId],
+  );
+
+  for (const row of r.rows) {
+    const classes = parseJsonStringArray(row.classes);
+    const methods = parseJsonStringArray(row.methods);
+    if (!grantCoversMethod({ classes, methods }, method, actionClass)) continue;
+    if (!grantRootMatches(row.root_scope, params)) continue;
+
+    if (row.uses_remaining !== null && row.uses_remaining !== undefined) {
+      const updated = await db.query<{ uses_remaining: number }>(
+        `UPDATE permission_grants
+         SET uses_remaining = uses_remaining - 1,
+             status = CASE WHEN uses_remaining - 1 <= 0 THEN 'exhausted' ELSE status END
+         WHERE id = $1 AND status = 'active' AND uses_remaining > 0
+         RETURNING uses_remaining`,
+        [row.id],
+      );
+      if (!updated.rows[0]) continue;
+    }
+
+    void db.query(`INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`, [
+      granteeAgentId,
+      'permission.grant_allowed',
+      JSON.stringify({
+        grantId: row.id,
+        method,
+        actionClass,
+      }),
+    ]);
+
+    return { grantId: row.id };
+  }
+
+  return null;
+}
+
+export interface IssueGrantInput {
+  granteeAgentId: string;
+  classes?: string[];
+  methods?: string[];
+  rootScope?: string | null;
+  expiresAt?: string | Date | null;
+  maxUses?: number | null;
+  issuedBy: string;
+}
+
+/**
+ * Operator-issued scope grant (spec §9). At least one of classes or methods
+ * required. Critical methods may only appear in methods[] (never as a class).
+ */
+export async function issueGrant(db: PGlite, input: IssueGrantInput): Promise<PermissionGrantRow> {
+  const grantee = input.granteeAgentId?.trim();
+  if (!grantee) {
+    throw new Error('permission.grant: granteeAgentId is required');
+  }
+  if (input.issuedBy === grantee) {
+    throw new Error('permission.grant: an agent cannot issue a grant to itself');
+  }
+
+  const classes = (input.classes ?? []).map((c) => c.trim().toLowerCase()).filter(Boolean);
+  const methods = (input.methods ?? []).map((m) => m.trim()).filter(Boolean);
+
+  for (const c of classes) {
+    if (c === 'critical') {
+      throw new Error(
+        'permission.grant: critical cannot be granted by class; name methods explicitly',
+      );
+    }
+    if (c === 'routine') {
+      throw new Error('permission.grant: routine needs no grant');
+    }
+    if (!(GRANTABLE_CLASSES as readonly string[]).includes(c)) {
+      throw new Error(`permission.grant: unknown class '${c}' (allowed: consequential)`);
+    }
+  }
+  if (classes.length === 0 && methods.length === 0) {
+    throw new Error('permission.grant: provide classes and/or methods');
+  }
+
+  let maxUses: number | null = null;
+  if (input.maxUses !== null && input.maxUses !== undefined) {
+    if (!Number.isInteger(input.maxUses) || input.maxUses < 1) {
+      throw new Error('permission.grant: maxUses must be a positive integer when set');
+    }
+    maxUses = input.maxUses;
+  }
+
+  let expiresAt: Date;
+  if (input.expiresAt) {
+    expiresAt = input.expiresAt instanceof Date ? input.expiresAt : new Date(input.expiresAt);
+    if (Number.isNaN(expiresAt.getTime())) {
+      throw new Error('permission.grant: expiresAt is not a valid date');
+    }
+    if (expiresAt.getTime() <= Date.now()) {
+      throw new Error('permission.grant: expiresAt must be in the future');
+    }
+  } else {
+    expiresAt = new Date(Date.now() + GRANT_DEFAULT_TTL_MS);
+  }
+
+  const id = randomUUID();
+  const rootScope =
+    typeof input.rootScope === 'string' && input.rootScope.trim() ? input.rootScope.trim() : null;
+
+  await db.query(
+    `INSERT INTO permission_grants (
+       id, grantee_agent_id, classes, methods, root_scope,
+       expires_at, max_uses, uses_remaining, issued_by, status
+     ) VALUES ($1, $2, $3::jsonb, $4::jsonb, $5, $6, $7, $8, $9, 'active')`,
+    [
+      id,
+      grantee,
+      JSON.stringify(classes),
+      JSON.stringify(methods),
+      rootScope,
+      expiresAt.toISOString(),
+      maxUses,
+      maxUses,
+      input.issuedBy,
+    ],
+  );
+
+  void db.query(`INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`, [
+    grantee,
+    'permission.grant_issued',
+    JSON.stringify({
+      grantId: id,
+      classes,
+      methods,
+      rootScope,
+      maxUses,
+      expiresAt: expiresAt.toISOString(),
+      issuedBy: input.issuedBy,
+    }),
+  ]);
+
+  return {
+    id,
+    granteeAgentId: grantee,
+    classes,
+    methods,
+    rootScope,
+    expiresAt: expiresAt.toISOString(),
+    maxUses,
+    usesRemaining: maxUses,
+    issuedBy: input.issuedBy,
+    issuedAt: new Date().toISOString(),
+    revokedAt: null,
+    status: 'active',
+  };
+}
+
+export async function listGrants(
+  db: PGlite,
+  granteeFilter?: string | null,
+  includeInactive = false,
+): Promise<PermissionGrantRow[]> {
+  await db.query(
+    `UPDATE permission_grants SET status = 'expired'
+     WHERE status = 'active' AND expires_at <= NOW()`,
+  );
+
+  const statusClause = includeInactive ? '' : ` AND status = 'active' AND expires_at > NOW()`;
+  const sql = granteeFilter
+    ? `SELECT id, grantee_agent_id, classes, methods, root_scope, expires_at,
+              max_uses, uses_remaining, issued_by, issued_at, revoked_at, status
+       FROM permission_grants
+       WHERE grantee_agent_id = $1${statusClause}
+       ORDER BY issued_at DESC`
+    : `SELECT id, grantee_agent_id, classes, methods, root_scope, expires_at,
+              max_uses, uses_remaining, issued_by, issued_at, revoked_at, status
+       FROM permission_grants
+       WHERE 1=1${statusClause}
+       ORDER BY issued_at DESC`;
+
+  const r = await db.query<{
+    id: string;
+    grantee_agent_id: string;
+    classes: unknown;
+    methods: unknown;
+    root_scope: string | null;
+    expires_at: string;
+    max_uses: number | null;
+    uses_remaining: number | null;
+    issued_by: string;
+    issued_at: string;
+    revoked_at: string | null;
+    status: string;
+  }>(sql, granteeFilter ? [granteeFilter] : []);
+
+  return r.rows.map((row) => ({
+    id: row.id,
+    granteeAgentId: row.grantee_agent_id,
+    classes: parseJsonStringArray(row.classes),
+    methods: parseJsonStringArray(row.methods),
+    rootScope: row.root_scope,
+    expiresAt: row.expires_at,
+    maxUses: row.max_uses,
+    usesRemaining: row.uses_remaining,
+    issuedBy: row.issued_by,
+    issuedAt: row.issued_at,
+    revokedAt: row.revoked_at,
+    status: row.status,
+  }));
+}
+
+export async function revokeGrant(
+  db: PGlite,
+  grantId: string,
+  operatorAgentId: string,
+): Promise<{ id: string; status: string }> {
+  if (!grantId?.trim()) {
+    throw new Error('permission.revokeGrant: grantId is required');
+  }
+
+  const found = await db.query<{
+    id: string;
+    grantee_agent_id: string;
+    status: string;
+  }>(`SELECT id, grantee_agent_id, status FROM permission_grants WHERE id = $1`, [grantId]);
+  const row = found.rows[0];
+  if (!row) {
+    throw new Error(`permission.revokeGrant: unknown grantId ${grantId}`);
+  }
+  if (row.status !== 'active') {
+    throw new Error(`permission.revokeGrant: grant ${grantId} is ${row.status}, not active`);
+  }
+
+  await db.query(
+    `UPDATE permission_grants
+     SET status = 'revoked', revoked_at = NOW()
+     WHERE id = $1 AND status = 'active'`,
+    [grantId],
+  );
+
+  void db.query(`INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`, [
+    row.grantee_agent_id,
+    'permission.grant_revoked',
+    JSON.stringify({ grantId, revokedBy: operatorAgentId }),
+  ]);
+
+  return { id: grantId, status: 'revoked' };
 }
 
 export function summarizeParams(

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -65,13 +65,17 @@ import {
   decideEnforcement,
   emitPermissionShadowEvent,
   evaluateShadow,
+  issueGrant,
+  listGrants,
   listPendingApprovals,
   parseSessionPermissionMode,
   queueApprovalRequired,
   resolveEffectiveMode,
   resolvePermissionMode,
+  revokeGrant,
   setSessionPermissionMode,
   tryConsumeApproval,
+  tryConsumeGrant,
 } from './permission.js';
 import { initSessionChecks, runSessionChecks } from './session-checks/index.js';
 import { migrate } from './storage/migrate.js';
@@ -278,8 +282,11 @@ export const MUTATING_OR_CONTENT_METHODS = new Set([
   'harness.prune',
   // GAP-294 Phase 1: approval decisions are signature-required mutations.
   // Phase 2: operator mode overrides are signature-required too.
+  // §9: agent-scope grant issue/revoke are operator-only mutations.
   'permission.decide',
   'permission.setMode',
+  'permission.grant',
+  'permission.revokeGrant',
   // gateway.revokeToken revokes an HTTP gateway bearer token (GAP-421
   // guardrail-2 remediation S5). Signature-required so an unsigned caller
   // cannot revoke another client's session.
@@ -921,9 +928,23 @@ export async function dispatchRpc(
             ? (req.params as Record<string, unknown>)
             : {};
         try {
-          const consumed = await tryConsumeApproval(db, agentForEvent, req.method, paramsObj);
-          if (!consumed) {
-            await queueApprovalRequired(db, agentForEvent, req.method, paramsObj);
+          // Spec §9: agent-scoped mode consults operator grants before the
+          // pending-approval queue (critical only by explicit method name).
+          if (mode === 'agent-scoped' || decision.reason === 'agent_scoped') {
+            const grantHit = await tryConsumeGrant(db, agentForEvent, req.method, paramsObj);
+            if (grantHit) {
+              // Covered by grant — proceed to dispatch.
+            } else {
+              const consumed = await tryConsumeApproval(db, agentForEvent, req.method, paramsObj);
+              if (!consumed) {
+                await queueApprovalRequired(db, agentForEvent, req.method, paramsObj);
+              }
+            }
+          } else {
+            const consumed = await tryConsumeApproval(db, agentForEvent, req.method, paramsObj);
+            if (!consumed) {
+              await queueApprovalRequired(db, agentForEvent, req.method, paramsObj);
+            }
           }
         } catch (permErr) {
           if (permErr instanceof ApprovalRequiredError) {
@@ -2132,6 +2153,45 @@ registerHandler('permission.setMode', async (params, db, ctx) => {
     ...result,
     daemonDefault: resolvePermissionMode(),
   };
+});
+
+registerHandler('permission.listGrants', async (params, db) => {
+  // Read surface: list agent-scope grants (GAP-294 §9). Optional grantee filter.
+  const grantee = strOrNull(params.granteeAgentId) ?? strOrNull(params.agentId) ?? null;
+  const includeInactive = params.includeInactive === true;
+  const grants = await listGrants(db, grantee, includeInactive);
+  return { grants };
+});
+
+registerHandler('permission.grant', async (params, db, ctx) => {
+  // Signature-required (MUTATING). Operator issues a scope grant to another agent.
+  const operator = await requireVerifiedAgent(ctx, db, params);
+  const granteeAgentId = str(params.granteeAgentId ?? params.agentId);
+  const classes = asStringArray(params.classes);
+  const methods = asStringArray(params.methods);
+  const rootScope = strOrNull(params.rootScope);
+  const expiresAt = strOrNull(params.expiresAt);
+  let maxUses: number | null = null;
+  if (params.maxUses !== null && params.maxUses !== undefined && params.maxUses !== '') {
+    maxUses = num(params.maxUses);
+  }
+  const grant = await issueGrant(db, {
+    granteeAgentId,
+    classes: classes.length > 0 ? classes : undefined,
+    methods: methods.length > 0 ? methods : undefined,
+    rootScope,
+    expiresAt,
+    maxUses,
+    issuedBy: operator,
+  });
+  return { grant };
+});
+
+registerHandler('permission.revokeGrant', async (params, db, ctx) => {
+  // Signature-required (MUTATING). Operator revokes an active grant.
+  const operator = await requireVerifiedAgent(ctx, db, params);
+  const grantId = str(params.grantId);
+  return revokeGrant(db, grantId, operator);
 });
 
 // -- Memory -----------------------------------------------------------------

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -118,10 +118,13 @@ export const RPC_METHODS = {
   'merge.list': 'merge.list',
   'merge.update': 'merge.update',
 
-  // Permission modes (GAP-294 Phase 1 pending/decide; Phase 2 setMode)
+  // Permission modes (GAP-294 Phase 1 pending/decide; Phase 2 setMode; §9 grants)
   'permission.pending': 'permission.pending',
   'permission.decide': 'permission.decide',
   'permission.setMode': 'permission.setMode',
+  'permission.listGrants': 'permission.listGrants',
+  'permission.grant': 'permission.grant',
+  'permission.revokeGrant': 'permission.revokeGrant',
 
   // HTTP gateway token management (GAP-421 guardrail-2 remediation S5)
   'gateway.revokeToken': 'gateway.revokeToken',


### PR DESCRIPTION
## Summary

Implements the free residual of **GAP-294**: agent-scoped mode operator grants (design §9). Manual/auto/shadow and Studio/bridge surfaces for pending approvals already landed; this PR makes `agent-scoped` more than a manual fallback.

- Migration **0009** `permission_grants` table
- `permission.grant` / `permission.listGrants` / `permission.revokeGrant` (grant/revoke signature-required; no self-issue)
- Gate consults grants before the pending-approval queue when effective mode is `agent-scoped`
  - **consequential**: covered by class `consequential` or by named method
  - **critical**: covered **only** by explicit method name (never by class)
  - optional `rootScope` prefix + optional `maxUses`
- Bridge MCP tools + Studio `signing.rs` parity with `MUTATING_OR_CONTENT_METHODS`
- Unit + PGlite tests; migrate runner reaches schema **v9**

**Not in this PR (owner-gated):** Phase 3 install default flip (`REVDEV_PERMISSION_MODE` shipping default remains shadow until soak).

## Test plan

- [x] `vitest` `permission.test.ts` (31) + `signature-gate.test.ts` (44)
- [x] `migrate.test.ts` (schema v9) + `rpc-contract.test.ts`
- [x] `pnpm --filter @revdev/daemon build` + bridge build
- [ ] CI green on PR

## Owner actions

Merge when green (agent does not self-merge):

```bash
gh pr merge <N> --merge
```