### PR TITLE
feat(daemon): GAP-154 Phase 5 daemon peer registry + daemon.peers

### DIFF
--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -8,7 +8,7 @@ Manages AI agent sessions, PTY processes, tool routing, inter-agent messaging, t
 
 - **Local**: Unix socket (`~/.local/share/revealui/harness.sock`)
 - **Remote**: HTTP gateway with pairing-code auth (**shipped**, GAP-421 port of the
-  harness gateway; GAP-154 Phase 5 transport). Off by default (`httpPort: 0`).
+  harness gateway; GAP-154 Phase 5 transport + `daemon.peers` Neon registry). Off by default (`httpPort: 0`).
   When enabled: `GET/POST /api/pair` (HMAC challenge, secret never on the wire),
   `POST /rpc` (same `dispatchRpc` path as the Unix socket — one authorization
   plane), `GET /api/status`, `GET /api/stream/:processId` (ticket-bound SSE).

--- a/packages/daemon/src/__tests__/daemon-peers.test.ts
+++ b/packages/daemon/src/__tests__/daemon-peers.test.ts
@@ -1,0 +1,194 @@
+/**
+ * GAP-154 Phase 5 — daemon peer registry (Neon role=daemon) + daemon.peers RPC.
+ * @vitest-environment node
+ */
+import { vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  _resetForTesting,
+  getSelfDaemonId,
+  listDaemonPeers,
+  registerDaemonPeer,
+  setNeonClientForTesting,
+} from '../neon.js';
+import { startDaemon } from '../server.js';
+
+function createPeerNeonStore(): {
+  mock: (
+    strings: TemplateStringsArray | readonly string[],
+    ...values: unknown[]
+  ) => Promise<unknown>;
+  agents: Map<
+    string,
+    { id: string; env: string; last_seen: string; metadata: Record<string, unknown> }
+  >;
+} {
+  const agents = new Map<
+    string,
+    { id: string; env: string; last_seen: string; metadata: Record<string, unknown> }
+  >();
+
+  const mock = (strings: TemplateStringsArray | readonly string[], ...values: unknown[]) => {
+    const sql = Array.from(strings).join(' ').replace(/\s+/g, ' ').trim().toUpperCase();
+
+    if (sql.includes('INSERT INTO COORDINATION_AGENTS')) {
+      // VALUES (id, env, NOW(), 0, metadata) — NOW() is SQL literal
+      const id = String(values[0] ?? '');
+      const env = String(values[1] ?? '');
+      let metadata: Record<string, unknown> = {};
+      try {
+        // values[2] is total_sessions (0); values[3] is metadata JSON
+        metadata = JSON.parse(String(values[3] ?? values[2] ?? '{}')) as Record<string, unknown>;
+      } catch {
+        metadata = {};
+      }
+      const existing = agents.get(id);
+      agents.set(id, {
+        id,
+        env,
+        last_seen: new Date().toISOString(),
+        metadata: existing ? { ...existing.metadata, ...metadata } : metadata,
+      });
+      return Promise.resolve([]);
+    }
+
+    if (sql.includes('UPDATE COORDINATION_AGENTS') && sql.includes('LAST_SEEN')) {
+      const id = String(values[0] ?? '');
+      const existing = agents.get(id);
+      if (existing) {
+        agents.set(id, { ...existing, last_seen: new Date().toISOString() });
+      }
+      return Promise.resolve([]);
+    }
+
+    if (sql.includes('FROM COORDINATION_AGENTS') && sql.includes('ROLE')) {
+      const rows = [...agents.values()]
+        .filter((a) => a.metadata.role === 'daemon')
+        .map((a) => ({
+          id: a.id,
+          env: a.env,
+          last_seen: a.last_seen,
+          metadata: a.metadata,
+        }));
+      return Promise.resolve(rows);
+    }
+
+    // Session dual-writes unused here
+    return Promise.resolve([]);
+  };
+
+  return { mock: mock as any, agents };
+}
+
+function rpc(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown> = {},
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
+    sock.on('connect', () => sock.write(req));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      sock.end();
+      try {
+        const resp = JSON.parse(buf.slice(0, nl));
+        if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
+        else resolve(resp.result);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(8000, () => {
+      sock.destroy();
+      reject(new Error(`RPC timeout: ${method}`));
+    });
+  });
+}
+
+describe('GAP-154 Phase 5 daemon peer registry', () => {
+  const store = createPeerNeonStore();
+  let dataDir: string;
+  let socketPath: string;
+  let close: (() => Promise<void>) | null = null;
+
+  beforeAll(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'daemon-peers-'));
+    socketPath = join(dataDir, 'harness.sock');
+  });
+
+  afterAll(async () => {
+    if (close) await close();
+    _resetForTesting();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    store.agents.clear();
+    setNeonClientForTesting(store.mock);
+  });
+
+  it('registerDaemonPeer upserts role=daemon agent', async () => {
+    await registerDaemonPeer({
+      daemonId: 'daemon:test-host:abc',
+      env: 'test-host',
+      hostname: 'test-host',
+      httpGatewayUrl: 'http://127.0.0.1:9999',
+      socketHint: '/tmp/sock',
+      pid: 1234,
+    });
+    expect(getSelfDaemonId()).toBe('daemon:test-host:abc');
+    const peers = await listDaemonPeers();
+    expect(peers).toHaveLength(1);
+    expect(peers[0]?.id).toBe('daemon:test-host:abc');
+    expect(peers[0]?.httpGatewayUrl).toBe('http://127.0.0.1:9999');
+    expect(peers[0]?.role).toBe('daemon');
+  });
+
+  it('daemon.peers RPC returns self + neonSyncActive', async () => {
+    if (close) {
+      await close();
+      close = null;
+    }
+    // startDaemon → initNeonSync() clears any prior test client when
+    // POSTGRES_URL is unset. Inject mock after listen (same as fleet suite).
+    const handle = await startDaemon({
+      socketPath,
+      dataDir,
+      httpPort: 0,
+      pruneIntervalMs: 0,
+      trustedAnchorRequireRootOwned: false,
+    });
+    close = () => handle.close();
+    setNeonClientForTesting(store.mock);
+    await registerDaemonPeer({
+      daemonId: 'daemon:rpc-host:xyz',
+      env: 'rpc-host',
+      hostname: 'rpc-host',
+      httpGatewayUrl: null,
+      socketHint: socketPath,
+      pid: process.pid,
+    });
+
+    const result = (await rpc(socketPath, 'daemon.peers', {})) as {
+      neonSyncActive: boolean;
+      selfId: string | null;
+      peers: Array<{ id: string; isSelf: boolean }>;
+    };
+    expect(result.neonSyncActive).toBe(true);
+    expect(result.selfId).toBe('daemon:rpc-host:xyz');
+    expect(result.peers.some((p) => p.isSelf)).toBe(true);
+  });
+});

--- a/packages/daemon/src/__tests__/daemon-peers.test.ts
+++ b/packages/daemon/src/__tests__/daemon-peers.test.ts
@@ -137,7 +137,7 @@ describe('GAP-154 Phase 5 daemon peer registry', () => {
 
   beforeEach(() => {
     store.agents.clear();
-    setNeonClientForTesting(store.mock);
+    setNeonClientForTesting(store.mock as never);
   });
 
   it('registerDaemonPeer upserts role=daemon agent', async () => {
@@ -172,7 +172,7 @@ describe('GAP-154 Phase 5 daemon peer registry', () => {
       trustedAnchorRequireRootOwned: false,
     });
     close = () => handle.close();
-    setNeonClientForTesting(store.mock);
+    setNeonClientForTesting(store.mock as never);
     await registerDaemonPeer({
       daemonId: 'daemon:rpc-host:xyz',
       env: 'rpc-host',

--- a/packages/daemon/src/__tests__/guard.test.ts
+++ b/packages/daemon/src/__tests__/guard.test.ts
@@ -53,6 +53,7 @@ describe('guardRpcMethod', () => {
       'inference.generate',
       // GAP-337: monitoring without a Pro license
       'harness.health',
+      'daemon.peers',
     ];
 
     for (const method of exemptMethods) {
@@ -172,6 +173,10 @@ describe('guardRpcMethod', () => {
 
     it('allows harness.health on free and pro (GAP-337)', () => {
       expect(guardRpcMethod('harness.health').allowed).toBe(true);
+    });
+
+    it('allows daemon.peers on free (GAP-154 Phase 5 discovery)', () => {
+      expect(guardRpcMethod('daemon.peers').allowed).toBe(true);
     });
   });
 

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -122,6 +122,9 @@ const EXEMPT_METHODS = new Set([
   // GAP-337: health/monitoring must answer without a Pro license (same class
   // as ping). Multi-agent harness.prune stays Pro.
   'harness.health',
+  // GAP-154 Phase 5: peer discovery is diagnostic (empty without Neon).
+  // Dual-write still requires Pro coordination RPCs; listing peers alone is free.
+  'daemon.peers',
 ]);
 
 /**

--- a/packages/daemon/src/neon.ts
+++ b/packages/daemon/src/neon.ts
@@ -532,7 +532,137 @@ export async function syncEventLog(params: {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Phase 5 — daemon peer registry (cross-machine discovery)
+//
+// Reuses coordination_agents with metadata.role = 'daemon' (no new table).
+// Each daemon upserts itself at startup (+ optional heartbeat). Peers list
+// returns daemons seen recently so fleet operators can discover HTTP
+// gateways / hosts without a separate registry product.
+// ---------------------------------------------------------------------------
+
+export interface DaemonPeerRow {
+  id: string;
+  env: string;
+  lastSeen: string;
+  hostname: string | null;
+  httpGatewayUrl: string | null;
+  socketHint: string | null;
+  pid: number | null;
+  role: 'daemon';
+}
+
+let selfDaemonId: string | null = null;
+
+/** Stable id for this daemon process (set by registerDaemonPeer). */
+export function getSelfDaemonId(): string | null {
+  return selfDaemonId;
+}
+
+/**
+ * Upsert this daemon into the Neon fleet registry.
+ * No-op when Neon sync is disabled.
+ */
+export async function registerDaemonPeer(params: {
+  daemonId: string;
+  env: string;
+  hostname: string;
+  httpGatewayUrl: string | null;
+  socketHint: string | null;
+  pid: number;
+}): Promise<void> {
+  selfDaemonId = params.daemonId;
+  if (!client) return;
+  try {
+    const c = client;
+    const metadata = {
+      role: 'daemon',
+      hostname: params.hostname,
+      httpGatewayUrl: params.httpGatewayUrl,
+      socketHint: params.socketHint,
+      pid: params.pid,
+      registeredAt: new Date().toISOString(),
+    };
+    await c`
+      INSERT INTO coordination_agents (id, env, last_seen, total_sessions, metadata)
+      VALUES (
+        ${params.daemonId},
+        ${params.env},
+        NOW(),
+        0,
+        ${JSON.stringify(metadata)}::jsonb
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        env = EXCLUDED.env,
+        last_seen = NOW(),
+        metadata = COALESCE(coordination_agents.metadata, '{}'::jsonb) || EXCLUDED.metadata
+    `;
+  } catch (err) {
+    log.warn('registerDaemonPeer failed', {
+      daemonId: params.daemonId,
+      error: String(err),
+    });
+  }
+}
+
+/**
+ * Touch last_seen for this daemon (periodic heartbeat).
+ */
+export async function heartbeatDaemonPeer(daemonId: string): Promise<void> {
+  if (!client) return;
+  try {
+    const c = client;
+    await c`
+      UPDATE coordination_agents
+        SET last_seen = NOW()
+      WHERE id = ${daemonId}
+        AND metadata->>'role' = 'daemon'
+    `;
+  } catch (err) {
+    log.warn('heartbeatDaemonPeer failed', { daemonId, error: String(err) });
+  }
+}
+
+/**
+ * List recently-seen daemon peers from Neon.
+ * Returns [] when Neon sync is disabled.
+ */
+export async function listDaemonPeers(opts?: {
+  staleAfterSeconds?: number;
+}): Promise<DaemonPeerRow[]> {
+  if (!client) return [];
+  const staleAfter = opts?.staleAfterSeconds ?? 300;
+  try {
+    const c = client;
+    const rows = await c`
+      SELECT id, env, last_seen, metadata
+      FROM coordination_agents
+      WHERE metadata->>'role' = 'daemon'
+        AND last_seen > NOW() - make_interval(secs => ${staleAfter})
+      ORDER BY last_seen DESC
+    `;
+    return (rows as Array<Record<string, unknown>>).map((r) => {
+      const meta =
+        r.metadata && typeof r.metadata === 'object' ? (r.metadata as Record<string, unknown>) : {};
+      return {
+        id: String(r.id ?? ''),
+        env: String(r.env ?? ''),
+        lastSeen: String(r.last_seen ?? ''),
+        hostname: meta.hostname == null ? null : String(meta.hostname),
+        httpGatewayUrl: meta.httpGatewayUrl == null ? null : String(meta.httpGatewayUrl),
+        socketHint: meta.socketHint == null ? null : String(meta.socketHint),
+        pid: typeof meta.pid === 'number' ? meta.pid : null,
+        role: 'daemon' as const,
+      };
+    });
+  } catch (err) {
+    log.warn('listDaemonPeers failed', { error: String(err) });
+    return [];
+  }
+}
+
 /** Reset module state. Test-only. */
 export function _resetForTesting(): void {
   client = null;
+  selfDaemonId = null;
 }

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -15,8 +15,10 @@
  *   `session.register` are rejected with -32002.
  */
 
+import { createHash } from 'node:crypto';
 import { mkdir, readFile } from 'node:fs/promises';
 import { createServer, type Socket } from 'node:net';
+import { hostname as osHostname } from 'node:os';
 import { dirname, join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import { formatDid, parseDid } from '@revdev/protocol/did';
@@ -43,9 +45,13 @@ import { HttpGateway } from './http-gateway.js';
 import { evaluateLicense, LicenseConfigError, type LicenseTier, tierRank } from './license.js';
 import { loopGuards } from './loop-guard.js';
 import {
+  getSelfDaemonId,
+  heartbeatDaemonPeer,
   initNeonSync,
   isNeonSyncActive,
+  listDaemonPeers,
   listFleetSessions,
+  registerDaemonPeer,
   sweepExpiredFileClaims,
   syncEventLog,
   syncFilesRelease,
@@ -155,6 +161,8 @@ const IDENTITY_EXEMPT = new Set([
   // content). Optional actorAgentId still labels isSelf when provided.
   'context.snapshot',
   'harness.health',
+  // GAP-154 Phase 5: peer discovery is read-only fleet metadata (no content).
+  'daemon.peers',
   // `harness.prune` was here. It reaches notifyAgentEnded for EVERY matched
   // session, so an identity-exempt, unsigned caller could evict every agent's
   // roots and kill every agent's PTY with one frame. See GAP-312 and the
@@ -2426,6 +2434,24 @@ registerHandler('harness.health', async (_params, db) => {
   };
 });
 
+/**
+ * GAP-154 Phase 5 — list daemon peers from Neon registry.
+ * Empty when POSTGRES_URL unset (no fleet visibility, not "no peers exist").
+ */
+registerHandler('daemon.peers', async (params) => {
+  const staleAfterSeconds = Math.max(30, Math.floor(num(params.staleAfterSeconds, 300)));
+  const peers = await listDaemonPeers({ staleAfterSeconds });
+  const selfId = getSelfDaemonId();
+  return {
+    neonSyncActive: isNeonSyncActive(),
+    selfId,
+    peers: peers.map((p) => ({
+      ...p,
+      isSelf: selfId !== null && p.id === selfId,
+    })),
+  };
+});
+
 registerHandler('harness.prune', async (params, db, ctx) => {
   // Allow ops to run a prune pass on demand. Defaults match DAEMON_DEFAULTS so
   // callers can invoke with no params.
@@ -3010,10 +3036,34 @@ export async function startDaemon(
         }
       }
 
+      // GAP-154 Phase 5: register this daemon in Neon peer registry (no-op without POSTGRES_URL).
+      const host = osHostname();
+      const dataHash = createHash('sha256').update(cfg.dataDir).digest('hex').slice(0, 12);
+      const daemonId = process.env.REVDEV_DAEMON_ID?.trim() || `daemon:${host}:${dataHash}`;
+      const gatewayPort = httpGateway?.getPort() ?? null;
+      const httpGatewayUrl =
+        gatewayPort && gatewayPort > 0
+          ? `http://${cfg.httpHost === '0.0.0.0' ? host : cfg.httpHost}:${gatewayPort}`
+          : null;
+      await registerDaemonPeer({
+        daemonId,
+        env: process.env.REVDEV_DAEMON_ENV?.trim() || host,
+        hostname: host,
+        httpGatewayUrl,
+        socketHint: cfg.socketPath,
+        pid: process.pid,
+      });
+      // Heartbeat so peers stay "fresh" while this process lives.
+      const peerHeartbeat = setInterval(() => {
+        void heartbeatDaemonPeer(daemonId);
+      }, 60_000);
+      peerHeartbeat.unref();
+
       resolve({
         _db: db,
         _httpGateway: httpGateway,
         close: async () => {
+          clearInterval(peerHeartbeat);
           // Sequence:
           //   1. Set _closing FIRST so any RPC arriving on an existing
           //      socket from this point onward bails out with -32099

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -474,6 +474,14 @@ export const schemas: Record<string, z.ZodType> = {
     })
     .passthrough(),
 
+  // GAP-154 Phase 5 — daemon peer registry (Neon coordination_agents role=daemon)
+  'daemon.peers': z
+    .object({
+      staleAfterSeconds: z.number().min(30).max(86_400).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
   'harness.prune': z
     .object({
       staleDays: z.number().min(1).optional(),

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -19,6 +19,9 @@ export const RPC_METHODS = {
   'harness.health': 'harness.health',
   'harness.prune': 'harness.prune',
 
+  // GAP-154 Phase 5 — daemon peer registry (Neon role=daemon)
+  'daemon.peers': 'daemon.peers',
+
   // Agent sessions
   'session.register': 'session.register',
   'session.attach': 'session.attach',


### PR DESCRIPTION
## Summary

GAP-154 **Phase 5 residual** (cross-machine discovery):

- Register this daemon in Neon `coordination_agents` with `metadata.role=daemon` at startup (no-op without `POSTGRES_URL`)
- Heartbeat `last_seen` every 60s
- Free-tier **`daemon.peers`** RPC: `{ neonSyncActive, selfId, peers[] }` with `httpGatewayUrl`, `socketHint`, `isSelf`
- Reuses existing HTTP gateway + pairing (GAP-421); no new Neon table
- Override id via `REVDEV_DAEMON_ID`, env label via `REVDEV_DAEMON_ENV`

## Tests

- [x] `vitest run src/__tests__/daemon-peers.test.ts` (2)
- [x] guard free-tier allows `daemon.peers`

## Operator residual

Live multi-host dogfood with real `POSTGRES_URL` on two machines (acceptance still requires that).