### PR TITLE
feat(daemon): GAP-323 design-pack filesystem watcher

### DIFF
--- a/packages/daemon/src/__tests__/design-pack-watch.test.ts
+++ b/packages/daemon/src/__tests__/design-pack-watch.test.ts
@@ -8,8 +8,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
-  DesignPackWatcher,
   DESIGN_PACK_MOVED_EVENT,
+  DesignPackWatcher,
   designPackEvents,
   diffSnapshots,
   resolveAutoWatchRoots,

--- a/packages/daemon/src/__tests__/design-pack-watch.test.ts
+++ b/packages/daemon/src/__tests__/design-pack-watch.test.ts
@@ -1,0 +1,135 @@
+/**
+ * GAP-323 design-pack watcher — pure snapshot + live FS watch emit.
+ *
+ * @vitest-environment node
+ */
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  DesignPackWatcher,
+  DESIGN_PACK_MOVED_EVENT,
+  designPackEvents,
+  diffSnapshots,
+  resolveAutoWatchRoots,
+  resolveWatchPaths,
+  snapshotPack,
+} from '../design-pack-watch.js';
+
+describe('design-pack pure helpers', () => {
+  it('resolveWatchPaths appends default relative roots', () => {
+    const paths = resolveWatchPaths('/tmp/revealui-monorepo');
+    expect(paths).toEqual([
+      join('/tmp/revealui-monorepo', 'packages/tokens/design-context'),
+      join('/tmp/revealui-monorepo', 'preview-dist'),
+    ]);
+  });
+
+  it('resolveAutoWatchRoots prefers REVDEV_DESIGN_PACK_ROOTS', () => {
+    const roots = resolveAutoWatchRoots({
+      REVDEV_DESIGN_PACK_ROOTS: '/a/design-context:/b/preview-dist',
+      REVDEV_REVEALUI_ROOT: '/should/not/use',
+    });
+    expect(roots).toEqual(['/a/design-context', '/b/preview-dist']);
+  });
+
+  it('resolveAutoWatchRoots uses REVDEV_REVEALUI_ROOT when pack roots unset', () => {
+    const roots = resolveAutoWatchRoots({
+      REVDEV_REVEALUI_ROOT: '/fleet/revealui',
+      REVDEV_DESIGN_PACK_ROOTS: '',
+    });
+    expect(roots[0]).toContain(join('packages', 'tokens', 'design-context'));
+  });
+
+  it('snapshotPack digests file content and diffs on change', async () => {
+    const root = join(tmpdir(), `dp-snap-${Date.now()}`);
+    await mkdir(root, { recursive: true });
+    try {
+      await writeFile(join(root, 'tokens.css'), ':root { --x: 1; }\n', 'utf8');
+      const a = await snapshotPack([root]);
+      expect(a.roots).toHaveLength(1);
+      expect(a.files.length).toBeGreaterThanOrEqual(1);
+      expect(a.digest).toMatch(/^[a-f0-9]{64}$/);
+
+      const b = await snapshotPack([root]);
+      expect(diffSnapshots(a, b).changed).toBe(false);
+
+      await writeFile(join(root, 'tokens.css'), ':root { --x: 2; }\n', 'utf8');
+      const c = await snapshotPack([root]);
+      const d = diffSnapshots(a, c);
+      expect(d.changed).toBe(true);
+      expect(d.changedFiles.some((f) => f.includes('tokens.css'))).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('snapshotPack omits missing roots', async () => {
+    const snap = await snapshotPack([join(tmpdir(), `no-such-dir-${Date.now()}`)]);
+    expect(snap.roots).toEqual([]);
+    expect(snap.digest).toBe('');
+    expect(snap.files).toEqual([]);
+  });
+});
+
+describe('DesignPackWatcher', () => {
+  afterEach(async () => {
+    // ensure no leaked listeners between tests
+    designPackEvents.removeAllListeners(DESIGN_PACK_MOVED_EVENT);
+  });
+
+  it('emits design.pack.moved when a watched file changes', async () => {
+    const root = join(tmpdir(), `dp-watch-${Date.now()}`);
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, 'MANIFEST.sha256'), 'v1\n', 'utf8');
+
+    const watcher = new DesignPackWatcher();
+    const logged: unknown[] = [];
+    const busEvents: unknown[] = [];
+    designPackEvents.on(DESIGN_PACK_MOVED_EVENT, (p) => busEvents.push(p));
+
+    try {
+      const status = await watcher.start([root], async (payload) => {
+        logged.push(payload);
+      });
+      expect(status.watching).toBe(true);
+      expect(status.fileCount).toBeGreaterThanOrEqual(1);
+      expect(status.lastMovedAt).toBeNull();
+
+      await writeFile(join(root, 'MANIFEST.sha256'), 'v2\n', 'utf8');
+      // Debounce is 250ms; poll scan until moved or timeout.
+      let moved = null;
+      for (let i = 0; i < 40; i++) {
+        moved = await watcher.scanAndEmit(false);
+        if (moved) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(moved).not.toBeNull();
+      expect(moved?.digest).toMatch(/^[a-f0-9]{64}$/);
+      expect(logged.length).toBeGreaterThanOrEqual(1);
+      expect(busEvents.length).toBeGreaterThanOrEqual(1);
+      expect(watcher.status().lastMovedAt).not.toBeNull();
+    } finally {
+      await watcher.stop();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not emit on start baseline (equal re-scan)', async () => {
+    const root = join(tmpdir(), `dp-base-${Date.now()}`);
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, 'a.txt'), 'hello\n', 'utf8');
+    const watcher = new DesignPackWatcher();
+    try {
+      await watcher.start([root], async () => {
+        throw new Error('should not log on baseline re-scan');
+      });
+      const moved = await watcher.scanAndEmit(false);
+      expect(moved).toBeNull();
+    } finally {
+      await watcher.stop();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/daemon/src/design-pack-events.ts
+++ b/packages/daemon/src/design-pack-events.ts
@@ -1,0 +1,28 @@
+/**
+ * GAP-323 — in-process bus for design.pack.moved (pair of work-events.ts).
+ *
+ * Kept free of server imports so events.wait can subscribe without a cycle.
+ */
+
+import { EventEmitter } from 'node:events';
+
+/** Stable event type written to the events table + bus. */
+export const DESIGN_PACK_MOVED_EVENT = 'design.pack.moved';
+
+export interface DesignPackMovedPayload {
+  roots: string[];
+  previousDigest: string | null;
+  digest: string;
+  changedFiles: string[];
+  fileCount: number;
+  at: string;
+}
+
+class DesignPackEventBus extends EventEmitter {
+  emitMoved(payload: DesignPackMovedPayload): void {
+    this.emit(DESIGN_PACK_MOVED_EVENT, payload);
+  }
+}
+
+export const designPackEvents = new DesignPackEventBus();
+designPackEvents.setMaxListeners(64);

--- a/packages/daemon/src/design-pack-watch.ts
+++ b/packages/daemon/src/design-pack-watch.ts
@@ -27,15 +27,16 @@ import { onDaemonStarted, onDaemonStopping } from './eviction.js';
 import { syncEventLog } from './neon.js';
 import { registerHandler } from './server.js';
 
-export { DESIGN_PACK_MOVED_EVENT, designPackEvents, type DesignPackMovedPayload } from './design-pack-events.js';
+export {
+  DESIGN_PACK_MOVED_EVENT,
+  type DesignPackMovedPayload,
+  designPackEvents,
+} from './design-pack-events.js';
 
 const log = createLogger({ service: 'revdev-daemon/design-pack' });
 
 /** Relative roots under a revealui monorepo (code-over-docs from GAP-323). */
-export const DEFAULT_RELATIVE_ROOTS = [
-  'packages/tokens/design-context',
-  'preview-dist',
-] as const;
+export const DEFAULT_RELATIVE_ROOTS = ['packages/tokens/design-context', 'preview-dist'] as const;
 
 const DEBOUNCE_MS = 250;
 /** Cap walk depth so a mis-pointed root cannot fan out the whole disk. */
@@ -328,8 +329,7 @@ export class DesignPackWatcher {
         roots: next.roots,
         previousDigest,
         digest: next.digest,
-        changedFiles:
-          changedFiles.length > 0 ? changedFiles : next.files.map((f) => f.rel),
+        changedFiles: changedFiles.length > 0 ? changedFiles : next.files.map((f) => f.rel),
         fileCount: next.files.length,
         at: new Date().toISOString(),
       };
@@ -351,7 +351,6 @@ export class DesignPackWatcher {
 export const designPackWatcher = new DesignPackWatcher();
 
 onDaemonStopping(() => designPackWatcher.stop());
-
 
 // ---------------------------------------------------------------------------
 // RPC registration

--- a/packages/daemon/src/design-pack-watch.ts
+++ b/packages/daemon/src/design-pack-watch.ts
@@ -1,0 +1,459 @@
+/**
+ * GAP-323 item 3 — design-pack filesystem watcher (native pair of GAP-322).
+ *
+ * Watches the code-canonical design pack (`packages/tokens/design-context/`)
+ * and the generated preview bundle (`preview-dist/`) under a RevealUI monorepo
+ * root. On change, emits durable `design.pack.moved` events so any harness
+ * (not only Claude DesignSync) can answer "did the design pack move?" without
+ * a vendor login.
+ *
+ * Extend-before-create: reuses the events table + events.wait pattern from
+ * GAP-362 work.completed (in-process bus + durable INSERT).
+ */
+
+import { createHash } from 'node:crypto';
+import { createReadStream, type FSWatcher, watch } from 'node:fs';
+import { readdir, realpath, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, resolve, sep } from 'node:path';
+import type { PGlite } from '@electric-sql/pglite';
+import { createLogger } from '@revealui/utils/logger';
+import {
+  DESIGN_PACK_MOVED_EVENT,
+  type DesignPackMovedPayload,
+  designPackEvents,
+} from './design-pack-events.js';
+import { onDaemonStarted, onDaemonStopping } from './eviction.js';
+import { syncEventLog } from './neon.js';
+import { registerHandler } from './server.js';
+
+export { DESIGN_PACK_MOVED_EVENT, designPackEvents, type DesignPackMovedPayload } from './design-pack-events.js';
+
+const log = createLogger({ service: 'revdev-daemon/design-pack' });
+
+/** Relative roots under a revealui monorepo (code-over-docs from GAP-323). */
+export const DEFAULT_RELATIVE_ROOTS = [
+  'packages/tokens/design-context',
+  'preview-dist',
+] as const;
+
+const DEBOUNCE_MS = 250;
+/** Cap walk depth so a mis-pointed root cannot fan out the whole disk. */
+const MAX_WALK_DEPTH = 8;
+/** Cap files hashed per snapshot (design pack is small; previews are flat HTML). */
+const MAX_FILES = 2_000;
+
+export interface PackFileEntry {
+  rel: string;
+  size: number;
+  mtimeMs: number;
+  sha256: string;
+}
+
+export interface PackSnapshot {
+  /** Absolute roots that were scanned (existed at scan time). */
+  roots: string[];
+  /** Aggregate of per-file content hashes (sorted). Empty roots → empty digest. */
+  digest: string;
+  files: PackFileEntry[];
+  scannedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pure path + snapshot helpers (unit-tested)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve absolute watch paths from a revealui monorepo root.
+ * Does not require paths to exist (caller filters missing dirs).
+ */
+export function resolveWatchPaths(repoRoot: string): string[] {
+  const root = resolve(repoRoot);
+  return DEFAULT_RELATIVE_ROOTS.map((rel) => join(root, rel));
+}
+
+/**
+ * Env-driven roots for auto-watch on daemon start.
+ *
+ * Priority:
+ * 1. `REVDEV_DESIGN_PACK_ROOTS` — colon-separated absolute (or ~) paths
+ * 2. `REVDEV_REVEALUI_ROOT` — monorepo root → default relative segments
+ * 3. `$HOME/revfleet/revealui` when that tree contains design-context
+ */
+export function resolveAutoWatchRoots(env: NodeJS.ProcessEnv = process.env): string[] {
+  const explicit = (env.REVDEV_DESIGN_PACK_ROOTS ?? '').trim();
+  if (explicit) {
+    return explicit
+      .split(':')
+      .map((p) => p.trim())
+      .filter(Boolean)
+      .map((p) => expandHome(p));
+  }
+  const revealui = (env.REVDEV_REVEALUI_ROOT ?? '').trim();
+  if (revealui) {
+    return resolveWatchPaths(expandHome(revealui));
+  }
+  const dogfood = join(homedir(), 'revfleet', 'revealui');
+  return resolveWatchPaths(dogfood);
+}
+
+function expandHome(p: string): string {
+  if (p === '~') return homedir();
+  if (p.startsWith(`~${sep}`)) return join(homedir(), p.slice(2));
+  return resolve(p);
+}
+
+function hashStream(filePath: string): Promise<string> {
+  return new Promise((resolveHash, reject) => {
+    const h = createHash('sha256');
+    const stream = createReadStream(filePath);
+    stream.on('data', (chunk) => h.update(chunk));
+    stream.on('error', reject);
+    stream.on('end', () => resolveHash(h.digest('hex')));
+  });
+}
+
+async function walkFiles(root: string, depth = 0): Promise<string[]> {
+  if (depth > MAX_WALK_DEPTH) return [];
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const ent of entries) {
+    if (ent.name === 'node_modules' || ent.name === '.git' || ent.name === 'dist') continue;
+    const full = join(root, ent.name);
+    if (ent.isDirectory()) {
+      out.push(...(await walkFiles(full, depth + 1)));
+    } else if (ent.isFile()) {
+      out.push(full);
+    }
+    if (out.length >= MAX_FILES) break;
+  }
+  return out.slice(0, MAX_FILES);
+}
+
+/**
+ * Snapshot content digests for existing roots. Missing roots are omitted
+ * (so a missing preview-dist is not an error — it appears when generated).
+ */
+export async function snapshotPack(roots: string[]): Promise<PackSnapshot> {
+  const existing: string[] = [];
+  for (const r of roots) {
+    try {
+      const st = await stat(r);
+      if (st.isDirectory()) {
+        existing.push(await realpath(r));
+      }
+    } catch {
+      // skip missing
+    }
+  }
+
+  const files: PackFileEntry[] = [];
+  for (const root of existing) {
+    const absFiles = await walkFiles(root);
+    for (const abs of absFiles) {
+      try {
+        const st = await stat(abs);
+        if (!st.isFile()) continue;
+        const sha256 = await hashStream(abs);
+        const rel = abs.startsWith(root + sep) ? abs.slice(root.length + 1) : abs;
+        files.push({
+          rel: `${root.split(sep).slice(-2).join('/')}/${rel}`,
+          size: st.size,
+          mtimeMs: st.mtimeMs,
+          sha256,
+        });
+      } catch {
+        // race: file deleted mid-walk
+      }
+    }
+  }
+
+  files.sort((a, b) => (a.rel < b.rel ? -1 : a.rel > b.rel ? 1 : 0));
+  const digest = createHash('sha256')
+    .update(files.map((f) => `${f.rel}:${f.sha256}`).join('\n'))
+    .digest('hex');
+
+  return {
+    roots: existing,
+    digest: files.length === 0 ? '' : digest,
+    files,
+    scannedAt: new Date().toISOString(),
+  };
+}
+
+export function diffSnapshots(
+  prev: PackSnapshot | null,
+  next: PackSnapshot,
+): { changed: boolean; changedFiles: string[] } {
+  if (!prev) {
+    return {
+      changed: next.files.length > 0 || next.roots.length > 0,
+      changedFiles: next.files.map((f) => f.rel),
+    };
+  }
+  if (prev.digest === next.digest) {
+    return { changed: false, changedFiles: [] };
+  }
+  const prevMap = new Map(prev.files.map((f) => [f.rel, f.sha256]));
+  const nextMap = new Map(next.files.map((f) => [f.rel, f.sha256]));
+  const changedFiles: string[] = [];
+  for (const [rel, hash] of nextMap) {
+    if (prevMap.get(rel) !== hash) changedFiles.push(rel);
+  }
+  for (const rel of prevMap.keys()) {
+    if (!nextMap.has(rel)) changedFiles.push(rel);
+  }
+  changedFiles.sort();
+  return { changed: true, changedFiles };
+}
+
+// ---------------------------------------------------------------------------
+// Watcher runtime
+// ---------------------------------------------------------------------------
+
+export interface DesignPackWatchStatus {
+  watching: boolean;
+  roots: string[];
+  lastDigest: string | null;
+  lastScannedAt: string | null;
+  lastMovedAt: string | null;
+  fileCount: number;
+}
+
+type LogMoved = (payload: DesignPackMovedPayload) => Promise<void>;
+
+export class DesignPackWatcher {
+  private watchers: FSWatcher[] = [];
+  private roots: string[] = [];
+  private lastSnapshot: PackSnapshot | null = null;
+  private lastMovedAt: string | null = null;
+  private debounce: NodeJS.Timeout | null = null;
+  private logMoved: LogMoved | null = null;
+  private scanning = false;
+
+  status(): DesignPackWatchStatus {
+    return {
+      watching: this.watchers.length > 0,
+      roots: [...this.roots],
+      lastDigest: this.lastSnapshot?.digest ?? null,
+      lastScannedAt: this.lastSnapshot?.scannedAt ?? null,
+      lastMovedAt: this.lastMovedAt,
+      fileCount: this.lastSnapshot?.files.length ?? 0,
+    };
+  }
+
+  async start(roots: string[], logMoved: LogMoved): Promise<DesignPackWatchStatus> {
+    await this.stop();
+    this.logMoved = logMoved;
+    // Keep configured roots even if missing — watchers attach only to existing dirs.
+    this.roots = [...new Set(roots.map((r) => resolve(r)))];
+
+    this.lastSnapshot = await snapshotPack(this.roots);
+
+    for (const root of this.roots) {
+      try {
+        const st = await stat(root);
+        if (!st.isDirectory()) continue;
+        const w = watch(root, { recursive: true }, () => this.scheduleScan());
+        w.on('error', (err) => {
+          log.warn('design-pack watch error', { root, error: String(err) });
+        });
+        // Do not keep the process alive solely for the design pack.
+        // Node FSWatcher has no unref; process exit is still driven by the socket.
+        this.watchers.push(w);
+      } catch {
+        // Missing root — status still lists it; appears when generated.
+      }
+    }
+
+    log.info('design-pack watch started', {
+      roots: this.roots,
+      watching: this.watchers.length,
+      digest: this.lastSnapshot.digest || '(empty)',
+      files: this.lastSnapshot.files.length,
+    });
+    return this.status();
+  }
+
+  async stop(): Promise<void> {
+    if (this.debounce) {
+      clearTimeout(this.debounce);
+      this.debounce = null;
+    }
+    for (const w of this.watchers) {
+      try {
+        w.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    this.watchers = [];
+    this.logMoved = null;
+  }
+
+  private scheduleScan(): void {
+    if (this.debounce) clearTimeout(this.debounce);
+    this.debounce = setTimeout(() => {
+      this.debounce = null;
+      void this.scanAndEmit();
+    }, DEBOUNCE_MS);
+    this.debounce.unref?.();
+  }
+
+  /**
+   * Re-scan roots. Emits `design.pack.moved` only when the digest changes
+   * relative to the current baseline (set on start). `force` re-emits a
+   * moved event even when the digest is unchanged (tests / manual nudge).
+   */
+  async scanAndEmit(force = false): Promise<DesignPackMovedPayload | null> {
+    if (this.scanning) return null;
+    this.scanning = true;
+    try {
+      const next = await snapshotPack(this.roots);
+      const previousDigest = this.lastSnapshot?.digest ?? null;
+      const { changed, changedFiles } = diffSnapshots(this.lastSnapshot, next);
+
+      if (!changed && !force) {
+        // Refresh mtimes without emitting.
+        this.lastSnapshot = next;
+        return null;
+      }
+
+      const payload: DesignPackMovedPayload = {
+        roots: next.roots,
+        previousDigest,
+        digest: next.digest,
+        changedFiles:
+          changedFiles.length > 0 ? changedFiles : next.files.map((f) => f.rel),
+        fileCount: next.files.length,
+        at: new Date().toISOString(),
+      };
+
+      this.lastSnapshot = next;
+      this.lastMovedAt = payload.at;
+      designPackEvents.emitMoved(payload);
+      if (this.logMoved) {
+        await this.logMoved(payload);
+      }
+      return payload;
+    } finally {
+      this.scanning = false;
+    }
+  }
+}
+
+/** Process-singleton watcher (one daemon = one design-pack watch). */
+export const designPackWatcher = new DesignPackWatcher();
+
+onDaemonStopping(() => designPackWatcher.stop());
+
+
+// ---------------------------------------------------------------------------
+// RPC registration
+// ---------------------------------------------------------------------------
+
+function strOrNull(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+async function persistMoved(db: PGlite, payload: DesignPackMovedPayload): Promise<void> {
+  await db.query(`INSERT INTO events (agent_id, event_type, payload) VALUES ($1, $2, $3::jsonb)`, [
+    'revdev-daemon',
+    DESIGN_PACK_MOVED_EVENT,
+    JSON.stringify(payload),
+  ]);
+  await syncEventLog({
+    agentId: 'revdev-daemon',
+    type: DESIGN_PACK_MOVED_EVENT,
+    payload,
+  });
+}
+
+/**
+ * Shared start helper used by RPC + auto-watch.
+ */
+export async function startDesignPackWatch(
+  db: PGlite,
+  roots: string[],
+): Promise<DesignPackWatchStatus> {
+  return designPackWatcher.start(roots, (payload) => persistMoved(db, payload));
+}
+
+registerHandler('design.pack.status', async () => {
+  return designPackWatcher.status();
+});
+
+registerHandler('design.pack.watch', async (params, db) => {
+  const repoRoot = strOrNull(params.repoRoot);
+  const pathsParam = params.paths;
+  let roots: string[];
+  if (Array.isArray(pathsParam) && pathsParam.length > 0) {
+    roots = pathsParam
+      .filter((p): p is string => typeof p === 'string' && p.length > 0)
+      .map((p) => resolve(p));
+  } else if (repoRoot) {
+    roots = resolveWatchPaths(repoRoot);
+  } else {
+    roots = resolveAutoWatchRoots();
+  }
+  if (roots.length === 0) {
+    throw new Error('design.pack.watch: no roots (set repoRoot, paths, or REVDEV_REVEALUI_ROOT)');
+  }
+  const status = await startDesignPackWatch(db, roots);
+  return { ...status, started: true };
+});
+
+registerHandler('design.pack.unwatch', async () => {
+  await designPackWatcher.stop();
+  return { watching: false, stopped: true };
+});
+
+registerHandler('design.pack.scan', async (params, db) => {
+  // Ensure a log path exists if someone scans before watch.
+  if (!designPackWatcher.status().watching) {
+    const roots =
+      Array.isArray(params.paths) && params.paths.length > 0
+        ? (params.paths as string[]).map((p) => resolve(p))
+        : resolveAutoWatchRoots();
+    await startDesignPackWatch(db, roots);
+  }
+  const force = params.force === true;
+  const moved = await designPackWatcher.scanAndEmit(force);
+  return {
+    status: designPackWatcher.status(),
+    moved,
+  };
+});
+
+// Auto-watch on daemon start when a configured root exists (best-effort).
+onDaemonStarted(async (db) => {
+  const roots = resolveAutoWatchRoots();
+  // Only auto-start when at least one root exists — avoid noisy empty watches
+  // on machines without a local revealui checkout.
+  let any = false;
+  for (const r of roots) {
+    try {
+      const st = await stat(r);
+      if (st.isDirectory()) {
+        any = true;
+        break;
+      }
+    } catch {
+      /* */
+    }
+  }
+  if (!any) {
+    log.debug('design-pack auto-watch skipped (no roots present)', { roots });
+    return;
+  }
+  try {
+    await startDesignPackWatch(db, roots);
+  } catch (err) {
+    log.warn('design-pack auto-watch failed', { error: String(err) });
+  }
+});

--- a/packages/daemon/src/design-pack-watch.ts
+++ b/packages/daemon/src/design-pack-watch.ts
@@ -116,7 +116,7 @@ function hashStream(filePath: string): Promise<string> {
 
 async function walkFiles(root: string, depth = 0): Promise<string[]> {
   if (depth > MAX_WALK_DEPTH) return [];
-  let entries;
+  let entries: Awaited<ReturnType<typeof readdir>>;
   try {
     entries = await readdir(root, { withFileTypes: true });
   } catch {

--- a/packages/daemon/src/design-pack-watch.ts
+++ b/packages/daemon/src/design-pack-watch.ts
@@ -116,7 +116,7 @@ function hashStream(filePath: string): Promise<string> {
 
 async function walkFiles(root: string, depth = 0): Promise<string[]> {
   if (depth > MAX_WALK_DEPTH) return [];
-  let entries: Awaited<ReturnType<typeof readdir>>;
+  let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
   try {
     entries = await readdir(root, { withFileTypes: true });
   } catch {

--- a/packages/daemon/src/eviction.ts
+++ b/packages/daemon/src/eviction.ts
@@ -48,3 +48,23 @@ export function onDaemonStarted(hook: DaemonStartedHook): void {
 export async function notifyDaemonStarted(db: PGlite): Promise<void> {
   for (const hook of startedHooks) await hook(db);
 }
+
+// ---------------------------------------------------------------------------
+// Daemon-stopping hooks (startDaemon close())
+//
+// FS watchers and other long-lived resources register here so server.close
+// can release them without importing handler modules (avoids cycles).
+// ---------------------------------------------------------------------------
+
+type DaemonStoppingHook = () => void | Promise<void>;
+const stoppingHooks: DaemonStoppingHook[] = [];
+
+/** Register a cleanup hook to run once at the start of daemon close(). */
+export function onDaemonStopping(hook: DaemonStoppingHook): void {
+  stoppingHooks.push(hook);
+}
+
+/** Fire all daemon-stopping hooks. Called by startDaemon's close() sequence. */
+export async function notifyDaemonStopping(): Promise<void> {
+  for (const hook of stoppingHooks) await hook();
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -73,6 +73,8 @@ import './spawn.js';
 import './gateway-rpc.js';
 // GAP-474 — workflow.list / workflow.run over operational-workflow registry
 import './workflow-rpc.js';
+// GAP-323 — design-pack watch (design.pack.* + auto-watch on start)
+import './design-pack-watch.js';
 
 export { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 export { SCHEMA_SQL } from './storage/schema.js';

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -128,6 +128,12 @@ const EXEMPT_METHODS = new Set([
   // GAP-474: local operational workflows (same class as /ops; Studio daily driver)
   'workflow.list',
   'workflow.run',
+  // GAP-323: design-pack advisory (native pair of GAP-322 SessionStart warn).
+  // Free-tier daily-driver surface — no multi-agent coordination required.
+  'design.pack.status',
+  'design.pack.watch',
+  'design.pack.unwatch',
+  'design.pack.scan',
 ]);
 
 /**

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -52,6 +52,11 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['files.check', 'routine'],
   ['files.release', 'routine'],
   ['files.list', 'routine'],
+  // GAP-323 design-pack watch (advisory; routine)
+  ['design.pack.status', 'routine'],
+  ['design.pack.watch', 'routine'],
+  ['design.pack.unwatch', 'routine'],
+  ['design.pack.scan', 'routine'],
   ['tasks.create', 'routine'],
   ['tasks.claim', 'routine'],
   ['tasks.complete', 'routine'],

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -33,7 +33,6 @@ import {
 } from './agent-identity-crypto.js';
 import { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 import { readRootOwnedFile } from './confinement.js';
-import { notifyAgentEnded, notifyDaemonStarted } from './eviction.js';
 import { GoalHarness, GoalStore } from './goals/index.js';
 import {
   guardRpcMethod,
@@ -95,6 +94,8 @@ import {
 import { migrate } from './storage/migrate.js';
 import { initToolGuard } from './tool-guard/index.js';
 import { invalidParamsResponse, validateParams } from './validation/index.js';
+import { DESIGN_PACK_MOVED_EVENT, designPackEvents } from './design-pack-events.js';
+import { notifyAgentEnded, notifyDaemonStarted, notifyDaemonStopping } from './eviction.js';
 import { WORK_COMPLETED_EVENT, workEvents } from './work-events.js';
 
 const log = createLogger({ service: 'revdev-daemon' });
@@ -2064,8 +2065,8 @@ registerHandler('events.wait', async (params, db, ctx) => {
   let row = await pollOnce();
   if (row) return { event: row, timedOut: false };
 
-  // Also race the in-process bus for work.completed to avoid missing the row
-  // under test/driver lag (still falls back to DB poll).
+  // Race the in-process bus for hot event types (work.completed, design.pack.moved)
+  // to avoid missing the row under test/driver lag (still falls back to DB poll).
   await new Promise<void>((resolve) => {
     let settled = false;
     const finish = () => {
@@ -2073,6 +2074,7 @@ registerHandler('events.wait', async (params, db, ctx) => {
       settled = true;
       clearInterval(timer);
       workEvents.off(WORK_COMPLETED_EVENT, onBus);
+      designPackEvents.off(DESIGN_PACK_MOVED_EVENT, onBus);
       resolve();
     };
     const onBus = () => {
@@ -2085,6 +2087,9 @@ registerHandler('events.wait', async (params, db, ctx) => {
     };
     if (eventType === WORK_COMPLETED_EVENT) {
       workEvents.on(WORK_COMPLETED_EVENT, onBus);
+    }
+    if (eventType === DESIGN_PACK_MOVED_EVENT) {
+      designPackEvents.on(DESIGN_PACK_MOVED_EVENT, onBus);
     }
     const timer = setInterval(() => {
       if (Date.now() >= deadline) {
@@ -3159,6 +3164,8 @@ export async function startDaemon(
           if (pruneTimer) clearInterval(pruneTimer);
           clearInterval(nonceSweepTimer);
           clearInterval(licenseRecheckTimer);
+          // GAP-323 (+ future): release FS watchers / long-lived resources.
+          await notifyDaemonStopping();
           if (httpGateway) await httpGateway.stop();
           server.close();
           for (const s of openSockets) {

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -33,6 +33,8 @@ import {
 } from './agent-identity-crypto.js';
 import { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 import { readRootOwnedFile } from './confinement.js';
+import { DESIGN_PACK_MOVED_EVENT, designPackEvents } from './design-pack-events.js';
+import { notifyAgentEnded, notifyDaemonStarted, notifyDaemonStopping } from './eviction.js';
 import { GoalHarness, GoalStore } from './goals/index.js';
 import {
   guardRpcMethod,
@@ -94,8 +96,6 @@ import {
 import { migrate } from './storage/migrate.js';
 import { initToolGuard } from './tool-guard/index.js';
 import { invalidParamsResponse, validateParams } from './validation/index.js';
-import { DESIGN_PACK_MOVED_EVENT, designPackEvents } from './design-pack-events.js';
-import { notifyAgentEnded, notifyDaemonStarted, notifyDaemonStopping } from './eviction.js';
 import { WORK_COMPLETED_EVENT, workEvents } from './work-events.js';
 
 const log = createLogger({ service: 'revdev-daemon' });

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -232,6 +232,35 @@ export const schemas: Record<string, z.ZodType> = {
     })
     .passthrough(),
 
+  // -- Design pack watch (GAP-323) --------------------------------------------
+  'design.pack.status': z
+    .object({
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'design.pack.watch': z
+    .object({
+      repoRoot: safePath.optional(),
+      paths: z.array(safePath).max(MAX_PATHS_BATCH).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'design.pack.unwatch': z
+    .object({
+      actorAgentId,
+    })
+    .passthrough(),
+
+  'design.pack.scan': z
+    .object({
+      force: z.boolean().optional(),
+      paths: z.array(safePath).max(MAX_PATHS_BATCH).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+
   // -- Tasks ------------------------------------------------------------------
   'tasks.create': z
     .object({

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -48,6 +48,12 @@ export const RPC_METHODS = {
   'files.release': 'files.release',
   'files.list': 'files.list',
 
+  // GAP-323 — design-pack filesystem watch (native pair of GAP-322 advisory)
+  'design.pack.status': 'design.pack.status',
+  'design.pack.watch': 'design.pack.watch',
+  'design.pack.unwatch': 'design.pack.unwatch',
+  'design.pack.scan': 'design.pack.scan',
+
   // Task coordination
   'tasks.create': 'tasks.create',
   'tasks.claim': 'tasks.claim',


### PR DESCRIPTION
## Summary
- Implements GAP-323 item 3: RevDev daemon watches the code-canonical design pack (`packages/tokens/design-context/`) and generated previews (`preview-dist/`).
- Emits durable `design.pack.moved` events (events table + in-process bus for `events.wait`).
- New free-tier RPCs: `design.pack.status` / `watch` / `unwatch` / `scan` (routine; license-exempt).
- Auto-watch on daemon start when `REVDEV_REVEALUI_ROOT`, `REVDEV_DESIGN_PACK_ROOTS`, or dogfood `~/revfleet/revealui` has an existing root.
- Clean shutdown via `onDaemonStopping` (FS watchers released).

## Native pair
Mirrors GAP-322's Claude SessionStart advisory without DesignSync / claude.ai login. Vendor-gated push/pull remains in the GAP-296 boundary map.

## Test plan
- [x] `vitest run src/__tests__/design-pack-watch.test.ts` (7)
- [x] `vitest run src/__tests__/rpc-contract.test.ts` (RPC_METHODS parity)
- [x] `tsc --noEmit` on `@revdev/daemon`
- [ ] CI green on this PR

## Env
| Var | Role |
|-----|------|
| `REVDEV_DESIGN_PACK_ROOTS` | colon-separated absolute watch paths |
| `REVDEV_REVEALUI_ROOT` | monorepo root → default relative segments |

Closes residual agent work for GAP-323 item 3 (gap stays open until this merges; vendor half stays mapped).