### PR TITLE
fix(daemon): classify daemon.peers in METHOD_ACTION_CLASS

### DIFF
--- a/packages/daemon/src/__tests__/daemon-peers.test.ts
+++ b/packages/daemon/src/__tests__/daemon-peers.test.ts
@@ -84,7 +84,7 @@ function createPeerNeonStore(): {
     return Promise.resolve([]);
   };
 
-  return { mock: mock as any, agents };
+  return { mock: mock as never, agents };
 }
 
 function rpc(

--- a/packages/daemon/src/__tests__/permission.test.ts
+++ b/packages/daemon/src/__tests__/permission.test.ts
@@ -47,6 +47,11 @@ describe('METHOD_ACTION_CLASS coverage', () => {
   it('unmapped method fails closed to critical', () => {
     expect(classifyMethod('totally.unknown.method')).toBe('critical');
   });
+
+  // Prove-red: without METHOD_ACTION_CLASS entry, classifyMethod fails closed to critical.
+  it('classifies daemon.peers as routine (GAP-154 Phase 5)', () => {
+    expect(classifyMethod('daemon.peers')).toBe('routine');
+  });
 });
 
 describe('shadow would (manual simulation)', () => {

--- a/packages/daemon/src/__tests__/postgres-url-file.test.ts
+++ b/packages/daemon/src/__tests__/postgres-url-file.test.ts
@@ -2,13 +2,13 @@
  * POSTGRES_URL_FILE resolution (GAP-154 finish).
  * @vitest-environment node
  */
-import { mkdtemp, writeFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { _resetForTesting, initNeonSync, isNeonSyncActive, resolvePostgresUrl } from "../neon.js";
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { _resetForTesting, resolvePostgresUrl } from '../neon.js';
 
-describe("resolvePostgresUrl / POSTGRES_URL_FILE", () => {
+describe('resolvePostgresUrl / POSTGRES_URL_FILE', () => {
   const prevUrl = process.env.POSTGRES_URL;
   const prevDb = process.env.DATABASE_URL;
   const prevFile = process.env.POSTGRES_URL_FILE;
@@ -23,20 +23,20 @@ describe("resolvePostgresUrl / POSTGRES_URL_FILE", () => {
     else process.env.POSTGRES_URL_FILE = prevFile;
   });
 
-  it("reads POSTGRES_URL_FILE when inline URL unset", async () => {
+  it('reads POSTGRES_URL_FILE when inline URL unset', async () => {
     delete process.env.POSTGRES_URL;
     delete process.env.DATABASE_URL;
-    const dir = await mkdtemp(join(tmpdir(), "pgurl-"));
-    const file = join(dir, "url");
-    await writeFile(file, "  postgresql://user:pass@example.com/db  \n");
+    const dir = await mkdtemp(join(tmpdir(), 'pgurl-'));
+    const file = join(dir, 'url');
+    await writeFile(file, '  postgresql://user:pass@example.com/db  \n');
     process.env.POSTGRES_URL_FILE = file;
-    expect(resolvePostgresUrl()).toBe("postgresql://user:pass@example.com/db");
+    expect(resolvePostgresUrl()).toBe('postgresql://user:pass@example.com/db');
     await rm(dir, { recursive: true, force: true });
   });
 
-  it("prefers POSTGRES_URL over file", async () => {
-    process.env.POSTGRES_URL = "postgresql://inline/db";
-    process.env.POSTGRES_URL_FILE = "/no/such/file";
-    expect(resolvePostgresUrl()).toBe("postgresql://inline/db");
+  it('prefers POSTGRES_URL over file', async () => {
+    process.env.POSTGRES_URL = 'postgresql://inline/db';
+    process.env.POSTGRES_URL_FILE = '/no/such/file';
+    expect(resolvePostgresUrl()).toBe('postgresql://inline/db');
   });
 });

--- a/packages/daemon/src/neon.ts
+++ b/packages/daemon/src/neon.ts
@@ -51,7 +51,7 @@ let client: NeonQueryFunction<false, false> | null = null;
  * (file path is stream-safe for systemd PrivateTmp materialization).
  */
 export function resolvePostgresUrl(databaseUrl?: string | undefined): string {
-  if (databaseUrl && databaseUrl.trim()) return databaseUrl.trim();
+  if (databaseUrl?.trim()) return databaseUrl.trim();
   const inline = process.env.POSTGRES_URL?.trim() || process.env.DATABASE_URL?.trim();
   if (inline) return inline;
   const filePath = process.env.POSTGRES_URL_FILE?.trim();

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -100,6 +100,8 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['agent.resize', 'routine'],
   ['agent.stop', 'routine'],
   ['agent.list', 'routine'],
+  // GAP-154 Phase 5 — read-only peer discovery (Neon role=daemon)
+  ['daemon.peers', 'routine'],
   // consequential
   ['file.write', 'consequential'],
   ['file.delete', 'consequential'],

--- a/scripts/gap-154-neon-fleet-dogfood.mjs
+++ b/scripts/gap-154-neon-fleet-dogfood.mjs
@@ -13,24 +13,23 @@
  *
  * Cleans up test sessions on both sockets when possible.
  */
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { connect } from "node:net";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { connect } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-const ROOT = new URL("..", import.meta.url).pathname;
-const DIST_CLI = join(ROOT, "packages/daemon/dist/cli.js");
+const ROOT = new URL('..', import.meta.url).pathname;
 
 function rpc(socketPath, method, params = {}) {
   return new Promise((resolve, reject) => {
     const sock = connect(socketPath);
-    let buf = "";
-    const frame = JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }) + "\n";
-    sock.on("connect", () => sock.write(frame));
-    sock.on("data", (d) => {
+    let buf = '';
+    const frame = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
+    sock.on('connect', () => sock.write(frame));
+    sock.on('data', (d) => {
       buf += d.toString();
-      const nl = buf.indexOf("\n");
+      const nl = buf.indexOf('\n');
       if (nl === -1) return;
       sock.end();
       try {
@@ -41,7 +40,7 @@ function rpc(socketPath, method, params = {}) {
         reject(e);
       }
     });
-    sock.on("error", reject);
+    sock.on('error', reject);
     sock.setTimeout(15_000, () => {
       sock.destroy();
       reject(new Error(`timeout ${method}`));
@@ -52,26 +51,26 @@ function rpc(socketPath, method, params = {}) {
 async function main() {
   if (!process.env.POSTGRES_URL && !process.env.POSTGRES_URL_FILE) {
     console.error(
-      "FAIL: set POSTGRES_URL (or POSTGRES_URL_FILE) via revvault run — see script header",
+      'FAIL: set POSTGRES_URL (or POSTGRES_URL_FILE) via revvault run — see script header',
     );
     process.exit(2);
   }
 
   // Dynamic import after env is set so neon init can see POSTGRES_URL
   const { startDaemon } = await import(
-    pathToFileURL(join(ROOT, "packages/daemon/dist/index.js")).href
+    pathToFileURL(join(ROOT, 'packages/daemon/dist/index.js')).href
   );
 
   const stamp = Date.now().toString(36);
   const agentA = `gap154-dogfood-a-${stamp}`;
   const agentB = `gap154-dogfood-b-${stamp}`;
 
-  const dirA = await mkdtemp(join(tmpdir(), "gap154-a-"));
-  const dirB = await mkdtemp(join(tmpdir(), "gap154-b-"));
-  const sockA = join(dirA, "harness.sock");
-  const sockB = join(dirB, "harness.sock");
-  await writeFile(join(dirA, "trusted-client-fingerprint"), "");
-  await writeFile(join(dirB, "trusted-client-fingerprint"), "");
+  const dirA = await mkdtemp(join(tmpdir(), 'gap154-a-'));
+  const dirB = await mkdtemp(join(tmpdir(), 'gap154-b-'));
+  const sockA = join(dirA, 'harness.sock');
+  const sockB = join(dirB, 'harness.sock');
+  await writeFile(join(dirA, 'trusted-client-fingerprint'), '');
+  await writeFile(join(dirB, 'trusted-client-fingerprint'), '');
 
   let closeA;
   let closeB;
@@ -81,7 +80,7 @@ async function main() {
       socketPath: sockA,
       dataDir: dirA,
       pruneIntervalMs: 0,
-      trustedClientFingerprintPath: join(dirA, "trusted-client-fingerprint"),
+      trustedClientFingerprintPath: join(dirA, 'trusted-client-fingerprint'),
       trustedAnchorRequireRootOwned: false,
     });
     closeA = a.close;
@@ -91,76 +90,70 @@ async function main() {
       socketPath: sockB,
       dataDir: dirB,
       pruneIntervalMs: 0,
-      trustedClientFingerprintPath: join(dirB, "trusted-client-fingerprint"),
+      trustedClientFingerprintPath: join(dirB, 'trusted-client-fingerprint'),
       trustedAnchorRequireRootOwned: false,
     });
     closeB = b.close;
 
-    const healthA = await rpc(sockA, "harness.health");
+    const healthA = await rpc(sockA, 'harness.health');
     if (!healthA.neonSyncActive) {
-      console.error("FAIL: neonSyncActive=false on A — POSTGRES_URL not loading");
+      console.error('FAIL: neonSyncActive=false on A — POSTGRES_URL not loading');
       process.exit(1);
     }
-    console.log("ok neonSyncActive on A");
+    console.log('ok neonSyncActive on A');
 
-    await rpc(sockA, "session.register", {
+    await rpc(sockA, 'session.register', {
       agentId: agentA,
       agentName: agentA,
-      env: "gap154-dogfood-a",
-      task: "gap-154 fleet dogfood",
+      env: 'gap154-dogfood-a',
+      task: 'gap-154 fleet dogfood',
     });
-    console.log("ok registered", agentA);
+    console.log('ok registered', agentA);
 
     // Allow Neon write lag
     await new Promise((r) => setTimeout(r, 1500));
 
-    const fleetB = await rpc(sockB, "session.list", { scope: "fleet" });
+    const fleetB = await rpc(sockB, 'session.list', { scope: 'fleet' });
     const sessions = fleetB.sessions || [];
     const found = sessions.some(
       (s) => s.agentId === agentA || s.id === agentA || s.agent_id === agentA,
     );
     if (!found) {
       console.error(
-        "FAIL: B fleet list missing A",
+        'FAIL: B fleet list missing A',
         JSON.stringify(
           sessions.slice(0, 5).map((s) => ({ id: s.id, agentId: s.agentId || s.agent_id })),
         ),
       );
       process.exit(1);
     }
-    console.log("ok B session.list({scope:fleet}) sees A");
+    console.log('ok B session.list({scope:fleet}) sees A');
 
-    const peersA = await rpc(sockA, "daemon.peers", {});
+    const peersA = await rpc(sockA, 'daemon.peers', {});
     if (!peersA.neonSyncActive) {
-      console.error("FAIL: daemon.peers neonSyncActive false");
+      console.error('FAIL: daemon.peers neonSyncActive false');
       process.exit(1);
     }
-    console.log(
-      "ok daemon.peers",
-      "selfId=",
-      peersA.selfId,
-      "count=",
-      (peersA.peers || []).length,
-    );
+    console.log('ok daemon.peers', 'selfId=', peersA.selfId, 'count=', (peersA.peers || []).length);
 
     // Cleanup test sessions (best-effort; may need signed end — try unsigned register end path)
     try {
-      await rpc(sockA, "session.end", { agentId: agentA });
+      await rpc(sockA, 'session.end', { agentId: agentA });
     } catch {
       /* optional */
     }
     try {
-      await rpc(sockB, "session.register", {
+      await rpc(sockB, 'session.register', {
         agentId: agentB,
         agentName: agentB,
-        env: "gap154-dogfood-b",
+        env: 'gap154-dogfood-b',
       });
-      await rpc(sockB, "session.end", { agentId: agentB });
+      await rpc(sockB, 'session.end', { agentId: agentB });
     } catch {
       /* optional */
     }
 
-    console.log("RESULT=PASS gap-154 neon fleet dogfood");
+    console.log('RESULT=PASS gap-154 neon fleet dogfood');
   } finally {
     if (closeB) await closeB().catch(() => undefined);
     if (closeA) await closeA().catch(() => undefined);
@@ -170,6 +163,6 @@ async function main() {
 }
 
 main().catch((e) => {
-  console.error("FAIL:", e.message);
+  console.error('FAIL:', e.message);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

- Maps `daemon.peers` as **routine** in `METHOD_ACTION_CLASS` (missed in #371 / GAP-154 Phase 5). Without it, `permission.test` fails CI Test on `test` (`classifyMethod` fail-closed → `critical`).
- Adds an explicit prove-red assertion: `classifyMethod('daemon.peers') === 'routine'` (red against base without the map entry).
- Biome Quality cleanup for GAP-154 dogfood/tests left red after #373/#374 merges on `test`.

## Why not #375

`main` has **no unique tree content** vs `test` (only a promote merge-commit). #375 was a topology-only backflow plus format-only test edits, so Prove-Red correctly rejected inert tests. This PR fixes the real red on `test` instead.

Supersedes https://github.com/RevealUIStudio/revdev/pull/375

## Test plan

- [x] Local: permission suite green with map entry
- [x] Local prove-red: new assert fails (`critical`) when map entry stashed
- [x] Biome clean on touched files
- [ ] CI: Quality, Prove-Red TS, Test green