### PR TITLE
feat(studio): GAP-362 long-poll work.completed for harness UI

### DIFF
--- a/apps/studio/src/__tests__/lib/work-completed-refresh.test.ts
+++ b/apps/studio/src/__tests__/lib/work-completed-refresh.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { runWorkCompletedRefreshLoop } from '../../lib/work-completed-refresh';
+
+describe('runWorkCompletedRefreshLoop', () => {
+  it('calls onEvent when wait returns an event and advances sinceId', async () => {
+    const ac = new AbortController();
+    let calls = 0;
+    const onEvent = vi.fn(async () => {
+      calls += 1;
+      if (calls >= 1) ac.abort();
+    });
+    const wait = vi
+      .fn()
+      .mockResolvedValueOnce({ event: { id: 7, event_type: 'work.completed' }, timedOut: false })
+      .mockImplementation(async () => {
+        // hang until abort
+        await new Promise<void>(() => {});
+        return { event: null, timedOut: true };
+      });
+
+    await runWorkCompletedRefreshLoop({
+      signal: ac.signal,
+      wait,
+      onEvent,
+      timeoutMs: 100,
+    });
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(wait).toHaveBeenCalledWith({ sinceId: 0, timeoutMs: 100 });
+  });
+
+  it('re-waits on timeout without calling onEvent', async () => {
+    const ac = new AbortController();
+    let waits = 0;
+    const onEvent = vi.fn();
+    const wait = vi.fn(async () => {
+      waits += 1;
+      if (waits >= 2) ac.abort();
+      return { event: null, timedOut: true };
+    });
+
+    await runWorkCompletedRefreshLoop({
+      signal: ac.signal,
+      wait,
+      onEvent,
+      timeoutMs: 50,
+    });
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(waits).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/studio/src/hooks/use-harness.ts
+++ b/apps/studio/src/hooks/use-harness.ts
@@ -13,7 +13,9 @@ import {
   harnessSendMessage,
   harnessSessions,
   harnessTasks,
+  harnessWaitForWorkCompleted,
 } from '../lib/invoke';
+import { runWorkCompletedRefreshLoop } from '../lib/work-completed-refresh';
 import type {
   HarnessClaimResult,
   HarnessMessage,
@@ -24,8 +26,11 @@ import type {
 } from '../types';
 import { usePollingFetch } from './use-polling-fetch';
 
-/** Fallback poll interval for browser dev mode (no Tauri events available) */
-const BROWSER_POLL_MS = 5_000;
+/**
+ * Fallback poll for mail/sessions/reservations (no work.completed bus).
+ * GAP-362: task completion is driven by events.wait long-poll below, not this.
+ */
+const BROWSER_POLL_MS = 30_000;
 
 export type HarnessStatus = 'connected' | 'connecting' | 'disconnected' | 'error';
 
@@ -193,13 +198,24 @@ export function useHarness(agentId?: string): UseHarnessReturn {
     };
   }, []);
 
-  // Browser mode: fall back to polling via usePollingFetch (no Tauri
-  // event system available). Tauri mode subscribes to push events
-  // (above) and disables the helper by passing intervalMs=null. The
-  // helper returns void from this fetcher — actual state lives in the
-  // outer setState calls that loadAll() makes; we're using the helper
-  // here purely for its abort + isMounted hygiene wrapping the polled
-  // call.
+  // Browser mode: GAP-362 long-poll work.completed (prefer over sub-minute
+  // tasks.list polls), plus a slower fallback poll for mail/sessions.
+  // Tauri mode uses harness:state push events and disables both loops.
+  useEffect(() => {
+    if (isTauri()) return;
+    const ac = new AbortController();
+    runWorkCompletedRefreshLoop({
+      signal: ac.signal,
+      wait: (p) => harnessWaitForWorkCompleted(p),
+      onEvent: () => loadAllRef.current(),
+    }).catch(() => {
+      /* aborted or daemon down — fallback poll still runs */
+    });
+    return () => {
+      ac.abort();
+    };
+  }, []);
+
   const browserPollFn = useCallback(async (_signal: AbortSignal): Promise<void> => {
     await loadAllRef.current();
   }, []);

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -381,6 +381,8 @@ const MOCK_DATA: Record<string, unknown> = {
   } satisfies HarnessTask,
   harness_claim_task: { success: true, owner: 'agent-ext-1' } satisfies HarnessClaimResult,
   harness_complete_task: true,
+  // GAP-362 mock: timeout with no event (browser demo has no live work bus)
+  harness_events_wait: { event: null, timedOut: true },
   harness_release_task: true,
   harness_reservations: [
     {
@@ -441,6 +443,8 @@ export const HARNESS_RPC_MAP: Record<string, string> = {
   harness_reservations: 'files.list',
   harness_reserve_file: 'files.reserve',
   harness_check_file: 'files.check',
+  // GAP-362: long-poll work.completed (prefer over client sub-minute task polls)
+  harness_events_wait: 'events.wait',
   // GAP-294 permission modes
   harness_permission_pending: 'permission.pending',
   harness_permission_decide: 'permission.decide',
@@ -1390,6 +1394,38 @@ export function harnessCompleteTask(taskId: string, agentId: string): Promise<bo
 
 export function harnessReleaseTask(taskId: string, agentId: string): Promise<boolean> {
   return invoke<boolean>('harness_release_task', { taskId, agentId });
+}
+
+/** GAP-362: long-poll until work.completed (or timeout). Prefer over polling tasks.list. */
+export function harnessEventsWait(params: {
+  eventType: string;
+  sinceId?: number;
+  timeoutMs?: number;
+}): Promise<{ event: Record<string, unknown> | null; timedOut: boolean }> {
+  return invoke<{ event: Record<string, unknown> | null; timedOut: boolean }>(
+    'harness_events_wait',
+    {
+      eventType: params.eventType,
+      sinceId: params.sinceId ?? 0,
+      timeoutMs: params.timeoutMs ?? 30_000,
+    },
+  );
+}
+
+/**
+ * GAP-362 adapter: wait for a coordination task completion via events.wait.
+ * Prefer this over polling tasks.list. Mirrors @revdev/protocol waitForWorkCompleted
+ * over the Studio invoke bridge (no runtime dep on protocol package).
+ */
+export function harnessWaitForWorkCompleted(params?: {
+  sinceId?: number;
+  timeoutMs?: number;
+}): Promise<{ event: Record<string, unknown> | null; timedOut: boolean }> {
+  return harnessEventsWait({
+    eventType: 'work.completed',
+    sinceId: params?.sinceId ?? 0,
+    timeoutMs: params?.timeoutMs ?? 30_000,
+  });
 }
 
 export function harnessReservations(agentId?: string): Promise<HarnessReservation[]> {

--- a/apps/studio/src/lib/work-completed-refresh.ts
+++ b/apps/studio/src/lib/work-completed-refresh.ts
@@ -1,0 +1,83 @@
+/**
+ * GAP-362 — browser-mode work.completed long-poll loop.
+ *
+ * Prefer events.wait over sub-minute tasks.list polls. Callers still keep a
+ * slower fallback poll for mail/sessions/reservations that do not emit
+ * work.completed.
+ */
+
+export interface WorkCompletedWaitResult {
+  event: Record<string, unknown> | null;
+  timedOut: boolean;
+}
+
+export type WorkCompletedWaitFn = (params: {
+  sinceId: number;
+  timeoutMs: number;
+}) => Promise<WorkCompletedWaitResult>;
+
+export interface RunWorkCompletedRefreshLoopOptions {
+  wait: WorkCompletedWaitFn;
+  onEvent: () => void | Promise<void>;
+  /** Abort when the React effect cleans up. */
+  signal: AbortSignal;
+  /** Per wait call timeout (ms). Default 25_000. */
+  timeoutMs?: number;
+  /** Backoff after errors (ms). Default 2_000. */
+  errorBackoffMs?: number;
+  /** Extract numeric event id for sinceId cursor. */
+  eventIdOf?: (event: Record<string, unknown>) => number;
+}
+
+function defaultEventId(event: Record<string, unknown>): number {
+  const id = event.id ?? event.eventId;
+  if (typeof id === 'number' && Number.isFinite(id)) return id;
+  if (typeof id === 'string' && id.trim() !== '') {
+    const n = Number(id);
+    if (Number.isFinite(n)) return n;
+  }
+  return 0;
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const t = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(t);
+      resolve();
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Long-poll work.completed until aborted. On each event, calls onEvent (typically
+ * a full harness refresh). Timeouts just re-wait — that is the notify path.
+ */
+export async function runWorkCompletedRefreshLoop(
+  options: RunWorkCompletedRefreshLoopOptions,
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 25_000;
+  const errorBackoffMs = options.errorBackoffMs ?? 2_000;
+  const eventIdOf = options.eventIdOf ?? defaultEventId;
+  let sinceId = 0;
+
+  while (!options.signal.aborted) {
+    try {
+      const result = await options.wait({ sinceId, timeoutMs });
+      if (options.signal.aborted) return;
+      if (result.event) {
+        const next = eventIdOf(result.event);
+        if (next > sinceId) sinceId = next;
+        await options.onEvent();
+      }
+    } catch {
+      if (options.signal.aborted) return;
+      await sleep(errorBackoffMs, options.signal);
+    }
+  }
+}

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -467,6 +467,28 @@ server.tool(
   },
 );
 
+// GAP-362: long-poll completion (prefer over client sub-minute polling)
+server.tool(
+  'events_wait',
+  'Long-poll for a daemon event (default work.completed). Prefer this over polling tasks_list or events_query on a timer (GAP-362 token-economy).',
+  {
+    eventType: z.string().optional().describe('Event type to wait for (default: work.completed)'),
+    sinceId: z.number().optional().describe('Only return events with id greater than this'),
+    timeoutMs: z
+      .number()
+      .optional()
+      .describe('Max wait milliseconds (daemon clamps 100–120000; default 30000)'),
+  },
+  async ({ eventType, sinceId, timeoutMs }) => {
+    const result = await daemon.call(RPC_METHODS['events.wait'], {
+      eventType: eventType ?? 'work.completed',
+      sinceId: sinceId ?? 0,
+      timeoutMs: timeoutMs ?? 30_000,
+    });
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
 // -- Permission modes (GAP-294) ---------------------------------------------
 // Headless decision surface (design: permission.pending / decide / setMode).
 // decide + setMode are signature-required; operator must use a trusted signed


### PR DESCRIPTION
## Summary

GAP-362 Studio/adapter residual after [revdev#385](https://github.com/RevealUIStudio/revdev/pull/385):

- **Studio:** `harness_events_wait` → `events.wait`; `harnessWaitForWorkCompleted`
- **Browser `useHarness`:** long-poll `work.completed` to refresh task board (not 5s `tasks.list` polls); fallback state poll **30s** for mail/sessions
- **Bridge MCP:** `events_wait` tool for agents (token-economy: prefer long-poll over timer polls)
- Tauri path unchanged (`harness:state` push)

## Tests

- `work-completed-refresh.test.ts` (2)
- `invoke.test.ts` (36, includes HARNESS_RPC_MAP ↔ RPC_METHODS contract)

## Peers

Stay off `use-harness` / harness events wait map while this PR is open, or claim first.