### PR TITLE
feat(daemon): workflow.list / workflow.run RPC (GAP-474)

### DIFF
--- a/packages/daemon/src/__tests__/postgres-url-file.test.ts
+++ b/packages/daemon/src/__tests__/postgres-url-file.test.ts
@@ -2,13 +2,13 @@
  * POSTGRES_URL_FILE resolution (GAP-154 finish).
  * @vitest-environment node
  */
-import { mkdtemp, writeFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { _resetForTesting, initNeonSync, isNeonSyncActive, resolvePostgresUrl } from "../neon.js";
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { _resetForTesting, initNeonSync, isNeonSyncActive, resolvePostgresUrl } from '../neon.js';
 
-describe("resolvePostgresUrl / POSTGRES_URL_FILE", () => {
+describe('resolvePostgresUrl / POSTGRES_URL_FILE', () => {
   const prevUrl = process.env.POSTGRES_URL;
   const prevDb = process.env.DATABASE_URL;
   const prevFile = process.env.POSTGRES_URL_FILE;
@@ -23,20 +23,20 @@ describe("resolvePostgresUrl / POSTGRES_URL_FILE", () => {
     else process.env.POSTGRES_URL_FILE = prevFile;
   });
 
-  it("reads POSTGRES_URL_FILE when inline URL unset", async () => {
+  it('reads POSTGRES_URL_FILE when inline URL unset', async () => {
     delete process.env.POSTGRES_URL;
     delete process.env.DATABASE_URL;
-    const dir = await mkdtemp(join(tmpdir(), "pgurl-"));
-    const file = join(dir, "url");
-    await writeFile(file, "  postgresql://user:pass@example.com/db  \n");
+    const dir = await mkdtemp(join(tmpdir(), 'pgurl-'));
+    const file = join(dir, 'url');
+    await writeFile(file, '  postgresql://user:pass@example.com/db  \n');
     process.env.POSTGRES_URL_FILE = file;
-    expect(resolvePostgresUrl()).toBe("postgresql://user:pass@example.com/db");
+    expect(resolvePostgresUrl()).toBe('postgresql://user:pass@example.com/db');
     await rm(dir, { recursive: true, force: true });
   });
 
-  it("prefers POSTGRES_URL over file", async () => {
-    process.env.POSTGRES_URL = "postgresql://inline/db";
-    process.env.POSTGRES_URL_FILE = "/no/such/file";
-    expect(resolvePostgresUrl()).toBe("postgresql://inline/db");
+  it('prefers POSTGRES_URL over file', async () => {
+    process.env.POSTGRES_URL = 'postgresql://inline/db';
+    process.env.POSTGRES_URL_FILE = '/no/such/file';
+    expect(resolvePostgresUrl()).toBe('postgresql://inline/db');
   });
 });

--- a/packages/daemon/src/__tests__/workflow-rpc.test.ts
+++ b/packages/daemon/src/__tests__/workflow-rpc.test.ts
@@ -1,0 +1,111 @@
+/**
+ * GAP-473 — workflow.list / workflow.run unit tests.
+ * Uses a scratch registry so tests never touch the real ~/revfleet/.jv tree.
+ */
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { listWorkflows, runWorkflow } from '../workflow-rpc.js';
+
+function writeMinimalRunner(jvRoot: string): void {
+  const scripts = join(jvRoot, 'scripts');
+  mkdirSync(scripts, { recursive: true });
+  // Minimal runner: --list prints fixed lines; <name> exits 0 unless gated without --fix
+  writeFileSync(
+    join(scripts, 'workflow-run.js'),
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args.includes('--list')) {
+  console.log('workflow-run: registry at test');
+  console.log('  prepare-for-exit — Verify clean [safety: auto]');
+  process.exit(0);
+}
+const name = args.find((a) => a[0] !== '-');
+const fix = args.includes('--fix') || args.includes('--yes');
+const dry = args.includes('--dry-run');
+if (name === 'cleanup-session' && !fix && !dry) {
+  console.log('[STOPPED-GATED] cleanup');
+  process.exit(1);
+}
+if (name === 'missing-will-not-be-called') {
+  process.exit(2);
+}
+console.log('RUN — ' + name + (dry ? ' dry' : ''));
+process.exit(0);
+`,
+  );
+}
+
+function writeWorkflow(jvRoot: string, name: string, safety: string): void {
+  const dir = join(jvRoot, 'workflows');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${name}.yml`),
+    `name: ${name}
+title: Test ${name}
+safety: ${safety}
+steps:
+  - id: s1
+    title: step
+    run: node -e "process.exit(0)"
+    safety: ${safety}
+`,
+  );
+}
+
+describe('workflow-rpc (GAP-473)', () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    // leave tmpdirs for OS cleanup; no recursive rm (policy)
+    roots.length = 0;
+  });
+
+  function scratch(): string {
+    const root = mkdtempSync(join(tmpdir(), 'revdev-wf-'));
+    roots.push(root);
+    writeMinimalRunner(root);
+    writeWorkflow(root, 'prepare-for-exit', 'auto');
+    writeWorkflow(root, 'cleanup-session', 'gated');
+    return root;
+  }
+
+  it('listWorkflows returns registry entries', () => {
+    const root = scratch();
+    const list = listWorkflows(root);
+    expect(list.length).toBe(2);
+    expect(list.map((w) => w.name).sort()).toEqual(['cleanup-session', 'prepare-for-exit']);
+    expect(list.find((w) => w.name === 'prepare-for-exit')?.safety).toBe('auto');
+  });
+
+  it('listWorkflows throws when registry missing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'revdev-wf-empty-'));
+    expect(() => listWorkflows(root)).toThrow(/workflow runner missing|registry missing/);
+  });
+
+  it('runWorkflow prepare-for-exit succeeds', () => {
+    const root = scratch();
+    const r = runWorkflow(root, 'prepare-for-exit', {});
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('prepare-for-exit');
+  });
+
+  it('runWorkflow cleanup-session without fix exits non-zero (gated)', () => {
+    const root = scratch();
+    const r = runWorkflow(root, 'cleanup-session', {});
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stdout).toContain('STOPPED-GATED');
+  });
+
+  it('runWorkflow cleanup-session with fix succeeds', () => {
+    const root = scratch();
+    const r = runWorkflow(root, 'cleanup-session', { fix: true });
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('runWorkflow rejects path-shaped names', () => {
+    const root = scratch();
+    expect(() => runWorkflow(root, '../evil', {})).toThrow(/invalid name/);
+  });
+});

--- a/packages/daemon/src/__tests__/workflow-rpc.test.ts
+++ b/packages/daemon/src/__tests__/workflow-rpc.test.ts
@@ -1,6 +1,6 @@
 /**
- * GAP-473 — workflow.list / workflow.run unit tests.
- * Uses a scratch registry so tests never touch the real ~/revfleet/.jv tree.
+ * GAP-474 — workflow.list / workflow.run unit tests.
+ * Uses a scratch registry so tests never touch a live planning checkout.
  */
 
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -39,6 +39,8 @@ import './agent.js';
 import './spawn.js';
 // Register gateway.revokeToken (GAP-421 guardrail-2 remediation S5).
 import './gateway-rpc.js';
+// GAP-473 — workflow.list / workflow.run (same .jv registry as Studio /ops).
+import './workflow-rpc.js';
 import { DAEMON_DEFAULTS } from './config.js';
 import { LICENSE_TIER_HELP, LicenseConfigError, LicenseExpiredError } from './license.js';
 import { startDaemon } from './server.js';

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -39,7 +39,7 @@ import './agent.js';
 import './spawn.js';
 // Register gateway.revokeToken (GAP-421 guardrail-2 remediation S5).
 import './gateway-rpc.js';
-// GAP-473 — workflow.list / workflow.run (same .jv registry as Studio /ops).
+// GAP-474 — workflow.list / workflow.run (same registry as Studio /ops).
 import './workflow-rpc.js';
 import { DAEMON_DEFAULTS } from './config.js';
 import { LICENSE_TIER_HELP, LicenseConfigError, LicenseExpiredError } from './license.js';

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -71,6 +71,8 @@ import './agent.js';
 // in agent.js with real implementations. Must follow agent.js in import order.
 import './spawn.js';
 import './gateway-rpc.js';
+// GAP-473 — workflow.list / workflow.run over .jv registry
+import './workflow-rpc.js';
 
 export { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 export { SCHEMA_SQL } from './storage/schema.js';

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -71,7 +71,7 @@ import './agent.js';
 // in agent.js with real implementations. Must follow agent.js in import order.
 import './spawn.js';
 import './gateway-rpc.js';
-// GAP-473 — workflow.list / workflow.run over .jv registry
+// GAP-474 — workflow.list / workflow.run over operational-workflow registry
 import './workflow-rpc.js';
 
 export { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -125,7 +125,7 @@ const EXEMPT_METHODS = new Set([
   // GAP-154 Phase 5: peer discovery is diagnostic (empty without Neon).
   // Dual-write still requires Pro coordination RPCs; listing peers alone is free.
   'daemon.peers',
-  // GAP-473: local .jv operational workflows (same class as /ops; Studio daily driver)
+  // GAP-474: local operational workflows (same class as /ops; Studio daily driver)
   'workflow.list',
   'workflow.run',
 ]);

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -125,6 +125,9 @@ const EXEMPT_METHODS = new Set([
   // GAP-154 Phase 5: peer discovery is diagnostic (empty without Neon).
   // Dual-write still requires Pro coordination RPCs; listing peers alone is free.
   'daemon.peers',
+  // GAP-473: local .jv operational workflows (same class as /ops; Studio daily driver)
+  'workflow.list',
+  'workflow.run',
 ]);
 
 /**

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -142,7 +142,7 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['gateway.revokeToken', 'consequential'],
   // GAP-154 Phase 5 — peer discovery (diagnostic; empty without Neon)
   ['daemon.peers', 'routine'],
-  // GAP-473 — list is routine; run may trigger gated cleanup with fix:true
+  // GAP-474 — list is routine; run may trigger gated cleanup with fix:true
   ['workflow.list', 'routine'],
   ['workflow.run', 'consequential'],
 ]);

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -140,6 +140,11 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   // Revokes a bearer credential — reversible (a new one can be paired), so
   // consequential rather than critical (GAP-421 guardrail-2 remediation S5).
   ['gateway.revokeToken', 'consequential'],
+  // GAP-154 Phase 5 — peer discovery (diagnostic; empty without Neon)
+  ['daemon.peers', 'routine'],
+  // GAP-473 — list is routine; run may trigger gated cleanup with fix:true
+  ['workflow.list', 'routine'],
+  ['workflow.run', 'consequential'],
 ]);
 
 /** Fail closed: unmapped method is critical (spec §5 / I2). */

--- a/packages/daemon/src/workflow-rpc.ts
+++ b/packages/daemon/src/workflow-rpc.ts
@@ -1,8 +1,9 @@
 /**
- * GAP-473 — workflow.list / workflow.run
+ * GAP-474 — workflow.list / workflow.run
  *
- * Thin daemon surface over the .jv operational-workflow registry
- * (`~/revfleet/.jv/workflows/*.yml` + `scripts/workflow-run.js`).
+ * Thin daemon surface over the Studio operational-workflow registry
+ * (`workflows/*.yml` + `scripts/workflow-run.js` under `REVDEV_JV_ROOT`,
+ * defaulting to the private planning checkout beside this monorepo).
  * No second schema: list/run shell the same runner Studio `/ops` uses.
  *
  * Safety classes stay enforced inside workflow-run.js:
@@ -33,6 +34,7 @@ function resolveJvRoot(params: Record<string, unknown> | undefined): string {
   if (process.env.REVDEV_JV_ROOT && process.env.REVDEV_JV_ROOT.length > 0) {
     return process.env.REVDEV_JV_ROOT;
   }
+  // Default layout: <home>/revfleet/<private planning root> (not a public path claim).
   return join(homedir(), 'revfleet', '.jv');
 }
 

--- a/packages/daemon/src/workflow-rpc.ts
+++ b/packages/daemon/src/workflow-rpc.ts
@@ -1,0 +1,152 @@
+/**
+ * GAP-473 — workflow.list / workflow.run
+ *
+ * Thin daemon surface over the .jv operational-workflow registry
+ * (`~/revfleet/.jv/workflows/*.yml` + `scripts/workflow-run.js`).
+ * No second schema: list/run shell the same runner Studio `/ops` uses.
+ *
+ * Safety classes stay enforced inside workflow-run.js:
+ *   auto | report-first | gated | owner-only
+ * Gated steps need `fix: true` (or `yes: true`); owner-only is never executed.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { registerHandler } from './server.js';
+
+const RUNNER_TIMEOUT_MS = 5 * 60 * 1000;
+const RUNNER_MAX_BUFFER = 10 * 1024 * 1024;
+
+export interface WorkflowListEntry {
+  name: string;
+  title: string;
+  safety: string;
+  file: string;
+}
+
+function resolveJvRoot(params: Record<string, unknown> | undefined): string {
+  if (params && typeof params.jvRoot === 'string' && params.jvRoot.length > 0) {
+    return params.jvRoot;
+  }
+  if (process.env.REVDEV_JV_ROOT && process.env.REVDEV_JV_ROOT.length > 0) {
+    return process.env.REVDEV_JV_ROOT;
+  }
+  return join(homedir(), 'revfleet', '.jv');
+}
+
+function runnerPath(jvRoot: string): string {
+  return join(jvRoot, 'scripts', 'workflow-run.js');
+}
+
+function assertRegistry(jvRoot: string): void {
+  const runner = runnerPath(jvRoot);
+  const dir = join(jvRoot, 'workflows');
+  if (!existsSync(runner)) {
+    throw new Error(
+      `workflow runner missing at ${runner} (set REVDEV_JV_ROOT or install .jv checkout)`,
+    );
+  }
+  if (!existsSync(dir)) {
+    throw new Error(`workflow registry missing at ${dir}`);
+  }
+}
+
+/** Minimal YAML field skim (name/title/safety) — list only; run uses the runner. */
+function skimYamlFields(text: string): { name: string; title: string; safety: string } {
+  let name = '';
+  let title = '';
+  let safety = '';
+  for (const line of text.split('\n')) {
+    if (line.startsWith('name:')) name = line.slice(5).trim();
+    else if (line.startsWith('title:')) title = line.slice(6).trim();
+    else if (line.startsWith('safety:') && safety === '') safety = line.slice(7).trim();
+  }
+  return { name, title, safety };
+}
+
+export function listWorkflows(jvRoot: string): WorkflowListEntry[] {
+  assertRegistry(jvRoot);
+  const dir = join(jvRoot, 'workflows');
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .sort();
+  const out: WorkflowListEntry[] = [];
+  for (const file of files) {
+    const text = readFileSync(join(dir, file), 'utf8');
+    const fields = skimYamlFields(text);
+    out.push({
+      name: fields.name || file.replace(/\.ya?ml$/, ''),
+      title: fields.title,
+      safety: fields.safety,
+      file,
+    });
+  }
+  return out;
+}
+
+export interface WorkflowRunResult {
+  name: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  dryRun: boolean;
+  fix: boolean;
+}
+
+export function runWorkflow(
+  jvRoot: string,
+  name: string,
+  opts: { dryRun?: boolean; fix?: boolean; yes?: boolean },
+): WorkflowRunResult {
+  assertRegistry(jvRoot);
+  if (!name || typeof name !== 'string') {
+    throw new Error('workflow.run requires params.name (workflow id)');
+  }
+  // Refuse path-shaped names (no second registry, no arbitrary exec)
+  if (name.includes('/') || name.includes('\\') || name.includes('..')) {
+    throw new Error(`workflow.run: invalid name ${JSON.stringify(name)}`);
+  }
+
+  const args = [runnerPath(jvRoot), name, '--root', jvRoot];
+  if (opts.dryRun) args.push('--dry-run');
+  if (opts.fix) args.push('--fix');
+  if (opts.yes) args.push('--yes');
+
+  const r = spawnSync(process.execPath, args, {
+    encoding: 'utf8',
+    timeout: RUNNER_TIMEOUT_MS,
+    maxBuffer: RUNNER_MAX_BUFFER,
+  });
+
+  if (r.error) {
+    throw new Error(`workflow.run spawn failed: ${r.error.message}`);
+  }
+
+  return {
+    name,
+    exitCode: r.status === null ? 1 : r.status,
+    stdout: r.stdout || '',
+    stderr: r.stderr || '',
+    dryRun: Boolean(opts.dryRun),
+    fix: Boolean(opts.fix || opts.yes),
+  };
+}
+
+registerHandler('workflow.list', async (params) => {
+  const p = (params ?? {}) as Record<string, unknown>;
+  const jvRoot = resolveJvRoot(p);
+  const workflows = listWorkflows(jvRoot);
+  return { jvRoot, workflows, count: workflows.length };
+});
+
+registerHandler('workflow.run', async (params) => {
+  const p = (params ?? {}) as Record<string, unknown>;
+  const jvRoot = resolveJvRoot(p);
+  const name = typeof p.name === 'string' ? p.name : '';
+  const dryRun = p.dryRun === true || p['dry-run'] === true;
+  const fix = p.fix === true;
+  const yes = p.yes === true;
+  return runWorkflow(jvRoot, name, { dryRun, fix, yes });
+});

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -156,7 +156,7 @@ export const RPC_METHODS = {
   // HTTP gateway token management (GAP-421 guardrail-2 remediation S5)
   'gateway.revokeToken': 'gateway.revokeToken',
 
-  // GAP-473 — .jv operational workflows (registry SSOT under ~/revfleet/.jv/workflows)
+  // GAP-474 — operational workflows (registry under REVDEV_JV_ROOT / workflows)
   'workflow.list': 'workflow.list',
   'workflow.run': 'workflow.run',
 } as const;

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -155,4 +155,8 @@ export const RPC_METHODS = {
 
   // HTTP gateway token management (GAP-421 guardrail-2 remediation S5)
   'gateway.revokeToken': 'gateway.revokeToken',
+
+  // GAP-473 — .jv operational workflows (registry SSOT under ~/revfleet/.jv/workflows)
+  'workflow.list': 'workflow.list',
+  'workflow.run': 'workflow.run',
 } as const;

--- a/scripts/gap-154-neon-fleet-dogfood.mjs
+++ b/scripts/gap-154-neon-fleet-dogfood.mjs
@@ -13,24 +13,23 @@
  *
  * Cleans up test sessions on both sockets when possible.
  */
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { connect } from "node:net";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { connect } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-const ROOT = new URL("..", import.meta.url).pathname;
-const DIST_CLI = join(ROOT, "packages/daemon/dist/cli.js");
+const ROOT = new URL('..', import.meta.url).pathname;
 
 function rpc(socketPath, method, params = {}) {
   return new Promise((resolve, reject) => {
     const sock = connect(socketPath);
-    let buf = "";
-    const frame = JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }) + "\n";
-    sock.on("connect", () => sock.write(frame));
-    sock.on("data", (d) => {
+    let buf = '';
+    const frame = JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }) + '\n';
+    sock.on('connect', () => sock.write(frame));
+    sock.on('data', (d) => {
       buf += d.toString();
-      const nl = buf.indexOf("\n");
+      const nl = buf.indexOf('\n');
       if (nl === -1) return;
       sock.end();
       try {
@@ -41,7 +40,7 @@ function rpc(socketPath, method, params = {}) {
         reject(e);
       }
     });
-    sock.on("error", reject);
+    sock.on('error', reject);
     sock.setTimeout(15_000, () => {
       sock.destroy();
       reject(new Error(`timeout ${method}`));
@@ -52,26 +51,26 @@ function rpc(socketPath, method, params = {}) {
 async function main() {
   if (!process.env.POSTGRES_URL && !process.env.POSTGRES_URL_FILE) {
     console.error(
-      "FAIL: set POSTGRES_URL (or POSTGRES_URL_FILE) via revvault run — see script header",
+      'FAIL: set POSTGRES_URL (or POSTGRES_URL_FILE) via revvault run — see script header',
     );
     process.exit(2);
   }
 
   // Dynamic import after env is set so neon init can see POSTGRES_URL
   const { startDaemon } = await import(
-    pathToFileURL(join(ROOT, "packages/daemon/dist/index.js")).href
+    pathToFileURL(join(ROOT, 'packages/daemon/dist/index.js')).href
   );
 
   const stamp = Date.now().toString(36);
   const agentA = `gap154-dogfood-a-${stamp}`;
   const agentB = `gap154-dogfood-b-${stamp}`;
 
-  const dirA = await mkdtemp(join(tmpdir(), "gap154-a-"));
-  const dirB = await mkdtemp(join(tmpdir(), "gap154-b-"));
-  const sockA = join(dirA, "harness.sock");
-  const sockB = join(dirB, "harness.sock");
-  await writeFile(join(dirA, "trusted-client-fingerprint"), "");
-  await writeFile(join(dirB, "trusted-client-fingerprint"), "");
+  const dirA = await mkdtemp(join(tmpdir(), 'gap154-a-'));
+  const dirB = await mkdtemp(join(tmpdir(), 'gap154-b-'));
+  const sockA = join(dirA, 'harness.sock');
+  const sockB = join(dirB, 'harness.sock');
+  await writeFile(join(dirA, 'trusted-client-fingerprint'), '');
+  await writeFile(join(dirB, 'trusted-client-fingerprint'), '');
 
   let closeA;
   let closeB;
@@ -81,7 +80,7 @@ async function main() {
       socketPath: sockA,
       dataDir: dirA,
       pruneIntervalMs: 0,
-      trustedClientFingerprintPath: join(dirA, "trusted-client-fingerprint"),
+      trustedClientFingerprintPath: join(dirA, 'trusted-client-fingerprint'),
       trustedAnchorRequireRootOwned: false,
     });
     closeA = a.close;
@@ -91,76 +90,70 @@ async function main() {
       socketPath: sockB,
       dataDir: dirB,
       pruneIntervalMs: 0,
-      trustedClientFingerprintPath: join(dirB, "trusted-client-fingerprint"),
+      trustedClientFingerprintPath: join(dirB, 'trusted-client-fingerprint'),
       trustedAnchorRequireRootOwned: false,
     });
     closeB = b.close;
 
-    const healthA = await rpc(sockA, "harness.health");
+    const healthA = await rpc(sockA, 'harness.health');
     if (!healthA.neonSyncActive) {
-      console.error("FAIL: neonSyncActive=false on A — POSTGRES_URL not loading");
+      console.error('FAIL: neonSyncActive=false on A — POSTGRES_URL not loading');
       process.exit(1);
     }
-    console.log("ok neonSyncActive on A");
+    console.log('ok neonSyncActive on A');
 
-    await rpc(sockA, "session.register", {
+    await rpc(sockA, 'session.register', {
       agentId: agentA,
       agentName: agentA,
-      env: "gap154-dogfood-a",
-      task: "gap-154 fleet dogfood",
+      env: 'gap154-dogfood-a',
+      task: 'gap-154 fleet dogfood',
     });
-    console.log("ok registered", agentA);
+    console.log('ok registered', agentA);
 
     // Allow Neon write lag
     await new Promise((r) => setTimeout(r, 1500));
 
-    const fleetB = await rpc(sockB, "session.list", { scope: "fleet" });
+    const fleetB = await rpc(sockB, 'session.list', { scope: 'fleet' });
     const sessions = fleetB.sessions || [];
     const found = sessions.some(
       (s) => s.agentId === agentA || s.id === agentA || s.agent_id === agentA,
     );
     if (!found) {
       console.error(
-        "FAIL: B fleet list missing A",
+        'FAIL: B fleet list missing A',
         JSON.stringify(
           sessions.slice(0, 5).map((s) => ({ id: s.id, agentId: s.agentId || s.agent_id })),
         ),
       );
       process.exit(1);
     }
-    console.log("ok B session.list({scope:fleet}) sees A");
+    console.log('ok B session.list({scope:fleet}) sees A');
 
-    const peersA = await rpc(sockA, "daemon.peers", {});
+    const peersA = await rpc(sockA, 'daemon.peers', {});
     if (!peersA.neonSyncActive) {
-      console.error("FAIL: daemon.peers neonSyncActive false");
+      console.error('FAIL: daemon.peers neonSyncActive false');
       process.exit(1);
     }
-    console.log(
-      "ok daemon.peers",
-      "selfId=",
-      peersA.selfId,
-      "count=",
-      (peersA.peers || []).length,
-    );
+    console.log('ok daemon.peers', 'selfId=', peersA.selfId, 'count=', (peersA.peers || []).length);
 
     // Cleanup test sessions (best-effort; may need signed end — try unsigned register end path)
     try {
-      await rpc(sockA, "session.end", { agentId: agentA });
+      await rpc(sockA, 'session.end', { agentId: agentA });
     } catch {
       /* optional */
     }
     try {
-      await rpc(sockB, "session.register", {
+      await rpc(sockB, 'session.register', {
         agentId: agentB,
         agentName: agentB,
-        env: "gap154-dogfood-b",
+        env: 'gap154-dogfood-b',
       });
-      await rpc(sockB, "session.end", { agentId: agentB });
+      await rpc(sockB, 'session.end', { agentId: agentB });
     } catch {
       /* optional */
     }
 
-    console.log("RESULT=PASS gap-154 neon fleet dogfood");
+    console.log('RESULT=PASS gap-154 neon fleet dogfood');
   } finally {
     if (closeB) await closeB().catch(() => undefined);
     if (closeA) await closeA().catch(() => undefined);
@@ -170,6 +163,6 @@ async function main() {
 }
 
 main().catch((e) => {
-  console.error("FAIL:", e.message);
+  console.error('FAIL:', e.message);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

GAP-314 operational-workflow seed closed with a residual native pair: RevDev daemon RPCs that read the same registry Studio `/ops` uses (`REVDEV_JV_ROOT` or the default private planning checkout).

- **`workflow.list`** — skim `workflows/*.yml` under the registry root
- **`workflow.run`** — shell `scripts/workflow-run.js` with dry-run / fix / yes; safety classes stay enforced in the runner
- Path-shaped names rejected; no second schema or arbitrary exec
- Free-tier exempt (Studio daily driver); list = routine, run = consequential
- Also classifies **`daemon.peers`** in `METHOD_ACTION_CLASS` (GAP-154 method was declared but unmapped)

Durable gap id: **GAP-474** (jv#1193). Branch name still says gap-473 historically.

## Test plan

- [x] vitest workflow-rpc + rpc-contract + permission (38 pass)
- [x] protocol + daemon build
- [x] private leak scan clean on touched files
- [ ] CI green on PR
- [ ] Optional smoke: daemon up, workflow.list against real registry