### PR TITLE
feat(studio): fleet map mermaid roadmap graph from TRACKER snapshot

### DIFF
--- a/apps/studio/src/__tests__/components/FleetMapPanel.test.tsx
+++ b/apps/studio/src/__tests__/components/FleetMapPanel.test.tsx
@@ -19,8 +19,11 @@ const mockPayload = {
       },
     ],
     freeSurfaces: [{ id: 'GAP-154', priority: 'high', initiativeId: 'INIT-002' }],
-    nodes: [{}, {}],
-    edges: [{}],
+    nodes: [
+      { id: 'INIT-002', kind: 'initiative', label: 'INIT-002', priority: 'P0' },
+      { id: 'GAP-154', kind: 'gap', label: 'GAP-154' },
+    ],
+    edges: [{ from: 'INIT-002', to: 'GAP-154', relation: 'member' }],
   },
   state: null,
   generatedAt: '2026-08-08T00:00:00.000Z',
@@ -52,6 +55,8 @@ describe('FleetMapPanel', () => {
     expect(screen.getByRole('heading', { name: 'Fleet map' })).toBeInTheDocument();
     expect(screen.getByText('RevDev daily driver')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /Free surfaces/i })).toBeInTheDocument();
+    expect(screen.getByTestId('fleet-map-mermaid')).toHaveTextContent('flowchart TB');
+    expect(screen.getByTestId('fleet-map-mermaid')).toHaveTextContent('INIT_002');
   });
 
   it('shows error when snapshot missing', async () => {

--- a/apps/studio/src/__tests__/lib/fleet-map-graph.test.ts
+++ b/apps/studio/src/__tests__/lib/fleet-map-graph.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { buildFleetMermaid, mermaidSafeId } from '../../lib/fleet-map-graph';
+
+describe('mermaidSafeId', () => {
+  it('keeps alnum and underscore', () => {
+    expect(mermaidSafeId('INIT-002')).toBe('INIT_002');
+    expect(mermaidSafeId('GAP-360')).toBe('GAP_360');
+  });
+});
+
+describe('buildFleetMermaid', () => {
+  it('renders empty graph message', () => {
+    const r = buildFleetMermaid([], []);
+    expect(r.nodeCount).toBe(0);
+    expect(r.mermaid).toContain('No graph nodes');
+  });
+
+  it('renders initiative edges', () => {
+    const r = buildFleetMermaid(
+      [
+        { id: 'INIT-002', kind: 'initiative', label: 'INIT-002', priority: 'P0' },
+        { id: 'INIT-003', kind: 'initiative', label: 'INIT-003', priority: 'P0' },
+        { id: 'GAP-360', kind: 'gap', label: 'GAP-360' },
+      ],
+      [
+        { from: 'INIT-002', to: 'INIT-003', relation: 'related' },
+        { from: 'INIT-002', to: 'GAP-360', relation: 'member' },
+      ],
+    );
+    expect(r.nodeCount).toBe(3);
+    expect(r.mermaid).toContain('flowchart TB');
+    expect(r.mermaid).toContain('INIT_002');
+    expect(r.mermaid).toContain('-->');
+  });
+
+  it('collapses to initiatives when graph is large', () => {
+    const nodes = Array.from({ length: 100 }, (_, i) => ({
+      id: i < 3 ? `INIT-00${i}` : `GAP-${i}`,
+      kind: i < 3 ? 'initiative' : 'gap',
+      label: i < 3 ? `INIT-00${i}` : `GAP-${i}`,
+    }));
+    const r = buildFleetMermaid(nodes, []);
+    expect(r.truncated).toBe(true);
+    expect(r.nodeCount).toBe(3);
+  });
+});

--- a/apps/studio/src/components/fleet/FleetMapPanel.tsx
+++ b/apps/studio/src/components/fleet/FleetMapPanel.tsx
@@ -1,10 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { type FleetMapPayload, readFleetMap } from '../../lib/fleet-map';
-import {
-  buildFleetMermaid,
-  type SnapshotEdge,
-  type SnapshotNode,
-} from '../../lib/fleet-map-graph';
+import { buildFleetMermaid, type SnapshotEdge, type SnapshotNode } from '../../lib/fleet-map-graph';
 import Button from '../adapters/Button';
 import ErrorAlert from '../adapters/ErrorAlert';
 import PanelHeader from '../adapters/PanelHeader';
@@ -78,12 +74,8 @@ export default function FleetMapPanel() {
   const free = useMemo(() => (data ? asFree(data.snapshot) : []), [data]);
   const graph = useMemo(() => {
     if (!data) return null;
-    const nodes = Array.isArray(data.snapshot.nodes)
-      ? (data.snapshot.nodes as SnapshotNode[])
-      : [];
-    const edges = Array.isArray(data.snapshot.edges)
-      ? (data.snapshot.edges as SnapshotEdge[])
-      : [];
+    const nodes = Array.isArray(data.snapshot.nodes) ? (data.snapshot.nodes as SnapshotNode[]) : [];
+    const edges = Array.isArray(data.snapshot.edges) ? (data.snapshot.edges as SnapshotEdge[]) : [];
     return buildFleetMermaid(nodes, edges);
   }, [data]);
 

--- a/apps/studio/src/components/fleet/FleetMapPanel.tsx
+++ b/apps/studio/src/components/fleet/FleetMapPanel.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { type FleetMapPayload, readFleetMap } from '../../lib/fleet-map';
+import {
+  buildFleetMermaid,
+  type SnapshotEdge,
+  type SnapshotNode,
+} from '../../lib/fleet-map-graph';
 import Button from '../adapters/Button';
 import ErrorAlert from '../adapters/ErrorAlert';
 import PanelHeader from '../adapters/PanelHeader';
@@ -71,6 +76,24 @@ export default function FleetMapPanel() {
 
   const inits = useMemo(() => (data ? asInits(data.snapshot) : []), [data]);
   const free = useMemo(() => (data ? asFree(data.snapshot) : []), [data]);
+  const graph = useMemo(() => {
+    if (!data) return null;
+    const nodes = Array.isArray(data.snapshot.nodes)
+      ? (data.snapshot.nodes as SnapshotNode[])
+      : [];
+    const edges = Array.isArray(data.snapshot.edges)
+      ? (data.snapshot.edges as SnapshotEdge[])
+      : [];
+    return buildFleetMermaid(nodes, edges);
+  }, [data]);
+
+  const copyId = useCallback(async (id: string) => {
+    try {
+      await navigator.clipboard.writeText(id);
+    } catch {
+      // clipboard may be denied in some WebView contexts
+    }
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -84,8 +107,9 @@ export default function FleetMapPanel() {
       />
 
       <p className="text-sm text-fg-muted">
-        Read-only view of the private TRACKER snapshot (initiatives, free surfaces, graph counts).
-        Agents keep YAML SSOT; this panel never writes the board.
+        Read-only visual roadmap: TRACKER snapshot graph (mermaid), initiatives, free surfaces.
+        Agents keep YAML SSOT; this panel never writes the board. Goal % comes from initiative
+        progress in the snapshot (spine projector soft-overlay; no daemon spawn).
       </p>
 
       <ErrorAlert message={error} />
@@ -123,6 +147,24 @@ export default function FleetMapPanel() {
               <div className="mt-1">STATE.json not present (run tracker sync).</div>
             )}
           </div>
+
+          {graph ? (
+            <section className="space-y-2">
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-fg-subtle">
+                Roadmap graph ({graph.nodeCount} nodes / {graph.edgeCount} edges
+                {graph.truncated ? ', truncated' : ''})
+              </h2>
+              <pre
+                className="max-h-72 overflow-auto rounded-lg border border-edge bg-surface-2 p-3 text-xs text-fg"
+                data-testid="fleet-map-mermaid"
+              >
+                {graph.mermaid}
+              </pre>
+              <p className="text-xs text-fg-muted">
+                Paste into any mermaid renderer, or view TRACKER.graph.md in .jv for the full DAG.
+              </p>
+            </section>
+          ) : null}
 
           <section className="space-y-2">
             <h2 className="text-xs font-semibold uppercase tracking-wider text-fg-subtle">
@@ -177,7 +219,16 @@ export default function FleetMapPanel() {
                 <tbody>
                   {free.slice(0, 20).map((row) => (
                     <tr key={row.id} className="border-t border-edge">
-                      <td className="px-3 py-2 font-mono text-xs">{row.id}</td>
+                      <td className="px-3 py-2 font-mono text-xs">
+                        <button
+                          type="button"
+                          className="text-left hover:underline"
+                          title="Copy gap id"
+                          onClick={() => void copyId(row.id)}
+                        >
+                          {row.id}
+                        </button>
+                      </td>
                       <td className="px-3 py-2">{row.priority ?? '—'}</td>
                       <td className="px-3 py-2 font-mono text-xs">{row.initiativeId ?? '—'}</td>
                     </tr>

--- a/apps/studio/src/lib/fleet-map-graph.ts
+++ b/apps/studio/src/lib/fleet-map-graph.ts
@@ -23,12 +23,7 @@ const MAX_GRAPH_NODES = 80;
 export function mermaidSafeId(raw: string): string {
   const chars = Array.from(raw);
   const mapped = chars.map((c) => {
-    if (
-      (c >= 'a' && c <= 'z') ||
-      (c >= 'A' && c <= 'Z') ||
-      (c >= '0' && c <= '9') ||
-      c === '_'
-    ) {
+    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c === '_') {
       return c;
     }
     return '_';

--- a/apps/studio/src/lib/fleet-map-graph.ts
+++ b/apps/studio/src/lib/fleet-map-graph.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure helpers: tracker-snapshot-v1 nodes/edges → mermaid flowchart (visual roadmap).
+ * IDs only in labels (no private gap titles). Zero authored regex.
+ */
+
+export type SnapshotNode = {
+  id: string;
+  kind?: string;
+  label?: string;
+  state?: string;
+  priority?: string;
+};
+
+export type SnapshotEdge = {
+  from: string;
+  to: string;
+  relation?: string;
+};
+
+const MAX_GRAPH_NODES = 80;
+
+/** Mermaid-safe node id: alnum and underscore only. */
+export function mermaidSafeId(raw: string): string {
+  const chars = Array.from(raw);
+  const mapped = chars.map((c) => {
+    if (
+      (c >= 'a' && c <= 'z') ||
+      (c >= 'A' && c <= 'Z') ||
+      (c >= '0' && c <= '9') ||
+      c === '_'
+    ) {
+      return c;
+    }
+    return '_';
+  });
+  return mapped.join('') || 'n';
+}
+
+/**
+ * Build a mermaid flowchart from snapshot graph.
+ * Prefer initiative nodes + membership edges; fall back to truncated full graph.
+ */
+export function buildFleetMermaid(
+  nodes: SnapshotNode[],
+  edges: SnapshotEdge[],
+): { mermaid: string; nodeCount: number; edgeCount: number; truncated: boolean } {
+  if (nodes.length === 0) {
+    return {
+      mermaid: 'flowchart TB\n  empty["No graph nodes in snapshot"]',
+      nodeCount: 0,
+      edgeCount: 0,
+      truncated: false,
+    };
+  }
+
+  const initNodes = nodes.filter((n) => n.kind === 'initiative');
+  const useInitsOnly = initNodes.length > 0 && nodes.length > MAX_GRAPH_NODES;
+  const selected = useInitsOnly ? initNodes : nodes.slice(0, MAX_GRAPH_NODES);
+  const selectedIds = new Set(selected.map((n) => n.id));
+  const truncated = useInitsOnly || nodes.length > MAX_GRAPH_NODES;
+
+  const lines: string[] = ['flowchart TB'];
+  for (const n of selected) {
+    const sid = mermaidSafeId(n.id);
+    const label = (n.label ?? n.id).replaceAll('"', "'");
+    const pri = n.priority ? ` ${n.priority}` : '';
+    lines.push(`  ${sid}["${label}${pri}"]`);
+  }
+
+  let edgeCount = 0;
+  for (const e of edges) {
+    if (!selectedIds.has(e.from) || !selectedIds.has(e.to)) continue;
+    // When init-only, keep member + blocked-by style edges into/out of inits
+    if (useInitsOnly && e.relation === 'member') {
+      // show init → gap as dashed if gap not in selected — skip external
+      continue;
+    }
+    const a = mermaidSafeId(e.from);
+    const b = mermaidSafeId(e.to);
+    const rel = e.relation ? `|${e.relation}|` : '';
+    lines.push(`  ${a} -->${rel} ${b}`);
+    edgeCount += 1;
+  }
+
+  // Init-only: still show membership counts as notes on edges between inits via shared structure
+  if (useInitsOnly) {
+    lines.push('  note["INIT-only view (graph collapsed)"]');
+  }
+
+  return {
+    mermaid: lines.join('\n'),
+    nodeCount: selected.length,
+    edgeCount,
+    truncated,
+  };
+}


### PR DESCRIPTION
## Summary

Visual roadmap v2 in Studio Fleet map:

- Render tracker-snapshot `nodes`/`edges` as **mermaid** flowchart (id-only labels)
- Collapse to INIT-only when graph is large
- Free-surface rows click to copy gap id
- Initiative progress % already from snapshot (spine soft-overlay)

## Test plan

- [x] Unit tests: fleet-map-graph + FleetMapPanel (6 tests)
- [ ] CI green