### PR TITLE
feat(daemon): license tier on harness.health (goal spine / Pro+)

### DIFF
--- a/packages/daemon/src/__tests__/goal-rpc-tier.test.ts
+++ b/packages/daemon/src/__tests__/goal-rpc-tier.test.ts
@@ -1,0 +1,36 @@
+/**
+ * goal.* RPCs are Pro-floor (default requiredTier). Enterprise ranks above Pro,
+ * so founder enterprise JWTs unlock the goal spine without a separate allowlist.
+ */
+import { describe, expect, it } from 'vitest';
+import { LICENSE_TIER_HELP, requiredTier, tierRank } from '../license.js';
+
+const GOAL_METHODS = [
+  'goal.create',
+  'goal.get',
+  'goal.list',
+  'goal.setStatus',
+  'goal.progress',
+  'goal.nextActions',
+  'goal.proposeTask',
+] as const;
+
+describe('goal.* license floor', () => {
+  it('defaults every goal.* method to pro', () => {
+    for (const m of GOAL_METHODS) {
+      expect(requiredTier(m)).toBe('pro');
+    }
+  });
+
+  it('enterprise and max satisfy the pro floor', () => {
+    const need = tierRank('pro');
+    expect(tierRank('enterprise')).toBeGreaterThanOrEqual(need);
+    expect(tierRank('max')).toBeGreaterThanOrEqual(need);
+    expect(tierRank('pro')).toBeGreaterThanOrEqual(need);
+    expect(tierRank('free')).toBeLessThan(need);
+  });
+
+  it('LICENSE_TIER_HELP documents goal.* under pro', () => {
+    expect(LICENSE_TIER_HELP).toMatch(/goal\.\*/);
+  });
+});

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -159,9 +159,9 @@ export const METHOD_MIN_TIER = new Map<string, LicenseTier>([
  */
 export const LICENSE_TIER_HELP = `License tiers (method gate; source: EXEMPT_METHODS + METHOD_MIN_TIER):
   free         Sessions, single-repo file/git, local inference run, harness.health
-  pro          Multi-agent coordination (mail, tasks, files.*, agent.*, merge.*, worktree, events, harness.prune, …)
+  pro          Multi-agent coordination (mail, tasks, files.*, goal.*, agent.*, merge.*, worktree, events, harness.prune, …)
   max          + full AI memory (memory.*) and local-model management (inference.pull/delete/start/stop)
-  enterprise   Same method surface as max today; commercial terms differ`;
+  enterprise   Same method surface as max; commercial terms differ (founder daily-driver JWT for goal spine)`;
 
 /**
  * Ordinal rank of a tier within LICENSE_TIERS (free=0 < pro=1 < max=2 <

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -39,6 +39,12 @@ import {
   licenseErrorResponse,
   runtimeLicenseRecheck,
 } from './guard.js';
+import {
+  evaluateLicense,
+  LicenseConfigError,
+  tierRank,
+  type LicenseTier,
+} from './license.js';
 import { HttpGateway } from './http-gateway.js';
 import { loopGuards } from './loop-guard.js';
 import {
@@ -2312,6 +2318,56 @@ registerHandler('context.snapshot', async (params, db, ctx) => {
 
 // -- Health -----------------------------------------------------------------
 
+
+function licenseHealthSummary(): {
+  tier: LicenseTier;
+  valid: boolean;
+  present: boolean;
+  source: 'env' | 'file' | 'none';
+  status: string;
+  expiresAt: number | null;
+  secondsRemaining: number | null;
+  goalRpcMinTier: 'pro';
+  goalRpcReady: boolean;
+  reason?: string;
+} {
+  // Never include key material — agents/Studio diagnose FREE vs Pro+ only.
+  try {
+    const ev = evaluateLicense();
+    return {
+      tier: ev.tier,
+      valid: ev.valid,
+      present: ev.present,
+      source: ev.source,
+      status: ev.status,
+      expiresAt: ev.expiresAt,
+      secondsRemaining: ev.secondsRemaining,
+      goalRpcMinTier: 'pro',
+      goalRpcReady: ev.valid && tierRank(ev.tier) >= tierRank('pro'),
+      ...(ev.reason ? { reason: ev.reason } : {}),
+    };
+  } catch (err) {
+    const reason =
+      err instanceof LicenseConfigError
+        ? err.message
+        : err instanceof Error
+          ? err.message
+          : 'license evaluation failed';
+    return {
+      tier: 'free',
+      valid: false,
+      present: true,
+      source: 'none',
+      status: 'invalid',
+      expiresAt: null,
+      secondsRemaining: null,
+      goalRpcMinTier: 'pro',
+      goalRpcReady: false,
+      reason,
+    };
+  }
+}
+
 registerHandler('harness.health', async (_params, db) => {
   const sessions = await db.query<{ count: string }>(
     `SELECT COUNT(*)::text as count FROM agent_sessions WHERE ended_at IS NULL`,
@@ -2366,6 +2422,9 @@ registerHandler('harness.health', async (_params, db) => {
     // from the trust anchor. Should be empty on a correctly provisioned
     // install; non-empty is a loud warning, not a daemon failure.
     anchorInconsistencies,
+    // License summary (no secrets): goal.* and other Pro-floor RPCs need
+    // valid Pro+ (enterprise daily-driver JWT satisfies this).
+    license: licenseHealthSummary(),
   };
 });
 

--- a/packages/daemon/systemd/license-file.conf.example
+++ b/packages/daemon/systemd/license-file.conf.example
@@ -11,6 +11,12 @@
 #     1. REVEALUI_LICENSE_KEY        (inline — must be UNSET to use the file)
 #     2. REVEALUI_LICENSE_KEY_FILE   (this pattern)
 #
+# Studio daily-driver / goal spine: mint an enterprise (or pro+)
+# Ed25519 JWT into revvault path revealui/dev/founder-license-key
+# via revdev/scripts/issue-license.ts --tier enterprise --customer founder
+# --perpetual, then systemctl --user restart revdev-daemon.
+# Legacy RVUI-* keys are rejected (daemon runs FREE silently).
+#
 # Install:
 #     mkdir -p ~/.config/systemd/user/revdev-daemon.service.d
 #     cp packages/daemon/systemd/license-file.conf.example \


### PR DESCRIPTION
## Summary

Enterprise / Pro+ **daily-driver daemon** residual for the goal spine:

1. **`harness.health.license`** — non-secret summary: `tier`, `valid`, `present`, `source` (env|file|none), `status`, `goalRpcReady`, optional `reason`. Never emits JWT material.
2. **`goal.*` is Pro-floor** — documented in `LICENSE_TIER_HELP`; enterprise ranks above Pro so founder enterprise JWTs unlock spine without a separate allowlist.
3. **systemd `license-file.conf.example`** — notes vault path `revealui/dev/founder-license-key` + `issue-license.ts --tier enterprise` for Studio daily-driver (legacy RVUI-* = silent FREE).

Pairs with jv PR (goal-client `license` CLI + tracker soft-project diagnosis).

## Why

Soft-project / `goal.*` fail on FREE with opaque -32001. Agents need a free-tier health read to report “tier=free, goalRpcReady=false” and the vault path, not owner shell recipes.

## Test plan

- [x] `vitest run src/__tests__/goal-rpc-tier.test.ts` (from packages/daemon)
- [ ] After merge + daemon restart: `harness.health` includes `license.goalRpcReady: true` with enterprise JWT via KEY_FILE
- [ ] FREE daemon: `goalRpcReady: false`