### PR TITLE
feat(daemon): POSTGRES_URL_FILE + GAP-154 Neon fleet dogfood

### DIFF
--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -90,6 +90,7 @@ Environment variables (all optional):
 | `REVDEV_DAEMON_PID` | `~/.local/share/revealui/harness.pid` | PID file location |
 | `REVDEV_DAEMON_LOG` | `~/.local/share/revealui/daemon.log` | Log file for `--detach` mode |
 | `POSTGRES_URL` | (none → sync disabled) | Neon URL for cross-machine `coordination_*` sync (GAP-154) |
+| `POSTGRES_URL_FILE` | (none) | File path to Neon URL (stream-safe systemd; same effect as POSTGRES_URL) |
 
 ## License tiers
 

--- a/packages/daemon/src/__tests__/postgres-url-file.test.ts
+++ b/packages/daemon/src/__tests__/postgres-url-file.test.ts
@@ -1,0 +1,42 @@
+/**
+ * POSTGRES_URL_FILE resolution (GAP-154 finish).
+ * @vitest-environment node
+ */
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { _resetForTesting, initNeonSync, isNeonSyncActive, resolvePostgresUrl } from "../neon.js";
+
+describe("resolvePostgresUrl / POSTGRES_URL_FILE", () => {
+  const prevUrl = process.env.POSTGRES_URL;
+  const prevDb = process.env.DATABASE_URL;
+  const prevFile = process.env.POSTGRES_URL_FILE;
+
+  afterEach(() => {
+    _resetForTesting();
+    if (prevUrl === undefined) delete process.env.POSTGRES_URL;
+    else process.env.POSTGRES_URL = prevUrl;
+    if (prevDb === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prevDb;
+    if (prevFile === undefined) delete process.env.POSTGRES_URL_FILE;
+    else process.env.POSTGRES_URL_FILE = prevFile;
+  });
+
+  it("reads POSTGRES_URL_FILE when inline URL unset", async () => {
+    delete process.env.POSTGRES_URL;
+    delete process.env.DATABASE_URL;
+    const dir = await mkdtemp(join(tmpdir(), "pgurl-"));
+    const file = join(dir, "url");
+    await writeFile(file, "  postgresql://user:pass@example.com/db  \n");
+    process.env.POSTGRES_URL_FILE = file;
+    expect(resolvePostgresUrl()).toBe("postgresql://user:pass@example.com/db");
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("prefers POSTGRES_URL over file", async () => {
+    process.env.POSTGRES_URL = "postgresql://inline/db";
+    process.env.POSTGRES_URL_FILE = "/no/such/file";
+    expect(resolvePostgresUrl()).toBe("postgresql://inline/db");
+  });
+});

--- a/packages/daemon/src/neon.ts
+++ b/packages/daemon/src/neon.ts
@@ -37,6 +37,7 @@
  *     reconcile across daemons. Until then they stay local-only by design.
  */
 
+import { readFileSync } from 'node:fs';
 import { type NeonQueryFunction, neon } from '@neondatabase/serverless';
 import { createLogger } from '@revealui/utils/logger';
 
@@ -45,12 +46,35 @@ const log = createLogger({ service: 'revdev-daemon-neon' });
 let client: NeonQueryFunction<false, false> | null = null;
 
 /**
- * Initialize the Neon client from `POSTGRES_URL` env var (or override).
- * Idempotent. When the URL is empty/unset, sync is disabled and all
- * helpers below are silent no-ops.
+ * Resolve Neon URL without putting secrets on argv.
+ * Priority: explicit arg → POSTGRES_URL → DATABASE_URL → POSTGRES_URL_FILE
+ * (file path is stream-safe for systemd PrivateTmp materialization).
+ */
+export function resolvePostgresUrl(databaseUrl?: string | undefined): string {
+  if (databaseUrl && databaseUrl.trim()) return databaseUrl.trim();
+  const inline = process.env.POSTGRES_URL?.trim() || process.env.DATABASE_URL?.trim();
+  if (inline) return inline;
+  const filePath = process.env.POSTGRES_URL_FILE?.trim();
+  if (!filePath) return '';
+  try {
+    const text = readFileSync(filePath, 'utf8').trim();
+    return text;
+  } catch (err) {
+    log.warn('POSTGRES_URL_FILE unreadable', {
+      path: filePath,
+      error: String(err),
+    });
+    return '';
+  }
+}
+
+/**
+ * Initialize the Neon client from `POSTGRES_URL` / `DATABASE_URL` /
+ * `POSTGRES_URL_FILE` (or override). Idempotent. When empty/unset, sync is
+ * disabled and all helpers below are silent no-ops.
  */
 export function initNeonSync(databaseUrl?: string | undefined): void {
-  const url = databaseUrl ?? process.env.POSTGRES_URL ?? process.env.DATABASE_URL ?? '';
+  const url = resolvePostgresUrl(databaseUrl);
   if (url) {
     client = neon(url);
     log.info('neon sync enabled', { hasUrl: true });

--- a/packages/daemon/systemd/postgres-url-file.conf.example
+++ b/packages/daemon/systemd/postgres-url-file.conf.example
@@ -1,0 +1,24 @@
+# revdev-daemon — Neon POSTGRES_URL via file (EXAMPLE; copy + adapt)
+# =============================================================================
+# Materializes the Neon connection string into PrivateTmp so the secret is not
+# stored long-term in the unit Environment= block. Pairs with GAP-154 dual-write
+# (initNeonSync reads POSTGRES_URL or POSTGRES_URL_FILE).
+#
+# Install:
+#     mkdir -p ~/.config/systemd/user/revdev-daemon.service.d
+#     cp packages/daemon/systemd/postgres-url-file.conf.example \
+#        ~/.config/systemd/user/revdev-daemon.service.d/postgres-url-file.conf
+#     # set revvault path + absolute revvault binary, then:
+#     systemctl --user daemon-reload && systemctl --user restart revdev-daemon
+#
+# Prefer a non-production Neon when dogfooding; path below is production —
+# override to a staging/dev vault path if one exists.
+#
+# Stream-safe: only vault *paths* appear in this unit file, never the URL.
+
+[Service]
+# Working SSOT for this machine's Neon (2026-08-08): revealui/prod/db/postgres-url
+# (revealui/prod/neon/postgres-url was stale/auth-failing — fix vault if re-used)
+ExecStartPre=/bin/sh -c 'umask 077; /usr/local/bin/revvault get revealui/prod/db/postgres-url --full > /tmp/revdev-postgres.url'
+Environment=POSTGRES_URL_FILE=/tmp/revdev-postgres.url
+ExecStopPost=/bin/sh -c 'shred -u /tmp/revdev-postgres.url 2>/dev/null || rm -f /tmp/revdev-postgres.url'

--- a/scripts/gap-154-neon-fleet-dogfood.mjs
+++ b/scripts/gap-154-neon-fleet-dogfood.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * GAP-154 live fleet dogfood (two process-local daemons, real Neon).
+ *
+ * Stream-safe: expects POSTGRES_URL already in the environment (use
+ *   revvault run --env POSTGRES_URL=revealui/prod/db/postgres-url -- \
+ *     node scripts/gap-154-neon-fleet-dogfood.mjs
+ * ). Never prints the URL. Prefer db/postgres-url over neon/postgres-url if the
+ * latter fails password auth (vault drift).
+ *
+ * Proves acceptance slice: A registers session → B session.list({scope:fleet})
+ * sees it; daemon.peers sees at least one self registration when sync is on.
+ *
+ * Cleans up test sessions on both sockets when possible.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+const DIST_CLI = join(ROOT, "packages/daemon/dist/cli.js");
+
+function rpc(socketPath, method, params = {}) {
+  return new Promise((resolve, reject) => {
+    const sock = connect(socketPath);
+    let buf = "";
+    const frame = JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }) + "\n";
+    sock.on("connect", () => sock.write(frame));
+    sock.on("data", (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf("\n");
+      if (nl === -1) return;
+      sock.end();
+      try {
+        const resp = JSON.parse(buf.slice(0, nl));
+        if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
+        else resolve(resp.result);
+      } catch (e) {
+        reject(e);
+      }
+    });
+    sock.on("error", reject);
+    sock.setTimeout(15_000, () => {
+      sock.destroy();
+      reject(new Error(`timeout ${method}`));
+    });
+  });
+}
+
+async function main() {
+  if (!process.env.POSTGRES_URL && !process.env.POSTGRES_URL_FILE) {
+    console.error(
+      "FAIL: set POSTGRES_URL (or POSTGRES_URL_FILE) via revvault run — see script header",
+    );
+    process.exit(2);
+  }
+
+  // Dynamic import after env is set so neon init can see POSTGRES_URL
+  const { startDaemon } = await import(
+    pathToFileURL(join(ROOT, "packages/daemon/dist/index.js")).href
+  );
+
+  const stamp = Date.now().toString(36);
+  const agentA = `gap154-dogfood-a-${stamp}`;
+  const agentB = `gap154-dogfood-b-${stamp}`;
+
+  const dirA = await mkdtemp(join(tmpdir(), "gap154-a-"));
+  const dirB = await mkdtemp(join(tmpdir(), "gap154-b-"));
+  const sockA = join(dirA, "harness.sock");
+  const sockB = join(dirB, "harness.sock");
+  await writeFile(join(dirA, "trusted-client-fingerprint"), "");
+  await writeFile(join(dirB, "trusted-client-fingerprint"), "");
+
+  let closeA;
+  let closeB;
+  try {
+    process.env.REVDEV_DAEMON_ID = `daemon:dogfood-a-${stamp}`;
+    const a = await startDaemon({
+      socketPath: sockA,
+      dataDir: dirA,
+      pruneIntervalMs: 0,
+      trustedClientFingerprintPath: join(dirA, "trusted-client-fingerprint"),
+      trustedAnchorRequireRootOwned: false,
+    });
+    closeA = a.close;
+
+    process.env.REVDEV_DAEMON_ID = `daemon:dogfood-b-${stamp}`;
+    const b = await startDaemon({
+      socketPath: sockB,
+      dataDir: dirB,
+      pruneIntervalMs: 0,
+      trustedClientFingerprintPath: join(dirB, "trusted-client-fingerprint"),
+      trustedAnchorRequireRootOwned: false,
+    });
+    closeB = b.close;
+
+    const healthA = await rpc(sockA, "harness.health");
+    if (!healthA.neonSyncActive) {
+      console.error("FAIL: neonSyncActive=false on A — POSTGRES_URL not loading");
+      process.exit(1);
+    }
+    console.log("ok neonSyncActive on A");
+
+    await rpc(sockA, "session.register", {
+      agentId: agentA,
+      agentName: agentA,
+      env: "gap154-dogfood-a",
+      task: "gap-154 fleet dogfood",
+    });
+    console.log("ok registered", agentA);
+
+    // Allow Neon write lag
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const fleetB = await rpc(sockB, "session.list", { scope: "fleet" });
+    const sessions = fleetB.sessions || [];
+    const found = sessions.some(
+      (s) => s.agentId === agentA || s.id === agentA || s.agent_id === agentA,
+    );
+    if (!found) {
+      console.error(
+        "FAIL: B fleet list missing A",
+        JSON.stringify(
+          sessions.slice(0, 5).map((s) => ({ id: s.id, agentId: s.agentId || s.agent_id })),
+        ),
+      );
+      process.exit(1);
+    }
+    console.log("ok B session.list({scope:fleet}) sees A");
+
+    const peersA = await rpc(sockA, "daemon.peers", {});
+    if (!peersA.neonSyncActive) {
+      console.error("FAIL: daemon.peers neonSyncActive false");
+      process.exit(1);
+    }
+    console.log(
+      "ok daemon.peers",
+      "selfId=",
+      peersA.selfId,
+      "count=",
+      (peersA.peers || []).length,
+    );
+
+    // Cleanup test sessions (best-effort; may need signed end — try unsigned register end path)
+    try {
+      await rpc(sockA, "session.end", { agentId: agentA });
+    } catch {
+      /* optional */
+    }
+    try {
+      await rpc(sockB, "session.register", {
+        agentId: agentB,
+        agentName: agentB,
+        env: "gap154-dogfood-b",
+      });
+      await rpc(sockB, "session.end", { agentId: agentB });
+    } catch {
+      /* optional */
+    }
+
+    console.log("RESULT=PASS gap-154 neon fleet dogfood");
+  } finally {
+    if (closeB) await closeB().catch(() => undefined);
+    if (closeA) await closeA().catch(() => undefined);
+    await rm(dirA, { recursive: true, force: true }).catch(() => undefined);
+    await rm(dirB, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+main().catch((e) => {
+  console.error("FAIL:", e.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Finishes GAP-154 operational residual:

- `POSTGRES_URL_FILE` resolution (stream-safe systemd PrivateTmp)
- `postgres-url-file.conf.example` (vault path `revealui/prod/db/postgres-url`)
- `scripts/gap-154-neon-fleet-dogfood.mjs` — two-daemon live A→B fleet proof
- Unit tests for URL file resolution

## Dogfood (this machine)

```text
RESULT=PASS gap-154 neon fleet dogfood
ok B session.list({scope:fleet}) sees A
ok daemon.peers count=2
```

Vault: `revealui/prod/db/postgres-url` (not `prod/neon/postgres-url` — auth fail).

## After merge (operator)

```bash
cp packages/daemon/systemd/postgres-url-file.conf.example \
  ~/.config/systemd/user/revdev-daemon.service.d/postgres-url-file.conf
# fix revvault absolute path if needed
systemctl --user daemon-reload && systemctl --user restart revdev-daemon
```