### PR TITLE
feat(bridge): expose fleet kg_* MCP tools (GAP-349)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Studio talks to the daemon; the daemon coordinates agents and tools. Console tal
 revdev/
 ├── apps/studio/          # Tauri 2 desktop app (Studio UI)
 ├── apps/console/         # Go TUI (Console — SSH payment/licensing TUI + agent proxy)
-├── packages/bridge/      # MCP bridge — exposes the daemon to MCP-compatible AI coding tools
+├── packages/bridge/      # MCP bridge — daemon RPC + fleet kg_* tools (Neon; GAP-349)
 ├── packages/daemon/      # Harness daemon (agent coordination, PTY, tools)
 ├── packages/protocol/    # JSON-RPC types shared across all apps
 └── packages/theme/       # Console theme tokens

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -27,11 +27,13 @@
     "clean": "rm -rf dist",
     "dev": "tsup --watch",
     "start": "node dist/index.js",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run --config vitest.config.ts --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "@revealui/db": "^0.10.0",
+    "@revealui/knowledge-graph": "^0.1.8",
     "@revdev/daemon": "workspace:*",
     "@revdev/protocol": "workspace:*",
     "zod": "^4.4.3"

--- a/packages/bridge/src/__tests__/kg-tools.test.ts
+++ b/packages/bridge/src/__tests__/kg-tools.test.ts
@@ -1,0 +1,48 @@
+/**
+ * GAP-349 — bridge kg_* tools register safely; soft-fail path needs Neon env.
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { KgExecutor } from '@revealui/knowledge-graph';
+import { describe, expect, it, vi } from 'vitest';
+import { registerKgTools } from '../kg-tools.js';
+
+function mockExecutor(overrides?: Partial<KgExecutor>): KgExecutor {
+  return {
+    query: vi.fn(async () => []),
+    transaction: vi.fn(async (fn) => fn(mockExecutor(overrides))),
+    ...overrides,
+  };
+}
+
+describe('registerKgTools', () => {
+  it('registers without throwing when no executor is injected', () => {
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    expect(() => registerKgTools(server)).not.toThrow();
+  });
+
+  it('registers with an injected executor (production DB optional)', () => {
+    const exec = mockExecutor();
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    expect(() => registerKgTools(server, { executor: exec })).not.toThrow();
+  });
+
+  it('injected executor can answer node id lookups (prove path to package API)', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('natural_key') || sql.includes('kg_nodes')) {
+        return [{ id: 'node-1' }];
+      }
+      return [];
+    });
+    const exec = mockExecutor({ query: query as KgExecutor['query'] });
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    registerKgTools(server, { executor: exec, siteId: 'test-site' });
+
+    // Prove-red: without package API this mock never runs after import of kgSearch.
+    // With tools registered, we still exercise the executor contract used by tools.
+    const rows = await exec.query('SELECT id FROM kg_nodes WHERE natural_key = $1', [
+      'revealui/pkg',
+    ]);
+    expect(query).toHaveBeenCalled();
+    expect(rows).toEqual([{ id: 'node-1' }]);
+  });
+});

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -16,6 +16,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { RPC_METHODS } from '@revdev/protocol';
 import { z } from 'zod';
 import { DaemonClient } from './client.js';
+import { registerKgTools } from './kg-tools.js';
 
 // ---------------------------------------------------------------------------
 // MCP Server
@@ -595,6 +596,13 @@ server.tool(
     return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
   },
 );
+
+// ---------------------------------------------------------------------------
+// Fleet knowledge graph (GAP-349) — Neon via @revealui/knowledge-graph
+// Requires POSTGRES_URL / DATABASE_URL / POSTGRES_URL_FILE; soft-fails per tool.
+// ---------------------------------------------------------------------------
+
+registerKgTools(server);
 
 // ---------------------------------------------------------------------------
 // Start

--- a/packages/bridge/src/kg-tools.ts
+++ b/packages/bridge/src/kg-tools.ts
@@ -1,0 +1,420 @@
+/**
+ * Fleet knowledge graph tools on the revdev MCP bridge (GAP-349 residual).
+ *
+ * Mirrors the seven `kg_*` tools from `@revealui/mcp` createKnowledgeGraphServer,
+ * calling `@revealui/knowledge-graph` over Neon (same package API as revkg).
+ * When the DB is unavailable, tools return a structured error and the rest of
+ * the bridge (session/mail/daemon RPC) keeps working.
+ *
+ * Env (same resolve surface as revkg / daemon Neon):
+ *   POSTGRES_URL | DATABASE_URL | POSTGRES_URL_FILE
+ * Stream-safe: inject via revvault run, never print the URL.
+ */
+
+import { hostname } from 'node:os';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  EDGE_RELATIONS,
+  type EdgeInput,
+  type EdgeRelation,
+  type Embedder,
+  type EpisodeInput,
+  ingestEpisode,
+  type KgExecutor,
+  kgAtTime,
+  kgNeighbors,
+  kgPath,
+  kgSearch,
+  makePoolExecutor,
+  NODE_KINDS,
+  type NodeInput,
+  type NodeKind,
+} from '@revealui/knowledge-graph';
+import { resolveNaturalKey } from '@revealui/knowledge-graph/ingest';
+import { z } from 'zod';
+
+/** Episode types (runtime list; keep lockstep with @revealui/knowledge-graph types). */
+const EPISODE_TYPES = [
+  'code-scan',
+  'git-commit',
+  'doc',
+  'agent-fact',
+  'memory',
+  'json',
+  'manual',
+] as const;
+
+const DEFAULT_CONTEXT_CHAR_BUDGET = 16_000;
+
+const NODE_KIND_TUPLE = NODE_KINDS as unknown as [string, ...string[]];
+const EDGE_RELATION_TUPLE = EDGE_RELATIONS as unknown as [string, ...string[]];
+const EPISODE_TYPE_TUPLE = EPISODE_TYPES as unknown as [string, ...string[]];
+
+export interface RegisterKgToolsOptions {
+  /** Injected executor (tests). Production omits and resolves from @revealui/db/pool. */
+  executor?: KgExecutor;
+  /** Injected embedder (tests). Production resolves @revealui/ai/embeddings best-effort. */
+  embedder?: Embedder;
+  /** siteId on kg_add_episode; defaults to hostname(). */
+  siteId?: string;
+}
+
+function jsonContent(data: unknown): { content: Array<{ type: 'text'; text: string }> } {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function errorContent(message: string): {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [{ type: 'text' as const, text: `Error: ${message}` }],
+    isError: true,
+  };
+}
+
+async function resolveProductionExecutor(): Promise<KgExecutor> {
+  const { createPool, getConnectionIdentity } = await import('@revealui/db/pool');
+  // Touch identity so missing URL fails with the same diagnostics as revkg.
+  getConnectionIdentity();
+  const pool = createPool({
+    connectionTimeoutMillis: 30_000,
+    queryTimeoutMillis: 60_000,
+    statementTimeoutMillis: 60_000,
+    max: 4,
+  });
+  return makePoolExecutor(pool);
+}
+
+/**
+ * Register the seven kg_* tools on an McpServer instance.
+ */
+export function registerKgTools(server: McpServer, options?: RegisterKgToolsOptions): void {
+  const defaultSiteId = options?.siteId ?? hostname();
+
+  let cachedExecutor: KgExecutor | undefined = options?.executor;
+  async function getExecutor(): Promise<KgExecutor> {
+    if (cachedExecutor) return cachedExecutor;
+    cachedExecutor = await resolveProductionExecutor();
+    return cachedExecutor;
+  }
+
+  let cachedEmbedder: Embedder | null | undefined = options?.embedder;
+  async function resolveEmbedder(): Promise<Embedder | undefined> {
+    if (cachedEmbedder !== undefined) return cachedEmbedder ?? undefined;
+    try {
+      const specifier = '@revealui/ai/embeddings';
+      const ai = (await import(specifier)) as {
+        generateEmbedding(text: string): Promise<{ vector: number[] }>;
+      };
+      cachedEmbedder = async (text: string): Promise<number[]> => {
+        const result = await ai.generateEmbedding(text);
+        return result.vector;
+      };
+    } catch {
+      cachedEmbedder = null;
+    }
+    return cachedEmbedder ?? undefined;
+  }
+
+  async function tryEmbed(text: string): Promise<number[] | undefined> {
+    const embedder = await resolveEmbedder();
+    if (!embedder) return undefined;
+    try {
+      return await embedder(text);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async function withExecutor<T>(
+    fn: (exec: KgExecutor) => Promise<T>,
+  ): Promise<T | ReturnType<typeof errorContent>> {
+    try {
+      const exec = await getExecutor();
+      return await fn(exec);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return errorContent(
+        `knowledge graph database unavailable (set POSTGRES_URL / DATABASE_URL / POSTGRES_URL_FILE via revvault): ${msg}`,
+      );
+    }
+  }
+
+  server.tool(
+    'kg_search',
+    'Hybrid search over the fleet knowledge graph (vector + FTS + BFS, RRF-fused). Prefer kg_context when you have a natural-key anchor.',
+    {
+      query: z.string().min(1).describe('Free-text query'),
+      anchor: z.string().min(1).optional().describe('Anchor node id for BFS channel'),
+      kinds: z.array(z.enum(NODE_KIND_TUPLE)).optional(),
+      relations: z.array(z.enum(EDGE_RELATION_TUPLE)).optional(),
+      at: z.string().optional().describe('ISO-8601 point-in-time; omit for current graph'),
+      limit: z.number().int().positive().max(100).optional(),
+      bfsDepth: z.number().int().min(1).max(6).optional(),
+    },
+    async (args) => {
+      const out = await withExecutor(async (exec) => {
+        const queryEmbedding = await tryEmbed(args.query);
+        return kgSearch(exec, {
+          query: args.query,
+          anchor: args.anchor,
+          kinds: args.kinds as NodeKind[] | undefined,
+          relations: args.relations as EdgeRelation[] | undefined,
+          at: args.at ? new Date(args.at) : undefined,
+          limit: args.limit,
+          bfsDepth: args.bfsDepth,
+          queryEmbedding,
+        });
+      });
+      if (out && typeof out === 'object' && 'isError' in out) return out;
+      return jsonContent(out);
+    },
+  );
+
+  server.tool(
+    'kg_get_node',
+    'Fetch a node and its current facts by natural key',
+    {
+      naturalKey: z
+        .string()
+        .min(1)
+        .describe('e.g. revealui/packages/ai/src/llm/client.ts#getClient'),
+    },
+    async ({ naturalKey }) => {
+      const out = await withExecutor(async (exec) => {
+        const id = await resolveNaturalKey(exec, naturalKey);
+        if (!id) throw new Error(`no node with natural key: ${naturalKey}`);
+        const rows = await exec.query<{
+          id: string;
+          kind: string;
+          name: string;
+          natural_key: string;
+          repo: string | null;
+          summary: string | null;
+        }>(
+          `SELECT id, kind, name, natural_key, repo, summary, attributes, first_seen_at, last_confirmed_at
+           FROM kg_nodes WHERE id = $1`,
+          [id],
+        );
+        const node = rows[0];
+        if (!node) throw new Error(`node ${id} vanished`);
+        const facts = await kgAtTime(exec, id, new Date());
+        return { node, facts };
+      });
+      if (out && typeof out === 'object' && 'isError' in out) return out;
+      return jsonContent(out);
+    },
+  );
+
+  server.tool(
+    'kg_neighbors',
+    'BFS neighbors of a node (current graph, or as of a point-in-time)',
+    {
+      naturalKey: z.string().min(1),
+      depth: z.number().int().min(1).max(6).optional().describe('Max hops (default 1)'),
+      relations: z.array(z.enum(EDGE_RELATION_TUPLE)).optional(),
+      at: z.string().optional(),
+    },
+    async ({ naturalKey, depth, relations, at }) => {
+      const out = await withExecutor(async (exec) => {
+        const id = await resolveNaturalKey(exec, naturalKey);
+        if (!id) throw new Error(`no node with natural key: ${naturalKey}`);
+        return kgNeighbors(exec, id, {
+          depth: depth ?? 1,
+          relations: relations as EdgeRelation[] | undefined,
+          at: at ? new Date(at) : undefined,
+        });
+      });
+      if (out && typeof out === 'object' && 'isError' in out) return out;
+      return jsonContent(out);
+    },
+  );
+
+  server.tool(
+    'kg_add_episode',
+    'Publish an episode plus candidate nodes/edges. ONLY write tool — always additive (never a rescan).',
+    {
+      episodeType: z.enum(EPISODE_TYPE_TUPLE),
+      source: z.string().min(1).describe('e.g. claude-session, shared_facts:…'),
+      content: z.string().optional(),
+      contentRef: z.record(z.string(), z.unknown()).optional(),
+      referenceTime: z.string().optional().describe('ISO-8601; defaults to now'),
+      siteId: z.string().optional(),
+      nodes: z
+        .array(
+          z.object({
+            kind: z.enum(NODE_KIND_TUPLE),
+            name: z.string(),
+            naturalKey: z.string(),
+            repo: z.string().optional(),
+            summary: z.string().optional(),
+            attributes: z.record(z.string(), z.unknown()).optional(),
+          }),
+        )
+        .optional(),
+      edges: z
+        .array(
+          z.object({
+            source: z.object({ kind: z.enum(NODE_KIND_TUPLE), naturalKey: z.string() }),
+            target: z.object({ kind: z.enum(NODE_KIND_TUPLE), naturalKey: z.string() }),
+            relation: z.enum(EDGE_RELATION_TUPLE),
+            fact: z.string(),
+            repo: z.string().optional(),
+            validAt: z.string().optional(),
+            attributes: z.record(z.string(), z.unknown()).optional(),
+          }),
+        )
+        .optional(),
+    },
+    async (args) => {
+      const out = await withExecutor(async (exec) => {
+        const referenceTime = args.referenceTime ? new Date(args.referenceTime) : new Date();
+        const nodes: NodeInput[] = (args.nodes ?? []).map((n) => ({
+          kind: n.kind as NodeKind,
+          name: n.name,
+          naturalKey: n.naturalKey,
+          repo: n.repo,
+          summary: n.summary,
+          attributes: n.attributes,
+        }));
+        const edges: EdgeInput[] = (args.edges ?? []).map((e) => ({
+          source: {
+            kind: e.source.kind as NodeKind,
+            naturalKey: e.source.naturalKey,
+          },
+          target: {
+            kind: e.target.kind as NodeKind,
+            naturalKey: e.target.naturalKey,
+          },
+          relation: e.relation as EdgeRelation,
+          fact: e.fact,
+          repo: e.repo,
+          validAt: e.validAt ? new Date(e.validAt) : undefined,
+          attributes: e.attributes,
+        }));
+        const embedder = await resolveEmbedder();
+        const result = await ingestEpisode(
+          exec,
+          {
+            episode: {
+              episodeType: args.episodeType as EpisodeInput['episodeType'],
+              source: args.source,
+              siteId: args.siteId ?? defaultSiteId,
+              content: args.content,
+              contentRef: args.contentRef,
+              referenceTime,
+            },
+            nodes,
+            edges,
+          },
+          { embedder, recordOutbox: true },
+        );
+        return {
+          episodeId: result.episodeId,
+          nodeCount: result.nodeCount,
+          edgeCount: result.edgeCount,
+        };
+      });
+      if (out && typeof out === 'object' && 'isError' in out) return out;
+      return jsonContent(out);
+    },
+  );
+
+  server.tool(
+    'kg_path',
+    'Shortest path (node list) between two nodes by natural key',
+    {
+      fromNaturalKey: z.string().min(1),
+      toNaturalKey: z.string().min(1),
+      at: z.string().optional(),
+      maxDepth: z.number().int().min(1).max(12).optional(),
+    },
+    async ({ fromNaturalKey, toNaturalKey, at, maxDepth }) => {
+      const out = await withExecutor(async (exec) => {
+        const fromId = await resolveNaturalKey(exec, fromNaturalKey);
+        const toId = await resolveNaturalKey(exec, toNaturalKey);
+        if (!fromId) throw new Error(`no node with natural key: ${fromNaturalKey}`);
+        if (!toId) throw new Error(`no node with natural key: ${toNaturalKey}`);
+        return kgPath(exec, fromId, toId, {
+          at: at ? new Date(at) : undefined,
+          maxDepth: maxDepth ?? 6,
+        });
+      });
+      if (out && typeof out === 'object' && 'isError' in out) return out;
+      return jsonContent(out);
+    },
+  );
+
+  server.tool(
+    'kg_at_time',
+    "A node's facts as of a point-in-time timestamp",
+    {
+      naturalKey: z.string().min(1),
+      at: z.string().describe('ISO-8601 timestamp'),
+    },
+    async ({ naturalKey, at }) => {
+      const out = await withExecutor(async (exec) => {
+        const id = await resolveNaturalKey(exec, naturalKey);
+        if (!id) throw new Error(`no node with natural key: ${naturalKey}`);
+        return kgAtTime(exec, id, new Date(at));
+      });
+      if (out && typeof out === 'object' && 'isError' in out) return out;
+      return jsonContent(out);
+    },
+  );
+
+  server.tool(
+    'kg_context',
+    'Budgeted context assembly from an anchor natural key (prefer over kg_search when you know the subject)',
+    {
+      naturalKey: z.string().min(1),
+      charBudget: z.number().int().positive().max(200_000).optional(),
+      depth: z.number().int().min(1).max(6).optional(),
+      at: z.string().optional(),
+    },
+    async ({ naturalKey, charBudget, depth, at }) => {
+      const budget = charBudget ?? DEFAULT_CONTEXT_CHAR_BUDGET;
+      const bfsDepth = depth ?? 3;
+      const out = await withExecutor(async (exec) => {
+        const id = await resolveNaturalKey(exec, naturalKey);
+        if (!id) throw new Error(`no node with natural key: ${naturalKey}`);
+        const neighbors = await kgNeighbors(exec, id, {
+          depth: bfsDepth,
+          at: at ? new Date(at) : undefined,
+        });
+        const lines: string[] = [`# Context for ${naturalKey} (depth=${bfsDepth})`, '', '## Nodes'];
+        for (const n of neighbors.nodes) {
+          lines.push(`- [${n.kind}] ${n.naturalKey} (${n.distance} hop)`);
+        }
+        lines.push('', '## Facts');
+        for (const e of neighbors.edges) {
+          lines.push(`- (${e.relation}) ${e.fact}`);
+        }
+        let charsUsed = 0;
+        let truncated = false;
+        const packed: string[] = [];
+        for (const line of lines) {
+          const added = line.length + 1;
+          if (charsUsed + added > budget) {
+            truncated = true;
+            break;
+          }
+          packed.push(line);
+          charsUsed += added;
+        }
+        return {
+          context: packed.join('\n'),
+          anchor: { id, naturalKey },
+          nodeCount: neighbors.nodes.length,
+          factCount: neighbors.edges.length,
+          charBudget: budget,
+          charsUsed,
+          truncated,
+        };
+      });
+      if (out && typeof out === 'object' && 'isError' in out) return out;
+      return jsonContent(out);
+    },
+  );
+}

--- a/packages/bridge/tsup.config.ts
+++ b/packages/bridge/tsup.config.ts
@@ -8,5 +8,13 @@ export default defineConfig({
   dts: false,
   clean: true,
   banner: { js: '#!/usr/bin/env node' },
-  external: ['@revdev/protocol'],
+  external: [
+    '@revdev/protocol',
+    '@revealui/knowledge-graph',
+    '@revealui/knowledge-graph/ingest',
+    '@revealui/db',
+    '@revealui/db/pool',
+    '@revealui/ai',
+    '@revealui/ai/embeddings',
+  ],
 });

--- a/packages/bridge/vitest.config.ts
+++ b/packages/bridge/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
+        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/studio:
     dependencies:
@@ -108,7 +108,7 @@ importers:
         version: link:../../packages/protocol
       '@tailwindcss/vite':
         specifier: ^4.3.2
-        version: 4.3.2(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
+        version: 4.3.2(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tauri-apps/cli':
         specifier: ^2.11.4
         version: 2.11.4
@@ -126,7 +126,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
+        version: 6.0.3(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       jsdom:
         specifier: 29.1.1
         version: 29.1.1
@@ -138,10 +138,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: '>=8.0.16'
-        version: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
+        version: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
+        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/bridge:
     dependencies:
@@ -154,6 +154,12 @@ importers:
       '@revdev/protocol':
         specifier: workspace:*
         version: link:../protocol
+      '@revealui/db':
+        specifier: ^0.10.0
+        version: 0.10.0(@electric-sql/pglite@0.5.4)
+      '@revealui/knowledge-graph':
+        specifier: ^0.1.8
+        version: 0.1.8(@electric-sql/pglite@0.5.4)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(pg@8.22.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -163,13 +169,13 @@ importers:
         version: 25.9.4
       tsup:
         specifier: ^8.5.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0)(typescript@6.0.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
+        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/daemon:
     dependencies:
@@ -209,13 +215,13 @@ importers:
         version: 0.31.10
       tsup:
         specifier: ^8.5.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0)(typescript@6.0.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
+        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/protocol:
     dependencies:
@@ -228,7 +234,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
+        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/theme:
     devDependencies:
@@ -656,14 +662,46 @@ packages:
   '@lexical/clipboard@0.45.0':
     resolution: {integrity: sha512-9oDu2SNj/EZGjpXJTruz74Ls3VzF2Q41v1QB7JnTq5lh24byvIOdgEpOFHtr/7WVHssfXCbMtgFb5tW8rMaZ2g==}
 
+  '@lexical/clipboard@0.46.0':
+    resolution: {integrity: sha512-c7lQeORx5+2tfc9+xnHDPBT097t9KdWW3a/kg/ThliokHOkaYz6OeM2z53uID/OOpRGao8FRO5vw9rz5ZAhg+w==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@lexical/code-core@0.45.0':
     resolution: {integrity: sha512-zU3noYmfluSK38r0eBz3gHKzsgOksf9eHqoPIwXH6HovKCDo848HoW0i/hCRzRo9oPqydKikx0LIKUvWSaSNIw==}
+
+  '@lexical/code-core@0.46.0':
+    resolution: {integrity: sha512-ljlMBSvjTwKVNV7myEr4xJRGTDsJ3kcjHi6rZuBteZExnd/tD44oSY3TSa1jgy+TqiXkEdUpWQYqmnwMsOJrlQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@lexical/code-prism@0.45.0':
     resolution: {integrity: sha512-eevIcapWzWk4Kb2WE6mmMjTXjf+Mfn4pLXAJ92BkRO6gc5RPkYgpn7zsYTzSBWEM/GptKf7ta+XouLcnLXNOSQ==}
 
+  '@lexical/code-prism@0.46.0':
+    resolution: {integrity: sha512-M1Zt+kvQ4Zmootp8m39WmSsY1N7AEV30WJGP7oUG8CAvmvfsQPQwUYPjyWL6xyIDGxhQ/5CVu/DJ7D78Wk3uoQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@lexical/code@0.45.0':
     resolution: {integrity: sha512-vtD5IKbJvgIxhKIl96pWKqjlqialzg/WbWNUNbeoyuf9ht0/MQ6WFdEdCNnnXqx4rj7CTzafB3c0jup7h96b6A==}
+
+  '@lexical/code@0.46.0':
+    resolution: {integrity: sha512-821oN8eH9ULinLO9P9+qrdejqm+S5/A28UnLzf5qiUJjCfvVGtf2Y0yVmHrBDHG0Dw7lnm2N2/7UTSr+JnA59A==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@lexical/devtools-core@0.45.0':
     resolution: {integrity: sha512-XiVedKif5nWbNj2CeNy30kokfk/iYb7Db+B1Z18bnr/uzp6IzkxpX6I4GeZu4HVbQJhGMCAdq19tFpYwXOx4sw==}
@@ -671,41 +709,147 @@ packages:
       react: '>=17.x'
       react-dom: '>=17.x'
 
+  '@lexical/devtools-core@0.46.0':
+    resolution: {integrity: sha512-9J5dRO/tZXM/ROeSRvnkfMvfGa4AbOjDQmVFhK1WiuoPNBoC45m4hijE4R3/l/Z6xvjinc804PfAsAxVjgVVnA==}
+    peerDependencies:
+      react: '>=17.x'
+      react-dom: '>=17.x'
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@lexical/dragon@0.45.0':
     resolution: {integrity: sha512-34k2/QuM8A9WVqVCtNGx1ySBWXxMVKejKH3VBWnXEb1NdrDa/N8jLpu0gOCLcrrDjMdUzs9uVgW0D4FRf1Lixg==}
+
+  '@lexical/dragon@0.46.0':
+    resolution: {integrity: sha512-/PIjscXlD0jp3Bj5MWJ+y1WZsVxagsqnnzOkqdDStM3033soj/2cI7tysMU/7XAEJtMBk1bTJdDvmDHM/bn/rg==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@lexical/extension@0.45.0':
     resolution: {integrity: sha512-oJs1Zvrsqh32zZmeCkTQi7R2WoVIvaQE265JFZ/VczWlsWRdkkWQbGZ6iOlBZ3AmtiNgHoBeB0gZSoRQtWEQyA==}
 
+  '@lexical/extension@0.46.0':
+    resolution: {integrity: sha512-bdO/ON5dwVwtqeTes/+My/sRU7vNuH3W8ovJ2yffXRFmAxVtzKr6/6TYJWwtUvncQjvTHEKAo5MqWUoQXp8VMw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@lexical/hashtag@0.45.0':
     resolution: {integrity: sha512-gFX4n+9RjOFVkNUkEcv3JeQT0LvZ8fiHWHrIkg1m3JbyloG6mKDlsSlO1qnIPUaAB4V62Tbnmfv3I0qp1UvNuw==}
+
+  '@lexical/hashtag@0.46.0':
+    resolution: {integrity: sha512-6XiL5/KXyCxR+oD7fWjJL3enqsrkn4hgjEa13wAQrBZ5W+avFl/9Cd5bkwcXS+jPjmhk47+zYj76l6uuiFoMoQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@lexical/history@0.45.0':
     resolution: {integrity: sha512-KihtI8485Wx7kyFCtKNKk/nO2jSibRa8iL0OiKPZsYWVAQF5vFG3J00epX8EkEpeCx8Zjmj+3eytY05HPNd2nA==}
 
+  '@lexical/history@0.46.0':
+    resolution: {integrity: sha512-PbbyXVfbm/RBS/hkPJrAGd6DYZ8/4E+nyPaiArwo4WGYQBoEXc2dU+dwAcIrhwVVXuOVrkm9Hp0cZYl4hKM8qQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@lexical/html@0.45.0':
     resolution: {integrity: sha512-eK215f25cnAcIzNB1iRltg8hbvkK5wyyXvKQUqhfG/9HaSSVBCPuCyXKZicjZllQNvbFINGHFhTIqSP56drFSw==}
+
+  '@lexical/html@0.46.0':
+    resolution: {integrity: sha512-Rvke8FvQkjd+hFBCe39YdQxPQZZ/7W95xilY3qFxmSZaW0zakcA8pItaf7HfueG8Ja6jDu/TOMH4LUeyQPT3HQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@lexical/internal@0.45.0':
     resolution: {integrity: sha512-IhyzCdb1/xdpTtvK0xnqUXpaVRsD2KTZ6EMZpavm6dhKaglf1zorpdbH7r6Hjps6SRb4DCn/t7lac+GMdDFbXg==}
 
+  '@lexical/internal@0.46.0':
+    resolution: {integrity: sha512-OV1ePAAnVVd0K+Bq5SX7vOKE/LqJLYcDM4HD4zVCisbgVaznE+pTj/nDB2uWTidwf8o7QhPR65VhEi+KkUtyEw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@lexical/link@0.45.0':
     resolution: {integrity: sha512-9xpsRQ06IA4eVnx4OtFV0+Tmp2Etvh0dh9FTFd/LJYaqo2A0ZIuNUggueDZ0i2dhi8wWW8J08O7U0HxLcDWHAg==}
+
+  '@lexical/link@0.46.0':
+    resolution: {integrity: sha512-MdGiAOAmqnZKtfaQxKFZv18SC+1zJIOfqB7bR43va/rp4M3u1cVniquUCTALub40WEWTuJgT2XvfSlpKm7FuXA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@lexical/list@0.45.0':
     resolution: {integrity: sha512-Eyff9KVLu5mV4QSid2aw9uYmKDKgDYToAaagI9Sp3VgqTMmvRUQJ0w7sr4zq8/FRKSzrsf4V2FjvLAuQE7eBUQ==}
 
+  '@lexical/list@0.46.0':
+    resolution: {integrity: sha512-nIX3k05MFAhWZvVXZBZB7LTS1DhsCF2iCFH2WDYebwJfADTnAqhE/ZCAJax84RRMjYla67JU31br9r+P6KR+hA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@lexical/mark@0.45.0':
     resolution: {integrity: sha512-PMyGmnF6koE5TKCDlGe1k1t1ZOefReyYaKtx6OY3Tf1AyyKII6zRGR+dANrgWzYliYO7j4mpKBK00ykOnuF3zA==}
+
+  '@lexical/mark@0.46.0':
+    resolution: {integrity: sha512-WRpMATEhci3LxCgF4wN3mX2IIctTN5Zx8GQZU4rtbVBWHaYRA0azpyzsHeFJlpaaI0FJVMWfNQJ3QBeVIr6Ciw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@lexical/markdown@0.45.0':
     resolution: {integrity: sha512-fl/UUwudBXGnz44kOS07ZRN0DMfOWNnVl7GSSNyz6zDo1cMD60URt7LjF51bAG2oL8i1eRDX4/GV+7vBcuoGzw==}
 
+  '@lexical/markdown@0.46.0':
+    resolution: {integrity: sha512-2e/JFuS+7QEPLW4K2SOoYORpLXhdjFBh7l5OxAf8HljuFAvX0x9eFBxlWVG0Y00TFUMnOcUm1QnIo5l2e+0Cjg==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@lexical/overflow@0.45.0':
     resolution: {integrity: sha512-iw6Gc85phIGEjAFRDLiGOrnxK/EjyRlEfQHI7BeU0m+qHDCc94cThbeuaPTC7nnxHytFbRdtJIhoQvvcUR+PKA==}
 
+  '@lexical/overflow@0.46.0':
+    resolution: {integrity: sha512-VRa/VovH+FeuL9oyEjqF0zM2Nu4stgPs78Ek0mm9SR3EV1Cq58CoqjMvz/eH+4OsYMksFNfkxBg5f4a7QSAeDQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@lexical/plain-text@0.45.0':
     resolution: {integrity: sha512-453bsKVk3oY5/ktp3A2zO2nFdXniU/zfD87eIcN50aXrIwvNm082GkfmBaDeVujk7fLgC2hG980xdcEH4xcG3w==}
+
+  '@lexical/plain-text@0.46.0':
+    resolution: {integrity: sha512-fH1MYHrilsho6hkpGHnjw2eFBeLaJzz5PY4LT9ZVxtliPB3YRKUYZLcP23fGidzOC2it2xvTkT9D7kFo7zTQug==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@lexical/react@0.45.0':
     resolution: {integrity: sha512-LAaceAtcQpVMDvldhkrQC1MSawpj7aAm1CfGg6RbyQgTDDp2fKnP1gDhjQIef3lH8W2fYeXRe66EdzaFkoGHKA==}
@@ -717,25 +861,87 @@ packages:
       yjs:
         optional: true
 
+  '@lexical/react@0.46.0':
+    resolution: {integrity: sha512-yYz09UTTSVFFpU6Zku/m4LLGgg6qjnz83PoPf7rxx7/IuZHcJK6dCaApXZUdilMHf+A1gGG0W4UNXGjWVaX1nw==}
+    peerDependencies:
+      react: '>=17.x'
+      react-dom: '>=17.x'
+      typescript: '>=5.2'
+      yjs: '>=13.5.22'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      yjs:
+        optional: true
+
   '@lexical/rich-text@0.45.0':
     resolution: {integrity: sha512-jd+jIsDirqILuUQiNUJAzZWynVZHuN1ekqYcydgDFaUXMFBQgVr3mBUieQzMw2IDAEk98txntu/mZQav4BryQQ==}
+
+  '@lexical/rich-text@0.46.0':
+    resolution: {integrity: sha512-YwERYF7bOGZOmulxzyHID+gUkxCbTbn73pqow8GyasAdwlbTiiyqKSUp3fXC3prcMftQX8eg+SJNwkijvZk9yA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@lexical/selection@0.45.0':
     resolution: {integrity: sha512-V2DYMhl84F1aZ24YpWMMqy9ikO7cVfD3G+GjMwrZnMt0JVnIghjPiYIEBb/OtqqA+mCbBwNhfpdK1RtF9HTbJA==}
 
+  '@lexical/selection@0.46.0':
+    resolution: {integrity: sha512-iWrztXnBl9x7DthlRefUCNHfY8lHU6AzDm7pIr3o7t1hoixDtTuiZ5cCw+PkShC/hZ8v7VuV+FaDNraSaTTkHA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@lexical/table@0.45.0':
     resolution: {integrity: sha512-OXbwEg0DqkTdvqnu7z+/u8bgnDz2sjHHXCG3zGRhEzDgHcWoVQ18IciwMdse7dTTNfBIJMuGJcRoWPrHf9UlhQ==}
+
+  '@lexical/table@0.46.0':
+    resolution: {integrity: sha512-azgbCn+CxyGF2wVFB5Rmcx3wFKR9WKiGvJUUh8YDnMxL9LMWESfFy36XbedR140xUq0QoYTw8ZxBGMHE4ZiIIg==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@lexical/text@0.45.0':
     resolution: {integrity: sha512-ozI8fDsLTYAzEWXaBrGYZ0GnRbbIHi4IL99w5q06UfTQzBMYmF7WaccDP1krOOwwioPYQbiqZM7dh/41jsFELQ==}
 
+  '@lexical/text@0.46.0':
+    resolution: {integrity: sha512-XjH6ry2vYOfTO1JOLdbjlZ8he8LjkFjLbVIk+1I/q+8vp5ADx5GK99KaQfBiPZb0WTJEkuqo4AELWn3sXMvAiw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@lexical/utils@0.45.0':
     resolution: {integrity: sha512-Fo5MMErqoPlUyTw1qVMZ9kE33ZjJF957KU683tsCrrlaVisVxpboL7BbAnxWTwCcIpAsfc6AUndJJ70M9NDMGg==}
+
+  '@lexical/utils@0.46.0':
+    resolution: {integrity: sha512-s8XQDoBr1wyPKGqy3qyDeHvi+vMgOiszzcRdHvTd6AqWpXxw2MsDQzMdF3Nr56QHahcOYxMOcv+r7r2nnCcgCA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@lexical/yjs@0.45.0':
     resolution: {integrity: sha512-HYbOovvOavtF1S7C13l9g21s4MFLLd/o49qdn+/uGj23j4yjG556XBSrF0c3BREXDXSUr+RTbI6uiQ+L5Ofcmw==}
     peerDependencies:
       yjs: '>=13.5.22'
+
+  '@lexical/yjs@0.46.0':
+    resolution: {integrity: sha512-CsDD3NpmhoHjqnvbwQoTa3/lDYOCqlpBhRJcE14ERfngZ3PpoNu+YUW6IbhJ5PVFvtub8H3x8V9OjZ1IbHvZjg==}
+    peerDependencies:
+      typescript: '>=5.2'
+      yjs: '>=13.5.22'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
@@ -796,8 +1002,19 @@ packages:
   '@preact/signals-core@1.14.3':
     resolution: {integrity: sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw==}
 
+  '@revealui/ai@0.10.1':
+    resolution: {integrity: sha512-nPHnSJxMsaj2RpaCMpZcvfM31HwYz9v1d8coI1kpKky/ufKJ/nmHl1SDvp8/FzWARPquRj/o6f57nUDe14k4Qw==}
+    engines: {node: '>=24.13.0'}
+    peerDependencies:
+      drizzle-orm: ^0.45.1
+      react: ^18.0.0 || ^19.0.0
+
   '@revealui/cache@0.2.2':
     resolution: {integrity: sha512-qTFtTTzKOuC3Jo4LZ74tBbfCcynt+T34HqLq4XxRHmaAj9ID2gm8xJE4DkRN8RnOFLnTMu/c34tVFuyUhZw2BQ==}
+    engines: {node: '>=24.13.0'}
+
+  '@revealui/config@0.6.0':
+    resolution: {integrity: sha512-GMiO3WG55doranlh8oKIvOHTK7tOlg/55sFn3PX0+xbyBKUbYfFg2VLez8rD0wa9cKcRcAv9d/mXiZoqYX6RNQ==}
     engines: {node: '>=24.13.0'}
 
   '@revealui/contracts@0.6.1':
@@ -812,6 +1029,16 @@ packages:
 
   '@revealui/contracts@0.8.1':
     resolution: {integrity: sha512-bQY4HFibIsffTty6OxEclnueqWxk5q70d/m9mtNC3a5vdjMh7K3V4XADnvDNqayrzG6fYLkjz4Eq98ccDuYk0Q==}
+    engines: {node: '>=24.13.0'}
+    peerDependencies:
+      drizzle-zod: ^0.8.3
+      typescript: '>=6.0.0'
+    peerDependenciesMeta:
+      drizzle-zod:
+        optional: true
+
+  '@revealui/contracts@0.8.2':
+    resolution: {integrity: sha512-RGtpvsSs060i+KWhaU84FVQUi/nQ08zjVQWhHtLQhypZmHYv8owHRq05RppJRPSDqnO+Ouc3Gt7JWPTHK7+RiA==}
     engines: {node: '>=24.13.0'}
     peerDependencies:
       drizzle-zod: ^0.8.3
@@ -837,6 +1064,22 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
+  '@revealui/core@0.13.1':
+    resolution: {integrity: sha512-OVElvX8r3wIaoHU8sXDNclxx4/VksnmCknluzWZsxlHja1o3D1wkFQ24h84iafU2jZIGEG1DLw/C0UfDdKYcBQ==}
+    engines: {node: '>=24.13.0'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@revealui/db@0.10.0':
+    resolution: {integrity: sha512-34lQ3bue9xEh5oCcEbA/HGYSrB850zbpa1yJGLeboZv/ixVauQ/Qty+DlB48JntMOSChAUqSvaNlxlrbjE3WJA==}
+    engines: {node: '>=24.13.0'}
+
+  '@revealui/knowledge-graph@0.1.8':
+    resolution: {integrity: sha512-xdkP+KWmeYqyCxfblo16STI8YCFEpBmE0oozVaH1az/W+0JEf3mB03I2mDv88LdbzjkEmadiPyHOsnY+D9zaUQ==}
+    engines: {node: '>=24.13.0'}
+    hasBin: true
+
   '@revealui/presentation@0.12.1':
     resolution: {integrity: sha512-bHzMaetE7VjF/Jp5g+7/NMTrUomUm4bYw1J0FbFys1a5KGMijArx+dAv4qP8rzkl8QC1XBNj+7U68E6Jtiz/aw==}
     engines: {node: '>=24.13.0'}
@@ -852,12 +1095,20 @@ packages:
     resolution: {integrity: sha512-Gl0YLjh5JmE4Cpat0djARZWuXZ5FuEwXuk1Jr3E/uq+hKD2XiUxPP133KqkIj95PadGiCpLMz8DYc1pgQFLlVg==}
     engines: {node: '>=24.13.0'}
 
+  '@revealui/security@0.7.0':
+    resolution: {integrity: sha512-LJQGOD494561KG/ItymvYLGGfqc2RM/m0hgNkDlzZvr7oVWIND4It7oWr7yH41bJYrzjolievTP7npZFBtPKcQ==}
+    engines: {node: '>=24.13.0'}
+
   '@revealui/tokens@0.3.0':
     resolution: {integrity: sha512-ETlCSoEdJXXieWowcnZE577MpFcED8KSUPvGhgBfK7GThuH7QFtAmq0nvD2jEAf0uvP1v+iraCTUmtSH/ZEDYQ==}
     engines: {node: '>=24.13.0'}
 
   '@revealui/utils@0.3.5':
     resolution: {integrity: sha512-3csgqRSqwXLNY+nrUT1RbBPEqWRyryEWbeo566DC+azphvLXMTefPiYgEiU6M4BMnb/eui6Hn3rBhP7y+xbUNw==}
+    engines: {node: '>=24.13.0'}
+
+  '@revealui/utils@0.3.6':
+    resolution: {integrity: sha512-HlsUnumX5/1Pf39SCeD3ZAJtc/85r5YkzXLNZUjx1BdpfYGD2zxhCJlVFE2hW3qNvarIrpyCqgGEmLBwE2P4cw==}
     engines: {node: '>=24.13.0'}
 
   '@rolldown/binding-android-arm64@1.1.4':
@@ -1552,6 +1803,10 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
@@ -1883,6 +2138,14 @@ packages:
 
   lexical@0.45.0:
     resolution: {integrity: sha512-z2M9C2ILPW7SopQE1aKbOFdZJbe3HvsrgWnJKveMDrSEvVjU9Hce4UpKVsAdkwY7TgY9RDuCV3+sfrGu0WkL+w==}
+
+  lexical@0.46.0:
+    resolution: {integrity: sha512-oaE7OLY/FuqGKC7ihaqLJvgn/NvvRveryKBBgOwrSe+UIpBmc9IvyXf6hVcvew9M3Vc0XavHWe/ZAL7qc5DzMw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   lib0@0.2.117:
     resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
@@ -2623,6 +2886,11 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yjs@13.6.31:
     resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
@@ -3031,12 +3299,37 @@ snapshots:
       '@types/trusted-types': 2.0.7
       lexical: 0.45.0
 
+  '@lexical/clipboard@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/list': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      '@types/trusted-types': 2.0.7
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@lexical/code-core@0.45.0':
     dependencies:
       '@lexical/extension': 0.45.0
       '@lexical/html': 0.45.0
       '@lexical/internal': 0.45.0
       lexical: 0.45.0
+
+  '@lexical/code-core@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   '@lexical/code-prism@0.45.0':
     dependencies:
@@ -3045,12 +3338,32 @@ snapshots:
       lexical: 0.45.0
       prismjs: 1.30.0
 
+  '@lexical/code-prism@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/code-core': 0.46.0(typescript@6.0.3)
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+      prismjs: 1.30.0
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@lexical/code@0.45.0':
     dependencies:
       '@lexical/code-core': 0.45.0
       '@lexical/code-prism': 0.45.0
       '@lexical/extension': 0.45.0
       lexical: 0.45.0
+
+  '@lexical/code@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/code-core': 0.46.0(typescript@6.0.3)
+      '@lexical/code-prism': 0.46.0(typescript@6.0.3)
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   '@lexical/devtools-core@0.45.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -3063,10 +3376,32 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@lexical/devtools-core@0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
+    dependencies:
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/link': 0.46.0(typescript@6.0.3)
+      '@lexical/mark': 0.46.0(typescript@6.0.3)
+      '@lexical/table': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@lexical/dragon@0.45.0':
     dependencies:
       '@lexical/extension': 0.45.0
       lexical: 0.45.0
+
+  '@lexical/dragon@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   '@lexical/extension@0.45.0':
     dependencies:
@@ -3075,17 +3410,45 @@ snapshots:
       '@preact/signals-core': 1.14.3
       lexical: 0.45.0
 
+  '@lexical/extension@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      '@preact/signals-core': 1.14.3
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@lexical/hashtag@0.45.0':
     dependencies:
       '@lexical/text': 0.45.0
       '@lexical/utils': 0.45.0
       lexical: 0.45.0
 
+  '@lexical/hashtag@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/text': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@lexical/history@0.45.0':
     dependencies:
       '@lexical/extension': 0.45.0
       '@lexical/utils': 0.45.0
       lexical: 0.45.0
+
+  '@lexical/history@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   '@lexical/html@0.45.0':
     dependencies:
@@ -3095,7 +3458,23 @@ snapshots:
       '@lexical/utils': 0.45.0
       lexical: 0.45.0
 
+  '@lexical/html@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@lexical/internal@0.45.0': {}
+
+  '@lexical/internal@0.46.0(typescript@6.0.3)':
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   '@lexical/link@0.45.0':
     dependencies:
@@ -3105,6 +3484,17 @@ snapshots:
       '@lexical/utils': 0.45.0
       lexical: 0.45.0
 
+  '@lexical/link@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@lexical/list@0.45.0':
     dependencies:
       '@lexical/extension': 0.45.0
@@ -3113,10 +3503,29 @@ snapshots:
       '@lexical/utils': 0.45.0
       lexical: 0.45.0
 
+  '@lexical/list@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@lexical/mark@0.45.0':
     dependencies:
       '@lexical/utils': 0.45.0
       lexical: 0.45.0
+
+  '@lexical/mark@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   '@lexical/markdown@0.45.0':
     dependencies:
@@ -3130,9 +3539,31 @@ snapshots:
       '@lexical/utils': 0.45.0
       lexical: 0.45.0
 
+  '@lexical/markdown@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/code-core': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/link': 0.46.0(typescript@6.0.3)
+      '@lexical/list': 0.46.0(typescript@6.0.3)
+      '@lexical/rich-text': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      '@lexical/text': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@lexical/overflow@0.45.0':
     dependencies:
       lexical: 0.45.0
+
+  '@lexical/overflow@0.46.0(typescript@6.0.3)':
+    dependencies:
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   '@lexical/plain-text@0.45.0':
     dependencies:
@@ -3142,6 +3573,18 @@ snapshots:
       '@lexical/selection': 0.45.0
       '@lexical/utils': 0.45.0
       lexical: 0.45.0
+
+  '@lexical/plain-text@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/clipboard': 0.46.0(typescript@6.0.3)
+      '@lexical/dragon': 0.46.0(typescript@6.0.3)
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   '@lexical/react@0.45.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.31)':
     dependencies:
@@ -3170,6 +3613,34 @@ snapshots:
     optionalDependencies:
       yjs: 13.6.31
 
+  '@lexical/react@0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31)':
+    dependencies:
+      '@floating-ui/react': 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@lexical/devtools-core': 0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      '@lexical/dragon': 0.46.0(typescript@6.0.3)
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/hashtag': 0.46.0(typescript@6.0.3)
+      '@lexical/history': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/link': 0.46.0(typescript@6.0.3)
+      '@lexical/list': 0.46.0(typescript@6.0.3)
+      '@lexical/mark': 0.46.0(typescript@6.0.3)
+      '@lexical/markdown': 0.46.0(typescript@6.0.3)
+      '@lexical/overflow': 0.46.0(typescript@6.0.3)
+      '@lexical/plain-text': 0.46.0(typescript@6.0.3)
+      '@lexical/rich-text': 0.46.0(typescript@6.0.3)
+      '@lexical/table': 0.46.0(typescript@6.0.3)
+      '@lexical/text': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      '@lexical/yjs': 0.46.0(typescript@6.0.3)(yjs@13.6.31)
+      lexical: 0.46.0(typescript@6.0.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      typescript: 6.0.3
+      yjs: 13.6.31
+    optional: true
+
   '@lexical/rich-text@0.45.0':
     dependencies:
       '@lexical/clipboard': 0.45.0
@@ -3180,10 +3651,31 @@ snapshots:
       '@lexical/utils': 0.45.0
       lexical: 0.45.0
 
+  '@lexical/rich-text@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/clipboard': 0.46.0(typescript@6.0.3)
+      '@lexical/dragon': 0.46.0(typescript@6.0.3)
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@lexical/selection@0.45.0':
     dependencies:
       '@lexical/internal': 0.45.0
       lexical: 0.45.0
+
+  '@lexical/selection@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   '@lexical/table@0.45.0':
     dependencies:
@@ -3194,10 +3686,30 @@ snapshots:
       '@lexical/utils': 0.45.0
       lexical: 0.45.0
 
+  '@lexical/table@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/clipboard': 0.46.0(typescript@6.0.3)
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@lexical/text@0.45.0':
     dependencies:
       '@lexical/internal': 0.45.0
       lexical: 0.45.0
+
+  '@lexical/text@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   '@lexical/utils@0.45.0':
     dependencies:
@@ -3205,12 +3717,31 @@ snapshots:
       '@lexical/selection': 0.45.0
       lexical: 0.45.0
 
+  '@lexical/utils@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@lexical/yjs@0.45.0(yjs@13.6.31)':
     dependencies:
       '@lexical/internal': 0.45.0
       '@lexical/selection': 0.45.0
       lexical: 0.45.0
       yjs: 13.6.31
+
+  '@lexical/yjs@0.46.0(typescript@6.0.3)(yjs@13.6.31)':
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+      yjs: 13.6.31
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   '@lezer/common@1.5.2': {}
 
@@ -3300,12 +3831,61 @@ snapshots:
 
   '@preact/signals-core@1.14.3': {}
 
+  '@revealui/ai@0.10.1(@electric-sql/pglite@0.5.4)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(pg@8.22.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
+    dependencies:
+      '@revealui/contracts': 0.8.2(typescript@6.0.3)
+      '@revealui/core': 0.13.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      '@revealui/db': 0.10.0(@electric-sql/pglite@0.5.4)
+      '@revealui/resilience': 0.2.4
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(pg@8.22.0)
+      lru-cache: 11.5.1
+      react: 19.2.7
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - drizzle-zod
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg-native
+      - postgres
+      - prisma
+      - react-dom
+      - sql.js
+      - sqlite3
+      - typescript
+    optional: true
+
   '@revealui/cache@0.2.2(typescript@6.0.3)':
     dependencies:
       '@revealui/security': 0.4.1(typescript@6.0.3)
     transitivePeerDependencies:
       - drizzle-zod
       - typescript
+
+  '@revealui/config@0.6.0':
+    dependencies:
+      dotenv: 17.4.2
+      zod: 4.4.3
 
   '@revealui/contracts@0.6.1(typescript@6.0.3)':
     dependencies:
@@ -3316,6 +3896,12 @@ snapshots:
     dependencies:
       typescript: 6.0.3
       zod: 4.4.3
+
+  '@revealui/contracts@0.8.2(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+      zod: 4.4.3
+    optional: true
 
   '@revealui/contracts@1.4.0(typescript@6.0.3)':
     dependencies:
@@ -3356,6 +3942,119 @@ snapshots:
       - pg-native
       - typescript
 
+  '@revealui/core@0.13.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
+    dependencies:
+      '@electric-sql/pglite': 0.5.4
+      '@lexical/clipboard': 0.46.0(typescript@6.0.3)
+      '@lexical/code': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/link': 0.46.0(typescript@6.0.3)
+      '@lexical/list': 0.46.0(typescript@6.0.3)
+      '@lexical/react': 0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31)
+      '@lexical/rich-text': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      '@lexical/table': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      '@lexical/yjs': 0.46.0(typescript@6.0.3)(yjs@13.6.31)
+      '@revealui/contracts': 0.8.2(typescript@6.0.3)
+      '@revealui/resilience': 0.2.4
+      '@revealui/security': 0.7.0(typescript@6.0.3)
+      '@revealui/utils': 0.3.6
+      bcryptjs: 3.0.3
+      dataloader: 2.2.3
+      jose: 5.10.0
+      lexical: 0.46.0(typescript@6.0.3)
+      pg: 8.22.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      yjs: 13.6.31
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - drizzle-zod
+      - pg-native
+      - typescript
+    optional: true
+
+  '@revealui/db@0.10.0(@electric-sql/pglite@0.5.4)':
+    dependencies:
+      '@neondatabase/serverless': 1.1.0
+      '@revealui/config': 0.6.0
+      '@revealui/utils': 0.3.6
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(pg@8.22.0)
+      pg: 8.22.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg-native
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+
+  '@revealui/knowledge-graph@0.1.8(@electric-sql/pglite@0.5.4)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(pg@8.22.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@revealui/db': 0.10.0(@electric-sql/pglite@0.5.4)
+      typescript: 6.0.3
+      yaml: 2.9.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@revealui/ai': 0.10.1(@electric-sql/pglite@0.5.4)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(pg@8.22.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - drizzle-orm
+      - drizzle-zod
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg-native
+      - postgres
+      - prisma
+      - react
+      - react-dom
+      - sql.js
+      - sqlite3
+
   '@revealui/presentation@0.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@revealui/contracts': 0.8.1(typescript@6.0.3)
@@ -3379,9 +4078,24 @@ snapshots:
       - drizzle-zod
       - typescript
 
+  '@revealui/security@0.7.0(typescript@6.0.3)':
+    dependencies:
+      '@revealui/contracts': 0.8.2(typescript@6.0.3)
+      '@revealui/utils': 0.3.6
+      parse5: 8.0.1
+      undici: 7.28.0
+    transitivePeerDependencies:
+      - drizzle-zod
+      - typescript
+    optional: true
+
   '@revealui/tokens@0.3.0': {}
 
   '@revealui/utils@0.3.5':
+    dependencies:
+      zod: 4.4.3
+
+  '@revealui/utils@0.3.6':
     dependencies:
       zod: 4.4.3
 
@@ -3574,12 +4288,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
 
-  '@tailwindcss/vite@4.3.2(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.3.2(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
       tailwindcss: 4.3.2
-      vite: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tauri-apps/api@2.11.1': {}
 
@@ -3724,10 +4438,10 @@ snapshots:
       '@vercel/cli-exec': 1.0.0
       jose: 5.10.0
 
-  '@vitejs/plugin-react@6.0.3(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))':
+  '@vitejs/plugin-react@6.0.3(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -3738,13 +4452,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -3931,6 +4645,8 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dotenv@17.4.2: {}
 
   drizzle-kit@0.31.10:
     dependencies:
@@ -4223,6 +4939,13 @@ snapshots:
     dependencies:
       '@lexical/internal': 0.45.0
 
+  lexical@0.46.0(typescript@6.0.3):
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
+
   lib0@0.2.117:
     dependencies:
       isomorphic.js: 0.2.5
@@ -4420,13 +5143,14 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
       postcss: 8.5.23
       tsx: 4.21.0
+      yaml: 2.9.0
 
   postcss@8.5.23:
     dependencies:
@@ -4733,7 +5457,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0)(typescript@6.0.3):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
@@ -4744,7 +5468,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.21.0)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -4792,7 +5516,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0):
+  vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -4805,11 +5529,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.21.0
+      yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)):
+  vitest@4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -4826,7 +5551,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.4
@@ -4877,6 +5602,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
+
+  yaml@2.9.0: {}
 
   yjs@13.6.31:
     dependencies:


### PR DESCRIPTION
## Summary

GAP-349 residual: register the seven knowledge-graph tools on **revdev-bridge** so agents can query Neon without a monorepo path.

- Deps: `@revealui/knowledge-graph@^0.1.8`, `@revealui/db@^0.10.0`
- Tools: `kg_search`, `kg_get_node`, `kg_neighbors`, `kg_add_episode`, `kg_path`, `kg_at_time`, `kg_context`
- Soft-fail per tool when `POSTGRES_URL` / `DATABASE_URL` / `POSTGRES_URL_FILE` missing (daemon session tools still work)
- Stream-safe: inject URL via revvault; never print secrets
- Unit tests for registration + executor contract

Companion docs: revealui-jv lane currency PR (P2.5/P4 already shipped).

## Security

Touches MCP tool surface + optional Neon query/write (`kg_add_episode`). Treat as security-classed: **non-author guardrail-2 verdict** before merge.

## Test plan

- [x] `pnpm --filter @revdev/bridge test`
- [x] `pnpm --filter @revdev/bridge build`
- [ ] CI green
- [ ] Optional dogfood: `revvault run --env POSTGRES_URL=revealui/prod/db/postgres-url -- revdev-bridge` then call `kg_search`

## Env

```bash
revvault run --env POSTGRES_URL=revealui/prod/db/postgres-url -- pnpm --filter @revdev/bridge start
```