### PR TITLE
feat(daemon): GAP-362 loop spend + waitForWorkCompleted

### DIFF
--- a/packages/daemon/src/__tests__/loop-guard.test.ts
+++ b/packages/daemon/src/__tests__/loop-guard.test.ts
@@ -63,4 +63,19 @@ describe('LoopGuardRegistry', () => {
     expect(reg.stop('L4').status).toBe('stopped');
     expect(() => reg.tick({ loopId: 'L4', advanced: true })).toThrow(/stopped/);
   });
+
+  it('accumulates spend on tick and recordSpend', () => {
+    const reg = new LoopGuardRegistry();
+    reg.arm({ loopId: 'L5', agentId: 'a1', intervalMs: 120_000 });
+    expect(reg.spend('L5')).toEqual({ tokensIn: 0, tokensOut: 0, costMicros: 0 });
+    reg.tick({ loopId: 'L5', advanced: true, tokensIn: 10, tokensOut: 20, costMicros: 500 });
+    expect(reg.spend('L5')).toEqual({ tokensIn: 10, tokensOut: 20, costMicros: 500 });
+    reg.recordSpend({ loopId: 'L5', tokensIn: 5, tokensOut: 0, costMicros: 100 });
+    expect(reg.spend('L5')).toEqual({ tokensIn: 15, tokensOut: 20, costMicros: 600 });
+    const snap = reg.get('L5');
+    expect(snap?.spend.tokensIn).toBe(15);
+    // clone isolation
+    snap!.spend.tokensIn = 999;
+    expect(reg.spend('L5')?.tokensIn).toBe(15);
+  });
 });

--- a/packages/daemon/src/__tests__/token-economy-rpc.test.ts
+++ b/packages/daemon/src/__tests__/token-economy-rpc.test.ts
@@ -144,4 +144,43 @@ describe('GAP-362 work.completed + loop guard', () => {
     })) as { loop: { status: string } };
     expect(stopped.loop.status).toBe('stopped');
   });
+
+  it('loop.tick + loop.spend accumulate token spend', async () => {
+    await rpcAgent(socketPath, 'loop.arm', {
+      loopId: 'loop-spend',
+      intervalMs: 120_000,
+    });
+    await rpcAgent(socketPath, 'loop.tick', {
+      loopId: 'loop-spend',
+      advanced: true,
+      tokensIn: 100,
+      tokensOut: 50,
+      costMicros: 1_000,
+    });
+    await rpcAgent(socketPath, 'loop.record_spend', {
+      loopId: 'loop-spend',
+      tokensIn: 10,
+      tokensOut: 5,
+      costMicros: 100,
+    });
+    const spent = (await rpcAgent(socketPath, 'loop.spend', {
+      loopId: 'loop-spend',
+    })) as {
+      spend: { tokensIn: number; tokensOut: number; costMicros: number };
+      tickCount: number;
+    };
+    expect(spent.spend).toEqual({ tokensIn: 110, tokensOut: 55, costMicros: 1_100 });
+    expect(spent.tickCount).toBe(1);
+
+    const status = (await rpcAgent(socketPath, 'loop.status', {
+      loopId: 'loop-spend',
+    })) as { loop: { spend: { tokensIn: number } } };
+    expect(status.loop.spend.tokensIn).toBe(110);
+
+    const q = (await rpcAgent(socketPath, 'events.query', {
+      eventType: 'loop.spend_delta',
+      limit: 10,
+    })) as { events: Array<{ event_type: string }> };
+    expect(q.events.some((e) => e.event_type === 'loop.spend_delta')).toBe(true);
+  });
 });

--- a/packages/daemon/src/loop-guard.ts
+++ b/packages/daemon/src/loop-guard.ts
@@ -14,6 +14,16 @@ export const MIN_IDLE_INTERVAL_MS = 60_000;
 
 export type LoopStatus = 'armed' | 'paused' | 'stopped' | 'not_advancing';
 
+/** Cumulative spend for a loop (process-local; also mirrored on loop.tick events). */
+export interface LoopSpend {
+  /** Provider input tokens attributed to this loop. */
+  tokensIn: number;
+  /** Provider output tokens attributed to this loop. */
+  tokensOut: number;
+  /** Optional micro-USD cost (integer micros; 1 USD = 1_000_000). */
+  costMicros: number;
+}
+
 export interface LoopState {
   loopId: string;
   agentId: string;
@@ -27,6 +37,8 @@ export interface LoopState {
   createdAt: number;
   updatedAt: number;
   lastSignal: string | null;
+  /** Per-loop spend (GAP-362 residual — queryable via loop.status / loop.spend). */
+  spend: LoopSpend;
 }
 
 export interface ArmLoopInput {
@@ -41,7 +53,24 @@ export interface TickLoopInput {
   loopId: string;
   /** True when this iteration advanced work (new output, task progress, etc.). */
   advanced: boolean;
+  /** Optional spend delta for this tick (token-economy metering). */
+  tokensIn?: number;
+  tokensOut?: number;
+  costMicros?: number;
   now?: number;
+}
+
+export interface RecordSpendInput {
+  loopId: string;
+  tokensIn?: number;
+  tokensOut?: number;
+  costMicros?: number;
+  now?: number;
+}
+
+function nonNegInt(n: number | undefined): number {
+  if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
 }
 
 export function cadenceWarningForInterval(intervalMs: number): string | null {
@@ -82,14 +111,32 @@ export class LoopGuardRegistry {
       createdAt: now,
       updatedAt: now,
       lastSignal: cadenceWarning,
+      spend: { tokensIn: 0, tokensOut: 0, costMicros: 0 },
     };
     this.loops.set(input.loopId, state);
-    return { ...state };
+    return this.clone(state);
   }
 
   get(loopId: string): LoopState | null {
     const s = this.loops.get(loopId);
-    return s ? { ...s } : null;
+    return s ? this.clone(s) : null;
+  }
+
+  /** Cumulative spend for a loop (null if unknown). */
+  spend(loopId: string): LoopSpend | null {
+    const s = this.loops.get(loopId);
+    return s ? { ...s.spend } : null;
+  }
+
+  recordSpend(input: RecordSpendInput): LoopState {
+    const s = this.require(input.loopId);
+    if (s.status === 'stopped') throw new Error(`loop ${input.loopId} is stopped`);
+    const now = input.now ?? Date.now();
+    s.spend.tokensIn += nonNegInt(input.tokensIn);
+    s.spend.tokensOut += nonNegInt(input.tokensOut);
+    s.spend.costMicros += nonNegInt(input.costMicros);
+    s.updatedAt = now;
+    return this.clone(s);
   }
 
   tick(input: TickLoopInput): LoopState {
@@ -101,6 +148,9 @@ export class LoopGuardRegistry {
     const now = input.now ?? Date.now();
     s.tickCount += 1;
     s.updatedAt = now;
+    s.spend.tokensIn += nonNegInt(input.tokensIn);
+    s.spend.tokensOut += nonNegInt(input.tokensOut);
+    s.spend.costMicros += nonNegInt(input.costMicros);
 
     if (input.advanced) {
       s.consecutiveNoOps = 0;
@@ -115,7 +165,7 @@ export class LoopGuardRegistry {
         s.lastSignal = null;
       }
     }
-    return { ...s };
+    return this.clone(s);
   }
 
   pause(loopId: string, now = Date.now()): LoopState {
@@ -124,7 +174,7 @@ export class LoopGuardRegistry {
     s.status = 'paused';
     s.updatedAt = now;
     s.lastSignal = 'paused';
-    return { ...s };
+    return this.clone(s);
   }
 
   resume(loopId: string, now = Date.now()): LoopState {
@@ -133,7 +183,7 @@ export class LoopGuardRegistry {
     s.status = 'armed';
     s.updatedAt = now;
     s.lastSignal = null;
-    return { ...s };
+    return this.clone(s);
   }
 
   stop(loopId: string, now = Date.now()): LoopState {
@@ -141,13 +191,17 @@ export class LoopGuardRegistry {
     s.status = 'stopped';
     s.updatedAt = now;
     s.lastSignal = 'stopped';
-    return { ...s };
+    return this.clone(s);
   }
 
   private require(loopId: string): LoopState {
     const s = this.loops.get(loopId);
     if (!s) throw new Error(`unknown loopId: ${loopId}`);
     return s;
+  }
+
+  private clone(s: LoopState): LoopState {
+    return { ...s, spend: { ...s.spend } };
   }
 }
 

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -73,6 +73,8 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['loop.arm', 'routine'],
   ['loop.tick', 'routine'],
   ['loop.status', 'routine'],
+  ['loop.spend', 'routine'],
+  ['loop.record_spend', 'routine'],
   ['loop.pause', 'routine'],
   ['loop.resume', 'routine'],
   ['loop.stop', 'routine'],

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -2124,11 +2124,41 @@ registerHandler('loop.tick', async (params, db, ctx) => {
   const agentId = await requireVerifiedAgent(ctx, db, params);
   const loopId = str(params.loopId);
   const advanced = params.advanced === true;
+  const tokensIn = params.tokensIn === undefined ? undefined : num(params.tokensIn, 0);
+  const tokensOut = params.tokensOut === undefined ? undefined : num(params.tokensOut, 0);
+  const costMicros = params.costMicros === undefined ? undefined : num(params.costMicros, 0);
   const existing = loopGuards.get(loopId);
   if (existing && existing.agentId !== agentId) {
     throw new Error(`loop ${loopId} is owned by another agent`);
   }
-  const state = loopGuards.tick({ loopId, advanced });
+  const state = loopGuards.tick({
+    loopId,
+    advanced,
+    tokensIn,
+    tokensOut,
+    costMicros,
+  });
+  // Durable spend sample on the event log (queryable; pairs with process-local spend)
+  if (tokensIn || tokensOut || costMicros) {
+    try {
+      await db.query(
+        `INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`,
+        [
+          agentId,
+          'loop.spend_delta',
+          JSON.stringify({
+            loopId,
+            tokensIn: tokensIn ?? 0,
+            tokensOut: tokensOut ?? 0,
+            costMicros: costMicros ?? 0,
+            cumulative: state.spend,
+          }),
+        ],
+      );
+    } catch {
+      /* best-effort */
+    }
+  }
   if (state.status === 'not_advancing') {
     await db.query(
       `INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`,
@@ -2140,6 +2170,7 @@ registerHandler('loop.tick', async (params, db, ctx) => {
           consecutiveNoOps: state.consecutiveNoOps,
           noopLimit: state.noopLimit,
           signal: state.lastSignal,
+          spend: state.spend,
         }),
       ],
     );
@@ -2153,6 +2184,46 @@ registerHandler('loop.status', async (params, db, ctx) => {
   const state = loopGuards.get(loopId);
   if (!state) return { loop: null };
   if (state.agentId !== agentId) throw new Error(`loop ${loopId} is owned by another agent`);
+  return { loop: state };
+});
+
+registerHandler('loop.spend', async (params, db, ctx) => {
+  const agentId = await requireVerifiedAgent(ctx, db, params);
+  const loopId = str(params.loopId);
+  const state = loopGuards.get(loopId);
+  if (!state) return { loopId, spend: null };
+  if (state.agentId !== agentId) throw new Error(`loop ${loopId} is owned by another agent`);
+  return { loopId, spend: state.spend, tickCount: state.tickCount, status: state.status };
+});
+
+registerHandler('loop.record_spend', async (params, db, ctx) => {
+  const agentId = await requireVerifiedAgent(ctx, db, params);
+  const loopId = str(params.loopId);
+  const existing = loopGuards.get(loopId);
+  if (!existing) throw new Error(`unknown loopId: ${loopId}`);
+  if (existing.agentId !== agentId) throw new Error(`loop ${loopId} is owned by another agent`);
+  const tokensIn = params.tokensIn === undefined ? undefined : num(params.tokensIn, 0);
+  const tokensOut = params.tokensOut === undefined ? undefined : num(params.tokensOut, 0);
+  const costMicros = params.costMicros === undefined ? undefined : num(params.costMicros, 0);
+  const state = loopGuards.recordSpend({ loopId, tokensIn, tokensOut, costMicros });
+  try {
+    await db.query(
+      `INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`,
+      [
+        agentId,
+        'loop.spend_delta',
+        JSON.stringify({
+          loopId,
+          tokensIn: tokensIn ?? 0,
+          tokensOut: tokensOut ?? 0,
+          costMicros: costMicros ?? 0,
+          cumulative: state.spend,
+        }),
+      ],
+    );
+  } catch {
+    /* best-effort */
+  }
   return { loop: state };
 });
 

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -338,6 +338,10 @@ export const schemas: Record<string, z.ZodType> = {
     .object({
       loopId: z.string().min(1).max(MAX_NAME_LENGTH),
       advanced: z.boolean(),
+      // Optional spend delta (GAP-362 residual metering)
+      tokensIn: z.number().int().min(0).max(100_000_000).optional(),
+      tokensOut: z.number().int().min(0).max(100_000_000).optional(),
+      costMicros: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).optional(),
       actorAgentId,
     })
     .passthrough(),
@@ -345,6 +349,23 @@ export const schemas: Record<string, z.ZodType> = {
   'loop.status': z
     .object({
       loopId: z.string().min(1).max(MAX_NAME_LENGTH),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'loop.spend': z
+    .object({
+      loopId: z.string().min(1).max(MAX_NAME_LENGTH),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'loop.record_spend': z
+    .object({
+      loopId: z.string().min(1).max(MAX_NAME_LENGTH),
+      tokensIn: z.number().int().min(0).max(100_000_000).optional(),
+      tokensOut: z.number().int().min(0).max(100_000_000).optional(),
+      costMicros: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).optional(),
       actorAgentId,
     })
     .passthrough(),

--- a/packages/protocol/src/__tests__/wait-for-work.test.ts
+++ b/packages/protocol/src/__tests__/wait-for-work.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { waitForWorkCompleted, WORK_COMPLETED_EVENT } from '../wait-for-work.js';
+
+describe('waitForWorkCompleted', () => {
+  it('calls events.wait with work.completed defaults', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      event: { id: 1, event_type: WORK_COMPLETED_EVENT },
+      timedOut: false,
+    });
+    const result = await waitForWorkCompleted(rpc);
+    expect(rpc).toHaveBeenCalledWith('events.wait', {
+      eventType: WORK_COMPLETED_EVENT,
+      sinceId: 0,
+      timeoutMs: 30_000,
+    });
+    expect(result.timedOut).toBe(false);
+    expect(result.event).toEqual({ id: 1, event_type: WORK_COMPLETED_EVENT });
+  });
+
+  it('forwards sinceId and timeoutMs', async () => {
+    const rpc = vi.fn().mockResolvedValue({ event: null, timedOut: true });
+    const result = await waitForWorkCompleted(rpc, { sinceId: 9, timeoutMs: 500 });
+    expect(rpc).toHaveBeenCalledWith('events.wait', {
+      eventType: WORK_COMPLETED_EVENT,
+      sinceId: 9,
+      timeoutMs: 500,
+    });
+    expect(result.timedOut).toBe(true);
+    expect(result.event).toBeNull();
+  });
+});

--- a/packages/protocol/src/__tests__/wait-for-work.test.ts
+++ b/packages/protocol/src/__tests__/wait-for-work.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 import { describe, expect, it, vi } from 'vitest';
-import { waitForWorkCompleted, WORK_COMPLETED_EVENT } from '../wait-for-work.js';
+import { WORK_COMPLETED_EVENT, waitForWorkCompleted } from '../wait-for-work.js';
 
 describe('waitForWorkCompleted', () => {
   it('calls events.wait with work.completed defaults', async () => {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -18,13 +18,6 @@ export type {
 } from './harness.js';
 export { RPC_METHODS } from './methods.js';
 export type { JsonRpcRequest, JsonRpcResponse, RpcErrorCode } from './rpc.js';
-export {
-  waitForWorkCompleted,
-  WORK_COMPLETED_EVENT,
-  type DaemonRpc,
-  type WaitForWorkParams,
-  type WaitForWorkResult,
-} from './wait-for-work.js';
 export type {
   AgentMemoryEntry,
   AgentMessage,
@@ -35,6 +28,13 @@ export type {
   FileReservation,
   MergeRequest,
 } from './schema.js';
+export {
+  type DaemonRpc,
+  type WaitForWorkParams,
+  type WaitForWorkResult,
+  WORK_COMPLETED_EVENT,
+  waitForWorkCompleted,
+} from './wait-for-work.js';
 export type {
   ConflictResult,
   TaskPriority,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -18,6 +18,13 @@ export type {
 } from './harness.js';
 export { RPC_METHODS } from './methods.js';
 export type { JsonRpcRequest, JsonRpcResponse, RpcErrorCode } from './rpc.js';
+export {
+  waitForWorkCompleted,
+  WORK_COMPLETED_EVENT,
+  type DaemonRpc,
+  type WaitForWorkParams,
+  type WaitForWorkResult,
+} from './wait-for-work.js';
 export type {
   AgentMemoryEntry,
   AgentMessage,

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -75,6 +75,8 @@ export const RPC_METHODS = {
   'loop.arm': 'loop.arm',
   'loop.tick': 'loop.tick',
   'loop.status': 'loop.status',
+  'loop.spend': 'loop.spend',
+  'loop.record_spend': 'loop.record_spend',
   'loop.pause': 'loop.pause',
   'loop.resume': 'loop.resume',
   'loop.stop': 'loop.stop',

--- a/packages/protocol/src/wait-for-work.ts
+++ b/packages/protocol/src/wait-for-work.ts
@@ -1,0 +1,47 @@
+/**
+ * GAP-362 — prefer long-poll over client-side task polling.
+ *
+ * Thin adapter helper: call `events.wait` with `work.completed` so harnesses
+ * wake on completion instead of self-scheduled sub-minute polls.
+ */
+
+export const WORK_COMPLETED_EVENT = 'work.completed';
+
+export interface WaitForWorkParams {
+  /** Exclusive lower bound on event id (default 0). */
+  sinceId?: number;
+  /** Cap wait (ms); daemon clamps 100–120_000. Default 30_000. */
+  timeoutMs?: number;
+}
+
+export interface WaitForWorkResult<TEvent = unknown> {
+  event: TEvent | null;
+  timedOut: boolean;
+}
+
+/**
+ * Shape expected from a daemon RPC client: (method, params) → result.
+ */
+export type DaemonRpc = (
+  method: string,
+  params: Record<string, unknown>,
+) => Promise<Record<string, unknown>>;
+
+/**
+ * Long-poll until a `work.completed` event arrives (or timeout).
+ * Prefer this over `setInterval` + `events.query` / `tasks.*` polls.
+ */
+export async function waitForWorkCompleted(
+  rpc: DaemonRpc,
+  params: WaitForWorkParams = {},
+): Promise<WaitForWorkResult> {
+  const result = await rpc('events.wait', {
+    eventType: WORK_COMPLETED_EVENT,
+    sinceId: params.sinceId ?? 0,
+    timeoutMs: params.timeoutMs ?? 30_000,
+  });
+  return {
+    event: (result.event as unknown) ?? null,
+    timedOut: result.timedOut === true,
+  };
+}


### PR DESCRIPTION
## Summary

GAP-362 residual after Phase 1 (`work.completed` / `events.wait` / `loop.*` guards):

- **Loop spend:** `tokensIn` / `tokensOut` / `costMicros` on `loop.tick` and `loop.record_spend`; query via `loop.spend` / `loop.status`
- **Durable samples:** `loop.spend_delta` events for spend deltas
- **Adapter helper:** `@revdev/protocol` `waitForWorkCompleted()` long-polls `events.wait` for `work.completed` (prefer over client poll)

## Tests

- `loop-guard.test.ts` (spend accumulate + clone isolation)
- `token-economy-rpc.test.ts` (RPC spend + spend_delta event)
- `wait-for-work.test.ts`
- `rpc-contract.test.ts` (method registry lockstep)

## Notes

- Process-local registry is the live spend view; events are the durable audit trail (daemon has no `usage_meters` table — extend-before-create on `events`)
- Studio UI still uses health polling for non-work signals; work completion should use this helper / `events.wait`