### PR TITLE
feat(daemon): check-and-reject format on file.write (GAP-309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Dates are ISO 8601 (UTC).
 
 ### Added
 
+- **GAP-309 format enforcement on `file.write`.** When a registered root declares
+  `biome.json` / `biome.jsonc` or `Cargo.toml`, unformatted content is
+  **check-and-rejected** with JSON-RPC `-32007` (includes `data.fixCommand`)
+  before any disk write. No rewrite of caller bytes; no hardcoded repo path
+  allow-list. See `docs/decisions/2026-08-05-file-write-format-check-and-reject.md`.
 - **GAP-294 §9 agent-scoped grants.** Operator-issued scope grants
   (`permission.grant` / `listGrants` / `revokeGrant`, migration 0009) cover
   sessions in `agent-scoped` mode: consequential by class or method; critical

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -313,8 +313,19 @@ Read a file inside a registered project root.
 
 Write (create/overwrite) a file inside a registered project root. Refuses `.git/` internals.
 
+**Format enforcement (GAP-309):** when the registered root declares a formatter
+(`biome.json` / `biome.jsonc` for JS/TS/JSON/CSS, or `Cargo.toml` for `.rs`), the
+daemon **check-and-rejects** unformatted content with `-32007` *before* writing.
+It does **not** rewrite the caller's bytes (rewrite would make agents believe
+they wrote what they sent). Fix by running the command named in
+`error.data.fixCommand` and re-sending. Repos with no formatter config, exempt
+paths (`node_modules`, `dist`, …), and non-formatter extensions are unchanged.
+CI remains the merge guarantee; this is harness-independent edit-time
+enforcement on the daemon path only.
+
 **Params**: `{ repoPath: string, filePath: string, content: string }` (content capped at 768 KiB)
 **Response**: `{ success: true, bytes: number }`
+**Errors**: `-32007` format rejected (`data.kind = "format-rejected"`, includes `fixCommand`)
 
 ---
 
@@ -791,6 +802,8 @@ Update merge request status (e.g., after PR creation or CI result).
 | -32002 | Identity required (call session.register or session.attach first) |
 | -32003 | Signature required (missing or invalid Ed25519 signature on a Signature-required method) |
 | -32004 | Untrusted client key (identity enrollment/rotation rejected; fingerprint not in the trust anchor) |
+| -32006 | Tool-guard denied (blocked command/path/content) |
+| -32007 | Format rejected (GAP-309: content not formatted per repo-declared biome/cargo; see `data.fixCommand`) |
 | -32099 | Server is shutting down |
 | -32000 | Internal error (handler threw) |
 

--- a/docs/decisions/2026-08-05-file-write-format-check-and-reject.md
+++ b/docs/decisions/2026-08-05-file-write-format-check-and-reject.md
@@ -1,0 +1,47 @@
+---
+type: decision
+date: 2026-08-05
+status: accepted
+owner: agent
+repos: revdev
+related: GAP-309
+---
+
+# Decision: `file.write` format posture is check-and-reject
+
+## Context
+
+GAP-309 moves edit-time formatting enforcement out of the Claude-only
+`post-edit.js` hook and onto the daemon `file.write` surface so every harness
+and human client hits the same chokepoint. Two postures were on the table:
+
+1. **Rewrite** — run the formatter and write the normalized bytes (Claude hook style).
+2. **Check-and-reject** — refuse the RPC when content differs from the formatter's output.
+
+## Decision
+
+**Check-and-reject.** Unformatted content returns JSON-RPC `-32007` with
+`data.fixCommand` and never touches the destination file.
+
+## Why
+
+- A daemon RPC that silently rewrites bytes makes the caller believe it wrote
+  what it sent. That is worse for agents and for Studio than a loud failure.
+- The Claude hook remains a **fast-feedback convenience** (rewrite on Edit/Write).
+  It can be deleted without weakening the daemon guarantee.
+- CI (`pnpm lint` / `cargo fmt --check`) remains the merge guarantee. This
+  decision only hardens the edit-time layer on the daemon path.
+
+## Detection
+
+No hardcoded repo path allow-list. Walk up from the target file inside the
+registered root to the nearest `biome.json` / `biome.jsonc` or `Cargo.toml`.
+Exempt generated segments (`node_modules`, `dist`, `target`, …). Extension-
+gated so a biome monorepo does not try to format `.md` / `.rs` by accident.
+
+## Out of scope
+
+- Git commit-time hooks (revkit / Husky) — separate layer; `core.hooksPath` is
+  single-valued so they cannot alone cover every fleet repo.
+- Auto-commit crash protection — stays opt-in on the Claude side only
+  (`CLAUDE_AUTOCOMMIT=1`); never ported to the daemon.

--- a/packages/daemon/src/__tests__/filegit-format.test.ts
+++ b/packages/daemon/src/__tests__/filegit-format.test.ts
@@ -1,0 +1,223 @@
+/**
+ * GAP-309 — end-to-end: signed file.write over the Unix socket enforces
+ * formatting without any Claude hook in the loop.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { formatDid } from '@revdev/protocol/did';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  computeFingerprint,
+  generateAgentKeypair,
+  generateNonce,
+  hashParams,
+  serializeEnvelope,
+  signEnvelope,
+} from '../agent-identity-crypto.js';
+import { FORMAT_REJECTED_CODE } from '../format-enforce.js';
+import { startDaemon } from '../server.js';
+// Side-effect: register project.open / file.* handlers.
+import '../filegit.js';
+
+vi.setConfig({ testTimeout: 45_000, hookTimeout: 45_000 });
+
+const here = dirname(fileURLToPath(import.meta.url));
+const monorepoRoot = join(here, '..', '..', '..', '..');
+const biomeBinDir = join(monorepoRoot, 'node_modules', '.bin');
+
+const MINIMAL_BIOME_JSON = `{
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always"
+    }
+  }
+}
+`;
+
+interface RpcResult {
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+function rpcFrame(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown>,
+  signature?: string,
+): Promise<RpcResult> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req: Record<string, unknown> = { jsonrpc: '2.0', id: 1, method, params };
+    if (signature) req['x-revdev-signature'] = signature;
+    sock.on('connect', () => sock.write(`${JSON.stringify(req)}\n`));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      sock.end();
+      try {
+        resolve(JSON.parse(buf.slice(0, nl)) as RpcResult);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(10_000, () => {
+      sock.destroy();
+      reject(new Error(`rpc timeout: ${method}`));
+    });
+  });
+}
+
+function sign(
+  method: string,
+  params: Record<string, unknown>,
+  did: string,
+  fingerprint: string,
+  privateKeyPem: string,
+): string {
+  const payload = {
+    did,
+    kid: fingerprint,
+    nonce: generateNonce(),
+    ts: Math.floor(Date.now() / 1000),
+    method,
+    paramsHash: hashParams(method, params),
+  };
+  return serializeEnvelope(signEnvelope(payload, privateKeyPem));
+}
+
+describe('file.write format enforcement (GAP-309 e2e)', () => {
+  let daemon: { close: () => Promise<void> };
+  let socketPath: string;
+  let dataDir: string;
+  let repo: string;
+  const agentId = 'format-enforce-test';
+  const kp = generateAgentKeypair();
+  const fingerprint = computeFingerprint(kp.publicKeyRaw);
+  const did = formatDid(agentId, fingerprint);
+  let prevPath: string | undefined;
+
+  beforeAll(async () => {
+    prevPath = process.env.PATH;
+    process.env.PATH = `${biomeBinDir}:${process.env.PATH ?? ''}`;
+
+    dataDir = await mkdtemp(join(tmpdir(), 'revdev-fmt-e2e-'));
+    repo = await mkdtemp(join(tmpdir(), 'revdev-fmt-repo-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo });
+    await writeFile(join(repo, 'biome.json'), MINIMAL_BIOME_JSON);
+    await mkdir(join(repo, 'src'), { recursive: true });
+
+    socketPath = join(dataDir, 'harness.sock');
+    const anchor = join(dataDir, 'trusted-client-fingerprint');
+    await writeFile(anchor, `# test trust anchor\n${agentId}:${fingerprint}\n`);
+    daemon = await startDaemon({
+      socketPath,
+      dataDir,
+      trustedClientFingerprintPath: anchor,
+      trustedAnchorRequireRootOwned: false,
+    });
+
+    // Register + open project once for the suite.
+    const reg = await rpcFrame(socketPath, 'session.register', {
+      agentId,
+      agentName: 'format-test',
+      backend: 'test',
+      publicKeyPem: kp.publicKeyPem,
+    });
+    expect(reg.error).toBeUndefined();
+
+    const openParams = { repoPath: repo };
+    const open = await rpcFrame(
+      socketPath,
+      'project.open',
+      openParams,
+      sign('project.open', openParams, did, fingerprint, kp.privateKeyPem),
+    );
+    expect((open.result as { success: boolean }).success).toBe(true);
+  });
+
+  afterAll(async () => {
+    process.env.PATH = prevPath;
+    await daemon.close();
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('rejects unformatted content with -32007 and does not write the file', async () => {
+    const writeParams = {
+      repoPath: repo,
+      filePath: 'src/unformatted.ts',
+      content: 'const  x =1',
+    };
+    const w = await rpcFrame(
+      socketPath,
+      'file.write',
+      writeParams,
+      sign('file.write', writeParams, did, fingerprint, kp.privateKeyPem),
+    );
+    expect(w.error?.code).toBe(FORMAT_REJECTED_CODE);
+    expect(w.error?.message).toMatch(/not formatted|biome/i);
+    expect(w.error?.data).toMatchObject({
+      kind: 'format-rejected',
+      formatter: 'biome',
+    });
+    // File must not exist on disk (check-and-reject, never write then revert).
+    await expect(readFile(join(repo, 'src', 'unformatted.ts'), 'utf8')).rejects.toThrow();
+  });
+
+  it('accepts formatted content and writes it through', async () => {
+    const formatted = execFileSync(
+      join(biomeBinDir, 'biome'),
+      ['format', '--stdin-file-path', 'src/ok.ts'],
+      {
+        cwd: repo,
+        input: 'const x = 1;\n',
+        encoding: 'utf8',
+      },
+    );
+    const writeParams = {
+      repoPath: repo,
+      filePath: 'src/ok.ts',
+      content: formatted,
+    };
+    const w = await rpcFrame(
+      socketPath,
+      'file.write',
+      writeParams,
+      sign('file.write', writeParams, did, fingerprint, kp.privateKeyPem),
+    );
+    expect(w.error).toBeUndefined();
+    expect((w.result as { success: boolean }).success).toBe(true);
+    expect(await readFile(join(repo, 'src', 'ok.ts'), 'utf8')).toBe(formatted);
+  });
+
+  it('does not enforce on paths outside the formatter domain', async () => {
+    const writeParams = {
+      repoPath: repo,
+      filePath: 'notes.txt',
+      content: 'any  mess   is fine',
+    };
+    const w = await rpcFrame(
+      socketPath,
+      'file.write',
+      writeParams,
+      sign('file.write', writeParams, did, fingerprint, kp.privateKeyPem),
+    );
+    expect(w.error).toBeUndefined();
+    expect((w.result as { success: boolean }).success).toBe(true);
+  });
+});

--- a/packages/daemon/src/__tests__/format-enforce.test.ts
+++ b/packages/daemon/src/__tests__/format-enforce.test.ts
@@ -1,0 +1,277 @@
+/**
+ * GAP-309 — format enforcement unit tests.
+ *
+ * Prove: repo-declared biome/cargo check-and-reject, no hardcoded paths,
+ * exempt paths skip, undeclared repos pass through.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  _isFormatExemptPathForTest,
+  assertFormattedContent,
+  FORMAT_REJECTED_CODE,
+  FormatRejectedError,
+} from '../format-enforce.js';
+import { detectDeclaredFormatter, resolveLocalBin } from '../repo-tooling.js';
+
+// Locate the worktree's biome binary so tests do not depend on a global install.
+const here = dirname(fileURLToPath(import.meta.url));
+const monorepoRoot = join(here, '..', '..', '..', '..');
+const biomeBinDir = join(monorepoRoot, 'node_modules', '.bin');
+
+const MINIMAL_BIOME_JSON = `{
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always"
+    }
+  }
+}
+`;
+
+describe('repo-tooling detection', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'revdev-tooling-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('returns null when no formatter is declared', async () => {
+    await writeFile(join(root, 'a.ts'), 'x');
+    expect(await detectDeclaredFormatter(root, join(root, 'a.ts'))).toBeNull();
+  });
+
+  it('finds biome.json by walking up within the root', async () => {
+    await writeFile(join(root, 'biome.json'), MINIMAL_BIOME_JSON);
+    await mkdir(join(root, 'src', 'nested'), { recursive: true });
+    const file = join(root, 'src', 'nested', 'a.ts');
+    await writeFile(file, 'x');
+    const found = await detectDeclaredFormatter(root, file);
+    expect(found).toEqual({
+      root,
+      formatter: 'biome',
+      configPath: join(root, 'biome.json'),
+    });
+  });
+
+  it('finds Cargo.toml for rust trees', async () => {
+    await writeFile(join(root, 'Cargo.toml'), '[package]\nname = "t"\nversion = "0.1.0"\n');
+    await mkdir(join(root, 'src'));
+    const file = join(root, 'src', 'lib.rs');
+    await writeFile(file, 'x');
+    const found = await detectDeclaredFormatter(root, file);
+    expect(found?.formatter).toBe('cargo');
+    expect(found?.root).toBe(root);
+  });
+
+  it('resolves local node_modules/.bin/biome when present', async () => {
+    await mkdir(join(root, 'node_modules', '.bin'), { recursive: true });
+    const bin = join(root, 'node_modules', '.bin', 'biome');
+    await writeFile(bin, '#!/bin/sh\necho stub\n', { mode: 0o755 });
+    expect(await resolveLocalBin(root, root, 'biome')).toBe(bin);
+  });
+
+  it('marks generated path segments as exempt', () => {
+    expect(_isFormatExemptPathForTest('/proj/node_modules/pkg/x.ts')).toBe(true);
+    expect(_isFormatExemptPathForTest('/proj/dist/out.js')).toBe(true);
+    expect(_isFormatExemptPathForTest('/proj/src/a.ts')).toBe(false);
+  });
+});
+
+describe('assertFormattedContent (biome check-and-reject)', () => {
+  let root: string;
+  let prevPath: string | undefined;
+
+  beforeAll(() => {
+    // Prefer the monorepo biome so fixtures only need a biome.json.
+    prevPath = process.env.PATH;
+    process.env.PATH = `${biomeBinDir}:${process.env.PATH ?? ''}`;
+  });
+
+  afterAll(() => {
+    process.env.PATH = prevPath;
+  });
+
+  afterEach(async () => {
+    if (root) await rm(root, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'revdev-fmt-'));
+    await writeFile(join(root, 'biome.json'), MINIMAL_BIOME_JSON);
+  });
+
+  it('rejects unformatted TypeScript content with -32007 and a fix command', async () => {
+    const abs = join(root, 'src', 'bad.ts');
+    await mkdir(dirname(abs), { recursive: true });
+    await expect(
+      assertFormattedContent({
+        repoReal: root,
+        absFile: abs,
+        content: 'const  x =1',
+      }),
+    ).rejects.toMatchObject({
+      name: 'FormatRejectedError',
+      code: FORMAT_REJECTED_CODE,
+      data: {
+        kind: 'format-rejected',
+        formatter: 'biome',
+      },
+    });
+
+    try {
+      await assertFormattedContent({
+        repoReal: root,
+        absFile: abs,
+        content: 'const  x =1',
+      });
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(FormatRejectedError);
+      const e = err as FormatRejectedError;
+      expect(e.message).toContain('biome');
+      expect(e.data.fixCommand).toContain('biome check --write');
+      expect(e.data.filePath).toBe('src/bad.ts');
+    }
+  });
+
+  it('accepts already-formatted TypeScript content', async () => {
+    // Derive the exact formatted form from the same biome the daemon uses.
+    const formatted = execFileSync(
+      join(biomeBinDir, 'biome'),
+      ['format', '--stdin-file-path', 'src/ok.ts'],
+      {
+        cwd: root,
+        input: 'const x = 1\n',
+        encoding: 'utf8',
+      },
+    );
+    const abs = join(root, 'src', 'ok.ts');
+    await mkdir(dirname(abs), { recursive: true });
+    await expect(
+      assertFormattedContent({
+        repoReal: root,
+        absFile: abs,
+        content: formatted,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('is a no-op when the repo declares no formatter', async () => {
+    await rm(join(root, 'biome.json'));
+    await expect(
+      assertFormattedContent({
+        repoReal: root,
+        absFile: join(root, 'x.ts'),
+        content: 'const  x =1',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('skips non-biome extensions even when biome.json is present', async () => {
+    await expect(
+      assertFormattedContent({
+        repoReal: root,
+        absFile: join(root, 'notes.md'),
+        content: '# title\n\n  messy   spaces',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('skips node_modules paths', async () => {
+    const abs = join(root, 'node_modules', 'pkg', 'index.ts');
+    await expect(
+      assertFormattedContent({
+        repoReal: root,
+        absFile: abs,
+        content: 'const  x =1',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('assertFormattedContent (cargo check-and-reject)', () => {
+  let root: string;
+  let cargoAvailable = false;
+
+  beforeAll(() => {
+    try {
+      execFileSync('cargo', ['--version'], { stdio: 'pipe' });
+      cargoAvailable = true;
+    } catch {
+      cargoAvailable = false;
+    }
+  });
+
+  afterEach(async () => {
+    if (root) await rm(root, { recursive: true, force: true });
+  });
+
+  it('rejects unformatted Rust when Cargo.toml is present', async () => {
+    if (!cargoAvailable) return;
+
+    root = await mkdtemp(join(tmpdir(), 'revdev-cargo-fmt-'));
+    execFileSync('cargo', ['init', '-q', '--name', 'fmtcheck'], { cwd: root });
+    const abs = join(root, 'src', 'main.rs');
+    await expect(
+      assertFormattedContent({
+        repoReal: root,
+        absFile: abs,
+        content: 'fn main(){println!("hi");}\n',
+      }),
+    ).rejects.toMatchObject({
+      name: 'FormatRejectedError',
+      code: FORMAT_REJECTED_CODE,
+      data: { formatter: 'cargo' },
+    });
+  });
+
+  it('accepts rustfmt-clean content', async () => {
+    if (!cargoAvailable) return;
+
+    root = await mkdtemp(join(tmpdir(), 'revdev-cargo-fmt-ok-'));
+    execFileSync('cargo', ['init', '-q', '--name', 'fmtok'], { cwd: root });
+    const abs = join(root, 'src', 'main.rs');
+    // Write then cargo fmt to get canonical form, then assert that form passes.
+    await writeFile(abs, 'fn main() {\n    println!("hi");\n}\n');
+    execFileSync('cargo', ['fmt', '--', 'src/main.rs'], { cwd: root });
+    const clean = await readFile(abs, 'utf8');
+    await expect(
+      assertFormattedContent({
+        repoReal: root,
+        absFile: abs,
+        content: clean,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not enforce cargo fmt on non-.rs files', async () => {
+    root = await mkdtemp(join(tmpdir(), 'revdev-cargo-skip-'));
+    await writeFile(
+      join(root, 'Cargo.toml'),
+      '[package]\nname = "t"\nversion = "0.1.0"\nedition = "2021"\n',
+    );
+    await expect(
+      assertFormattedContent({
+        repoReal: root,
+        absFile: join(root, 'README.md'),
+        content: 'messy',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/daemon/src/filegit.ts
+++ b/packages/daemon/src/filegit.ts
@@ -32,6 +32,7 @@ import type { PGlite } from '@electric-sql/pglite';
 import { createLogger } from '@revealui/utils/logger';
 import { findNeverBoundOverlap, neverBoundSet, resolveOperatorHome } from './confinement.js';
 import { onAgentEnded, onDaemonStarted } from './eviction.js';
+import { assertFormattedContent } from './format-enforce.js';
 import { getDaemonConfig, registerHandler } from './server.js';
 import { denyToolAction, evaluateToolAction } from './tool-guard/index.js';
 import { runGit, type ShellResult } from './vcs.js';
@@ -821,6 +822,10 @@ registerHandler('file.write', async (params, db, ctx) => {
   if (!verdict.allowed) {
     throw await denyToolAction(db, 'file.write', ctx.agentId, verdict, { path: target });
   }
+  // GAP-309: check-and-reject format enforcement. Driven by the repo's own
+  // biome.json / Cargo.toml (no hardcoded path allow-list). Refuses unformatted
+  // content rather than rewriting it so the caller always knows what landed.
+  await assertFormattedContent({ repoReal, absFile: target, content });
   // Open with O_NOFOLLOW so a symlink swapped in at the FINAL component between
   // resolveInRoot's parent-realpath check and the write (leaf TOCTOU) is
   // refused (ELOOP) — a write can't be redirected outside the registered root.

--- a/packages/daemon/src/format-enforce.ts
+++ b/packages/daemon/src/format-enforce.ts
@@ -1,0 +1,292 @@
+/**
+ * Format enforcement for the daemon file surface (GAP-309).
+ *
+ * Posture: **check-and-reject** (not rewrite).
+ *
+ * A signed `file.write` that targets a registered root which declares a
+ * formatter (biome.json / Cargo.toml) is rejected with JSON-RPC -32007 when the
+ * bytes differ from what the formatter would produce. The caller's content is
+ * never silently rewritten — the client must re-send the formatted form.
+ *
+ * Why reject rather than rewrite: a daemon RPC that mutates bytes behind the
+ * caller's back makes the agent believe it wrote what it sent. The Claude
+ * post-edit hook rewrites for latency; that is a harness convenience. The
+ * durable chokepoint (this module) refuses unformatted content so every
+ * harness and human client sees the same hard failure.
+ *
+ * CI remains the merge guarantee; this is harness-independent edit-time
+ * enforcement on the daemon path only.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { unlink, writeFile } from 'node:fs/promises';
+import { basename, dirname, extname, join, relative, sep } from 'node:path';
+import { createLogger } from '@revealui/utils/logger';
+import {
+  type DeclaredFormatter,
+  detectDeclaredFormatter,
+  isFormatExemptPath,
+  repoRelativePath,
+  resolveLocalBin,
+  type ToolingRoot,
+} from './repo-tooling.js';
+import { runChild } from './vcs.js';
+
+const log = createLogger({ service: 'revdev-daemon/format-enforce' });
+
+/** JSON-RPC error code for format-policy rejection (GAP-309). */
+export const FORMAT_REJECTED_CODE = -32007;
+
+/** Wall-clock budget for a single formatter spawn (ms). */
+const FORMAT_TIMEOUT_MS = 15_000;
+
+export class FormatRejectedError extends Error {
+  readonly code = FORMAT_REJECTED_CODE;
+  readonly data: {
+    kind: 'format-rejected';
+    formatter: DeclaredFormatter;
+    fixCommand: string;
+    filePath: string;
+  };
+
+  constructor(opts: {
+    message: string;
+    formatter: DeclaredFormatter;
+    fixCommand: string;
+    filePath: string;
+  }) {
+    super(opts.message);
+    this.name = 'FormatRejectedError';
+    this.data = {
+      kind: 'format-rejected',
+      formatter: opts.formatter,
+      fixCommand: opts.fixCommand,
+      filePath: opts.filePath,
+    };
+  }
+}
+
+/** Extensions Biome commonly formats when a biome.json is present. */
+const BIOME_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.cts',
+  '.mts',
+  '.json',
+  '.jsonc',
+  '.css',
+  '.graphql',
+  '.gql',
+]);
+
+function normAbs(p: string): string {
+  return p.split('\\').join('/');
+}
+
+function isBiomeCandidate(filePath: string): boolean {
+  return BIOME_EXTENSIONS.has(extname(filePath).toLowerCase());
+}
+
+function isCargoCandidate(filePath: string): boolean {
+  return extname(filePath).toLowerCase() === '.rs';
+}
+
+/**
+ * Assert content is formatted according to the repo's declared tooling.
+ * No-op when the repo declares no formatter, the path is exempt, or the
+ * extension is outside the formatter's domain.
+ *
+ * Throws FormatRejectedError on drift or missing required tooling.
+ */
+export async function assertFormattedContent(opts: {
+  repoReal: string;
+  absFile: string;
+  content: string;
+}): Promise<void> {
+  const { repoReal, absFile, content } = opts;
+  const absNorm = normAbs(absFile);
+
+  if (isFormatExemptPath(absNorm)) {
+    return;
+  }
+
+  const tooling = await detectDeclaredFormatter(repoReal, absFile);
+  if (!tooling) {
+    return;
+  }
+
+  if (tooling.formatter === 'biome') {
+    if (!isBiomeCandidate(absFile)) return;
+    await assertBiomeFormatted(tooling, repoReal, absFile, content);
+    return;
+  }
+
+  if (tooling.formatter === 'cargo') {
+    if (!isCargoCandidate(absFile)) return;
+    await assertCargoFormatted(tooling, repoReal, absFile, content);
+  }
+}
+
+async function assertBiomeFormatted(
+  tooling: ToolingRoot,
+  repoReal: string,
+  absFile: string,
+  content: string,
+): Promise<void> {
+  const relForStdin = relative(tooling.root, absFile).split(sep).join('/') || basename(absFile);
+  const fixRel = repoRelativePath(repoReal, absFile);
+  const fixCommand = `biome check --write ${fixRel}`;
+
+  const bin = (await resolveLocalBin(tooling.root, repoReal, 'biome')) ?? 'biome';
+
+  const result = await runChild(bin, ['format', '--stdin-file-path', relForStdin], {
+    cwd: tooling.root,
+    timeoutMs: FORMAT_TIMEOUT_MS,
+    stdin: content,
+    trimOutput: false,
+  });
+
+  if (result.aborted) {
+    throw new FormatRejectedError({
+      message: `file.write rejected: biome format check aborted (${result.abortReason ?? 'unknown'}) for ${fixRel}`,
+      formatter: 'biome',
+      fixCommand,
+      filePath: fixRel,
+    });
+  }
+
+  // Biome exits non-zero when the language has no formatter (e.g. .txt) or
+  // when the binary is missing. If stderr says the formatter is disabled /
+  // unsupported, treat as out-of-scope (pass). Any other failure is hard.
+  const stderr = result.stderr;
+  if (!result.ok) {
+    if (
+      stderr.includes('formatter is currently disabled') ||
+      stderr.includes('is not supported') ||
+      stderr.includes('unrecognized file extension')
+    ) {
+      return;
+    }
+    if (
+      stderr.includes('ENOENT') ||
+      stderr.includes('not found') ||
+      (result.code === -1 && stderr.length > 0)
+    ) {
+      throw new FormatRejectedError({
+        message: `file.write rejected: biome is declared (${tooling.configPath}) but the biome binary is unavailable for ${fixRel}. Install biome in the project or on PATH, then run: ${fixCommand}`,
+        formatter: 'biome',
+        fixCommand,
+        filePath: fixRel,
+      });
+    }
+    throw new FormatRejectedError({
+      message: `file.write rejected: biome format check failed for ${fixRel}: ${stderr || `exit ${result.code}`}. Fix with: ${fixCommand}`,
+      formatter: 'biome',
+      fixCommand,
+      filePath: fixRel,
+    });
+  }
+
+  // Stdin format prints the formatted file on stdout (exit 0). Compare bytes
+  // after normalizing only CRLF → LF so Windows clients are not punished.
+  const formatted = result.stdout.replace(/\r\n/g, '\n');
+  const input = content.replace(/\r\n/g, '\n');
+  if (formatted !== input) {
+    log.info('format-enforce rejected unformatted write', {
+      formatter: 'biome',
+      file: fixRel,
+    });
+    throw new FormatRejectedError({
+      message: `file.write rejected: content is not formatted by biome for ${fixRel}. Fix with: ${fixCommand}`,
+      formatter: 'biome',
+      fixCommand,
+      filePath: fixRel,
+    });
+  }
+}
+
+async function assertCargoFormatted(
+  tooling: ToolingRoot,
+  repoReal: string,
+  absFile: string,
+  content: string,
+): Promise<void> {
+  const fixRel = repoRelativePath(repoReal, absFile);
+  const fixCommand = `cargo fmt -- ${fixRel}`;
+
+  // cargo fmt --check needs a file on disk inside the package. Use a unique
+  // sibling temp so we never overwrite the real target before the write path.
+  const parent = dirname(absFile);
+  const token = randomBytes(6).toString('hex');
+  const tmpAbs = join(parent, `.revdev-fmt-check-${token}.rs`);
+  const tmpRelFromCargo = relative(tooling.root, tmpAbs).split(sep).join('/');
+
+  try {
+    await writeFile(tmpAbs, content, 'utf8');
+  } catch (err) {
+    throw new FormatRejectedError({
+      message: `file.write rejected: could not stage cargo fmt check for ${fixRel}: ${err instanceof Error ? err.message : String(err)}`,
+      formatter: 'cargo',
+      fixCommand,
+      filePath: fixRel,
+    });
+  }
+
+  try {
+    const result = await runChild('cargo', ['fmt', '--', '--check', tmpRelFromCargo], {
+      cwd: tooling.root,
+      timeoutMs: FORMAT_TIMEOUT_MS,
+      trimOutput: false,
+    });
+
+    if (result.aborted) {
+      throw new FormatRejectedError({
+        message: `file.write rejected: cargo fmt check aborted (${result.abortReason ?? 'unknown'}) for ${fixRel}`,
+        formatter: 'cargo',
+        fixCommand,
+        filePath: fixRel,
+      });
+    }
+
+    if (!result.ok) {
+      // Exit 1 with "Diff in" means unformatted; missing cargo is different.
+      const combined = `${result.stdout}\n${result.stderr}`;
+      if (
+        combined.includes('not found') ||
+        combined.includes('ENOENT') ||
+        (result.code === -1 && result.stderr.length > 0 && !combined.includes('Diff in'))
+      ) {
+        throw new FormatRejectedError({
+          message: `file.write rejected: Cargo.toml declares rustfmt but cargo is unavailable for ${fixRel}. Install rustup/cargo, then run: ${fixCommand}`,
+          formatter: 'cargo',
+          fixCommand,
+          filePath: fixRel,
+        });
+      }
+      log.info('format-enforce rejected unformatted write', {
+        formatter: 'cargo',
+        file: fixRel,
+      });
+      throw new FormatRejectedError({
+        message: `file.write rejected: content is not formatted by cargo fmt for ${fixRel}. Fix with: ${fixCommand}`,
+        formatter: 'cargo',
+        fixCommand,
+        filePath: fixRel,
+      });
+    }
+  } finally {
+    await unlink(tmpAbs).catch(() => {});
+  }
+}
+
+/** @internal — test seam for pure path exemption. */
+export function _isFormatExemptPathForTest(absPathNorm: string): boolean {
+  return isFormatExemptPath(absPathNorm);
+}
+
+/** @internal — re-export detector for unit tests without circular imports. */
+export type { ToolingRoot };

--- a/packages/daemon/src/repo-tooling.ts
+++ b/packages/daemon/src/repo-tooling.ts
@@ -1,0 +1,148 @@
+/**
+ * Repo-declared tooling detection (GAP-309).
+ *
+ * Walks up from a target path (never outside the registered project root) to
+ * find the nearest directory that declares a formatter:
+ *   - biome.json / biome.jsonc → Biome
+ *   - Cargo.toml → cargo fmt / rustfmt
+ *
+ * No hardcoded repo path allow-list. Repos with neither marker are a no-op for
+ * format enforcement. Shared so temp-artifact lifecycle (GAP-295) and other
+ * "repo declares its own tooling" callers can reuse the same detection.
+ */
+
+import { access, constants as fsConstants } from 'node:fs/promises';
+import { dirname, join, relative, sep } from 'node:path';
+
+export type DeclaredFormatter = 'biome' | 'cargo';
+
+export interface ToolingRoot {
+  /** Absolute directory holding the config file. */
+  root: string;
+  formatter: DeclaredFormatter;
+  /** Absolute path of the config that declared the formatter. */
+  configPath: string;
+}
+
+/** Max walk-up depth inside a registered root (guards pathological trees). */
+const MAX_WALK_DEPTH = 40;
+
+function withinRoot(root: string, target: string): boolean {
+  return target === root || target.startsWith(root + sep);
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect the formatter declared for `absFile` inside `repoReal`.
+ * Prefers the nearest config walking from the file's directory up to
+ * (and including) the registered root. When both biome and cargo configs
+ * exist at the same directory, both are considered by the caller via
+ * extension matching — this returns biome first (JS/TS monorepos that also
+ * have incidental Cargo.toml are rare; dual-config at one level is rarer).
+ */
+export async function detectDeclaredFormatter(
+  repoReal: string,
+  absFile: string,
+): Promise<ToolingRoot | null> {
+  let dir = dirname(absFile);
+  if (!withinRoot(repoReal, dir) && dir !== repoReal) {
+    dir = repoReal;
+  }
+
+  for (let depth = 0; depth < MAX_WALK_DEPTH; depth += 1) {
+    if (!withinRoot(repoReal, dir) && dir !== repoReal) {
+      return null;
+    }
+
+    const biomeJson = join(dir, 'biome.json');
+    const biomeJsonc = join(dir, 'biome.jsonc');
+    if (await pathExists(biomeJson)) {
+      return { root: dir, formatter: 'biome', configPath: biomeJson };
+    }
+    if (await pathExists(biomeJsonc)) {
+      return { root: dir, formatter: 'biome', configPath: biomeJsonc };
+    }
+
+    const cargoToml = join(dir, 'Cargo.toml');
+    if (await pathExists(cargoToml)) {
+      return { root: dir, formatter: 'cargo', configPath: cargoToml };
+    }
+
+    if (dir === repoReal) {
+      return null;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Resolve an executable under node_modules/.bin walking from `start` up to
+ * `repoReal` (inclusive). Used to find the repo's own biome without depending
+ * on a global install or a hardcoded monorepo path.
+ */
+export async function resolveLocalBin(
+  start: string,
+  repoReal: string,
+  binName: string,
+): Promise<string | null> {
+  let dir = start;
+  for (let depth = 0; depth < MAX_WALK_DEPTH; depth += 1) {
+    if (!withinRoot(repoReal, dir) && dir !== repoReal) {
+      break;
+    }
+    const candidate = join(dir, 'node_modules', '.bin', binName);
+    if (await pathExists(candidate)) {
+      return candidate;
+    }
+    if (dir === repoReal) {
+      break;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return null;
+}
+
+/** Repo-relative path for diagnostics / fix commands (forward slashes). */
+export function repoRelativePath(repoReal: string, absFile: string): string {
+  const rel = relative(repoReal, absFile);
+  return rel.split(sep).join('/');
+}
+
+/**
+ * Paths that must never run through format enforcement (generated / vendor).
+ * Checked against a forward-slash normalized absolute path.
+ */
+export function isFormatExemptPath(absPathNorm: string): boolean {
+  const segments = absPathNorm.split('/');
+  const exempt = new Set([
+    'node_modules',
+    'dist',
+    '.turbo',
+    'opensrc',
+    'target',
+    '.git',
+    'coverage',
+    '.next',
+  ]);
+  for (const seg of segments) {
+    if (exempt.has(seg)) return true;
+  }
+  return false;
+}

--- a/packages/daemon/src/vcs.ts
+++ b/packages/daemon/src/vcs.ts
@@ -59,6 +59,17 @@ export interface RunChildOptions {
    * env (see `gitHardenedEnv`); only the generic test seam leaves it unset.
    */
   env?: NodeJS.ProcessEnv;
+  /**
+   * Optional stdin payload. When set, the child's stdin is a pipe and this
+   * string is written then closed (used by format-enforce biome --stdin).
+   */
+  stdin?: string;
+  /**
+   * When true (default), trim stdout/stderr. Set false for byte-sensitive
+   * consumers such as format comparison (GAP-309) where trailing newlines
+   * are load-bearing.
+   */
+  trimOutput?: boolean;
 }
 
 /**
@@ -99,9 +110,13 @@ export function runChild(
     if (signal.aborted) onAbort();
     else signal.addEventListener('abort', onAbort, { once: true });
 
+    const useStdin = opts.stdin !== undefined;
+    const trimOutput = opts.trimOutput !== false;
+    const finish = (s: string): string => (trimOutput ? s.trim() : s);
+
     const child = spawn(command, args, {
       cwd: opts.cwd,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: [useStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
       signal,
       // Only override the environment when a caller supplies one (runGit does;
       // the generic runChild test seam does not). Passing `undefined` here would
@@ -109,12 +124,29 @@ export function runChild(
       ...(opts.env ? { env: opts.env } : {}),
     });
 
+    if (useStdin && child.stdin) {
+      child.stdin.write(opts.stdin);
+      child.stdin.end();
+    }
+
     let stdout = '';
     let stderr = '';
-    child.stdout.on('data', (d) => {
+    // stdio[1]/stdio[2] are always 'pipe' above; narrow for TS when stdin is dynamic.
+    const childStdout = child.stdout;
+    const childStderr = child.stderr;
+    if (!childStdout || !childStderr) {
+      resolve({
+        ok: false,
+        stdout: '',
+        stderr: 'spawn did not open stdout/stderr pipes',
+        code: -1,
+      });
+      return;
+    }
+    childStdout.on('data', (d) => {
       stdout += d.toString();
     });
-    child.stderr.on('data', (d) => {
+    childStderr.on('data', (d) => {
       stderr += d.toString();
     });
 
@@ -126,8 +158,8 @@ export function runChild(
           : `${command} aborted by daemon shutdown`;
       return {
         ok: false,
-        stdout: stdout.trim(),
-        stderr: stderr.trim() || message,
+        stdout: finish(stdout),
+        stderr: finish(stderr) || message,
         code,
         aborted: true,
         abortReason: reason,
@@ -141,8 +173,8 @@ export function runChild(
       }
       resolve({
         ok: code === 0,
-        stdout: stdout.trim(),
-        stderr: stderr.trim(),
+        stdout: finish(stdout),
+        stderr: finish(stderr),
         code: code ?? -1,
       });
     });


### PR DESCRIPTION
## Summary

- Daemon `file.write` now **check-and-rejects** unformatted content when the registered root declares a formatter (`biome.json` / `biome.jsonc` or `Cargo.toml`).
- Posture is **reject, not rewrite** (JSON-RPC `-32007` + `data.fixCommand`) so callers never believe they wrote different bytes than they sent.
- Detection walks up inside the registered root only — no hardcoded `/suite/` or repo path allow-list.
- Claude `post-edit.js` remains optional fast-feedback rewrite; the durable chokepoint is the daemon.

Closes fleet gap GAP-309 (RevealUI-native formatting enforcement).

## Decision

See `docs/decisions/2026-08-05-file-write-format-check-and-reject.md`.

## Test plan

- [x] Unit: `format-enforce.test.ts` (biome reject/pass/skip, cargo reject/pass/skip, detector)
- [x] E2E: `filegit-format.test.ts` signed `file.write` over socket rejects unformatted TS with `-32007` and does not write the file
- [x] Regression: `filegit-signed`, `filegit`, `filegit-neverbound`, `vcs` tests
- [ ] CI green on this PR

## Owner

Merge when green (non-security tooling surface). No gate labels required for format enforcement itself.