### PR TITLE
chore(release): promote test → main (GAP-474 workflow RPC + GAP-154 peers)

### DIFF
--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -8,7 +8,7 @@ Manages AI agent sessions, PTY processes, tool routing, inter-agent messaging, t
 
 - **Local**: Unix socket (`~/.local/share/revealui/harness.sock`)
 - **Remote**: HTTP gateway with pairing-code auth (**shipped**, GAP-421 port of the
-  harness gateway; GAP-154 Phase 5 transport). Off by default (`httpPort: 0`).
+  harness gateway; GAP-154 Phase 5 transport + `daemon.peers` Neon registry). Off by default (`httpPort: 0`).
   When enabled: `GET/POST /api/pair` (HMAC challenge, secret never on the wire),
   `POST /rpc` (same `dispatchRpc` path as the Unix socket — one authorization
   plane), `GET /api/status`, `GET /api/stream/:processId` (ticket-bound SSE).

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -90,6 +90,7 @@ Environment variables (all optional):
 | `REVDEV_DAEMON_PID` | `~/.local/share/revealui/harness.pid` | PID file location |
 | `REVDEV_DAEMON_LOG` | `~/.local/share/revealui/daemon.log` | Log file for `--detach` mode |
 | `POSTGRES_URL` | (none → sync disabled) | Neon URL for cross-machine `coordination_*` sync (GAP-154) |
+| `POSTGRES_URL_FILE` | (none) | File path to Neon URL (stream-safe systemd; same effect as POSTGRES_URL) |
 
 ## License tiers
 

--- a/packages/daemon/src/__tests__/daemon-peers.test.ts
+++ b/packages/daemon/src/__tests__/daemon-peers.test.ts
@@ -1,0 +1,194 @@
+/**
+ * GAP-154 Phase 5 — daemon peer registry (Neon role=daemon) + daemon.peers RPC.
+ * @vitest-environment node
+ */
+import { vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  _resetForTesting,
+  getSelfDaemonId,
+  listDaemonPeers,
+  registerDaemonPeer,
+  setNeonClientForTesting,
+} from '../neon.js';
+import { startDaemon } from '../server.js';
+
+function createPeerNeonStore(): {
+  mock: (
+    strings: TemplateStringsArray | readonly string[],
+    ...values: unknown[]
+  ) => Promise<unknown>;
+  agents: Map<
+    string,
+    { id: string; env: string; last_seen: string; metadata: Record<string, unknown> }
+  >;
+} {
+  const agents = new Map<
+    string,
+    { id: string; env: string; last_seen: string; metadata: Record<string, unknown> }
+  >();
+
+  const mock = (strings: TemplateStringsArray | readonly string[], ...values: unknown[]) => {
+    const sql = Array.from(strings).join(' ').replace(/\s+/g, ' ').trim().toUpperCase();
+
+    if (sql.includes('INSERT INTO COORDINATION_AGENTS')) {
+      // VALUES (id, env, NOW(), 0, metadata) — NOW() is SQL literal
+      const id = String(values[0] ?? '');
+      const env = String(values[1] ?? '');
+      let metadata: Record<string, unknown> = {};
+      try {
+        // values[2] is total_sessions (0); values[3] is metadata JSON
+        metadata = JSON.parse(String(values[3] ?? values[2] ?? '{}')) as Record<string, unknown>;
+      } catch {
+        metadata = {};
+      }
+      const existing = agents.get(id);
+      agents.set(id, {
+        id,
+        env,
+        last_seen: new Date().toISOString(),
+        metadata: existing ? { ...existing.metadata, ...metadata } : metadata,
+      });
+      return Promise.resolve([]);
+    }
+
+    if (sql.includes('UPDATE COORDINATION_AGENTS') && sql.includes('LAST_SEEN')) {
+      const id = String(values[0] ?? '');
+      const existing = agents.get(id);
+      if (existing) {
+        agents.set(id, { ...existing, last_seen: new Date().toISOString() });
+      }
+      return Promise.resolve([]);
+    }
+
+    if (sql.includes('FROM COORDINATION_AGENTS') && sql.includes('ROLE')) {
+      const rows = [...agents.values()]
+        .filter((a) => a.metadata.role === 'daemon')
+        .map((a) => ({
+          id: a.id,
+          env: a.env,
+          last_seen: a.last_seen,
+          metadata: a.metadata,
+        }));
+      return Promise.resolve(rows);
+    }
+
+    // Session dual-writes unused here
+    return Promise.resolve([]);
+  };
+
+  return { mock: mock as any, agents };
+}
+
+function rpc(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown> = {},
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = connect(socketPath);
+    let buf = '';
+    const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
+    sock.on('connect', () => sock.write(req));
+    sock.on('data', (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf('\n');
+      if (nl === -1) return;
+      sock.end();
+      try {
+        const resp = JSON.parse(buf.slice(0, nl));
+        if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
+        else resolve(resp.result);
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+    sock.on('error', reject);
+    sock.setTimeout(8000, () => {
+      sock.destroy();
+      reject(new Error(`RPC timeout: ${method}`));
+    });
+  });
+}
+
+describe('GAP-154 Phase 5 daemon peer registry', () => {
+  const store = createPeerNeonStore();
+  let dataDir: string;
+  let socketPath: string;
+  let close: (() => Promise<void>) | null = null;
+
+  beforeAll(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'daemon-peers-'));
+    socketPath = join(dataDir, 'harness.sock');
+  });
+
+  afterAll(async () => {
+    if (close) await close();
+    _resetForTesting();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    store.agents.clear();
+    setNeonClientForTesting(store.mock);
+  });
+
+  it('registerDaemonPeer upserts role=daemon agent', async () => {
+    await registerDaemonPeer({
+      daemonId: 'daemon:test-host:abc',
+      env: 'test-host',
+      hostname: 'test-host',
+      httpGatewayUrl: 'http://127.0.0.1:9999',
+      socketHint: '/tmp/sock',
+      pid: 1234,
+    });
+    expect(getSelfDaemonId()).toBe('daemon:test-host:abc');
+    const peers = await listDaemonPeers();
+    expect(peers).toHaveLength(1);
+    expect(peers[0]?.id).toBe('daemon:test-host:abc');
+    expect(peers[0]?.httpGatewayUrl).toBe('http://127.0.0.1:9999');
+    expect(peers[0]?.role).toBe('daemon');
+  });
+
+  it('daemon.peers RPC returns self + neonSyncActive', async () => {
+    if (close) {
+      await close();
+      close = null;
+    }
+    // startDaemon → initNeonSync() clears any prior test client when
+    // POSTGRES_URL is unset. Inject mock after listen (same as fleet suite).
+    const handle = await startDaemon({
+      socketPath,
+      dataDir,
+      httpPort: 0,
+      pruneIntervalMs: 0,
+      trustedAnchorRequireRootOwned: false,
+    });
+    close = () => handle.close();
+    setNeonClientForTesting(store.mock);
+    await registerDaemonPeer({
+      daemonId: 'daemon:rpc-host:xyz',
+      env: 'rpc-host',
+      hostname: 'rpc-host',
+      httpGatewayUrl: null,
+      socketHint: socketPath,
+      pid: process.pid,
+    });
+
+    const result = (await rpc(socketPath, 'daemon.peers', {})) as {
+      neonSyncActive: boolean;
+      selfId: string | null;
+      peers: Array<{ id: string; isSelf: boolean }>;
+    };
+    expect(result.neonSyncActive).toBe(true);
+    expect(result.selfId).toBe('daemon:rpc-host:xyz');
+    expect(result.peers.some((p) => p.isSelf)).toBe(true);
+  });
+});

--- a/packages/daemon/src/__tests__/daemon-peers.test.ts
+++ b/packages/daemon/src/__tests__/daemon-peers.test.ts
@@ -137,7 +137,7 @@ describe('GAP-154 Phase 5 daemon peer registry', () => {
 
   beforeEach(() => {
     store.agents.clear();
-    setNeonClientForTesting(store.mock);
+    setNeonClientForTesting(store.mock as never);
   });
 
   it('registerDaemonPeer upserts role=daemon agent', async () => {
@@ -172,7 +172,7 @@ describe('GAP-154 Phase 5 daemon peer registry', () => {
       trustedAnchorRequireRootOwned: false,
     });
     close = () => handle.close();
-    setNeonClientForTesting(store.mock);
+    setNeonClientForTesting(store.mock as never);
     await registerDaemonPeer({
       daemonId: 'daemon:rpc-host:xyz',
       env: 'rpc-host',

--- a/packages/daemon/src/__tests__/guard.test.ts
+++ b/packages/daemon/src/__tests__/guard.test.ts
@@ -53,6 +53,7 @@ describe('guardRpcMethod', () => {
       'inference.generate',
       // GAP-337: monitoring without a Pro license
       'harness.health',
+      'daemon.peers',
     ];
 
     for (const method of exemptMethods) {
@@ -172,6 +173,10 @@ describe('guardRpcMethod', () => {
 
     it('allows harness.health on free and pro (GAP-337)', () => {
       expect(guardRpcMethod('harness.health').allowed).toBe(true);
+    });
+
+    it('allows daemon.peers on free (GAP-154 Phase 5 discovery)', () => {
+      expect(guardRpcMethod('daemon.peers').allowed).toBe(true);
     });
   });
 

--- a/packages/daemon/src/__tests__/postgres-url-file.test.ts
+++ b/packages/daemon/src/__tests__/postgres-url-file.test.ts
@@ -1,0 +1,42 @@
+/**
+ * POSTGRES_URL_FILE resolution (GAP-154 finish).
+ * @vitest-environment node
+ */
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { _resetForTesting, initNeonSync, isNeonSyncActive, resolvePostgresUrl } from "../neon.js";
+
+describe("resolvePostgresUrl / POSTGRES_URL_FILE", () => {
+  const prevUrl = process.env.POSTGRES_URL;
+  const prevDb = process.env.DATABASE_URL;
+  const prevFile = process.env.POSTGRES_URL_FILE;
+
+  afterEach(() => {
+    _resetForTesting();
+    if (prevUrl === undefined) delete process.env.POSTGRES_URL;
+    else process.env.POSTGRES_URL = prevUrl;
+    if (prevDb === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prevDb;
+    if (prevFile === undefined) delete process.env.POSTGRES_URL_FILE;
+    else process.env.POSTGRES_URL_FILE = prevFile;
+  });
+
+  it("reads POSTGRES_URL_FILE when inline URL unset", async () => {
+    delete process.env.POSTGRES_URL;
+    delete process.env.DATABASE_URL;
+    const dir = await mkdtemp(join(tmpdir(), "pgurl-"));
+    const file = join(dir, "url");
+    await writeFile(file, "  postgresql://user:pass@example.com/db  \n");
+    process.env.POSTGRES_URL_FILE = file;
+    expect(resolvePostgresUrl()).toBe("postgresql://user:pass@example.com/db");
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("prefers POSTGRES_URL over file", async () => {
+    process.env.POSTGRES_URL = "postgresql://inline/db";
+    process.env.POSTGRES_URL_FILE = "/no/such/file";
+    expect(resolvePostgresUrl()).toBe("postgresql://inline/db");
+  });
+});

--- a/packages/daemon/src/__tests__/postgres-url-file.test.ts
+++ b/packages/daemon/src/__tests__/postgres-url-file.test.ts
@@ -2,13 +2,13 @@
  * POSTGRES_URL_FILE resolution (GAP-154 finish).
  * @vitest-environment node
  */
-import { mkdtemp, writeFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { _resetForTesting, initNeonSync, isNeonSyncActive, resolvePostgresUrl } from "../neon.js";
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { _resetForTesting, initNeonSync, isNeonSyncActive, resolvePostgresUrl } from '../neon.js';
 
-describe("resolvePostgresUrl / POSTGRES_URL_FILE", () => {
+describe('resolvePostgresUrl / POSTGRES_URL_FILE', () => {
   const prevUrl = process.env.POSTGRES_URL;
   const prevDb = process.env.DATABASE_URL;
   const prevFile = process.env.POSTGRES_URL_FILE;
@@ -23,20 +23,20 @@ describe("resolvePostgresUrl / POSTGRES_URL_FILE", () => {
     else process.env.POSTGRES_URL_FILE = prevFile;
   });
 
-  it("reads POSTGRES_URL_FILE when inline URL unset", async () => {
+  it('reads POSTGRES_URL_FILE when inline URL unset', async () => {
     delete process.env.POSTGRES_URL;
     delete process.env.DATABASE_URL;
-    const dir = await mkdtemp(join(tmpdir(), "pgurl-"));
-    const file = join(dir, "url");
-    await writeFile(file, "  postgresql://user:pass@example.com/db  \n");
+    const dir = await mkdtemp(join(tmpdir(), 'pgurl-'));
+    const file = join(dir, 'url');
+    await writeFile(file, '  postgresql://user:pass@example.com/db  \n');
     process.env.POSTGRES_URL_FILE = file;
-    expect(resolvePostgresUrl()).toBe("postgresql://user:pass@example.com/db");
+    expect(resolvePostgresUrl()).toBe('postgresql://user:pass@example.com/db');
     await rm(dir, { recursive: true, force: true });
   });
 
-  it("prefers POSTGRES_URL over file", async () => {
-    process.env.POSTGRES_URL = "postgresql://inline/db";
-    process.env.POSTGRES_URL_FILE = "/no/such/file";
-    expect(resolvePostgresUrl()).toBe("postgresql://inline/db");
+  it('prefers POSTGRES_URL over file', async () => {
+    process.env.POSTGRES_URL = 'postgresql://inline/db';
+    process.env.POSTGRES_URL_FILE = '/no/such/file';
+    expect(resolvePostgresUrl()).toBe('postgresql://inline/db');
   });
 });

--- a/packages/daemon/src/__tests__/workflow-rpc.test.ts
+++ b/packages/daemon/src/__tests__/workflow-rpc.test.ts
@@ -1,0 +1,111 @@
+/**
+ * GAP-473 — workflow.list / workflow.run unit tests.
+ * Uses a scratch registry so tests never touch the real ~/revfleet/.jv tree.
+ */
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { listWorkflows, runWorkflow } from '../workflow-rpc.js';
+
+function writeMinimalRunner(jvRoot: string): void {
+  const scripts = join(jvRoot, 'scripts');
+  mkdirSync(scripts, { recursive: true });
+  // Minimal runner: --list prints fixed lines; <name> exits 0 unless gated without --fix
+  writeFileSync(
+    join(scripts, 'workflow-run.js'),
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args.includes('--list')) {
+  console.log('workflow-run: registry at test');
+  console.log('  prepare-for-exit — Verify clean [safety: auto]');
+  process.exit(0);
+}
+const name = args.find((a) => a[0] !== '-');
+const fix = args.includes('--fix') || args.includes('--yes');
+const dry = args.includes('--dry-run');
+if (name === 'cleanup-session' && !fix && !dry) {
+  console.log('[STOPPED-GATED] cleanup');
+  process.exit(1);
+}
+if (name === 'missing-will-not-be-called') {
+  process.exit(2);
+}
+console.log('RUN — ' + name + (dry ? ' dry' : ''));
+process.exit(0);
+`,
+  );
+}
+
+function writeWorkflow(jvRoot: string, name: string, safety: string): void {
+  const dir = join(jvRoot, 'workflows');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${name}.yml`),
+    `name: ${name}
+title: Test ${name}
+safety: ${safety}
+steps:
+  - id: s1
+    title: step
+    run: node -e "process.exit(0)"
+    safety: ${safety}
+`,
+  );
+}
+
+describe('workflow-rpc (GAP-473)', () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    // leave tmpdirs for OS cleanup; no recursive rm (policy)
+    roots.length = 0;
+  });
+
+  function scratch(): string {
+    const root = mkdtempSync(join(tmpdir(), 'revdev-wf-'));
+    roots.push(root);
+    writeMinimalRunner(root);
+    writeWorkflow(root, 'prepare-for-exit', 'auto');
+    writeWorkflow(root, 'cleanup-session', 'gated');
+    return root;
+  }
+
+  it('listWorkflows returns registry entries', () => {
+    const root = scratch();
+    const list = listWorkflows(root);
+    expect(list.length).toBe(2);
+    expect(list.map((w) => w.name).sort()).toEqual(['cleanup-session', 'prepare-for-exit']);
+    expect(list.find((w) => w.name === 'prepare-for-exit')?.safety).toBe('auto');
+  });
+
+  it('listWorkflows throws when registry missing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'revdev-wf-empty-'));
+    expect(() => listWorkflows(root)).toThrow(/workflow runner missing|registry missing/);
+  });
+
+  it('runWorkflow prepare-for-exit succeeds', () => {
+    const root = scratch();
+    const r = runWorkflow(root, 'prepare-for-exit', {});
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('prepare-for-exit');
+  });
+
+  it('runWorkflow cleanup-session without fix exits non-zero (gated)', () => {
+    const root = scratch();
+    const r = runWorkflow(root, 'cleanup-session', {});
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stdout).toContain('STOPPED-GATED');
+  });
+
+  it('runWorkflow cleanup-session with fix succeeds', () => {
+    const root = scratch();
+    const r = runWorkflow(root, 'cleanup-session', { fix: true });
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('runWorkflow rejects path-shaped names', () => {
+    const root = scratch();
+    expect(() => runWorkflow(root, '../evil', {})).toThrow(/invalid name/);
+  });
+});

--- a/packages/daemon/src/__tests__/workflow-rpc.test.ts
+++ b/packages/daemon/src/__tests__/workflow-rpc.test.ts
@@ -1,6 +1,6 @@
 /**
- * GAP-473 — workflow.list / workflow.run unit tests.
- * Uses a scratch registry so tests never touch the real ~/revfleet/.jv tree.
+ * GAP-474 — workflow.list / workflow.run unit tests.
+ * Uses a scratch registry so tests never touch a live planning checkout.
  */
 
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -39,6 +39,8 @@ import './agent.js';
 import './spawn.js';
 // Register gateway.revokeToken (GAP-421 guardrail-2 remediation S5).
 import './gateway-rpc.js';
+// GAP-473 — workflow.list / workflow.run (same .jv registry as Studio /ops).
+import './workflow-rpc.js';
 import { DAEMON_DEFAULTS } from './config.js';
 import { LICENSE_TIER_HELP, LicenseConfigError, LicenseExpiredError } from './license.js';
 import { startDaemon } from './server.js';

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -39,7 +39,7 @@ import './agent.js';
 import './spawn.js';
 // Register gateway.revokeToken (GAP-421 guardrail-2 remediation S5).
 import './gateway-rpc.js';
-// GAP-473 — workflow.list / workflow.run (same .jv registry as Studio /ops).
+// GAP-474 — workflow.list / workflow.run (same registry as Studio /ops).
 import './workflow-rpc.js';
 import { DAEMON_DEFAULTS } from './config.js';
 import { LICENSE_TIER_HELP, LicenseConfigError, LicenseExpiredError } from './license.js';

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -71,6 +71,8 @@ import './agent.js';
 // in agent.js with real implementations. Must follow agent.js in import order.
 import './spawn.js';
 import './gateway-rpc.js';
+// GAP-473 — workflow.list / workflow.run over .jv registry
+import './workflow-rpc.js';
 
 export { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 export { SCHEMA_SQL } from './storage/schema.js';

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -71,7 +71,7 @@ import './agent.js';
 // in agent.js with real implementations. Must follow agent.js in import order.
 import './spawn.js';
 import './gateway-rpc.js';
-// GAP-473 — workflow.list / workflow.run over .jv registry
+// GAP-474 — workflow.list / workflow.run over operational-workflow registry
 import './workflow-rpc.js';
 
 export { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -125,7 +125,7 @@ const EXEMPT_METHODS = new Set([
   // GAP-154 Phase 5: peer discovery is diagnostic (empty without Neon).
   // Dual-write still requires Pro coordination RPCs; listing peers alone is free.
   'daemon.peers',
-  // GAP-473: local .jv operational workflows (same class as /ops; Studio daily driver)
+  // GAP-474: local operational workflows (same class as /ops; Studio daily driver)
   'workflow.list',
   'workflow.run',
 ]);

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -122,6 +122,9 @@ const EXEMPT_METHODS = new Set([
   // GAP-337: health/monitoring must answer without a Pro license (same class
   // as ping). Multi-agent harness.prune stays Pro.
   'harness.health',
+  // GAP-154 Phase 5: peer discovery is diagnostic (empty without Neon).
+  // Dual-write still requires Pro coordination RPCs; listing peers alone is free.
+  'daemon.peers',
 ]);
 
 /**

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -125,6 +125,9 @@ const EXEMPT_METHODS = new Set([
   // GAP-154 Phase 5: peer discovery is diagnostic (empty without Neon).
   // Dual-write still requires Pro coordination RPCs; listing peers alone is free.
   'daemon.peers',
+  // GAP-473: local .jv operational workflows (same class as /ops; Studio daily driver)
+  'workflow.list',
+  'workflow.run',
 ]);
 
 /**

--- a/packages/daemon/src/neon.ts
+++ b/packages/daemon/src/neon.ts
@@ -532,7 +532,137 @@ export async function syncEventLog(params: {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Phase 5 — daemon peer registry (cross-machine discovery)
+//
+// Reuses coordination_agents with metadata.role = 'daemon' (no new table).
+// Each daemon upserts itself at startup (+ optional heartbeat). Peers list
+// returns daemons seen recently so fleet operators can discover HTTP
+// gateways / hosts without a separate registry product.
+// ---------------------------------------------------------------------------
+
+export interface DaemonPeerRow {
+  id: string;
+  env: string;
+  lastSeen: string;
+  hostname: string | null;
+  httpGatewayUrl: string | null;
+  socketHint: string | null;
+  pid: number | null;
+  role: 'daemon';
+}
+
+let selfDaemonId: string | null = null;
+
+/** Stable id for this daemon process (set by registerDaemonPeer). */
+export function getSelfDaemonId(): string | null {
+  return selfDaemonId;
+}
+
+/**
+ * Upsert this daemon into the Neon fleet registry.
+ * No-op when Neon sync is disabled.
+ */
+export async function registerDaemonPeer(params: {
+  daemonId: string;
+  env: string;
+  hostname: string;
+  httpGatewayUrl: string | null;
+  socketHint: string | null;
+  pid: number;
+}): Promise<void> {
+  selfDaemonId = params.daemonId;
+  if (!client) return;
+  try {
+    const c = client;
+    const metadata = {
+      role: 'daemon',
+      hostname: params.hostname,
+      httpGatewayUrl: params.httpGatewayUrl,
+      socketHint: params.socketHint,
+      pid: params.pid,
+      registeredAt: new Date().toISOString(),
+    };
+    await c`
+      INSERT INTO coordination_agents (id, env, last_seen, total_sessions, metadata)
+      VALUES (
+        ${params.daemonId},
+        ${params.env},
+        NOW(),
+        0,
+        ${JSON.stringify(metadata)}::jsonb
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        env = EXCLUDED.env,
+        last_seen = NOW(),
+        metadata = COALESCE(coordination_agents.metadata, '{}'::jsonb) || EXCLUDED.metadata
+    `;
+  } catch (err) {
+    log.warn('registerDaemonPeer failed', {
+      daemonId: params.daemonId,
+      error: String(err),
+    });
+  }
+}
+
+/**
+ * Touch last_seen for this daemon (periodic heartbeat).
+ */
+export async function heartbeatDaemonPeer(daemonId: string): Promise<void> {
+  if (!client) return;
+  try {
+    const c = client;
+    await c`
+      UPDATE coordination_agents
+        SET last_seen = NOW()
+      WHERE id = ${daemonId}
+        AND metadata->>'role' = 'daemon'
+    `;
+  } catch (err) {
+    log.warn('heartbeatDaemonPeer failed', { daemonId, error: String(err) });
+  }
+}
+
+/**
+ * List recently-seen daemon peers from Neon.
+ * Returns [] when Neon sync is disabled.
+ */
+export async function listDaemonPeers(opts?: {
+  staleAfterSeconds?: number;
+}): Promise<DaemonPeerRow[]> {
+  if (!client) return [];
+  const staleAfter = opts?.staleAfterSeconds ?? 300;
+  try {
+    const c = client;
+    const rows = await c`
+      SELECT id, env, last_seen, metadata
+      FROM coordination_agents
+      WHERE metadata->>'role' = 'daemon'
+        AND last_seen > NOW() - make_interval(secs => ${staleAfter})
+      ORDER BY last_seen DESC
+    `;
+    return (rows as Array<Record<string, unknown>>).map((r) => {
+      const meta =
+        r.metadata && typeof r.metadata === 'object' ? (r.metadata as Record<string, unknown>) : {};
+      return {
+        id: String(r.id ?? ''),
+        env: String(r.env ?? ''),
+        lastSeen: String(r.last_seen ?? ''),
+        hostname: meta.hostname == null ? null : String(meta.hostname),
+        httpGatewayUrl: meta.httpGatewayUrl == null ? null : String(meta.httpGatewayUrl),
+        socketHint: meta.socketHint == null ? null : String(meta.socketHint),
+        pid: typeof meta.pid === 'number' ? meta.pid : null,
+        role: 'daemon' as const,
+      };
+    });
+  } catch (err) {
+    log.warn('listDaemonPeers failed', { error: String(err) });
+    return [];
+  }
+}
+
 /** Reset module state. Test-only. */
 export function _resetForTesting(): void {
   client = null;
+  selfDaemonId = null;
 }

--- a/packages/daemon/src/neon.ts
+++ b/packages/daemon/src/neon.ts
@@ -37,6 +37,7 @@
  *     reconcile across daemons. Until then they stay local-only by design.
  */
 
+import { readFileSync } from 'node:fs';
 import { type NeonQueryFunction, neon } from '@neondatabase/serverless';
 import { createLogger } from '@revealui/utils/logger';
 
@@ -45,12 +46,35 @@ const log = createLogger({ service: 'revdev-daemon-neon' });
 let client: NeonQueryFunction<false, false> | null = null;
 
 /**
- * Initialize the Neon client from `POSTGRES_URL` env var (or override).
- * Idempotent. When the URL is empty/unset, sync is disabled and all
- * helpers below are silent no-ops.
+ * Resolve Neon URL without putting secrets on argv.
+ * Priority: explicit arg → POSTGRES_URL → DATABASE_URL → POSTGRES_URL_FILE
+ * (file path is stream-safe for systemd PrivateTmp materialization).
+ */
+export function resolvePostgresUrl(databaseUrl?: string | undefined): string {
+  if (databaseUrl && databaseUrl.trim()) return databaseUrl.trim();
+  const inline = process.env.POSTGRES_URL?.trim() || process.env.DATABASE_URL?.trim();
+  if (inline) return inline;
+  const filePath = process.env.POSTGRES_URL_FILE?.trim();
+  if (!filePath) return '';
+  try {
+    const text = readFileSync(filePath, 'utf8').trim();
+    return text;
+  } catch (err) {
+    log.warn('POSTGRES_URL_FILE unreadable', {
+      path: filePath,
+      error: String(err),
+    });
+    return '';
+  }
+}
+
+/**
+ * Initialize the Neon client from `POSTGRES_URL` / `DATABASE_URL` /
+ * `POSTGRES_URL_FILE` (or override). Idempotent. When empty/unset, sync is
+ * disabled and all helpers below are silent no-ops.
  */
 export function initNeonSync(databaseUrl?: string | undefined): void {
-  const url = databaseUrl ?? process.env.POSTGRES_URL ?? process.env.DATABASE_URL ?? '';
+  const url = resolvePostgresUrl(databaseUrl);
   if (url) {
     client = neon(url);
     log.info('neon sync enabled', { hasUrl: true });

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -142,7 +142,7 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['gateway.revokeToken', 'consequential'],
   // GAP-154 Phase 5 — peer discovery (diagnostic; empty without Neon)
   ['daemon.peers', 'routine'],
-  // GAP-473 — list is routine; run may trigger gated cleanup with fix:true
+  // GAP-474 — list is routine; run may trigger gated cleanup with fix:true
   ['workflow.list', 'routine'],
   ['workflow.run', 'consequential'],
 ]);

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -140,6 +140,11 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   // Revokes a bearer credential — reversible (a new one can be paired), so
   // consequential rather than critical (GAP-421 guardrail-2 remediation S5).
   ['gateway.revokeToken', 'consequential'],
+  // GAP-154 Phase 5 — peer discovery (diagnostic; empty without Neon)
+  ['daemon.peers', 'routine'],
+  // GAP-473 — list is routine; run may trigger gated cleanup with fix:true
+  ['workflow.list', 'routine'],
+  ['workflow.run', 'consequential'],
 ]);
 
 /** Fail closed: unmapped method is critical (spec §5 / I2). */

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -15,8 +15,10 @@
  *   `session.register` are rejected with -32002.
  */
 
+import { createHash } from 'node:crypto';
 import { mkdir, readFile } from 'node:fs/promises';
 import { createServer, type Socket } from 'node:net';
+import { hostname as osHostname } from 'node:os';
 import { dirname, join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import { formatDid, parseDid } from '@revdev/protocol/did';
@@ -43,9 +45,13 @@ import { HttpGateway } from './http-gateway.js';
 import { evaluateLicense, LicenseConfigError, type LicenseTier, tierRank } from './license.js';
 import { loopGuards } from './loop-guard.js';
 import {
+  getSelfDaemonId,
+  heartbeatDaemonPeer,
   initNeonSync,
   isNeonSyncActive,
+  listDaemonPeers,
   listFleetSessions,
+  registerDaemonPeer,
   sweepExpiredFileClaims,
   syncEventLog,
   syncFilesRelease,
@@ -155,6 +161,8 @@ const IDENTITY_EXEMPT = new Set([
   // content). Optional actorAgentId still labels isSelf when provided.
   'context.snapshot',
   'harness.health',
+  // GAP-154 Phase 5: peer discovery is read-only fleet metadata (no content).
+  'daemon.peers',
   // `harness.prune` was here. It reaches notifyAgentEnded for EVERY matched
   // session, so an identity-exempt, unsigned caller could evict every agent's
   // roots and kill every agent's PTY with one frame. See GAP-312 and the
@@ -2426,6 +2434,24 @@ registerHandler('harness.health', async (_params, db) => {
   };
 });
 
+/**
+ * GAP-154 Phase 5 — list daemon peers from Neon registry.
+ * Empty when POSTGRES_URL unset (no fleet visibility, not "no peers exist").
+ */
+registerHandler('daemon.peers', async (params) => {
+  const staleAfterSeconds = Math.max(30, Math.floor(num(params.staleAfterSeconds, 300)));
+  const peers = await listDaemonPeers({ staleAfterSeconds });
+  const selfId = getSelfDaemonId();
+  return {
+    neonSyncActive: isNeonSyncActive(),
+    selfId,
+    peers: peers.map((p) => ({
+      ...p,
+      isSelf: selfId !== null && p.id === selfId,
+    })),
+  };
+});
+
 registerHandler('harness.prune', async (params, db, ctx) => {
   // Allow ops to run a prune pass on demand. Defaults match DAEMON_DEFAULTS so
   // callers can invoke with no params.
@@ -3010,10 +3036,34 @@ export async function startDaemon(
         }
       }
 
+      // GAP-154 Phase 5: register this daemon in Neon peer registry (no-op without POSTGRES_URL).
+      const host = osHostname();
+      const dataHash = createHash('sha256').update(cfg.dataDir).digest('hex').slice(0, 12);
+      const daemonId = process.env.REVDEV_DAEMON_ID?.trim() || `daemon:${host}:${dataHash}`;
+      const gatewayPort = httpGateway?.getPort() ?? null;
+      const httpGatewayUrl =
+        gatewayPort && gatewayPort > 0
+          ? `http://${cfg.httpHost === '0.0.0.0' ? host : cfg.httpHost}:${gatewayPort}`
+          : null;
+      await registerDaemonPeer({
+        daemonId,
+        env: process.env.REVDEV_DAEMON_ENV?.trim() || host,
+        hostname: host,
+        httpGatewayUrl,
+        socketHint: cfg.socketPath,
+        pid: process.pid,
+      });
+      // Heartbeat so peers stay "fresh" while this process lives.
+      const peerHeartbeat = setInterval(() => {
+        void heartbeatDaemonPeer(daemonId);
+      }, 60_000);
+      peerHeartbeat.unref();
+
       resolve({
         _db: db,
         _httpGateway: httpGateway,
         close: async () => {
+          clearInterval(peerHeartbeat);
           // Sequence:
           //   1. Set _closing FIRST so any RPC arriving on an existing
           //      socket from this point onward bails out with -32099

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -474,6 +474,14 @@ export const schemas: Record<string, z.ZodType> = {
     })
     .passthrough(),
 
+  // GAP-154 Phase 5 — daemon peer registry (Neon coordination_agents role=daemon)
+  'daemon.peers': z
+    .object({
+      staleAfterSeconds: z.number().min(30).max(86_400).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
   'harness.prune': z
     .object({
       staleDays: z.number().min(1).optional(),

--- a/packages/daemon/src/workflow-rpc.ts
+++ b/packages/daemon/src/workflow-rpc.ts
@@ -1,8 +1,9 @@
 /**
- * GAP-473 — workflow.list / workflow.run
+ * GAP-474 — workflow.list / workflow.run
  *
- * Thin daemon surface over the .jv operational-workflow registry
- * (`~/revfleet/.jv/workflows/*.yml` + `scripts/workflow-run.js`).
+ * Thin daemon surface over the Studio operational-workflow registry
+ * (`workflows/*.yml` + `scripts/workflow-run.js` under `REVDEV_JV_ROOT`,
+ * defaulting to the private planning checkout beside this monorepo).
  * No second schema: list/run shell the same runner Studio `/ops` uses.
  *
  * Safety classes stay enforced inside workflow-run.js:
@@ -33,6 +34,7 @@ function resolveJvRoot(params: Record<string, unknown> | undefined): string {
   if (process.env.REVDEV_JV_ROOT && process.env.REVDEV_JV_ROOT.length > 0) {
     return process.env.REVDEV_JV_ROOT;
   }
+  // Default layout: <home>/revfleet/<private planning root> (not a public path claim).
   return join(homedir(), 'revfleet', '.jv');
 }
 

--- a/packages/daemon/src/workflow-rpc.ts
+++ b/packages/daemon/src/workflow-rpc.ts
@@ -1,0 +1,152 @@
+/**
+ * GAP-473 — workflow.list / workflow.run
+ *
+ * Thin daemon surface over the .jv operational-workflow registry
+ * (`~/revfleet/.jv/workflows/*.yml` + `scripts/workflow-run.js`).
+ * No second schema: list/run shell the same runner Studio `/ops` uses.
+ *
+ * Safety classes stay enforced inside workflow-run.js:
+ *   auto | report-first | gated | owner-only
+ * Gated steps need `fix: true` (or `yes: true`); owner-only is never executed.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { registerHandler } from './server.js';
+
+const RUNNER_TIMEOUT_MS = 5 * 60 * 1000;
+const RUNNER_MAX_BUFFER = 10 * 1024 * 1024;
+
+export interface WorkflowListEntry {
+  name: string;
+  title: string;
+  safety: string;
+  file: string;
+}
+
+function resolveJvRoot(params: Record<string, unknown> | undefined): string {
+  if (params && typeof params.jvRoot === 'string' && params.jvRoot.length > 0) {
+    return params.jvRoot;
+  }
+  if (process.env.REVDEV_JV_ROOT && process.env.REVDEV_JV_ROOT.length > 0) {
+    return process.env.REVDEV_JV_ROOT;
+  }
+  return join(homedir(), 'revfleet', '.jv');
+}
+
+function runnerPath(jvRoot: string): string {
+  return join(jvRoot, 'scripts', 'workflow-run.js');
+}
+
+function assertRegistry(jvRoot: string): void {
+  const runner = runnerPath(jvRoot);
+  const dir = join(jvRoot, 'workflows');
+  if (!existsSync(runner)) {
+    throw new Error(
+      `workflow runner missing at ${runner} (set REVDEV_JV_ROOT or install .jv checkout)`,
+    );
+  }
+  if (!existsSync(dir)) {
+    throw new Error(`workflow registry missing at ${dir}`);
+  }
+}
+
+/** Minimal YAML field skim (name/title/safety) — list only; run uses the runner. */
+function skimYamlFields(text: string): { name: string; title: string; safety: string } {
+  let name = '';
+  let title = '';
+  let safety = '';
+  for (const line of text.split('\n')) {
+    if (line.startsWith('name:')) name = line.slice(5).trim();
+    else if (line.startsWith('title:')) title = line.slice(6).trim();
+    else if (line.startsWith('safety:') && safety === '') safety = line.slice(7).trim();
+  }
+  return { name, title, safety };
+}
+
+export function listWorkflows(jvRoot: string): WorkflowListEntry[] {
+  assertRegistry(jvRoot);
+  const dir = join(jvRoot, 'workflows');
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .sort();
+  const out: WorkflowListEntry[] = [];
+  for (const file of files) {
+    const text = readFileSync(join(dir, file), 'utf8');
+    const fields = skimYamlFields(text);
+    out.push({
+      name: fields.name || file.replace(/\.ya?ml$/, ''),
+      title: fields.title,
+      safety: fields.safety,
+      file,
+    });
+  }
+  return out;
+}
+
+export interface WorkflowRunResult {
+  name: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  dryRun: boolean;
+  fix: boolean;
+}
+
+export function runWorkflow(
+  jvRoot: string,
+  name: string,
+  opts: { dryRun?: boolean; fix?: boolean; yes?: boolean },
+): WorkflowRunResult {
+  assertRegistry(jvRoot);
+  if (!name || typeof name !== 'string') {
+    throw new Error('workflow.run requires params.name (workflow id)');
+  }
+  // Refuse path-shaped names (no second registry, no arbitrary exec)
+  if (name.includes('/') || name.includes('\\') || name.includes('..')) {
+    throw new Error(`workflow.run: invalid name ${JSON.stringify(name)}`);
+  }
+
+  const args = [runnerPath(jvRoot), name, '--root', jvRoot];
+  if (opts.dryRun) args.push('--dry-run');
+  if (opts.fix) args.push('--fix');
+  if (opts.yes) args.push('--yes');
+
+  const r = spawnSync(process.execPath, args, {
+    encoding: 'utf8',
+    timeout: RUNNER_TIMEOUT_MS,
+    maxBuffer: RUNNER_MAX_BUFFER,
+  });
+
+  if (r.error) {
+    throw new Error(`workflow.run spawn failed: ${r.error.message}`);
+  }
+
+  return {
+    name,
+    exitCode: r.status === null ? 1 : r.status,
+    stdout: r.stdout || '',
+    stderr: r.stderr || '',
+    dryRun: Boolean(opts.dryRun),
+    fix: Boolean(opts.fix || opts.yes),
+  };
+}
+
+registerHandler('workflow.list', async (params) => {
+  const p = (params ?? {}) as Record<string, unknown>;
+  const jvRoot = resolveJvRoot(p);
+  const workflows = listWorkflows(jvRoot);
+  return { jvRoot, workflows, count: workflows.length };
+});
+
+registerHandler('workflow.run', async (params) => {
+  const p = (params ?? {}) as Record<string, unknown>;
+  const jvRoot = resolveJvRoot(p);
+  const name = typeof p.name === 'string' ? p.name : '';
+  const dryRun = p.dryRun === true || p['dry-run'] === true;
+  const fix = p.fix === true;
+  const yes = p.yes === true;
+  return runWorkflow(jvRoot, name, { dryRun, fix, yes });
+});

--- a/packages/daemon/systemd/postgres-url-file.conf.example
+++ b/packages/daemon/systemd/postgres-url-file.conf.example
@@ -8,17 +8,19 @@
 #     mkdir -p ~/.config/systemd/user/revdev-daemon.service.d
 #     cp packages/daemon/systemd/postgres-url-file.conf.example \
 #        ~/.config/systemd/user/revdev-daemon.service.d/postgres-url-file.conf
-#     # set revvault path + absolute revvault binary, then:
+#     # REQUIRED: set absolute revvault to the same binary as license-file.conf
+#     #   command -v revvault
+#     # Do NOT use /usr/local/bin/revvault unless that path exists — missing
+#     # binary yields ExecStartPre exit 127 and the unit never starts.
 #     systemctl --user daemon-reload && systemctl --user restart revdev-daemon
 #
-# Prefer a non-production Neon when dogfooding; path below is production —
-# override to a staging/dev vault path if one exists.
+# Working vault path on founder machine (2026-08-08): revealui/prod/db/postgres-url
+# (revealui/prod/neon/postgres-url was password-auth-failing — fix vault if re-used)
 #
 # Stream-safe: only vault *paths* appear in this unit file, never the URL.
 
 [Service]
-# Working SSOT for this machine's Neon (2026-08-08): revealui/prod/db/postgres-url
-# (revealui/prod/neon/postgres-url was stale/auth-failing — fix vault if re-used)
-ExecStartPre=/bin/sh -c 'umask 077; /usr/local/bin/revvault get revealui/prod/db/postgres-url --full > /tmp/revdev-postgres.url'
+# Replace /ABS/PATH/TO/revvault with `command -v revvault` (match license-file.conf).
+ExecStartPre=/bin/sh -c 'umask 077; /ABS/PATH/TO/revvault get revealui/prod/db/postgres-url --full > /tmp/revdev-postgres.url'
 Environment=POSTGRES_URL_FILE=/tmp/revdev-postgres.url
 ExecStopPost=/bin/sh -c 'shred -u /tmp/revdev-postgres.url 2>/dev/null || rm -f /tmp/revdev-postgres.url'

--- a/packages/daemon/systemd/postgres-url-file.conf.example
+++ b/packages/daemon/systemd/postgres-url-file.conf.example
@@ -1,0 +1,24 @@
+# revdev-daemon — Neon POSTGRES_URL via file (EXAMPLE; copy + adapt)
+# =============================================================================
+# Materializes the Neon connection string into PrivateTmp so the secret is not
+# stored long-term in the unit Environment= block. Pairs with GAP-154 dual-write
+# (initNeonSync reads POSTGRES_URL or POSTGRES_URL_FILE).
+#
+# Install:
+#     mkdir -p ~/.config/systemd/user/revdev-daemon.service.d
+#     cp packages/daemon/systemd/postgres-url-file.conf.example \
+#        ~/.config/systemd/user/revdev-daemon.service.d/postgres-url-file.conf
+#     # set revvault path + absolute revvault binary, then:
+#     systemctl --user daemon-reload && systemctl --user restart revdev-daemon
+#
+# Prefer a non-production Neon when dogfooding; path below is production —
+# override to a staging/dev vault path if one exists.
+#
+# Stream-safe: only vault *paths* appear in this unit file, never the URL.
+
+[Service]
+# Working SSOT for this machine's Neon (2026-08-08): revealui/prod/db/postgres-url
+# (revealui/prod/neon/postgres-url was stale/auth-failing — fix vault if re-used)
+ExecStartPre=/bin/sh -c 'umask 077; /usr/local/bin/revvault get revealui/prod/db/postgres-url --full > /tmp/revdev-postgres.url'
+Environment=POSTGRES_URL_FILE=/tmp/revdev-postgres.url
+ExecStopPost=/bin/sh -c 'shred -u /tmp/revdev-postgres.url 2>/dev/null || rm -f /tmp/revdev-postgres.url'

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -19,6 +19,9 @@ export const RPC_METHODS = {
   'harness.health': 'harness.health',
   'harness.prune': 'harness.prune',
 
+  // GAP-154 Phase 5 — daemon peer registry (Neon role=daemon)
+  'daemon.peers': 'daemon.peers',
+
   // Agent sessions
   'session.register': 'session.register',
   'session.attach': 'session.attach',

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -156,7 +156,7 @@ export const RPC_METHODS = {
   // HTTP gateway token management (GAP-421 guardrail-2 remediation S5)
   'gateway.revokeToken': 'gateway.revokeToken',
 
-  // GAP-473 — .jv operational workflows (registry SSOT under ~/revfleet/.jv/workflows)
+  // GAP-474 — operational workflows (registry under REVDEV_JV_ROOT / workflows)
   'workflow.list': 'workflow.list',
   'workflow.run': 'workflow.run',
 } as const;

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -155,4 +155,8 @@ export const RPC_METHODS = {
 
   // HTTP gateway token management (GAP-421 guardrail-2 remediation S5)
   'gateway.revokeToken': 'gateway.revokeToken',
+
+  // GAP-473 — .jv operational workflows (registry SSOT under ~/revfleet/.jv/workflows)
+  'workflow.list': 'workflow.list',
+  'workflow.run': 'workflow.run',
 } as const;

--- a/scripts/gap-154-neon-fleet-dogfood.mjs
+++ b/scripts/gap-154-neon-fleet-dogfood.mjs
@@ -13,24 +13,23 @@
  *
  * Cleans up test sessions on both sockets when possible.
  */
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { connect } from "node:net";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { connect } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-const ROOT = new URL("..", import.meta.url).pathname;
-const DIST_CLI = join(ROOT, "packages/daemon/dist/cli.js");
+const ROOT = new URL('..', import.meta.url).pathname;
 
 function rpc(socketPath, method, params = {}) {
   return new Promise((resolve, reject) => {
     const sock = connect(socketPath);
-    let buf = "";
-    const frame = JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }) + "\n";
-    sock.on("connect", () => sock.write(frame));
-    sock.on("data", (d) => {
+    let buf = '';
+    const frame = JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }) + '\n';
+    sock.on('connect', () => sock.write(frame));
+    sock.on('data', (d) => {
       buf += d.toString();
-      const nl = buf.indexOf("\n");
+      const nl = buf.indexOf('\n');
       if (nl === -1) return;
       sock.end();
       try {
@@ -41,7 +40,7 @@ function rpc(socketPath, method, params = {}) {
         reject(e);
       }
     });
-    sock.on("error", reject);
+    sock.on('error', reject);
     sock.setTimeout(15_000, () => {
       sock.destroy();
       reject(new Error(`timeout ${method}`));
@@ -52,26 +51,26 @@ function rpc(socketPath, method, params = {}) {
 async function main() {
   if (!process.env.POSTGRES_URL && !process.env.POSTGRES_URL_FILE) {
     console.error(
-      "FAIL: set POSTGRES_URL (or POSTGRES_URL_FILE) via revvault run — see script header",
+      'FAIL: set POSTGRES_URL (or POSTGRES_URL_FILE) via revvault run — see script header',
     );
     process.exit(2);
   }
 
   // Dynamic import after env is set so neon init can see POSTGRES_URL
   const { startDaemon } = await import(
-    pathToFileURL(join(ROOT, "packages/daemon/dist/index.js")).href
+    pathToFileURL(join(ROOT, 'packages/daemon/dist/index.js')).href
   );
 
   const stamp = Date.now().toString(36);
   const agentA = `gap154-dogfood-a-${stamp}`;
   const agentB = `gap154-dogfood-b-${stamp}`;
 
-  const dirA = await mkdtemp(join(tmpdir(), "gap154-a-"));
-  const dirB = await mkdtemp(join(tmpdir(), "gap154-b-"));
-  const sockA = join(dirA, "harness.sock");
-  const sockB = join(dirB, "harness.sock");
-  await writeFile(join(dirA, "trusted-client-fingerprint"), "");
-  await writeFile(join(dirB, "trusted-client-fingerprint"), "");
+  const dirA = await mkdtemp(join(tmpdir(), 'gap154-a-'));
+  const dirB = await mkdtemp(join(tmpdir(), 'gap154-b-'));
+  const sockA = join(dirA, 'harness.sock');
+  const sockB = join(dirB, 'harness.sock');
+  await writeFile(join(dirA, 'trusted-client-fingerprint'), '');
+  await writeFile(join(dirB, 'trusted-client-fingerprint'), '');
 
   let closeA;
   let closeB;
@@ -81,7 +80,7 @@ async function main() {
       socketPath: sockA,
       dataDir: dirA,
       pruneIntervalMs: 0,
-      trustedClientFingerprintPath: join(dirA, "trusted-client-fingerprint"),
+      trustedClientFingerprintPath: join(dirA, 'trusted-client-fingerprint'),
       trustedAnchorRequireRootOwned: false,
     });
     closeA = a.close;
@@ -91,76 +90,70 @@ async function main() {
       socketPath: sockB,
       dataDir: dirB,
       pruneIntervalMs: 0,
-      trustedClientFingerprintPath: join(dirB, "trusted-client-fingerprint"),
+      trustedClientFingerprintPath: join(dirB, 'trusted-client-fingerprint'),
       trustedAnchorRequireRootOwned: false,
     });
     closeB = b.close;
 
-    const healthA = await rpc(sockA, "harness.health");
+    const healthA = await rpc(sockA, 'harness.health');
     if (!healthA.neonSyncActive) {
-      console.error("FAIL: neonSyncActive=false on A — POSTGRES_URL not loading");
+      console.error('FAIL: neonSyncActive=false on A — POSTGRES_URL not loading');
       process.exit(1);
     }
-    console.log("ok neonSyncActive on A");
+    console.log('ok neonSyncActive on A');
 
-    await rpc(sockA, "session.register", {
+    await rpc(sockA, 'session.register', {
       agentId: agentA,
       agentName: agentA,
-      env: "gap154-dogfood-a",
-      task: "gap-154 fleet dogfood",
+      env: 'gap154-dogfood-a',
+      task: 'gap-154 fleet dogfood',
     });
-    console.log("ok registered", agentA);
+    console.log('ok registered', agentA);
 
     // Allow Neon write lag
     await new Promise((r) => setTimeout(r, 1500));
 
-    const fleetB = await rpc(sockB, "session.list", { scope: "fleet" });
+    const fleetB = await rpc(sockB, 'session.list', { scope: 'fleet' });
     const sessions = fleetB.sessions || [];
     const found = sessions.some(
       (s) => s.agentId === agentA || s.id === agentA || s.agent_id === agentA,
     );
     if (!found) {
       console.error(
-        "FAIL: B fleet list missing A",
+        'FAIL: B fleet list missing A',
         JSON.stringify(
           sessions.slice(0, 5).map((s) => ({ id: s.id, agentId: s.agentId || s.agent_id })),
         ),
       );
       process.exit(1);
     }
-    console.log("ok B session.list({scope:fleet}) sees A");
+    console.log('ok B session.list({scope:fleet}) sees A');
 
-    const peersA = await rpc(sockA, "daemon.peers", {});
+    const peersA = await rpc(sockA, 'daemon.peers', {});
     if (!peersA.neonSyncActive) {
-      console.error("FAIL: daemon.peers neonSyncActive false");
+      console.error('FAIL: daemon.peers neonSyncActive false');
       process.exit(1);
     }
-    console.log(
-      "ok daemon.peers",
-      "selfId=",
-      peersA.selfId,
-      "count=",
-      (peersA.peers || []).length,
-    );
+    console.log('ok daemon.peers', 'selfId=', peersA.selfId, 'count=', (peersA.peers || []).length);
 
     // Cleanup test sessions (best-effort; may need signed end — try unsigned register end path)
     try {
-      await rpc(sockA, "session.end", { agentId: agentA });
+      await rpc(sockA, 'session.end', { agentId: agentA });
     } catch {
       /* optional */
     }
     try {
-      await rpc(sockB, "session.register", {
+      await rpc(sockB, 'session.register', {
         agentId: agentB,
         agentName: agentB,
-        env: "gap154-dogfood-b",
+        env: 'gap154-dogfood-b',
       });
-      await rpc(sockB, "session.end", { agentId: agentB });
+      await rpc(sockB, 'session.end', { agentId: agentB });
     } catch {
       /* optional */
     }
 
-    console.log("RESULT=PASS gap-154 neon fleet dogfood");
+    console.log('RESULT=PASS gap-154 neon fleet dogfood');
   } finally {
     if (closeB) await closeB().catch(() => undefined);
     if (closeA) await closeA().catch(() => undefined);
@@ -170,6 +163,6 @@ async function main() {
 }
 
 main().catch((e) => {
-  console.error("FAIL:", e.message);
+  console.error('FAIL:', e.message);
   process.exit(1);
 });

--- a/scripts/gap-154-neon-fleet-dogfood.mjs
+++ b/scripts/gap-154-neon-fleet-dogfood.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * GAP-154 live fleet dogfood (two process-local daemons, real Neon).
+ *
+ * Stream-safe: expects POSTGRES_URL already in the environment (use
+ *   revvault run --env POSTGRES_URL=revealui/prod/db/postgres-url -- \
+ *     node scripts/gap-154-neon-fleet-dogfood.mjs
+ * ). Never prints the URL. Prefer db/postgres-url over neon/postgres-url if the
+ * latter fails password auth (vault drift).
+ *
+ * Proves acceptance slice: A registers session → B session.list({scope:fleet})
+ * sees it; daemon.peers sees at least one self registration when sync is on.
+ *
+ * Cleans up test sessions on both sockets when possible.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+const DIST_CLI = join(ROOT, "packages/daemon/dist/cli.js");
+
+function rpc(socketPath, method, params = {}) {
+  return new Promise((resolve, reject) => {
+    const sock = connect(socketPath);
+    let buf = "";
+    const frame = JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }) + "\n";
+    sock.on("connect", () => sock.write(frame));
+    sock.on("data", (d) => {
+      buf += d.toString();
+      const nl = buf.indexOf("\n");
+      if (nl === -1) return;
+      sock.end();
+      try {
+        const resp = JSON.parse(buf.slice(0, nl));
+        if (resp.error) reject(new Error(`${resp.error.code}: ${resp.error.message}`));
+        else resolve(resp.result);
+      } catch (e) {
+        reject(e);
+      }
+    });
+    sock.on("error", reject);
+    sock.setTimeout(15_000, () => {
+      sock.destroy();
+      reject(new Error(`timeout ${method}`));
+    });
+  });
+}
+
+async function main() {
+  if (!process.env.POSTGRES_URL && !process.env.POSTGRES_URL_FILE) {
+    console.error(
+      "FAIL: set POSTGRES_URL (or POSTGRES_URL_FILE) via revvault run — see script header",
+    );
+    process.exit(2);
+  }
+
+  // Dynamic import after env is set so neon init can see POSTGRES_URL
+  const { startDaemon } = await import(
+    pathToFileURL(join(ROOT, "packages/daemon/dist/index.js")).href
+  );
+
+  const stamp = Date.now().toString(36);
+  const agentA = `gap154-dogfood-a-${stamp}`;
+  const agentB = `gap154-dogfood-b-${stamp}`;
+
+  const dirA = await mkdtemp(join(tmpdir(), "gap154-a-"));
+  const dirB = await mkdtemp(join(tmpdir(), "gap154-b-"));
+  const sockA = join(dirA, "harness.sock");
+  const sockB = join(dirB, "harness.sock");
+  await writeFile(join(dirA, "trusted-client-fingerprint"), "");
+  await writeFile(join(dirB, "trusted-client-fingerprint"), "");
+
+  let closeA;
+  let closeB;
+  try {
+    process.env.REVDEV_DAEMON_ID = `daemon:dogfood-a-${stamp}`;
+    const a = await startDaemon({
+      socketPath: sockA,
+      dataDir: dirA,
+      pruneIntervalMs: 0,
+      trustedClientFingerprintPath: join(dirA, "trusted-client-fingerprint"),
+      trustedAnchorRequireRootOwned: false,
+    });
+    closeA = a.close;
+
+    process.env.REVDEV_DAEMON_ID = `daemon:dogfood-b-${stamp}`;
+    const b = await startDaemon({
+      socketPath: sockB,
+      dataDir: dirB,
+      pruneIntervalMs: 0,
+      trustedClientFingerprintPath: join(dirB, "trusted-client-fingerprint"),
+      trustedAnchorRequireRootOwned: false,
+    });
+    closeB = b.close;
+
+    const healthA = await rpc(sockA, "harness.health");
+    if (!healthA.neonSyncActive) {
+      console.error("FAIL: neonSyncActive=false on A — POSTGRES_URL not loading");
+      process.exit(1);
+    }
+    console.log("ok neonSyncActive on A");
+
+    await rpc(sockA, "session.register", {
+      agentId: agentA,
+      agentName: agentA,
+      env: "gap154-dogfood-a",
+      task: "gap-154 fleet dogfood",
+    });
+    console.log("ok registered", agentA);
+
+    // Allow Neon write lag
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const fleetB = await rpc(sockB, "session.list", { scope: "fleet" });
+    const sessions = fleetB.sessions || [];
+    const found = sessions.some(
+      (s) => s.agentId === agentA || s.id === agentA || s.agent_id === agentA,
+    );
+    if (!found) {
+      console.error(
+        "FAIL: B fleet list missing A",
+        JSON.stringify(
+          sessions.slice(0, 5).map((s) => ({ id: s.id, agentId: s.agentId || s.agent_id })),
+        ),
+      );
+      process.exit(1);
+    }
+    console.log("ok B session.list({scope:fleet}) sees A");
+
+    const peersA = await rpc(sockA, "daemon.peers", {});
+    if (!peersA.neonSyncActive) {
+      console.error("FAIL: daemon.peers neonSyncActive false");
+      process.exit(1);
+    }
+    console.log(
+      "ok daemon.peers",
+      "selfId=",
+      peersA.selfId,
+      "count=",
+      (peersA.peers || []).length,
+    );
+
+    // Cleanup test sessions (best-effort; may need signed end — try unsigned register end path)
+    try {
+      await rpc(sockA, "session.end", { agentId: agentA });
+    } catch {
+      /* optional */
+    }
+    try {
+      await rpc(sockB, "session.register", {
+        agentId: agentB,
+        agentName: agentB,
+        env: "gap154-dogfood-b",
+      });
+      await rpc(sockB, "session.end", { agentId: agentB });
+    } catch {
+      /* optional */
+    }
+
+    console.log("RESULT=PASS gap-154 neon fleet dogfood");
+  } finally {
+    if (closeB) await closeB().catch(() => undefined);
+    if (closeA) await closeA().catch(() => undefined);
+    await rm(dirA, { recursive: true, force: true }).catch(() => undefined);
+    await rm(dirB, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+main().catch((e) => {
+  console.error("FAIL:", e.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Promote `test` → `main` (Create a merge commit only).

Ships since last main promote (#369):

- **GAP-474 / revdev#376** — `workflow.list` / `workflow.run` RPC over operational-workflow registry
- **GAP-154** — daemon peers + Neon dogfood / `POSTGRES_URL_FILE` path honesty
- Postgres drop-in revvault path docs

## Deploy / laptop

After merge: pull main on `~/revfleet/revdev`, build `@revdev/daemon`, restart `revdev-daemon.service`.

## Test plan

- [ ] promotion-gate green
- [ ] CI on promote PR green (or required checks)
- [ ] Owner merge with `--merge` only