### PR TITLE
feat(studio): compose presentation for remaining tier-1 hosts (GAP-479)

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -18,7 +18,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/inter-tight": "^5.2.7",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
-    "@revealui/presentation": "^0.12.1",
+    "@revealui/presentation": "^0.13.1",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-shell": "^2.3.5",

--- a/apps/studio/src/components/adapters/ConfirmDialog.tsx
+++ b/apps/studio/src/components/adapters/ConfirmDialog.tsx
@@ -1,4 +1,6 @@
 import { type ReactNode, useId, useState } from 'react';
+import Button from './Button';
+import Input from './Input';
 import Modal from './Modal';
 
 interface ConfirmDialogProps {
@@ -64,21 +66,12 @@ export default function ConfirmDialog({
       maxWidth="sm"
       footer={
         <>
-          <button
-            type="button"
-            onClick={handleClose}
-            className="rounded-md px-3 py-1.5 text-sm font-medium text-fg-muted hover:bg-surface-2"
-          >
+          <Button type="button" variant="ghost" onClick={handleClose}>
             {cancelLabel}
-          </button>
-          <button
-            type="button"
-            onClick={handleConfirm}
-            disabled={confirmDisabled}
-            className="rounded-md bg-error px-3 py-1.5 text-sm font-medium text-fg hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
-          >
+          </Button>
+          <Button type="button" variant="danger" onClick={handleConfirm} disabled={confirmDisabled}>
             {confirmLabel}
-          </button>
+          </Button>
         </>
       }
     >
@@ -100,7 +93,7 @@ export default function ConfirmDialog({
             <span className="text-xs text-fg-muted">
               Type <span className="font-mono text-fg">{typeToConfirm}</span> to confirm:
             </span>
-            <input
+            <Input
               id={inputId}
               type="text"
               value={typed}
@@ -108,7 +101,7 @@ export default function ConfirmDialog({
               autoComplete="off"
               // biome-ignore lint/a11y/noAutofocus: focusing the gate input is the expected UX
               autoFocus
-              className="w-full rounded border border-edge bg-surface-1 px-2 py-1 font-mono text-sm text-fg outline-none focus:border-error"
+              mono
             />
           </label>
         )}

--- a/apps/studio/src/components/adapters/Input.tsx
+++ b/apps/studio/src/components/adapters/Input.tsx
@@ -1,10 +1,11 @@
 import { Input as PresentationInput } from '@revealui/presentation';
-import type { ComponentProps, InputHTMLAttributes } from 'react';
+import type { ComponentProps, InputHTMLAttributes, Ref } from 'react';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   hint?: string;
   mono?: boolean;
+  ref?: Ref<HTMLInputElement>;
 }
 
 /**
@@ -27,6 +28,7 @@ export default function Input({
   id,
   className,
   type,
+  ref,
   ...props
 }: InputProps) {
   return (
@@ -39,6 +41,7 @@ export default function Input({
       )}
       <PresentationInput
         id={id}
+        ref={ref}
         type={type as ComponentProps<typeof PresentationInput>['type']}
         className={
           [mono && '[&_input]:font-mono', className].filter(Boolean).join(' ') || undefined

--- a/apps/studio/src/components/agent/AgentChat.tsx
+++ b/apps/studio/src/components/agent/AgentChat.tsx
@@ -5,8 +5,10 @@
  * modes with model selection. Renders tool call badges inline with text output.
  */
 
+import { Textarea } from '@revealui/presentation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSettingsContext } from '../../hooks/use-settings';
+import Button from '../adapters/Button';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -179,16 +181,18 @@ function ToolBadge({
 
   return (
     <div className="my-1">
-      <button
+      <Button
         type="button"
+        variant="ghost"
+        size="sm"
         onClick={() => result && setExpanded(!expanded)}
-        className={`inline-flex items-center gap-1.5 rounded border px-2 py-0.5 text-[10px] font-medium ${statusColor} ${result ? 'cursor-pointer hover:brightness-110' : 'cursor-default'}`}
+        className={`inline-flex h-auto items-center gap-1.5 rounded border px-2 py-0.5 text-[10px] font-medium ${statusColor} ${result ? 'cursor-pointer hover:brightness-110' : 'cursor-default'}`}
       >
         {status === 'running' ? (
           <span className="size-1.5 animate-pulse rounded-full bg-info" />
         ) : null}
         {label}
-      </button>
+      </Button>
       {expanded && result ? (
         <pre className="mt-1 max-h-32 overflow-auto rounded border border-edge bg-surface-0 p-2 text-[10px] text-fg-muted">
           {result}
@@ -357,8 +361,10 @@ export default function AgentChat() {
       <div className="border-t border-edge px-3 py-2.5">
         <div className="mb-2 flex items-center gap-2">
           <div className="flex items-center rounded border border-edge">
-            <button
+            <Button
               type="button"
+              variant={mode === 'coding' ? 'primary' : 'ghost'}
+              size="sm"
               onClick={() => setMode('coding')}
               disabled={stream.isStreaming}
               className={`rounded-l px-2 py-0.5 text-[10px] font-medium transition-colors ${
@@ -368,9 +374,11 @@ export default function AgentChat() {
               }`}
             >
               Coding
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              variant={mode === 'content' ? 'primary' : 'ghost'}
+              size="sm"
               onClick={() => setMode('content')}
               disabled={stream.isStreaming}
               className={`rounded-r px-2 py-0.5 text-[10px] font-medium transition-colors ${
@@ -380,7 +388,7 @@ export default function AgentChat() {
               }`}
             >
               admin
-            </button>
+            </Button>
           </div>
           <span className="text-[10px] text-fg-subtle">
             {mode === 'coding' ? 'Code + admin tools' : 'admin tools only'}
@@ -388,7 +396,7 @@ export default function AgentChat() {
         </div>
 
         <form onSubmit={handleSubmit} className="flex items-end gap-2">
-          <textarea
+          <Textarea
             ref={textareaRef}
             value={input}
             onChange={(e) => setInput(e.target.value)}
@@ -396,24 +404,29 @@ export default function AgentChat() {
             rows={1}
             placeholder={mode === 'coding' ? 'Ask about code...' : 'Ask the assistant...'}
             disabled={stream.isStreaming}
-            className="flex-1 resize-none rounded-lg border border-edge bg-surface-2 px-3 py-2 text-xs text-fg outline-none placeholder:text-fg-subtle focus:border-brand"
+            resizable={false}
+            className="flex-1"
           />
           {stream.isStreaming ? (
-            <button
+            <Button
               type="button"
+              variant="danger"
+              size="sm"
               onClick={stream.abort}
-              className="shrink-0 rounded-lg bg-error px-3 py-2 text-xs font-medium text-on-brand hover:brightness-110"
+              className="shrink-0 rounded-lg px-3 py-2 text-xs font-medium"
             >
               Stop
-            </button>
+            </Button>
           ) : (
-            <button
+            <Button
               type="submit"
+              variant="primary"
+              size="sm"
               disabled={!input.trim()}
-              className="shrink-0 rounded-lg bg-brand px-3 py-2 text-xs font-medium text-on-brand hover:bg-brand-hover disabled:opacity-40"
+              className="shrink-0 rounded-lg px-3 py-2 text-xs font-medium"
             >
               Send
-            </button>
+            </Button>
           )}
         </form>
         <p className="mt-1.5 text-center text-[10px] text-fg-subtle">

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -19,6 +19,7 @@ const AGENT_POLL_INTERVAL_MS = 30_000;
 
 type RightTab = 'changes' | 'chat' | 'messages' | 'tasks' | 'reservations' | 'approvals';
 
+import { IconMinus, IconPlus, IconRefresh, IconUsers } from '@revealui/presentation';
 import { useHarness } from '../../hooks/use-harness';
 import { useSettingsContext } from '../../hooks/use-settings';
 import type { AgentCard } from '../../lib/a2a-api';
@@ -31,6 +32,8 @@ import {
   gitUnstageFile,
 } from '../../lib/invoke';
 import type { AgentSession, GitFileEntry, GitStatusResult } from '../../types';
+import Button from '../adapters/Button';
+import Input from '../adapters/Input';
 
 // ── Workboard parser ──────────────────────────────────────────────────────────
 
@@ -140,34 +143,40 @@ function ChangeRow({ entry, staged, onStage, onUnstage, onDiscard }: ChangeRowPr
       ) : null}
       <div className="hidden shrink-0 items-center gap-1 group-hover:flex">
         {onStage ? (
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             title="Stage"
             onClick={onStage}
             className="flex size-5 items-center justify-center rounded text-fg-subtle transition-colors hover:bg-surface-3 hover:text-fg"
           >
             <PlusIcon />
-          </button>
+          </Button>
         ) : null}
         {onUnstage ? (
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             title="Unstage"
             onClick={onUnstage}
             className="flex size-5 items-center justify-center rounded text-fg-subtle transition-colors hover:bg-surface-3 hover:text-fg"
           >
             <MinusIcon />
-          </button>
+          </Button>
         ) : null}
         {onDiscard ? (
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             title="Discard"
             onClick={onDiscard}
             className="flex size-5 items-center justify-center rounded text-fg-subtle transition-colors hover:bg-error-subtle hover:text-error"
           >
             <UndoIcon />
-          </button>
+          </Button>
         ) : null}
       </div>
     </div>
@@ -475,7 +484,7 @@ export default function AgentPanel() {
                 applyWorkboardPath();
               }}
             >
-              <input
+              <Input
                 ref={workboardInputRef}
                 value={draftWorkboard}
                 onChange={(e) => setDraftWorkboard(e.target.value)}
@@ -483,12 +492,13 @@ export default function AgentPanel() {
                 onKeyDown={(e) => {
                   if (e.key === 'Escape') setEditingWorkboard(false);
                 }}
-                className="w-full rounded border border-edge-strong bg-surface-2 px-2 py-1 text-[11px] text-fg focus:border-brand focus:outline-none"
               />
             </form>
           ) : (
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={() => {
                 setDraftWorkboard(workboardPath);
                 setEditingWorkboard(true);
@@ -497,7 +507,7 @@ export default function AgentPanel() {
               title="Change workboard path"
             >
               {workboardPath}
-            </button>
+            </Button>
           )}
         </div>
 
@@ -564,8 +574,10 @@ export default function AgentPanel() {
       <div className="flex min-w-0 flex-1 flex-col bg-surface-0">
         {/* Tab bar — horizontally scrollable on mobile */}
         <div className="flex items-center overflow-x-auto border-b border-edge">
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => setRightTab('changes')}
             className={`px-4 py-2 text-xs font-medium transition-colors ${
               rightTab === 'changes'
@@ -579,9 +591,11 @@ export default function AgentPanel() {
                 {totalChanges}
               </span>
             ) : null}
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => setRightTab('chat')}
             className={`px-4 py-2 text-xs font-medium transition-colors ${
               rightTab === 'chat'
@@ -590,9 +604,11 @@ export default function AgentPanel() {
             }`}
           >
             Agent Chat
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => setRightTab('messages')}
             className={`px-4 py-2 text-xs font-medium transition-colors ${
               rightTab === 'messages'
@@ -606,9 +622,11 @@ export default function AgentPanel() {
                 {harness.messages.filter((m) => !m.read).length}
               </span>
             ) : null}
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => setRightTab('tasks')}
             className={`px-4 py-2 text-xs font-medium transition-colors ${
               rightTab === 'tasks'
@@ -617,9 +635,11 @@ export default function AgentPanel() {
             }`}
           >
             Tasks
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => setRightTab('reservations')}
             className={`px-4 py-2 text-xs font-medium transition-colors ${
               rightTab === 'reservations'
@@ -633,9 +653,11 @@ export default function AgentPanel() {
                 {harness.reservations.length}
               </span>
             ) : null}
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => setRightTab('approvals')}
             className={`px-4 py-2 text-xs font-medium transition-colors ${
               rightTab === 'approvals'
@@ -644,38 +666,44 @@ export default function AgentPanel() {
             }`}
           >
             Approvals
-          </button>
+          </Button>
           {rightTab === 'changes' ? (
             <div className="ml-auto flex items-center gap-1 pr-2">
               {(gitState?.unstaged.length ?? 0) + (gitState?.untracked.length ?? 0) > 0 ? (
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="sm"
                   onClick={() => void stageAll()}
                   disabled={stagingAll}
                   className="rounded bg-surface-2 px-2 py-1 text-[10px] text-fg-muted transition-colors hover:bg-surface-3 disabled:opacity-40"
                 >
                   {stagingAll ? 'Staging…' : 'Stage All'}
-                </button>
+                </Button>
               ) : null}
               {(gitState?.unstaged.length ?? 0) > 0 ? (
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="sm"
                   onClick={() => setConfirmDiscardAll(true)}
                   disabled={discardingAll}
                   className="rounded px-2 py-1 text-[10px] text-fg-subtle transition-colors hover:bg-error-subtle hover:text-error disabled:opacity-40"
                 >
                   {discardingAll ? 'Discarding…' : 'Discard All'}
-                </button>
+                </Button>
               ) : null}
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="sm"
                 onClick={() => void refresh()}
                 disabled={loading}
                 title="Refresh"
                 className="flex size-6 items-center justify-center rounded text-fg-subtle transition-colors hover:bg-surface-2 hover:text-fg-muted disabled:opacity-40"
               >
                 <RefreshIcon spinning={loading} />
-              </button>
+              </Button>
             </div>
           ) : null}
         </div>
@@ -692,7 +720,7 @@ export default function AgentPanel() {
                     applyRepoPath();
                   }}
                 >
-                  <input
+                  <Input
                     ref={repoInputRef}
                     value={draftRepo}
                     onChange={(e) => setDraftRepo(e.target.value)}
@@ -700,12 +728,13 @@ export default function AgentPanel() {
                     onKeyDown={(e) => {
                       if (e.key === 'Escape') setEditingRepo(false);
                     }}
-                    className="w-full rounded border border-edge-strong bg-surface-2 px-2 py-1 text-[11px] text-fg focus:border-brand focus:outline-none"
                   />
                 </form>
               ) : (
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="sm"
                   onClick={() => {
                     setDraftRepo(repoPath);
                     setEditingRepo(true);
@@ -714,7 +743,7 @@ export default function AgentPanel() {
                   title="Change repository path"
                 >
                   {repoPath}
-                </button>
+                </Button>
               )}
               {gitState ? (
                 <p className="mt-0.5 text-[10px] text-fg-subtle">
@@ -883,65 +912,19 @@ function RemoteAgentCard({ agent }: { agent: AgentCard }) {
 // ── Icons ─────────────────────────────────────────────────────────────────────
 
 function AgentIcon() {
-  return (
-    <svg
-      className="size-4 shrink-0 text-fg-muted"
-      aria-hidden="true"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2}
-    >
-      <rect x="7" y="7" width="10" height="10" rx="1" />
-      <path d="M9 7V5m3 2V5m3 2V5M9 17v2m3-2v2m3-2v2M7 9H5m2 3H5m2 3H5M17 9h2m-2 3h2m-2 3h2" />
-    </svg>
-  );
+  return <IconUsers size="sm" className="text-fg-muted" />;
 }
 
 function RefreshIcon({ spinning }: { spinning: boolean }) {
-  return (
-    <svg
-      className={`size-3.5 ${spinning ? 'animate-spin' : ''}`}
-      aria-hidden="true"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2}
-    >
-      <path d="M4 4v5h5M20 20v-5h-5" />
-      <path d="M20.49 9A9 9 0 0 0 5.64 5.64L4 7m16 10l-1.64 1.36A9 9 0 0 1 3.51 15" />
-    </svg>
-  );
+  return <IconRefresh size="sm" className={`size-3.5 ${spinning ? 'animate-spin' : ''}`} />;
 }
 
 function PlusIcon() {
-  return (
-    <svg
-      className="size-3"
-      aria-hidden="true"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2.5}
-    >
-      <path d="M12 5v14M5 12h14" />
-    </svg>
-  );
+  return <IconPlus size="sm" className="size-3" />;
 }
 
 function MinusIcon() {
-  return (
-    <svg
-      className="size-3"
-      aria-hidden="true"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2.5}
-    >
-      <path d="M5 12h14" />
-    </svg>
-  );
+  return <IconMinus size="sm" className="size-3" />;
 }
 
 function UndoIcon() {

--- a/apps/studio/src/components/agent/AgentTerminalPane.tsx
+++ b/apps/studio/src/components/agent/AgentTerminalPane.tsx
@@ -193,11 +193,12 @@ export default function AgentTerminalPane() {
             </p>
           )}
           {sessions.map((s) => (
-            <button
+            <Button
               key={s.id}
               type="button"
+              variant="ghost"
               onClick={() => setActiveSession(s.id)}
-              className={`flex w-full items-center gap-2 border-b border-edge/50 px-3 py-2 text-left text-sm transition-colors hover:bg-surface-2/50 ${
+              className={`flex h-auto w-full items-center gap-2 rounded-none border-b border-edge/50 px-3 py-2 text-left text-sm transition-colors hover:bg-surface-2/50 ${
                 activeSession === s.id ? 'bg-surface-2' : ''
               }`}
             >
@@ -212,8 +213,10 @@ export default function AgentTerminalPane() {
                 </div>
               </div>
               {s.status === 'running' && (
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
                     stopSession(s.id);
@@ -222,9 +225,9 @@ export default function AgentTerminalPane() {
                   aria-label="Stop agent"
                 >
                   <span aria-hidden="true">■</span>
-                </button>
+                </Button>
               )}
-            </button>
+            </Button>
           ))}
         </div>
       </div>

--- a/apps/studio/src/components/agent/ApprovalQueue.tsx
+++ b/apps/studio/src/components/agent/ApprovalQueue.tsx
@@ -5,6 +5,7 @@
  * permission.decide. Also offers per-session mode override (permission.setMode).
  */
 
+import { Select } from '@revealui/presentation';
 import { useCallback, useEffect, useState } from 'react';
 import {
   harnessPermissionDecide,
@@ -12,6 +13,7 @@ import {
   harnessPermissionSetMode,
 } from '../../lib/invoke';
 import type { HarnessApproval, HarnessSession } from '../../types';
+import Button from '../adapters/Button';
 
 const POLL_MS = 5_000;
 
@@ -137,13 +139,15 @@ export default function ApprovalQueue({ sessions, connected, onChanged }: Approv
             {blocked.length} blocked
           </span>
         ) : null}
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="sm"
           onClick={() => void refresh()}
           className="ml-auto rounded px-2 py-1 text-[10px] text-fg-subtle hover:bg-surface-2 hover:text-fg-muted"
         >
           Refresh
-        </button>
+        </Button>
       </div>
 
       {error ? (
@@ -182,22 +186,26 @@ export default function ApprovalQueue({ sessions, connected, onChanged }: Approv
                     </p>
                   </div>
                   <div className="flex shrink-0 flex-col gap-1">
-                    <button
+                    <Button
                       type="button"
+                      variant="success"
+                      size="sm"
                       disabled={busyId === a.id}
                       onClick={() => void decide(a.id, 'approved')}
                       className="rounded bg-success-subtle px-2 py-1 text-[10px] font-medium text-success hover:bg-success-subtle/70 disabled:opacity-40"
                     >
                       Approve
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                       type="button"
+                      variant="danger"
+                      size="sm"
                       disabled={busyId === a.id}
                       onClick={() => void decide(a.id, 'denied')}
                       className="rounded bg-error-subtle px-2 py-1 text-[10px] font-medium text-error hover:bg-error-subtle/70 disabled:opacity-40"
                     >
                       Deny
-                    </button>
+                    </Button>
                   </div>
                 </div>
               </li>
@@ -215,10 +223,10 @@ export default function ApprovalQueue({ sessions, connected, onChanged }: Approv
           Operator-only. Cannot set Studio&apos;s own mode. Clears to daemon default when empty.
         </p>
         <div className="flex flex-wrap items-center gap-2">
-          <select
+          <Select
             value={modeAgent}
             onChange={(e) => setModeAgent(e.target.value)}
-            className="min-w-0 flex-1 rounded border border-edge bg-surface-2 px-2 py-1 text-[11px] text-fg"
+            className="min-w-0 flex-1"
           >
             <option value="">Target session…</option>
             {liveSessions.map((s) => (
@@ -228,26 +236,24 @@ export default function ApprovalQueue({ sessions, connected, onChanged }: Approv
                 {s.activity_state === 'blocked' ? ' [blocked]' : ''}
               </option>
             ))}
-          </select>
-          <select
-            value={modeValue}
-            onChange={(e) => setModeValue(e.target.value)}
-            className="rounded border border-edge bg-surface-2 px-2 py-1 text-[11px] text-fg"
-          >
+          </Select>
+          <Select value={modeValue} onChange={(e) => setModeValue(e.target.value)}>
             {MODE_OPTIONS.map((o) => (
               <option key={o.value || 'default'} value={o.value}>
                 {o.label}
               </option>
             ))}
-          </select>
-          <button
+          </Select>
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             disabled={modeBusy || !modeAgent}
             onClick={() => void applyMode()}
             className="rounded bg-info-subtle px-2 py-1 text-[10px] font-medium text-info hover:bg-info-subtle/70 disabled:opacity-40"
           >
             {modeBusy ? '…' : 'Apply'}
-          </button>
+          </Button>
         </div>
         {modeMsg ? <p className="mt-1.5 text-[10px] text-success">{modeMsg}</p> : null}
       </div>

--- a/apps/studio/src/components/agent/MessageInbox.tsx
+++ b/apps/studio/src/components/agent/MessageInbox.tsx
@@ -1,5 +1,8 @@
+import { Select, Textarea } from '@revealui/presentation';
 import { useState } from 'react';
 import type { HarnessMessage, HarnessSession } from '../../types';
+import Button from '../adapters/Button';
+import Input from '../adapters/Input';
 
 interface MessageInboxProps {
   messages: HarnessMessage[];
@@ -66,21 +69,25 @@ export default function MessageInbox({
         ) : null}
         <div className="ml-auto flex gap-1">
           {unreadCount > 0 ? (
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={() => void handleMarkAllRead()}
               className="rounded px-2 py-1 text-[10px] text-fg-subtle hover:bg-surface-2 hover:text-fg-muted"
             >
               Mark all read
-            </button>
+            </Button>
           ) : null}
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => setComposing(!composing)}
             className="rounded bg-info-subtle px-2 py-1 text-[10px] font-medium text-info hover:bg-info-subtle/70"
           >
             {composing ? 'Cancel' : 'Compose'}
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -88,11 +95,7 @@ export default function MessageInbox({
       {composing ? (
         <div className="border-b border-edge bg-surface-1/50 p-3">
           <div className="mb-2 flex gap-2">
-            <select
-              value={toAgent}
-              onChange={(e) => setToAgent(e.target.value)}
-              className="flex-1 rounded border border-edge bg-surface-2 px-2 py-1 text-xs text-fg focus:border-brand focus:outline-none"
-            >
+            <Select value={toAgent} onChange={(e) => setToAgent(e.target.value)} className="flex-1">
               <option value="">To agent…</option>
               {sessions
                 .filter((s) => s.id !== agentId && !s.ended_at)
@@ -101,29 +104,31 @@ export default function MessageInbox({
                     {s.id}
                   </option>
                 ))}
-            </select>
+            </Select>
           </div>
-          <input
+          <Input
             value={subject}
             onChange={(e) => setSubject(e.target.value)}
             placeholder="Subject"
-            className="mb-2 w-full rounded border border-edge bg-surface-2 px-2 py-1 text-xs text-fg placeholder:text-fg-subtle focus:border-brand focus:outline-none"
+            className="mb-2"
           />
-          <textarea
+          <Textarea
             value={body}
             onChange={(e) => setBody(e.target.value)}
             placeholder="Message body…"
             rows={3}
-            className="mb-2 w-full resize-none rounded border border-edge bg-surface-2 px-2 py-1.5 text-xs text-fg placeholder:text-fg-subtle focus:border-brand focus:outline-none"
+            resizable={false}
+            className="mb-2"
           />
-          <button
+          <Button
             type="button"
+            variant="primary"
+            size="sm"
             onClick={() => void handleSend()}
             disabled={sending || !toAgent.trim() || !subject.trim()}
-            className="rounded bg-brand px-3 py-1 text-xs font-medium text-on-brand hover:bg-brand-hover disabled:opacity-40"
           >
             {sending ? 'Sending…' : 'Send'}
-          </button>
+          </Button>
         </div>
       ) : null}
 
@@ -137,14 +142,15 @@ export default function MessageInbox({
             const isExpanded = expanded === msg.id;
             const isIncoming = msg.to_agent === agentId;
             return (
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 key={msg.id}
                 onClick={() => {
                   setExpanded(isExpanded ? null : msg.id);
                   if (!msg.read && isIncoming) void onMarkRead([msg.id]);
                 }}
-                className={`w-full rounded-lg border p-2.5 text-left transition-colors ${
+                className={`h-auto w-full rounded-lg border p-2.5 text-left transition-colors ${
                   msg.read ? 'border-edge bg-surface-1/40' : 'border-info/40 bg-info-subtle'
                 } hover:bg-surface-2/50`}
               >
@@ -163,7 +169,7 @@ export default function MessageInbox({
                     {msg.body}
                   </p>
                 ) : null}
-              </button>
+              </Button>
             );
           })}
         </div>

--- a/apps/studio/src/components/agent/SpawnerPanel.tsx
+++ b/apps/studio/src/components/agent/SpawnerPanel.tsx
@@ -6,6 +6,7 @@
  *   - Secondary: local inference (Snap / Ollama) — not the daily-driver path
  */
 
+import { Textarea } from '@revealui/presentation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSpawner } from '../../hooks/use-spawner';
 import {
@@ -15,7 +16,9 @@ import {
   harnessAgentStop,
 } from '../../lib/invoke';
 import type { AgentBackend, HarnessAgentProcess } from '../../types';
+import Button from '../adapters/Button';
 import ConfirmDialog from '../adapters/ConfirmDialog';
+import Input from '../adapters/Input';
 
 type SpawnMode = 'harness' | 'local';
 
@@ -112,32 +115,38 @@ export default function SpawnerPanel() {
     <div className="mt-4">
       <div className="mb-1.5 flex items-center justify-between gap-1">
         <div className="flex items-center gap-1 rounded bg-surface-2 p-0.5">
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => setMode('harness')}
             className={`rounded px-2 py-0.5 text-[10px] font-medium transition-colors ${
               mode === 'harness' ? 'bg-accent-soft text-accent' : 'text-fg-muted hover:text-fg'
             }`}
           >
             Harness
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => setMode('local')}
             className={`rounded px-2 py-0.5 text-[10px] font-medium transition-colors ${
               mode === 'local' ? 'bg-accent-soft text-accent' : 'text-fg-muted hover:text-fg'
             }`}
           >
             Local inference
-          </button>
+          </Button>
         </div>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="sm"
           onClick={() => setShowSpawn(!showSpawn)}
           className="rounded bg-accent-soft px-2 py-0.5 text-[10px] font-medium text-accent transition-colors hover:bg-accent-soft/70"
         >
           + Spawn
-        </button>
+        </Button>
       </div>
 
       <p className="mb-2 text-[10px] leading-snug text-fg-subtle">
@@ -185,8 +194,10 @@ export default function SpawnerPanel() {
                     : 'border-edge hover:border-edge-strong'
                 }`}
               >
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="sm"
                   className="w-full text-left"
                   onClick={() => setSelectedSession(selectedSession === s.id ? null : s.id)}
                 >
@@ -218,21 +229,25 @@ export default function SpawnerPanel() {
                     </p>
                   ) : null}
                   <p className="mt-0.5 font-mono text-[10px] text-fg-muted">{s.id.slice(0, 8)}…</p>
-                </button>
+                </Button>
                 <div className="mt-2 flex items-center gap-1">
                   {s.status === 'running' ? (
-                    <button
+                    <Button
                       type="button"
+                      variant="ghost"
+                      size="sm"
                       onClick={() =>
                         setPendingAction({ kind: 'stop', id: s.id, name: s.name, mode: 'harness' })
                       }
                       className="rounded bg-error-subtle px-2 py-0.5 text-[10px] text-error transition-colors hover:bg-error-subtle/70"
                     >
                       Stop
-                    </button>
+                    </Button>
                   ) : (
-                    <button
+                    <Button
                       type="button"
+                      variant="ghost"
+                      size="sm"
                       onClick={() =>
                         setPendingAction({
                           kind: 'remove',
@@ -244,7 +259,7 @@ export default function SpawnerPanel() {
                       className="rounded bg-surface-2 px-2 py-0.5 text-[10px] text-fg-muted transition-colors hover:bg-surface-3"
                     >
                       Remove
-                    </button>
+                    </Button>
                   )}
                 </div>
               </div>
@@ -258,8 +273,10 @@ export default function SpawnerPanel() {
                     : 'border-edge hover:border-edge-strong'
                 }`}
               >
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="sm"
                   className="w-full text-left"
                   onClick={() => setSelectedSession(selectedSession === s.id ? null : s.id)}
                 >
@@ -284,28 +301,32 @@ export default function SpawnerPanel() {
                   <p className="mt-0.5 truncate text-[11px] leading-snug text-fg-muted">
                     {s.prompt}
                   </p>
-                </button>
+                </Button>
                 <div className="mt-2 flex items-center gap-1">
                   {s.status === 'running' ? (
-                    <button
+                    <Button
                       type="button"
+                      variant="ghost"
+                      size="sm"
                       onClick={() =>
                         setPendingAction({ kind: 'stop', id: s.id, name: s.name, mode: 'local' })
                       }
                       className="rounded bg-error-subtle px-2 py-0.5 text-[10px] text-error transition-colors hover:bg-error-subtle/70"
                     >
                       Stop
-                    </button>
+                    </Button>
                   ) : (
-                    <button
+                    <Button
                       type="button"
+                      variant="ghost"
+                      size="sm"
                       onClick={() =>
                         setPendingAction({ kind: 'remove', id: s.id, name: s.name, mode: 'local' })
                       }
                       className="rounded bg-surface-2 px-2 py-0.5 text-[10px] text-fg-muted transition-colors hover:bg-surface-3"
                     >
                       Remove
-                    </button>
+                    </Button>
                   )}
                 </div>
                 {selectedSession === s.id && local.output[s.id] ? (
@@ -386,22 +407,29 @@ function HarnessSpawnForm({ onSpawn, onCancel }: HarnessSpawnFormProps) {
         Spawns via daemon <code className="text-fg">agent.spawn</code> (signed, confined). Requires
         a project root the Studio identity can open.
       </p>
-      <label className="mb-2 block">
-        <span className="mb-0.5 block text-[10px] font-medium text-fg-muted">Project root</span>
-        <input
+      <div className="mb-2">
+        <label
+          htmlFor="spawn-repo-path"
+          className="mb-0.5 block text-[10px] font-medium text-fg-muted"
+        >
+          Project root
+        </label>
+        <Input
+          id="spawn-repo-path"
           value={repoPath}
           onChange={(e) => setRepoPath(e.target.value)}
           placeholder="/home/…/revfleet/revealui"
-          className="w-full rounded border border-edge bg-surface-2 px-2 py-1 text-xs text-fg focus:border-accent focus:outline-none"
         />
-      </label>
+      </div>
       <div className="mb-2">
         <span className="mb-0.5 block text-[10px] font-medium text-fg-muted">Preset</span>
         <div className="flex flex-wrap gap-1">
           {HARNESS_PRESETS.map((p) => (
-            <button
+            <Button
               key={p.label}
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={() => {
                 setCommand(p.command);
                 setArgsText(p.args);
@@ -409,50 +437,61 @@ function HarnessSpawnForm({ onSpawn, onCancel }: HarnessSpawnFormProps) {
               className="rounded bg-surface-2 px-2 py-0.5 text-[10px] text-fg-muted hover:bg-surface-3 hover:text-fg"
             >
               {p.label}
-            </button>
+            </Button>
           ))}
         </div>
       </div>
-      <label className="mb-2 block">
-        <span className="mb-0.5 block text-[10px] font-medium text-fg-muted">Command</span>
-        <input
+      <div className="mb-2">
+        <label
+          htmlFor="spawn-command"
+          className="mb-0.5 block text-[10px] font-medium text-fg-muted"
+        >
+          Command
+        </label>
+        <Input
+          id="spawn-command"
           value={command}
           onChange={(e) => setCommand(e.target.value)}
           placeholder="bash"
-          className="w-full rounded border border-edge bg-surface-2 px-2 py-1 font-mono text-xs text-fg focus:border-accent focus:outline-none"
+          mono
         />
-      </label>
-      <label className="mb-3 block">
-        <span className="mb-0.5 block text-[10px] font-medium text-fg-muted">
+      </div>
+      <div className="mb-3">
+        <label htmlFor="spawn-args" className="mb-0.5 block text-[10px] font-medium text-fg-muted">
           Args (space-separated)
-        </span>
-        <input
+        </label>
+        <Input
+          id="spawn-args"
           value={argsText}
           onChange={(e) => setArgsText(e.target.value)}
           placeholder="-l"
-          className="w-full rounded border border-edge bg-surface-2 px-2 py-1 font-mono text-xs text-fg focus:border-accent focus:outline-none"
+          mono
         />
-      </label>
+      </div>
       {formError ? (
         <div className="mb-2 rounded border border-error/40 bg-error-subtle px-2 py-1.5 text-[10px] text-error">
           {formError}
         </div>
       ) : null}
       <div className="flex justify-end gap-2">
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="sm"
           onClick={onCancel}
           className="rounded px-3 py-1 text-xs text-fg-muted transition-colors hover:text-fg"
         >
           Cancel
-        </button>
-        <button
+        </Button>
+        <Button
           type="submit"
+          variant="primary"
+          size="sm"
           disabled={submitting || !command.trim() || !repoPath.trim()}
           className="rounded bg-accent px-3 py-1 text-xs font-medium text-on-accent transition-colors hover:bg-accent-hover disabled:opacity-40"
         >
           {submitting ? 'Spawning…' : 'Spawn confined'}
-        </button>
+        </Button>
       </div>
     </form>
   );
@@ -471,7 +510,6 @@ function LocalSpawnForm({ onSpawn, onCancel }: LocalSpawnFormProps) {
   const [model, setModel] = useState('nemotron-3-nano');
   const [prompt, setPrompt] = useState('');
   const [submitting, setSubmitting] = useState(false);
-  const nameRef = useRef<HTMLInputElement>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -492,23 +530,29 @@ function LocalSpawnForm({ onSpawn, onCancel }: LocalSpawnFormProps) {
       <p className="mb-2 text-[10px] text-fg-subtle">
         Local inference only (Ubuntu Inference Snaps / Ollama). Not the confined harness path.
       </p>
-      <label className="mb-2 block">
-        <span className="mb-0.5 block text-[10px] font-medium text-fg-muted">Name</span>
-        <input
-          ref={nameRef}
+      <div className="mb-2">
+        <label
+          htmlFor="local-spawn-name"
+          className="mb-0.5 block text-[10px] font-medium text-fg-muted"
+        >
+          Name
+        </label>
+        <Input
+          id="local-spawn-name"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="my-agent"
-          className="w-full rounded border border-edge bg-surface-2 px-2 py-1 text-xs text-fg focus:border-accent focus:outline-none"
         />
-      </label>
+      </div>
       <div className="mb-2">
         <span className="mb-0.5 block text-[10px] font-medium text-fg-muted">Backend</span>
         <div className="flex gap-1.5">
           {(['Snap', 'Ollama'] as const).map((b) => (
-            <button
+            <Button
               key={b}
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={() => setBackend(b)}
               className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${
                 backend === b
@@ -517,44 +561,59 @@ function LocalSpawnForm({ onSpawn, onCancel }: LocalSpawnFormProps) {
               }`}
             >
               {b === 'Snap' ? 'Snaps' : b}
-            </button>
+            </Button>
           ))}
         </div>
       </div>
-      <label className="mb-2 block">
-        <span className="mb-0.5 block text-[10px] font-medium text-fg-muted">Model</span>
-        <input
+      <div className="mb-2">
+        <label
+          htmlFor="local-spawn-model"
+          className="mb-0.5 block text-[10px] font-medium text-fg-muted"
+        >
+          Model
+        </label>
+        <Input
+          id="local-spawn-model"
           value={model}
           onChange={(e) => setModel(e.target.value)}
           placeholder={backend === 'Snap' ? 'nemotron-3-nano' : 'gemma4:e2b'}
-          className="w-full rounded border border-edge bg-surface-2 px-2 py-1 text-xs text-fg focus:border-accent focus:outline-none"
         />
-      </label>
-      <label className="mb-3 block">
-        <span className="mb-0.5 block text-[10px] font-medium text-fg-muted">Prompt</span>
-        <textarea
+      </div>
+      <div className="mb-3">
+        <label
+          htmlFor="local-spawn-prompt"
+          className="mb-0.5 block text-[10px] font-medium text-fg-muted"
+        >
+          Prompt
+        </label>
+        <Textarea
+          id="local-spawn-prompt"
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           placeholder="What should this agent do?"
           rows={3}
-          className="w-full resize-none rounded border border-edge bg-surface-2 px-2 py-1 text-xs text-fg focus:border-accent focus:outline-none"
+          resizable={false}
         />
-      </label>
+      </div>
       <div className="flex justify-end gap-2">
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="sm"
           onClick={onCancel}
           className="rounded px-3 py-1 text-xs text-fg-muted transition-colors hover:text-fg"
         >
           Cancel
-        </button>
-        <button
+        </Button>
+        <Button
           type="submit"
+          variant="secondary"
+          size="sm"
           disabled={submitting || !name.trim() || !model.trim() || !prompt.trim()}
           className="rounded bg-surface-3 px-3 py-1 text-xs font-medium text-fg transition-colors hover:bg-surface-2 disabled:opacity-40"
         >
           {submitting ? 'Spawning…' : 'Spawn local'}
-        </button>
+        </Button>
       </div>
     </form>
   );

--- a/apps/studio/src/components/agent/TaskBoard.tsx
+++ b/apps/studio/src/components/agent/TaskBoard.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import type { HarnessTask } from '../../types';
+import Button from '../adapters/Button';
+import Input from '../adapters/Input';
 
 interface TaskBoardProps {
   tasks: HarnessTask[];
@@ -68,38 +70,41 @@ export default function TaskBoard({
         <span className="rounded bg-surface-2 px-1.5 py-0.5 text-[10px] text-fg-muted">
           {tasks.length}
         </span>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="sm"
           onClick={() => setCreating(!creating)}
           className="ml-auto rounded bg-info-subtle px-2 py-1 text-[10px] font-medium text-info hover:bg-info-subtle/70"
         >
           {creating ? 'Cancel' : '+ Task'}
-        </button>
+        </Button>
       </div>
 
       {/* Create form */}
       {creating ? (
         <div className="border-b border-edge bg-surface-1/50 p-3">
-          <input
+          <Input
             value={newId}
             onChange={(e) => setNewId(e.target.value)}
             placeholder="Task ID (e.g. task-004)"
-            className="mb-2 w-full rounded border border-edge bg-surface-2 px-2 py-1 text-xs text-fg placeholder:text-fg-subtle focus:border-brand focus:outline-none"
+            className="mb-2"
           />
-          <input
+          <Input
             value={newDesc}
             onChange={(e) => setNewDesc(e.target.value)}
             placeholder="Description"
-            className="mb-2 w-full rounded border border-edge bg-surface-2 px-2 py-1 text-xs text-fg placeholder:text-fg-subtle focus:border-brand focus:outline-none"
+            className="mb-2"
           />
-          <button
+          <Button
             type="button"
+            variant="primary"
+            size="sm"
             onClick={() => void handleCreate()}
             disabled={submitting || !newId.trim() || !newDesc.trim()}
-            className="rounded bg-brand px-3 py-1 text-xs font-medium text-on-brand hover:bg-brand-hover disabled:opacity-40"
           >
             {submitting ? 'Creating…' : 'Create'}
-          </button>
+          </Button>
         </div>
       ) : null}
 
@@ -175,30 +180,36 @@ function TaskCard({ task, agentId, relativeTime, onClaim, onComplete, onRelease 
       {/* Actions */}
       <div className="mt-1.5 flex gap-1">
         {task.status === 'open' ? (
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             onClick={onClaim}
             className="rounded bg-info-subtle px-2 py-0.5 text-[10px] font-medium text-info hover:bg-info-subtle/70"
           >
             Claim
-          </button>
+          </Button>
         ) : null}
         {task.status === 'claimed' && isOwned ? (
           <>
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={onComplete}
               className="rounded bg-success-subtle px-2 py-0.5 text-[10px] font-medium text-success hover:bg-success-subtle/70"
             >
               Complete
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={onRelease}
               className="rounded bg-surface-3/40 px-2 py-0.5 text-[10px] font-medium text-fg-muted hover:bg-surface-3/60"
             >
               Release
-            </button>
+            </Button>
           </>
         ) : null}
       </div>

--- a/apps/studio/src/components/auth/LoginScreen.tsx
+++ b/apps/studio/src/components/auth/LoginScreen.tsx
@@ -140,24 +140,28 @@ export default function LoginScreen() {
               Verify
             </Button>
             <div className="flex items-center justify-between text-xs">
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="sm"
                 onClick={handleResend}
                 disabled={loading || resendBlocked}
-                className="text-fg-subtle hover:text-accent disabled:cursor-not-allowed disabled:opacity-50"
+                className="h-auto p-0 text-fg-subtle hover:text-accent disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {resendBlocked ? `Resend in ${resendCooldown}s` : 'Resend code'}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                variant="ghost"
+                size="sm"
                 onClick={() => {
                   setOtpSent(false);
                   setCode('');
                 }}
-                className="text-fg-subtle hover:text-fg-muted"
+                className="h-auto p-0 text-fg-subtle hover:text-fg-muted"
               >
                 Use different email
-              </button>
+              </Button>
             </div>
           </form>
         ) : null}
@@ -165,13 +169,14 @@ export default function LoginScreen() {
         {/* Local mode escape hatch (email step only) */}
         {showOtp ? null : (
           <div className="space-y-2 border-t border-edge pt-4">
-            <button
+            <Button
               type="button"
+              variant="ghost"
               onClick={() => updateSettings({ localMode: true })}
               className="w-full rounded-md border border-edge px-3 py-2 text-sm text-fg-muted transition-colors hover:border-brand hover:text-fg"
             >
               Continue in local mode
-            </button>
+            </Button>
             <p className="text-center text-[11px] text-fg-subtle">
               Use local tools (terminal, shell, git) without signing in. Account features stay
               disabled until you sign in.

--- a/apps/studio/src/components/dashboard/WelcomeBanner.tsx
+++ b/apps/studio/src/components/dashboard/WelcomeBanner.tsx
@@ -1,4 +1,6 @@
+import { IconClose } from '@revealui/presentation';
 import { useCallback, useState } from 'react';
+import Button from '../adapters/Button';
 
 const STORAGE_KEY = 'revealui-welcome-dismissed';
 
@@ -14,23 +16,16 @@ export default function WelcomeBanner() {
 
   return (
     <div className="relative rounded-lg border border-brand/40 bg-brand-subtle px-5 py-4">
-      <button
+      <Button
         type="button"
+        variant="ghost"
+        size="sm"
         onClick={dismiss}
-        className="absolute right-3 top-3 text-fg-subtle hover:text-fg-muted"
+        className="absolute right-3 top-3 p-1 text-fg-subtle hover:text-fg-muted"
         aria-label="Dismiss welcome message"
       >
-        <svg
-          className="size-4"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-          aria-hidden="true"
-        >
-          <path d="M18 6 6 18M6 6l12 12" />
-        </svg>
-      </button>
+        <IconClose size="sm" />
+      </Button>
       <h2 className="text-sm font-semibold text-brand-text">
         Run your agents on your own infrastructure
       </h2>

--- a/apps/studio/src/components/deploy/DeployWizard.tsx
+++ b/apps/studio/src/components/deploy/DeployWizard.tsx
@@ -1,3 +1,4 @@
+import { IconCheck } from '@revealui/presentation';
 import { useState } from 'react';
 import { useConfig } from '../../hooks/use-config';
 import { useDeployWizard } from '../../hooks/use-deploy-wizard';
@@ -105,12 +106,13 @@ export default function DeployWizard({ onComplete }: DeployWizardProps) {
             const done = wizard.isStepDone(s.id);
             const active = i === wizard.currentStep;
             return (
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 key={s.id}
                 onClick={() => wizard.goTo(i)}
                 aria-current={active ? 'step' : undefined}
-                className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition ${
+                className={`flex h-auto w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition ${
                   active
                     ? 'bg-surface-2 text-fg'
                     : done
@@ -127,22 +129,10 @@ export default function DeployWizard({ onComplete }: DeployWizardProps) {
                         : 'border border-edge-strong text-fg-subtle'
                   }`}
                 >
-                  {done ? (
-                    <svg viewBox="0 0 16 16" fill="none" className="size-3.5" aria-hidden="true">
-                      <path
-                        d="M3 8l3.5 3.5L13 4"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      />
-                    </svg>
-                  ) : (
-                    i + 1
-                  )}
+                  {done ? <IconCheck size="sm" className="size-3.5" /> : i + 1}
                 </span>
                 {s.label}
-              </button>
+              </Button>
             );
           })}
         </nav>

--- a/apps/studio/src/components/deploy/StepDomain.tsx
+++ b/apps/studio/src/components/deploy/StepDomain.tsx
@@ -1,3 +1,4 @@
+import { Checkbox, CheckboxField } from '@revealui/presentation';
 import { useState } from 'react';
 import type { StudioConfig, WizardData } from '../../types';
 import Button from '../adapters/Button';
@@ -132,19 +133,17 @@ export default function StepDomain({
           </div>
         )}
 
-        <label className="flex items-center gap-2 text-sm text-fg-muted cursor-pointer">
-          <input
-            type="checkbox"
+        <CheckboxField disabled={saved} className="text-sm text-fg-muted">
+          <Checkbox
             checked={signupOpen}
-            onChange={(e) => {
-              setSignupOpen(e.target.checked);
+            onChange={(checked) => {
+              setSignupOpen(checked);
               setSaved(false);
             }}
             disabled={saved}
-            className="rounded border-edge-strong bg-surface-2 text-brand focus:ring-brand"
           />
-          Allow public signups (REVEALUI_SIGNUP_OPEN)
-        </label>
+          <span>Allow public signups (REVEALUI_SIGNUP_OPEN)</span>
+        </CheckboxField>
 
         <Input
           id="brand-name"

--- a/apps/studio/src/components/deploy/StepSecrets.tsx
+++ b/apps/studio/src/components/deploy/StepSecrets.tsx
@@ -1,3 +1,4 @@
+import { IconCheck } from '@revealui/presentation';
 import { useState } from 'react';
 import { generateKek, generateSecret } from '../../lib/deploy';
 import type { WizardData } from '../../types';
@@ -89,18 +90,7 @@ export default function StepSecrets({ data, onUpdateData, onNext }: StepSecretsP
 function SecretRow({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-2 rounded-md border border-success/50 bg-success-subtle px-3 py-2">
-      <svg
-        className="size-4 shrink-0 text-success"
-        viewBox="0 0 20 20"
-        fill="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          fillRule="evenodd"
-          d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
-          clipRule="evenodd"
-        />
-      </svg>
+      <IconCheck size="sm" className="shrink-0 text-success" />
       <span className="text-sm font-mono text-fg-muted">{label}</span>
       <span className="text-xs text-success">Generated</span>
     </div>

--- a/apps/studio/src/components/editor/CodeEditor.tsx
+++ b/apps/studio/src/components/editor/CodeEditor.tsx
@@ -18,9 +18,11 @@ import { rust } from '@codemirror/lang-rust';
 import type { Extension } from '@codemirror/state';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { EditorView, keymap } from '@codemirror/view';
+import { IconChevronLeft } from '@revealui/presentation';
 import { basicSetup } from 'codemirror';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { gitReadFile, gitWriteFile } from '../../lib/invoke';
+import Button from '../adapters/Button';
 
 interface Props {
   repoPath: string;
@@ -151,23 +153,17 @@ export default function CodeEditor({ repoPath, filePath, onClose }: Props) {
       {/* Header */}
       <div className="flex items-center gap-2 border-b border-edge px-3 py-2">
         {onClose && (
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             onClick={onClose}
             className="rounded p-1 text-fg-subtle hover:bg-surface-2 hover:text-fg-muted"
             title="Close editor"
+            aria-label="Close editor"
           >
-            <svg
-              className="size-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-              aria-hidden="true"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-            </svg>
-          </button>
+            <IconChevronLeft size="sm" />
+          </Button>
         )}
 
         {/* Breadcrumb */}
@@ -192,15 +188,17 @@ export default function CodeEditor({ repoPath, filePath, onClose }: Props) {
         {saveStatus === 'saved' && <span className="text-xs text-success">Saved</span>}
         {saveStatus === 'error' && <span className="text-xs text-error">Save failed</span>}
 
-        <button
+        <Button
           type="button"
+          variant="secondary"
+          size="sm"
           onClick={() => void save()}
           disabled={!isDirty || saveStatus === 'saving'}
-          className="rounded bg-surface-2 px-2.5 py-1 text-xs text-fg-muted hover:bg-surface-3 disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded px-2.5 py-1 text-xs"
           title="Save (Ctrl+S)"
         >
           Save
-        </button>
+        </Button>
       </div>
 
       {/* Editor or error */}

--- a/apps/studio/src/components/fleet/FleetMapPanel.tsx
+++ b/apps/studio/src/components/fleet/FleetMapPanel.tsx
@@ -212,14 +212,16 @@ export default function FleetMapPanel() {
                   {free.slice(0, 20).map((row) => (
                     <tr key={row.id} className="border-t border-edge">
                       <td className="px-3 py-2 font-mono text-xs">
-                        <button
+                        <Button
                           type="button"
-                          className="text-left hover:underline"
+                          variant="ghost"
+                          size="sm"
+                          className="h-auto p-0 text-left font-mono text-xs hover:underline"
                           title="Copy gap id"
                           onClick={() => void copyId(row.id)}
                         >
                           {row.id}
-                        </button>
+                        </Button>
                       </td>
                       <td className="px-3 py-2">{row.priority ?? '—'}</td>
                       <td className="px-3 py-2 font-mono text-xs">{row.initiativeId ?? '—'}</td>

--- a/apps/studio/src/components/gallery/CategorySection.tsx
+++ b/apps/studio/src/components/gallery/CategorySection.tsx
@@ -1,5 +1,7 @@
+import { IconChevronRight } from '@revealui/presentation';
 import type { CategoryWithTiles } from '../../hooks/use-tiles';
 import type { TileDefinition } from '../../lib/tiles';
+import Button from '../adapters/Button';
 import Tile from './Tile';
 
 interface CategorySectionProps {
@@ -24,26 +26,21 @@ export default function CategorySection({
 
   return (
     <section>
-      <button
+      <Button
         type="button"
+        variant="ghost"
         onClick={onToggleCollapse}
-        className="flex w-full items-center gap-2 py-2 text-left"
+        className="flex h-auto w-full items-center gap-2 py-2 text-left"
       >
-        <svg
+        <IconChevronRight
+          size="sm"
           className={`size-3.5 shrink-0 text-fg-subtle transition-transform ${collapsed ? '' : 'rotate-90'}`}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2.5}
-          aria-hidden="true"
-        >
-          <polyline points="9 18 15 12 9 6" />
-        </svg>
+        />
         <h2 className="text-xs font-semibold uppercase tracking-wider text-fg-subtle">
           {category.label}
         </h2>
         <span className="text-xs text-fg-subtle">{tileCount}</span>
-      </button>
+      </Button>
 
       {!collapsed && (
         <div className="grid grid-cols-2 gap-2 pb-4 sm:grid-cols-3 lg:grid-cols-4">

--- a/apps/studio/src/components/gallery/Tile.tsx
+++ b/apps/studio/src/components/gallery/Tile.tsx
@@ -1,4 +1,6 @@
+import { IconEye, IconEyeOff } from '@revealui/presentation';
 import type { TileDefinition } from '../../lib/tiles';
+import Button from '../adapters/Button';
 import TileIcon from './TileIcon';
 
 interface TileProps {
@@ -14,8 +16,9 @@ export default function Tile({ tile, hidden, editing, running, onLaunch, onToggl
   const isUrl = tile.action.type === 'url';
 
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
       onClick={() => {
         if (editing && onToggle) {
           onToggle(tile.id);
@@ -23,7 +26,7 @@ export default function Tile({ tile, hidden, editing, running, onLaunch, onToggl
           onLaunch(tile);
         }
       }}
-      className={`group flex items-center gap-3 rounded-lg border px-3 py-2.5 text-left text-sm transition-all ${
+      className={`group flex h-auto items-center gap-3 rounded-lg border px-3 py-2.5 text-left text-sm transition-all ${
         hidden
           ? 'border-edge/50 bg-surface-1/30 text-fg-subtle'
           : running
@@ -58,33 +61,12 @@ export default function Tile({ tile, hidden, editing, running, onLaunch, onToggl
       {editing && (
         <span className="ml-auto shrink-0">
           {hidden ? (
-            <svg
-              className="size-4 text-fg-subtle"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={1.5}
-              aria-hidden="true"
-            >
-              <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
-              <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
-              <line x1="1" x2="23" y1="1" y2="23" />
-            </svg>
+            <IconEyeOff size="sm" className="text-fg-subtle" />
           ) : (
-            <svg
-              className="size-4 text-fg-subtle"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={1.5}
-              aria-hidden="true"
-            >
-              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8Z" />
-              <circle cx="12" cy="12" r="3" />
-            </svg>
+            <IconEye size="sm" className="text-fg-subtle" />
           )}
         </span>
       )}
-    </button>
+    </Button>
   );
 }

--- a/apps/studio/src/components/gallery/TileGallery.tsx
+++ b/apps/studio/src/components/gallery/TileGallery.tsx
@@ -1,5 +1,7 @@
+import { IconClose, IconSearch } from '@revealui/presentation';
 import { useTiles } from '../../hooks/use-tiles';
 import Button from '../adapters/Button';
+import Input from '../adapters/Input';
 import PanelHeader from '../adapters/PanelHeader';
 import CategorySection from './CategorySection';
 import Tile from './Tile';
@@ -31,42 +33,28 @@ export default function TileGallery() {
 
       {/* Search bar */}
       <div className="relative">
-        <svg
-          className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-fg-subtle"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          aria-hidden="true"
-        >
-          <circle cx="11" cy="11" r="8" />
-          <line x1="21" x2="16.65" y1="21" y2="16.65" />
-        </svg>
-        <input
+        <IconSearch
+          size="sm"
+          className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2 text-fg-subtle"
+        />
+        <Input
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search tiles..."
-          className="w-full rounded-lg border border-edge bg-surface-1 py-2 pl-10 pr-3 text-sm text-fg placeholder:text-fg-subtle focus:border-brand focus:outline-none"
+          className="pl-10 pr-9"
         />
         {query && (
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => setQuery('')}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-fg-subtle hover:text-fg-muted"
+            className="absolute right-2 top-1/2 z-10 h-auto -translate-y-1/2 p-1 text-fg-subtle hover:text-fg-muted"
+            aria-label="Clear search"
           >
-            <svg
-              className="size-4"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={2}
-              aria-hidden="true"
-            >
-              <line x1="18" x2="6" y1="6" y2="18" />
-              <line x1="6" x2="18" y1="6" y2="18" />
-            </svg>
-          </button>
+            <IconClose size="sm" />
+          </Button>
         )}
       </div>
 

--- a/apps/studio/src/components/git/GitPanel.tsx
+++ b/apps/studio/src/components/git/GitPanel.tsx
@@ -4,6 +4,17 @@ const COMMIT_SUCCESS_FEEDBACK_MS = 3_000;
 const REMOTE_SUCCESS_FEEDBACK_MS = 2_000;
 
 import {
+  IconCheck,
+  IconChevronDown,
+  IconDownload,
+  IconEdit,
+  IconMinus,
+  IconPlus,
+  IconRefresh,
+  IconUpload,
+  Textarea,
+} from '@revealui/presentation';
+import {
   gitCommit,
   gitCreateBranch,
   gitDiffContent,
@@ -24,8 +35,10 @@ import type {
   GitFileEntry,
   GitStatusResult,
 } from '../../types';
+import Button from '../adapters/Button';
 import ConfirmDialog from '../adapters/ConfirmDialog';
 import ErrorAlert from '../adapters/ErrorAlert';
+import Input from '../adapters/Input';
 import DiffView from './DiffView';
 
 // ── Status badge ─────────────────────────────────────────────────────────────
@@ -77,8 +90,10 @@ function FileRow({
   const dir = entry.path.includes('/') ? entry.path.slice(0, entry.path.lastIndexOf('/')) : '';
 
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
+      size="sm"
       onClick={onSelect}
       className={`group flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors ${
         selected ? 'bg-surface-3 text-fg' : 'text-fg-muted hover:bg-surface-2 hover:text-fg'
@@ -136,7 +151,7 @@ function FileRow({
           </ActionBtn>
         )}
       </div>
-    </button>
+    </Button>
   );
 }
 
@@ -152,8 +167,10 @@ function ActionBtn({
   danger?: boolean;
 }) {
   return (
-    <button
+    <Button
       type="button"
+      variant="danger"
+      size="sm"
       title={title}
       onClick={onClick}
       className={`flex size-5 items-center justify-center rounded transition-colors ${
@@ -163,7 +180,7 @@ function ActionBtn({
       }`}
     >
       {children}
-    </button>
+    </Button>
   );
 }
 
@@ -234,7 +251,7 @@ function CommitForm({ stagedCount, onCommit }: CommitFormProps) {
 
   return (
     <div className="border-t border-edge p-3">
-      <textarea
+      <Textarea
         ref={textareaRef}
         value={msg}
         onChange={(e) => setMsg(e.target.value)}
@@ -244,22 +261,23 @@ function CommitForm({ stagedCount, onCommit }: CommitFormProps) {
         }
         disabled={stagedCount === 0 || busy}
         rows={3}
-        className="w-full resize-none rounded border border-edge bg-surface-0 px-2.5 py-2 text-xs text-fg placeholder:text-fg-subtle focus:border-edge-strong focus:outline-none disabled:opacity-40"
+        resizable={false}
       />
       {err && <p className="mt-1 text-[10px] text-error">{err}</p>}
       {ok && <p className="mt-1 text-[10px] text-success">{ok}</p>}
-      <button
+      <Button
         type="button"
+        variant="primary"
         onClick={() => {
           void handleCommit();
         }}
         disabled={!msg.trim() || stagedCount === 0 || busy}
-        className="mt-2 w-full rounded bg-brand px-3 py-1.5 text-xs font-medium text-on-brand transition-colors hover:bg-brand-hover disabled:cursor-not-allowed disabled:opacity-40"
+        className="mt-2 w-full"
       >
         {busy
           ? 'Committing…'
           : `Commit${stagedCount > 0 ? ` ${stagedCount} file${stagedCount !== 1 ? 's' : ''}` : ''}`}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -339,20 +357,21 @@ function NewBranchInput({
         }}
         className="flex gap-1"
       >
-        <input
+        <Input
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="New branch name…"
           disabled={creating}
-          className="min-w-0 flex-1 rounded border border-edge-strong bg-surface-0 px-2 py-1 text-[11px] text-fg placeholder:text-fg-subtle focus:border-edge focus:outline-none disabled:opacity-40"
         />
-        <button
+        <Button
           type="submit"
+          variant="ghost"
+          size="sm"
           disabled={!name.trim() || creating}
           className="rounded bg-surface-3 px-2 py-1 text-[11px] text-fg hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
         >
           {creating ? '…' : 'Create'}
-        </button>
+        </Button>
       </form>
     </div>
   );
@@ -636,7 +655,7 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
               }}
               className="flex gap-1.5"
             >
-              <input
+              <Input
                 ref={pathInputRef}
                 value={draftPath}
                 onChange={(e) => setDraftPath(e.target.value)}
@@ -644,7 +663,6 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
                 onKeyDown={(e) => {
                   if (e.key === 'Escape') setEditingPath(false);
                 }}
-                className="min-w-0 flex-1 rounded border border-edge-strong bg-surface-2 px-2 py-1 text-xs text-fg focus:border-edge focus:outline-none"
               />
             </form>
           ) : (
@@ -652,8 +670,10 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
               <div className="flex items-center gap-1">
                 {/* Branch dropdown trigger */}
                 <div ref={branchDropdownRef} className="relative min-w-0 flex-1">
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={() => {
                       setBranchError(null);
                       setShowBranchDropdown((v) => !v);
@@ -665,7 +685,7 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
                       {currentBranch}
                     </span>
                     <ChevronDownIcon />
-                  </button>
+                  </Button>
 
                   {showBranchDropdown && (
                     <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-lg border border-edge bg-surface-2 shadow-xl">
@@ -674,9 +694,11 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
                           <p className="px-3 py-2 text-[11px] text-fg-subtle">No branches found</p>
                         )}
                         {branches.map((b) => (
-                          <button
+                          <Button
                             key={b.name}
                             type="button"
+                            variant="ghost"
+                            size="sm"
                             onClick={() => {
                               if (!b.is_current) void switchBranch(b.name);
                             }}
@@ -688,20 +710,7 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
                             } disabled:opacity-60`}
                           >
                             {b.is_current ? (
-                              <svg
-                                className="size-3 shrink-0"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                                strokeWidth={2.5}
-                                aria-hidden="true"
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  d="M5 13l4 4L19 7"
-                                />
-                              </svg>
+                              <IconCheck size="sm" className="size-3 shrink-0" />
                             ) : (
                               <span className="size-3 shrink-0" />
                             )}
@@ -709,7 +718,7 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
                             {switchingTo === b.name && (
                               <span className="ml-auto text-[10px] text-fg-subtle">switching…</span>
                             )}
-                          </button>
+                          </Button>
                         ))}
                       </div>
                       {branchError && (
@@ -724,8 +733,10 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
 
                 {/* Toolbar: pull, push, refresh */}
                 <div className="flex shrink-0 items-center gap-0.5">
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={() => void handlePull()}
                     disabled={pullStatus === 'loading'}
                     title="Pull"
@@ -738,9 +749,11 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
                     }`}
                   >
                     <DownloadIcon spinning={pullStatus === 'loading'} />
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={() => void handlePush()}
                     disabled={pushStatus === 'loading'}
                     title="Push"
@@ -753,22 +766,26 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
                     }`}
                   >
                     <UploadIcon spinning={pushStatus === 'loading'} />
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={() => void refresh()}
                     disabled={loadingStatus}
                     title="Refresh"
                     className="flex size-6 items-center justify-center rounded text-fg-subtle transition-colors hover:bg-surface-2 hover:text-fg-muted disabled:opacity-40"
                   >
                     <RefreshIcon spinning={loadingStatus} />
-                  </button>
+                  </Button>
                 </div>
               </div>
 
               {/* Repo path */}
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="sm"
                 onClick={() => {
                   setDraftPath(repoPath);
                   setEditingPath(true);
@@ -777,14 +794,16 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
                 title="Change repository path"
               >
                 {repoPath}
-              </button>
+              </Button>
 
               {/* Remote error — persists until the user dismisses it */}
               {remoteError && (
                 <div className="mt-0.5 flex items-start gap-1 text-[10px] text-error">
                   <span className="flex-1 break-words">{remoteError}</span>
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={() => {
                       setRemoteError(null);
                       if (pushStatus === 'error') setPushStatus('idle');
@@ -794,7 +813,7 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
                     aria-label="Dismiss error"
                   >
                     ×
-                  </button>
+                  </Button>
                 </div>
               )}
             </>
@@ -905,24 +924,28 @@ export default function GitPanel({ onOpenEditor }: GitPanelProps) {
         {/* Tab bar */}
         <div className="flex items-center gap-3 border-b border-edge px-3 py-1.5">
           <div className="flex gap-0.5">
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={() => setRightTab('diff')}
               className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
                 rightTab === 'diff' ? 'bg-surface-3 text-fg' : 'text-fg-subtle hover:text-fg-muted'
               }`}
             >
               Diff
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={() => setRightTab('log')}
               className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
                 rightTab === 'log' ? 'bg-surface-3 text-fg' : 'text-fg-subtle hover:text-fg-muted'
               }`}
             >
               Log
-            </button>
+            </Button>
           </div>
           {rightTab === 'diff' && selected && (
             <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -1007,102 +1030,27 @@ function BranchIcon() {
 }
 
 function ChevronDownIcon() {
-  return (
-    <svg
-      className="size-3 shrink-0 text-fg-subtle"
-      aria-hidden="true"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2.5}
-    >
-      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-    </svg>
-  );
+  return <IconChevronDown size="sm" className="size-3 shrink-0 text-fg-subtle" />;
 }
 
 function RefreshIcon({ spinning }: { spinning: boolean }) {
-  return (
-    <svg
-      className={`size-3.5 ${spinning ? 'animate-spin' : ''}`}
-      aria-hidden="true"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2}
-    >
-      <path d="M4 4v5h5M20 20v-5h-5" />
-      <path d="M20.49 9A9 9 0 0 0 5.64 5.64L4 7m16 10l-1.64 1.36A9 9 0 0 1 3.51 15" />
-    </svg>
-  );
+  return <IconRefresh size="sm" className={`size-3.5 ${spinning ? 'animate-spin' : ''}`} />;
 }
 
 function DownloadIcon({ spinning }: { spinning: boolean }) {
-  return (
-    <svg
-      className={`size-3.5 ${spinning ? 'animate-pulse' : ''}`}
-      aria-hidden="true"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2}
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
-      />
-    </svg>
-  );
+  return <IconDownload size="sm" className={`size-3.5 ${spinning ? 'animate-pulse' : ''}`} />;
 }
 
 function UploadIcon({ spinning }: { spinning: boolean }) {
-  return (
-    <svg
-      className={`size-3.5 ${spinning ? 'animate-pulse' : ''}`}
-      aria-hidden="true"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2}
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
-      />
-    </svg>
-  );
+  return <IconUpload size="sm" className={`size-3.5 ${spinning ? 'animate-pulse' : ''}`} />;
 }
 
 function PlusIcon() {
-  return (
-    <svg
-      className="size-3"
-      aria-hidden="true"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2.5}
-    >
-      <path d="M12 5v14M5 12h14" />
-    </svg>
-  );
+  return <IconPlus size="sm" className="size-3" />;
 }
 
 function MinusIcon() {
-  return (
-    <svg
-      className="size-3"
-      aria-hidden="true"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2.5}
-    >
-      <path d="M5 12h14" />
-    </svg>
-  );
+  return <IconMinus size="sm" className="size-3" />;
 }
 
 function UndoIcon() {
@@ -1122,20 +1070,5 @@ function UndoIcon() {
 }
 
 function PencilIcon() {
-  return (
-    <svg
-      className="size-3"
-      aria-hidden="true"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2}
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
-      />
-    </svg>
-  );
+  return <IconEdit size="sm" className="size-3" />;
 }

--- a/apps/studio/src/components/inference/InferencePanel.tsx
+++ b/apps/studio/src/components/inference/InferencePanel.tsx
@@ -9,7 +9,9 @@ import { useState } from 'react';
 
 import { useInference } from '../../hooks/use-inference';
 import type { LocalAiTier } from '../../types';
+import Button from '../adapters/Button';
 import ConfirmDialog from '../adapters/ConfirmDialog';
+import Input from '../adapters/Input';
 
 interface PendingDelete {
   kind: 'model' | 'snapshot';
@@ -84,13 +86,15 @@ export default function InferencePanel() {
             Manage local AI models — no cloud, no API keys, fully sovereign
           </p>
         </div>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="sm"
           onClick={() => void refresh()}
           className="rounded bg-surface-2 px-3 py-1.5 text-xs text-fg-muted transition-colors hover:bg-surface-3"
         >
           Refresh
-        </button>
+        </Button>
       </div>
 
       {error ? (
@@ -120,9 +124,11 @@ export default function InferencePanel() {
           {TIERS.map((t) => {
             const selected = activeTier === t.id;
             return (
-              <button
+              <Button
                 key={t.id}
                 type="button"
+                variant="ghost"
+                size="sm"
                 disabled={applyingTier}
                 onClick={() => void applyTier(t.id)}
                 className={`rounded-lg border px-2.5 py-2 text-left transition-colors disabled:opacity-50 ${
@@ -135,7 +141,7 @@ export default function InferencePanel() {
                 <span className="mt-0.5 block text-[10px] leading-snug text-fg-subtle">
                   {t.blurb}
                 </span>
-              </button>
+              </Button>
             );
           })}
         </div>
@@ -216,26 +222,30 @@ export default function InferencePanel() {
                   <span className="inline-block rounded bg-success-subtle px-2 py-0.5 text-[10px] font-medium text-success">
                     Running
                   </span>
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={() => void stopOllama()}
                     className="rounded bg-error-subtle px-2 py-0.5 text-[10px] text-error transition-colors hover:bg-error-subtle/50"
                   >
                     Stop
-                  </button>
+                  </Button>
                 </>
               ) : (
                 <>
                   <span className="inline-block rounded bg-warning-subtle px-2 py-0.5 text-[10px] font-medium text-warning">
                     Stopped
                   </span>
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={() => void startOllama()}
                     className="rounded bg-success-subtle px-2 py-0.5 text-[10px] text-success transition-colors hover:bg-success-subtle/50"
                   >
                     Start
-                  </button>
+                  </Button>
                 </>
               )
             ) : (
@@ -265,23 +275,27 @@ export default function InferencePanel() {
                   <span className="rounded bg-success-subtle px-2 py-0.5 text-[10px] font-medium text-success">
                     Installed
                   </span>
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="sm"
                     onClick={() => setPendingDelete({ kind: 'snapshot', name: snap.name })}
                     className="rounded px-2 py-0.5 text-[10px] text-fg-subtle transition-colors hover:bg-error-subtle hover:text-error"
                   >
                     Remove
-                  </button>
+                  </Button>
                 </div>
               ) : (
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="sm"
                   onClick={() => void installSnap(snap.name)}
                   disabled={installingSnap !== null}
                   className="shrink-0 rounded bg-warning-subtle px-3 py-1 text-[10px] font-medium text-warning transition-colors hover:bg-warning-subtle/50 disabled:opacity-40"
                 >
                   {installingSnap === snap.name ? 'Installing…' : 'Install'}
-                </button>
+                </Button>
               )}
             </div>
           ))}
@@ -308,20 +322,22 @@ export default function InferencePanel() {
             }}
             className="mb-3 flex gap-2"
           >
-            <input
+            <Input
               value={pullInput}
               onChange={(e) => setPullInput(e.target.value)}
               placeholder="Pull a model (e.g. gemma3:1b)"
               disabled={pulling}
-              className="flex-1 rounded border border-edge-strong bg-surface-2 px-2.5 py-1.5 text-xs text-fg placeholder:text-fg-subtle focus:border-brand focus:outline-none disabled:opacity-50"
+              className="flex-1"
             />
-            <button
+            <Button
               type="submit"
+              variant="primary"
+              size="sm"
               disabled={pulling || !pullInput.trim()}
               className="shrink-0 rounded bg-brand px-3 py-1.5 text-xs font-medium text-on-brand transition-colors hover:bg-brand-hover disabled:opacity-40"
             >
               {pulling ? 'Pulling…' : 'Pull'}
-            </button>
+            </Button>
           </form>
         ) : null}
 
@@ -335,13 +351,15 @@ export default function InferencePanel() {
                     {m.size} · {m.modified}
                   </span>
                 </div>
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="sm"
                   onClick={() => setPendingDelete({ kind: 'model', name: m.name })}
                   className="shrink-0 rounded px-2 py-0.5 text-[10px] text-fg-subtle transition-colors hover:bg-error-subtle hover:text-error"
                 >
                   Delete
-                </button>
+                </Button>
               </div>
             ))}
           </div>

--- a/apps/studio/src/components/infrastructure/DaemonPanel.tsx
+++ b/apps/studio/src/components/infrastructure/DaemonPanel.tsx
@@ -7,6 +7,7 @@ import {
   daemonStatus,
   daemonStop,
 } from '../../lib/invoke';
+import Button from '../adapters/Button';
 import ConfirmDialog from '../adapters/ConfirmDialog';
 
 interface DaemonPanelProps {
@@ -103,32 +104,36 @@ export default function DaemonPanel({ harnessStatus }: DaemonPanelProps) {
       {/* Controls */}
       <div className="flex gap-2">
         {!status?.running ? (
-          <button
+          <Button
             type="button"
+            variant="success"
+            size="sm"
             onClick={handleStart}
             disabled={loading}
-            className="rounded bg-success px-3 py-1.5 text-xs font-medium text-fg hover:brightness-110 disabled:opacity-50"
+            loading={loading}
           >
             {loading ? 'Starting...' : 'Start Daemon'}
-          </button>
+          </Button>
         ) : (
           <>
-            <button
+            <Button
               type="button"
+              size="sm"
               onClick={() => setPendingAction('restart')}
               disabled={loading}
-              className="rounded bg-warning px-3 py-1.5 text-xs font-medium text-fg hover:brightness-110 disabled:opacity-50"
+              className="bg-warning text-fg hover:brightness-110"
             >
               {loading && pendingAction === null ? 'Restarting...' : 'Restart'}
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              variant="danger"
+              size="sm"
               onClick={() => setPendingAction('stop')}
               disabled={loading}
-              className="rounded bg-error px-3 py-1.5 text-xs font-medium text-fg hover:brightness-110 disabled:opacity-50"
             >
               {loading && pendingAction === null ? 'Stopping...' : 'Stop'}
-            </button>
+            </Button>
           </>
         )}
       </div>

--- a/apps/studio/src/components/infrastructure/InfrastructurePanel.tsx
+++ b/apps/studio/src/components/infrastructure/InfrastructurePanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useHarness } from '../../hooks/use-harness';
+import Button from '../adapters/Button';
 import AppsPanel from '../apps/AppsPanel';
 import DevBoxPanel from '../devbox/DevBoxPanel';
 import DaemonPanel from './DaemonPanel';
@@ -38,14 +39,15 @@ function TabButton({
   onClick: () => void;
 }) {
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
       onClick={onClick}
-      className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
-        active ? 'border-brand text-fg' : 'border-transparent text-fg-muted hover:text-fg'
+      className={`-mb-px rounded-none border-b-2 px-4 py-2 text-sm font-medium ${
+        active ? 'border-brand text-fg' : 'border-transparent text-fg-muted'
       }`}
     >
       {label}
-    </button>
+    </Button>
   );
 }

--- a/apps/studio/src/components/intent/IntentScreen.tsx
+++ b/apps/studio/src/components/intent/IntentScreen.tsx
@@ -37,10 +37,11 @@ export default function IntentScreen({ onSelect }: IntentScreenProps) {
         </div>
 
         <div className="grid grid-cols-2 gap-6">
-          <button
+          <Button
             type="button"
+            variant="ghost"
             onClick={() => setSelected('deploy')}
-            className={`rounded-xl border-2 p-6 text-left transition ${
+            className={`h-auto rounded-xl border-2 p-6 text-left ${
               selected === 'deploy'
                 ? 'border-brand bg-surface-2'
                 : 'border-edge bg-surface-1 hover:border-edge'
@@ -51,12 +52,13 @@ export default function IntentScreen({ onSelect }: IntentScreenProps) {
             <p className="mt-1 text-sm text-fg-muted">
               I want to run RevealUI for my business. Set up Vercel, database, Stripe, and go live.
             </p>
-          </button>
+          </Button>
 
-          <button
+          <Button
             type="button"
+            variant="ghost"
             onClick={() => setSelected('develop')}
-            className={`rounded-xl border-2 p-6 text-left transition ${
+            className={`h-auto rounded-xl border-2 p-6 text-left ${
               selected === 'develop'
                 ? 'border-brand bg-surface-2'
                 : 'border-edge bg-surface-1 hover:border-edge'
@@ -67,7 +69,7 @@ export default function IntentScreen({ onSelect }: IntentScreenProps) {
             <p className="mt-1 text-sm text-fg-muted">
               I want to contribute to RevealUI. Set up the dev environment with WSL, Nix, and tools.
             </p>
-          </button>
+          </Button>
         </div>
 
         <div className="mt-8 flex flex-col items-center gap-4">

--- a/apps/studio/src/components/layout/AppShell.tsx
+++ b/apps/studio/src/components/layout/AppShell.tsx
@@ -1,6 +1,8 @@
+import { IconMenu } from '@revealui/presentation';
 import { type ReactNode, useState } from 'react';
 import { StatusContext, useStatus } from '../../hooks/use-status';
 import type { Page } from '../../types';
+import Button from '../adapters/Button';
 import DegradedBanner from './DegradedBanner';
 import Sidebar from './Sidebar';
 import StatusBar from './StatusBar';
@@ -33,9 +35,10 @@ export default function AppShell({ currentPage, onNavigate, children, padless }:
         {/* Mobile sidebar: overlay + slide-in, only rendered when open */}
         {sidebarOpen && (
           <>
-            <button
+            <Button
               type="button"
-              className="fixed inset-0 z-30 bg-black/50 md:hidden"
+              variant="ghost"
+              className="fixed inset-0 z-30 h-auto rounded-none bg-black/50 md:hidden"
               onClick={() => setSidebarOpen(false)}
               aria-label="Close sidebar"
             />
@@ -51,23 +54,16 @@ export default function AppShell({ currentPage, onNavigate, children, padless }:
 
           {/* Mobile top bar with hamburger */}
           <div className="flex items-center gap-3 border-b border-edge bg-surface-1 px-3 py-2 md:hidden">
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={() => setSidebarOpen(true)}
-              className="rounded-md p-1.5 text-fg-muted hover:bg-surface-2 hover:text-fg"
+              className="p-1.5 text-fg-muted"
               aria-label="Open menu"
             >
-              <svg
-                className="size-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-                aria-hidden="true"
-              >
-                <path d="M4 6h16M4 12h16M4 18h16" />
-              </svg>
-            </button>
+              <IconMenu size="md" />
+            </Button>
             <span className="text-sm font-semibold text-fg">RevealUI Studio</span>
           </div>
 

--- a/apps/studio/src/components/layout/DegradedBanner.tsx
+++ b/apps/studio/src/components/layout/DegradedBanner.tsx
@@ -1,3 +1,4 @@
+import { IconAlertTriangle } from '@revealui/presentation';
 import { useDegradedMode } from '../../lib/degraded-mode';
 
 /**
@@ -17,20 +18,7 @@ export default function DegradedBanner() {
       aria-live="polite"
       className="flex items-center gap-2 border-b border-warning/40 bg-warning/15 px-3 py-1.5 text-xs font-medium text-warning-text"
     >
-      <svg
-        className="size-4 shrink-0"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M12 9v3.75m0 3.75h.008M10.34 3.94l-7.5 12.99A1.5 1.5 0 004.14 19.5h15.72a1.5 1.5 0 001.3-2.57l-7.5-12.99a1.5 1.5 0 00-2.6 0z"
-        />
-      </svg>
+      <IconAlertTriangle size="sm" className="shrink-0" />
       <span>{reason ?? 'Demo data — not connected to a real system.'}</span>
     </div>
   );

--- a/apps/studio/src/components/layout/Sidebar.tsx
+++ b/apps/studio/src/components/layout/Sidebar.tsx
@@ -1,5 +1,14 @@
+import {
+  IconCode,
+  IconLock,
+  IconRefresh,
+  IconSettings,
+  IconTerminal,
+  IconUsers,
+} from '@revealui/presentation';
 import { useMemo, useState } from 'react';
 import type { Page } from '../../types';
+import Button from '../adapters/Button';
 
 interface SidebarProps {
   currentPage: Page;
@@ -102,8 +111,10 @@ export default function Sidebar({ currentPage, onNavigate }: SidebarProps) {
           const isOpen = effectiveOpen[group.id];
           return (
             <div key={group.id} className="pb-1">
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="sm"
                 onClick={() => toggleGroup(group.id)}
                 aria-expanded={isOpen}
                 className="flex w-full items-center justify-between rounded-md px-3 py-1.5 text-xs font-semibold tracking-wide text-fg-muted uppercase hover:bg-surface-3 hover:text-fg"
@@ -112,13 +123,15 @@ export default function Sidebar({ currentPage, onNavigate }: SidebarProps) {
                 <span aria-hidden="true" className="text-[10px]">
                   {isOpen ? '▾' : '▸'}
                 </span>
-              </button>
+              </Button>
               {isOpen && (
                 <div className="mt-0.5 space-y-0.5">
                   {group.items.map((item) => (
-                    <button
+                    <Button
                       key={item.page}
                       type="button"
+                      variant="ghost"
+                      size="sm"
                       onClick={() => onNavigate(item.page)}
                       className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors ${
                         currentPage === item.page
@@ -128,7 +141,7 @@ export default function Sidebar({ currentPage, onNavigate }: SidebarProps) {
                     >
                       <NavIcon name={item.icon} />
                       {item.label}
-                    </button>
+                    </Button>
                   ))}
                 </div>
               )}
@@ -156,19 +169,7 @@ function NavIcon({ name }: { name: string }) {
         </svg>
       );
     case 'lock':
-      return (
-        <svg
-          className="size-4"
-          aria-hidden="true"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
-          <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-        </svg>
-      );
+      return <IconLock size="sm" />;
     case 'server':
       return (
         <svg
@@ -186,47 +187,11 @@ function NavIcon({ name }: { name: string }) {
         </svg>
       );
     case 'refresh':
-      return (
-        <svg
-          className="size-4"
-          aria-hidden="true"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path d="M4 4v5h5M20 20v-5h-5" />
-          <path d="M20.49 9A9 9 0 0 0 5.64 5.64L4 7m16 10l-1.64 1.36A9 9 0 0 1 3.51 15" />
-        </svg>
-      );
+      return <IconRefresh size="sm" />;
     case 'terminal':
-      return (
-        <svg
-          className="size-4"
-          aria-hidden="true"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <polyline points="4 17 10 11 4 5" />
-          <line x1="12" x2="20" y1="19" y2="19" />
-        </svg>
-      );
+      return <IconTerminal size="sm" />;
     case 'settings':
-      return (
-        <svg
-          className="size-4"
-          aria-hidden="true"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2Z" />
-          <circle cx="12" cy="12" r="3" />
-        </svg>
-      );
+      return <IconSettings size="sm" />;
     case 'git':
       return (
         <svg
@@ -245,33 +210,9 @@ function NavIcon({ name }: { name: string }) {
         </svg>
       );
     case 'editor':
-      return (
-        <svg
-          className="size-4"
-          aria-hidden="true"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <polyline points="16 18 22 12 16 6" />
-          <polyline points="8 6 2 12 8 18" />
-        </svg>
-      );
+      return <IconCode size="sm" />;
     case 'agent':
-      return (
-        <svg
-          className="size-4"
-          aria-hidden="true"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <rect x="7" y="7" width="10" height="10" rx="1" />
-          <path d="M9 7V5m3 2V5m3 2V5M9 17v2m3-2v2m3-2v2M7 9H5m2 3H5m2 3H5M17 9h2m-2 3h2m-2 3h2" />
-        </svg>
-      );
+      return <IconUsers size="sm" />;
     case 'inference':
       return (
         <svg
@@ -304,18 +245,7 @@ function NavIcon({ name }: { name: string }) {
         </svg>
       );
     case 'wrench':
-      return (
-        <svg
-          className="size-4"
-          aria-hidden="true"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76Z" />
-        </svg>
-      );
+      return <IconSettings size="sm" />;
     case 'map':
       return (
         <svg

--- a/apps/studio/src/components/layout/StatusBar.tsx
+++ b/apps/studio/src/components/layout/StatusBar.tsx
@@ -1,4 +1,5 @@
 import { useStatusContext } from '../../hooks/use-status';
+import Button from '../adapters/Button';
 import StatusDot from '../adapters/StatusDot';
 
 /** Max characters for truncated error message in the status bar. */
@@ -50,15 +51,17 @@ export default function StatusBar() {
           </div>
         </>
       )}
-      <button
+      <Button
         type="button"
-        className="ml-auto text-fg-subtle transition-colors hover:text-fg-muted"
+        variant="ghost"
+        size="sm"
+        className="ml-auto text-fg-subtle"
         onClick={refresh}
         aria-label="Refresh status"
         title="Refresh status"
       >
         &#x21bb;
-      </button>
+      </Button>
     </footer>
   );
 }

--- a/apps/studio/src/components/settings/SettingsPanel.tsx
+++ b/apps/studio/src/components/settings/SettingsPanel.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from 'react';
 import type { Theme } from '../../hooks/use-settings';
 import { useSettingsContext } from '../../hooks/use-settings';
 import { getDaemonUrl, pairWithDaemon, setDaemonToken, setDaemonUrl } from '../../lib/invoke';
+import Button from '../adapters/Button';
 import Card from '../adapters/Card';
+import Input from '../adapters/Input';
 import PanelHeader from '../adapters/PanelHeader';
 
 type SettingsTab = 'appearance' | 'connection' | 'about';
@@ -56,9 +58,10 @@ export default function SettingsPanel() {
       {/* Tab bar */}
       <div className="flex gap-1 rounded-lg bg-surface-1 p-1">
         {TABS.map((tab) => (
-          <button
+          <Button
             key={tab.key}
             type="button"
+            variant="ghost"
             onClick={() => setActiveTab(tab.key)}
             className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
               activeTab === tab.key ? 'bg-surface-2 text-fg' : 'text-fg-subtle hover:text-fg-muted'
@@ -70,7 +73,7 @@ export default function SettingsPanel() {
                 LOCAL
               </span>
             )}
-          </button>
+          </Button>
         ))}
       </div>
 
@@ -81,9 +84,10 @@ export default function SettingsPanel() {
             <span className="text-sm text-fg-muted">Theme</span>
             <div className="flex gap-2">
               {(['dark', 'light', 'system'] as const).map((option) => (
-                <button
+                <Button
                   key={option}
                   type="button"
+                  variant={settings.theme === option ? 'primary' : 'ghost'}
                   onClick={() => updateSettings({ theme: option as Theme })}
                   className={`rounded-md px-4 py-2 text-sm capitalize transition-colors ${
                     settings.theme === option
@@ -92,7 +96,7 @@ export default function SettingsPanel() {
                   }`}
                 >
                   {option}
-                </button>
+                </Button>
               ))}
             </div>
           </div>
@@ -106,21 +110,22 @@ export default function SettingsPanel() {
               <label htmlFor="settings-api-url" className="text-sm text-fg-muted">
                 API URL
               </label>
-              <input
+              <Input
                 id="settings-api-url"
                 type="text"
                 value={settings.apiUrl}
                 onChange={(e) => updateSettings({ apiUrl: e.target.value })}
-                className="rounded-md border border-edge bg-surface-2 px-3 py-2 text-sm text-fg-muted focus:border-edge focus:outline-none"
               />
             </div>
             <div className="flex flex-col gap-1">
               <span className="text-sm text-fg-muted">Polling interval</span>
               <div className="flex gap-2">
                 {POLLING_OPTIONS.map((opt) => (
-                  <button
+                  <Button
                     key={opt.value}
                     type="button"
+                    variant={settings.pollingIntervalMs === opt.value ? 'primary' : 'ghost'}
+                    size="sm"
                     onClick={() => updateSettings({ pollingIntervalMs: opt.value })}
                     className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
                       settings.pollingIntervalMs === opt.value
@@ -129,7 +134,7 @@ export default function SettingsPanel() {
                     }`}
                   >
                     {opt.label}
-                  </button>
+                  </Button>
                 ))}
               </div>
             </div>
@@ -144,9 +149,10 @@ export default function SettingsPanel() {
               </div>
               <div className="flex gap-2">
                 {LOCAL_MODE_OPTIONS.map((opt) => (
-                  <button
+                  <Button
                     key={opt.label}
                     type="button"
+                    variant={settings.localMode === opt.value ? 'primary' : 'ghost'}
                     onClick={() => updateSettings({ localMode: opt.value })}
                     className={`rounded-md px-4 py-2 text-sm transition-colors ${
                       settings.localMode === opt.value
@@ -155,7 +161,7 @@ export default function SettingsPanel() {
                     }`}
                   >
                     {opt.label}
-                  </button>
+                  </Button>
                 ))}
               </div>
               <span className="text-xs text-fg-subtle">
@@ -189,13 +195,15 @@ export default function SettingsPanel() {
               <span className="text-sm text-fg-subtle">revnation.discourse.group</span>
             </div>
             <div className="pt-2 border-t border-edge">
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="sm"
                 onClick={resetSettings}
-                className="text-sm text-fg-subtle hover:text-fg-muted transition-colors"
+                className="h-auto p-0 text-sm text-fg-subtle hover:text-fg-muted transition-colors"
               >
                 Reset all settings to defaults
-              </button>
+              </Button>
             </div>
           </div>
         </Card>
@@ -254,53 +262,55 @@ function RemoteDaemonPairing() {
             <span className="text-sm text-fg-muted">
               Paired with <span className="text-fg">{pairedUrl}</span>
             </span>
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={handleForget}
-              className="text-sm text-fg-subtle hover:text-fg-muted transition-colors"
+              className="h-auto p-0 text-sm text-fg-subtle hover:text-fg-muted transition-colors"
             >
               Forget
-            </button>
+            </Button>
           </div>
         )}
         <div className="flex flex-col gap-1">
           <label htmlFor="daemon-pair-url" className="text-sm text-fg-muted">
             Daemon URL
           </label>
-          <input
+          <Input
             id="daemon-pair-url"
             type="text"
             placeholder="http://127.0.0.1:7890"
             value={daemonUrl}
             onChange={(e) => setDaemonUrlInput(e.target.value)}
-            className="rounded-md border border-edge bg-surface-2 px-3 py-2 text-sm text-fg-muted focus:border-edge focus:outline-none"
           />
         </div>
         <div className="flex flex-col gap-1">
           <label htmlFor="daemon-pair-secret" className="text-sm text-fg-muted">
             Pairing secret
           </label>
-          <input
+          <Input
             id="daemon-pair-secret"
             type="password"
             placeholder="contents of the daemon's gateway-pairing-secret file"
             value={secret}
             onChange={(e) => setSecret(e.target.value)}
-            className="rounded-md border border-edge bg-surface-2 px-3 py-2 text-sm text-fg-muted focus:border-edge focus:outline-none"
           />
           <span className="text-xs text-fg-subtle">
             Read from the 0600 secret file the daemon printed at boot. Never sent on the wire — used
             only to sign the pairing challenge locally.
           </span>
         </div>
-        <button
+        <Button
           type="button"
+          variant="primary"
           onClick={() => void handlePair()}
           disabled={status.kind === 'pairing'}
-          className="self-start rounded-md bg-brand px-4 py-2 text-sm text-on-brand transition-colors disabled:opacity-60"
+          loading={status.kind === 'pairing'}
+          className="self-start"
         >
           {status.kind === 'pairing' ? 'Pairing…' : 'Pair'}
-        </button>
+        </Button>
         {status.message && (
           <span className={`text-xs ${status.kind === 'error' ? 'text-error' : 'text-fg-subtle'}`}>
             {status.message}

--- a/apps/studio/src/components/sync/SyncPanel.tsx
+++ b/apps/studio/src/components/sync/SyncPanel.tsx
@@ -1,3 +1,4 @@
+import { IconRefresh } from '@revealui/presentation';
 import { useSync } from '../../hooks/use-sync';
 import Button from '../adapters/Button';
 import ErrorAlert from '../adapters/ErrorAlert';
@@ -42,16 +43,7 @@ export default function SyncPanel() {
       {results.length === 0 && !anySyncing && (
         <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
           <div className="flex size-10 items-center justify-center rounded-lg bg-surface-2">
-            <svg
-              className="size-5 text-fg-subtle"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-              strokeWidth={1.5}
-            >
-              <path d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182" />
-            </svg>
+            <IconRefresh size="md" className="text-fg-subtle" />
           </div>
           <p className="text-sm text-fg-subtle">
             Click "Sync All" to fetch and sync all registered repos.

--- a/apps/studio/src/components/terminal/ConnectForm.tsx
+++ b/apps/studio/src/components/terminal/ConnectForm.tsx
@@ -102,23 +102,26 @@ export default function ConnectForm({ onConnect, connecting }: ConnectFormProps)
                 key={b.id}
                 className="group flex items-center justify-between rounded-md border border-edge bg-surface-3 px-3 py-2"
               >
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   onClick={() => handleSelectBookmark(b)}
-                  className="flex-1 text-left"
+                  className="h-auto flex-1 justify-start p-0 text-left"
                 >
                   <span className="text-sm text-fg">{b.label}</span>
                   <span className="ml-2 text-xs text-fg-subtle">
                     :{b.port} ({b.auth_method})
                   </span>
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="sm"
                   onClick={() => setPendingDeleteBookmark(b)}
-                  className="ml-2 text-xs text-fg-subtle opacity-0 transition-opacity hover:text-error group-hover:opacity-100"
+                  className="ml-2 h-auto p-0 text-xs text-fg-subtle opacity-0 transition-opacity hover:text-error group-hover:opacity-100"
                 >
                   remove
-                </button>
+                </Button>
               </div>
             ))}
           </div>
@@ -173,8 +176,10 @@ export default function ConnectForm({ onConnect, connecting }: ConnectFormProps)
           <div>
             <span className="mb-2 block text-xs font-medium text-fg-muted">Authentication</span>
             <div className="flex gap-1 rounded-md border border-edge bg-surface-2 p-1">
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="sm"
                 onClick={() => setAuthMethod('key')}
                 className={`flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors ${
                   authMethod === 'key'
@@ -183,9 +188,11 @@ export default function ConnectForm({ onConnect, connecting }: ConnectFormProps)
                 }`}
               >
                 SSH Key
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                variant="ghost"
+                size="sm"
                 onClick={() => setAuthMethod('password')}
                 className={`flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors ${
                   authMethod === 'password'
@@ -194,7 +201,7 @@ export default function ConnectForm({ onConnect, connecting }: ConnectFormProps)
                 }`}
               >
                 Password
-              </button>
+              </Button>
             </div>
           </div>
 

--- a/apps/studio/src/components/terminal/TerminalPanel.tsx
+++ b/apps/studio/src/components/terminal/TerminalPanel.tsx
@@ -43,15 +43,17 @@ function TabButton({
   children: React.ReactNode;
 }) {
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
+      size="sm"
       onClick={onClick}
       className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
         active ? 'bg-surface-2 text-fg' : 'text-fg-muted hover:bg-surface-1 hover:text-fg'
       }`}
     >
       {children}
-    </button>
+    </Button>
   );
 }
 

--- a/apps/studio/src/components/vault/CreateSecretDialog.tsx
+++ b/apps/studio/src/components/vault/CreateSecretDialog.tsx
@@ -1,3 +1,4 @@
+import { Textarea } from '@revealui/presentation';
 import { useState } from 'react';
 import Button from '../adapters/Button';
 import ErrorAlert from '../adapters/ErrorAlert';
@@ -71,13 +72,13 @@ export default function CreateSecretDialog({ onConfirm, onClose }: CreateSecretD
           <label htmlFor="secret-value" className="mb-1 block text-xs font-medium text-fg-muted">
             Value
           </label>
-          <textarea
+          <Textarea
             id="secret-value"
             value={value}
             onChange={(e) => setValue(e.target.value)}
             placeholder="Secret value..."
             rows={3}
-            className="w-full resize-none rounded-md border border-edge bg-surface-2 px-3 py-2 font-mono text-sm text-fg placeholder:text-fg-subtle focus:border-brand focus:outline-none"
+            className="[&_textarea]:font-mono"
           />
         </div>
       </form>

--- a/apps/studio/src/components/vault/NamespaceFilter.tsx
+++ b/apps/studio/src/components/vault/NamespaceFilter.tsx
@@ -1,3 +1,5 @@
+import Button from '../adapters/Button';
+
 interface NamespaceFilterProps {
   namespaces: string[];
   active: string | null;
@@ -10,30 +12,28 @@ export default function NamespaceFilter({ namespaces, active, onChange }: Namesp
       <p className="mb-1 px-2 text-xs font-medium uppercase tracking-wider text-fg-subtle">
         Namespaces
       </p>
-      <button
+      <Button
         type="button"
+        variant="ghost"
         onClick={() => onChange(null)}
-        className={`rounded px-2 py-1.5 text-left text-sm transition-colors ${
-          active === null
-            ? 'bg-surface-2 text-fg'
-            : 'text-fg-muted hover:bg-surface-3 hover:text-fg'
+        className={`justify-start rounded px-2 py-1.5 text-left text-sm ${
+          active === null ? 'bg-surface-2 text-fg' : 'text-fg-muted'
         }`}
       >
         All
-      </button>
+      </Button>
       {namespaces.map((ns) => (
-        <button
+        <Button
           key={ns}
           type="button"
+          variant="ghost"
           onClick={() => onChange(ns)}
-          className={`rounded px-2 py-1.5 text-left text-sm transition-colors ${
-            active === ns
-              ? 'bg-surface-2 text-fg'
-              : 'text-fg-muted hover:bg-surface-3 hover:text-fg'
+          className={`justify-start rounded px-2 py-1.5 text-left text-sm ${
+            active === ns ? 'bg-surface-2 text-fg' : 'text-fg-muted'
           }`}
         >
           {ns}
-        </button>
+        </Button>
       ))}
       {namespaces.length === 0 && <p className="px-2 py-1 text-xs text-fg-subtle">No namespaces</p>}
     </div>

--- a/apps/studio/src/components/vault/SearchBar.tsx
+++ b/apps/studio/src/components/vault/SearchBar.tsx
@@ -1,3 +1,6 @@
+import { IconSearch } from '@revealui/presentation';
+import Input from '../adapters/Input';
+
 interface SearchBarProps {
   query: string;
   onChange: (query: string) => void;
@@ -6,23 +9,16 @@ interface SearchBarProps {
 export default function SearchBar({ query, onChange }: SearchBarProps) {
   return (
     <div className="relative">
-      <svg
-        className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-fg-subtle"
-        aria-hidden="true"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <circle cx="11" cy="11" r="8" />
-        <path d="m21 21-4.35-4.35" />
-      </svg>
-      <input
+      <IconSearch
+        size="sm"
+        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-fg-subtle"
+      />
+      <Input
         type="search"
         value={query}
         onChange={(e) => onChange(e.target.value)}
         placeholder="Search secrets..."
-        className="w-full rounded-md border border-edge bg-surface-2 py-2 pl-9 pr-4 text-sm text-fg placeholder:text-fg-subtle focus:border-brand focus:outline-none"
+        className="pl-9"
       />
     </div>
   );

--- a/apps/studio/src/components/vault/SecretList.tsx
+++ b/apps/studio/src/components/vault/SecretList.tsx
@@ -1,5 +1,7 @@
+import { IconTrash } from '@revealui/presentation';
 import { useState } from 'react';
 import type { SecretInfo } from '../../types';
+import Button from '../adapters/Button';
 import ConfirmDialog from '../adapters/ConfirmDialog';
 
 interface SecretListProps {
@@ -34,16 +36,21 @@ export default function SecretList({ secrets, selectedPath, onSelect, onDelete }
                 : 'text-fg-muted hover:bg-surface-3 hover:text-fg'
             }`}
           >
-            <button
+            <Button
               type="button"
-              className="flex-1 text-left"
+              variant="ghost"
+              className="h-auto flex-1 justify-start p-0 text-left"
               onClick={() => onSelect(secret.path)}
             >
-              <p className="truncate text-sm font-medium">{secret.path.split('/').pop()}</p>
-              <p className="truncate text-xs text-fg-subtle">{secret.path}</p>
-            </button>
-            <button
+              <span className="block w-full">
+                <p className="truncate text-sm font-medium">{secret.path.split('/').pop()}</p>
+                <p className="truncate text-xs text-fg-subtle">{secret.path}</p>
+              </span>
+            </Button>
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={(e) => {
                 e.stopPropagation();
                 setPendingDelete(secret.path);
@@ -51,17 +58,8 @@ export default function SecretList({ secrets, selectedPath, onSelect, onDelete }
               className="ml-2 hidden rounded p-1 text-fg-subtle transition-colors hover:bg-error-subtle hover:text-error group-hover:flex"
               aria-label={`Delete ${secret.path}`}
             >
-              <svg
-                className="size-3.5"
-                aria-hidden="true"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
-              </svg>
-            </button>
+              <IconTrash size="sm" className="size-3.5" />
+            </Button>
           </div>
         ))}
       </div>

--- a/apps/studio/src/components/vault/VaultPanel.tsx
+++ b/apps/studio/src/components/vault/VaultPanel.tsx
@@ -1,3 +1,4 @@
+import { IconLock, IconPlus } from '@revealui/presentation';
 import { useState } from 'react';
 import { useVault } from '../../hooks/use-vault';
 import Button from '../adapters/Button';
@@ -38,17 +39,7 @@ export default function VaultPanel() {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-4">
         <div className="flex size-12 items-center justify-center rounded-xl bg-surface-2">
-          <svg
-            className="size-6 text-fg-muted"
-            aria-hidden="true"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
-            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-          </svg>
+          <IconLock size="lg" className="text-fg-muted" />
         </div>
         <div className="text-center">
           <h3 className="text-base font-semibold text-fg">Vault not initialized</h3>
@@ -72,16 +63,7 @@ export default function VaultPanel() {
           <SearchBar query={searchQuery} onChange={setSearchQuery} />
         </div>
         <Button variant="primary" onClick={() => setShowCreate(true)}>
-          <svg
-            className="mr-1.5 size-4"
-            aria-hidden="true"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path d="M12 5v14M5 12h14" />
-          </svg>
+          <IconPlus size="sm" className="mr-1.5" />
           New Secret
         </Button>
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,8 +77,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@revealui/presentation':
-        specifier: ^0.12.1
-        version: 0.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
+        specifier: ^0.13.1
+        version: 0.13.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
       '@tauri-apps/api':
         specifier: ^2.11.1
         version: 2.11.1
@@ -1013,16 +1013,6 @@ packages:
       drizzle-zod:
         optional: true
 
-  '@revealui/contracts@0.8.1':
-    resolution: {integrity: sha512-bQY4HFibIsffTty6OxEclnueqWxk5q70d/m9mtNC3a5vdjMh7K3V4XADnvDNqayrzG6fYLkjz4Eq98ccDuYk0Q==}
-    engines: {node: '>=24.13.0'}
-    peerDependencies:
-      drizzle-zod: ^0.8.3
-      typescript: 7.0.2
-    peerDependenciesMeta:
-      drizzle-zod:
-        optional: true
-
   '@revealui/contracts@0.8.2':
     resolution: {integrity: sha512-RGtpvsSs060i+KWhaU84FVQUi/nQ08zjVQWhHtLQhypZmHYv8owHRq05RppJRPSDqnO+Ouc3Gt7JWPTHK7+RiA==}
     engines: {node: '>=24.13.0'}
@@ -1066,8 +1056,8 @@ packages:
     engines: {node: '>=24.13.0'}
     hasBin: true
 
-  '@revealui/presentation@0.12.1':
-    resolution: {integrity: sha512-bHzMaetE7VjF/Jp5g+7/NMTrUomUm4bYw1J0FbFys1a5KGMijArx+dAv4qP8rzkl8QC1XBNj+7U68E6Jtiz/aw==}
+  '@revealui/presentation@0.13.1':
+    resolution: {integrity: sha512-ToFzalCnB5t0JAEfgb9HQn6yAx1UHUIp0bP5lKK9BR2hTm31r/RoFXHOlEhaMblQ1EkLfshulUqVhJLyU7wSRA==}
     engines: {node: '>=24.13.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -1085,8 +1075,8 @@ packages:
     resolution: {integrity: sha512-LJQGOD494561KG/ItymvYLGGfqc2RM/m0hgNkDlzZvr7oVWIND4It7oWr7yH41bJYrzjolievTP7npZFBtPKcQ==}
     engines: {node: '>=24.13.0'}
 
-  '@revealui/tokens@0.3.0':
-    resolution: {integrity: sha512-ETlCSoEdJXXieWowcnZE577MpFcED8KSUPvGhgBfK7GThuH7QFtAmq0nvD2jEAf0uvP1v+iraCTUmtSH/ZEDYQ==}
+  '@revealui/tokens@0.3.2':
+    resolution: {integrity: sha512-rGfDmcBxJlYvCuHvpcakFfZUkrzIiR6Bx/hsphFRXQl5l2ghPxZlXywzPfW/mbTE3jTiH0ybn6AlHKlgxKvTXQ==}
     engines: {node: '>=24.13.0'}
 
   '@revealui/utils@0.3.5':
@@ -4034,16 +4024,10 @@ snapshots:
       typescript: 7.0.2
       zod: 4.4.3
 
-  '@revealui/contracts@0.8.1(typescript@7.0.2)':
-    dependencies:
-      typescript: 7.0.2
-      zod: 4.4.3
-
   '@revealui/contracts@0.8.2(typescript@7.0.2)':
     dependencies:
       typescript: 7.0.2
       zod: 4.4.3
-    optional: true
 
   '@revealui/contracts@1.4.0(typescript@7.0.2)':
     dependencies:
@@ -4197,10 +4181,10 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@revealui/presentation@0.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)':
+  '@revealui/presentation@0.13.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)':
     dependencies:
-      '@revealui/contracts': 0.8.1(typescript@7.0.2)
-      '@revealui/tokens': 0.3.0
+      '@revealui/contracts': 0.8.2(typescript@7.0.2)
+      '@revealui/tokens': 0.3.2
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       tailwind-merge: 3.6.0
@@ -4231,7 +4215,7 @@ snapshots:
       - typescript
     optional: true
 
-  '@revealui/tokens@0.3.0': {}
+  '@revealui/tokens@0.3.2': {}
 
   '@revealui/utils@0.3.5':
     dependencies:


### PR DESCRIPTION
## Summary
Burns Studio interactive Tier-1 hosts (button, input, select, textarea) onto existing adapters and `@revealui/presentation`. 194 → 21 remaining hits, all custom path SVGs (tile glyphs, six nav icons, two git/agent icons, file glyph).

Bumps `@revealui/presentation` to ^0.13.1.

## Test plan
- [x] `pnpm --filter studio exec vitest run src/__tests__/components` — 45 files, 356 passed
- [x] shared AST gate: 0 remaining button/input/select/textarea
- [ ] full `pnpm --filter studio test` includes pre-existing `invoke.test.ts` failure without `@revdev/protocol` dist in a fresh worktree