### PR TITLE
docs(daemon): GAP-154 Phase 5 gateway is shipped (not planned)

### DIFF
--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -7,8 +7,14 @@ Manages AI agent sessions, PTY processes, tool routing, inter-agent messaging, t
 ## Transport
 
 - **Local**: Unix socket (`~/.local/share/revealui/harness.sock`)
-- **Remote**: HTTP gateway with pairing-code auth (planned, GAP-154 Phase 5)
-- **Protocol**: JSON-RPC 2.0 over newline-delimited JSON
+- **Remote**: HTTP gateway with pairing-code auth (**shipped**, GAP-421 port of the
+  harness gateway; GAP-154 Phase 5 transport). Off by default (`httpPort: 0`).
+  When enabled: `GET/POST /api/pair` (HMAC challenge, secret never on the wire),
+  `POST /rpc` (same `dispatchRpc` path as the Unix socket — one authorization
+  plane), `GET /api/status`, `GET /api/stream/:processId` (ticket-bound SSE).
+  Default bind is `127.0.0.1`; do not expose to untrusted networks without a
+  reverse proxy and operator review.
+- **Protocol**: JSON-RPC 2.0 over newline-delimited JSON (socket) or HTTP JSON body (`/rpc`)
 
 ## Running the daemon
 
@@ -118,7 +124,9 @@ echo '{"jsonrpc":"2.0","id":1,"method":"ping"}' | \
 
 - `src/server.ts` — JSON-RPC dispatch, license guard, RPC handler registry, periodic stale-session prune (GAP-153).
 - `src/storage/schema.ts` — PGlite schema (11 tables: agent_sessions, agent_messages, file_reservations, tasks, events, worktrees, agent_memory, merge_requests, agent_identity, agent_identity_keys, agent_identity_nonces).
-- `src/neon.ts` — daemon → Neon dual-write helpers (GAP-154 Phases 2 + 3). Best-effort, no-op when `POSTGRES_URL` unset.
+- `src/neon.ts` — daemon → Neon dual-write helpers (GAP-154 Phases 2 + 3). Best-effort, no-op when `POSTGRES_URL` unset. Sessions, mail, files, tasks, events dual-write; `memory.*` / `merge.*` stay local-only until Neon schema grows (documented in-module).
+- `src/http-gateway.ts` — TCP HTTP gateway + pairing + SSE (GAP-421 / GAP-154 Phase 5 transport). Off unless `httpPort > 0`.
+- `src/gateway-store.ts` — durable gateway tokens + bootstrap secret hash.
 - `src/guard.ts` — license tier check at RPC dispatch time.
 - `systemd/revdev-daemon.service` — systemd-user unit template.
 - `systemd/install.sh` — installer that resolves the unit's exec path and enables it.


### PR DESCRIPTION
## Summary
Code-over-docs for **GAP-154 Phase 5 transport**.

`packages/daemon/src/http-gateway.ts` already implements pairing + `/rpc` + status + ticket SSE (GAP-421 port). The daemon README still said remote transport was **planned** — that was false and misrouted implementers.

## Changes
- Transport section: shipped, off by default (`httpPort: 0`), routes + bind caution
- Architecture pointers: `http-gateway.ts`, `gateway-store.ts`, neon memory/merge local-only note

## Residual (gap stays open)
Multi-host dogfood, optional discovery registry, Phase 6 offline replay. See companion jv progress PR.

## Test plan
- [x] README matches `http-gateway.ts` header contract
- [x] No code/runtime change