### PR TITLE
feat(daemon): skills.list read-only catalog RPC

### DIFF
--- a/packages/daemon/src/__tests__/skill-catalog.test.ts
+++ b/packages/daemon/src/__tests__/skill-catalog.test.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { listSkillCatalog, skimSkillFrontmatter } from '../skill-catalog.js';
+
+describe('daemon skill catalog (GAP-293 Phase B)', () => {
+  it('skims frontmatter only', () => {
+    const fields = skimSkillFrontmatter(`---
+name: Listed
+description: 'Read only'
+---
+# must not run
+`);
+    expect(fields).toEqual({ name: 'Listed', description: 'Read only' });
+  });
+
+  it('lists content and revskills; content wins on id', () => {
+    const project = mkdtempSync(join(tmpdir(), 'revdev-sk-proj-'));
+    const revskills = mkdtempSync(join(tmpdir(), 'revdev-sk-rs-'));
+    const contentDir = join(project, '.revealui/content/skills/shared');
+    const rsDir = join(revskills, 'skills/shared');
+    const otherDir = join(revskills, 'skills/only-rs');
+    mkdirSync(contentDir, { recursive: true });
+    mkdirSync(rsDir, { recursive: true });
+    mkdirSync(otherDir, { recursive: true });
+    writeFileSync(
+      join(contentDir, 'SKILL.md'),
+      `---
+name: From content
+description: Project tree
+---
+`,
+    );
+    writeFileSync(
+      join(rsDir, 'SKILL.md'),
+      `---
+name: From revskills
+description: Should lose
+---
+`,
+    );
+    writeFileSync(
+      join(otherDir, 'SKILL.md'),
+      `---
+name: Only revskills
+description: Kept
+---
+`,
+    );
+
+    const list = listSkillCatalog({ projectRoot: project, revskillsRoot: revskills });
+    expect(list.map((s) => s.id).sort()).toEqual(['only-rs', 'shared']);
+    const shared = list.find((s) => s.id === 'shared');
+    expect(shared?.source).toBe('content');
+    expect(shared?.name).toBe('From content');
+    expect(list.find((s) => s.id === 'only-rs')?.source).toBe('revskills');
+  });
+
+  it('returns empty when trees are missing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'revdev-sk-empty-'));
+    expect(listSkillCatalog({ projectRoot: root, revskillsRoot: join(root, 'nope') })).toEqual([]);
+  });
+});

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -41,6 +41,7 @@ import './spawn.js';
 import './gateway-rpc.js';
 // GAP-474 — workflow.list / workflow.run (same registry as Studio /ops).
 import './workflow-rpc.js';
+import './skills-rpc.js';
 import { DAEMON_DEFAULTS } from './config.js';
 import { LICENSE_TIER_HELP, LicenseConfigError, LicenseExpiredError } from './license.js';
 import { startDaemon } from './server.js';

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -73,6 +73,7 @@ import './spawn.js';
 import './gateway-rpc.js';
 // GAP-474 — workflow.list / workflow.run over operational-workflow registry
 import './workflow-rpc.js';
+import './skills-rpc.js';
 // GAP-323 — design-pack watch (design.pack.* + auto-watch on start)
 import './design-pack-watch.js';
 

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -128,6 +128,8 @@ const EXEMPT_METHODS = new Set([
   // GAP-474: local operational workflows (same class as /ops; Studio daily driver)
   'workflow.list',
   'workflow.run',
+  // GAP-293 Phase B: catalog read is a daily-driver inspect (no execution)
+  'skills.list',
   // GAP-323: design-pack advisory (native pair of GAP-322 SessionStart warn).
   // Free-tier daily-driver surface — no multi-agent coordination required.
   'design.pack.status',

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -152,6 +152,7 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   // GAP-474 — list is routine; run may trigger gated cleanup with fix:true
   ['workflow.list', 'routine'],
   ['workflow.run', 'consequential'],
+  ['skills.list', 'routine'],
 ]);
 
 /** Fail closed: unmapped method is critical (spec §5 / I2). */

--- a/packages/daemon/src/skill-catalog.ts
+++ b/packages/daemon/src/skill-catalog.ts
@@ -1,0 +1,120 @@
+/**
+ * GAP-293 Phase B — disk skill catalog (name / path / description).
+ *
+ * Lockstep with `@revealui/harnesses` `listSkillCatalog` disk walk. Daemon
+ * stays free of a harnesses compile dependency (separate repo). Definitions
+ * appear once content is materialized under `.revealui/content/skills`.
+ * Never executes SKILL.md.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export type SkillCatalogSource = 'content' | 'revskills';
+
+export interface SkillCatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+  source: SkillCatalogSource;
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'ENOENT'
+  );
+}
+
+function unquote(raw: string): string {
+  if (raw.length >= 2) {
+    const a = raw[0];
+    const b = raw[raw.length - 1];
+    if ((a === '"' && b === '"') || (a === "'" && b === "'")) {
+      return raw.slice(1, -1);
+    }
+  }
+  return raw;
+}
+
+export function skimSkillFrontmatter(text: string): { name: string; description: string } {
+  const lines = text.split('\n');
+  let inFm = false;
+  let name = '';
+  let description = '';
+  for (const line of lines) {
+    if (line === '---') {
+      if (!inFm) {
+        inFm = true;
+        continue;
+      }
+      break;
+    }
+    if (!inFm) break;
+    if (line.startsWith('name:')) name = unquote(line.slice(5).trim());
+    else if (line.startsWith('description:')) description = unquote(line.slice(12).trim());
+  }
+  return { name, description };
+}
+
+function readSkillFile(filePath: string): string | null {
+  try {
+    return readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    if (isEnoent(err)) return null;
+    throw err;
+  }
+}
+
+function listSkillDir(skillsDir: string, source: SkillCatalogSource): SkillCatalogEntry[] {
+  let names: string[];
+  try {
+    names = readdirSync(skillsDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch (err) {
+    if (isEnoent(err)) return [];
+    throw err;
+  }
+  const out: SkillCatalogEntry[] = [];
+  for (const id of names) {
+    const path = join(skillsDir, id, 'SKILL.md');
+    const text = readSkillFile(path);
+    if (text === null) continue;
+    const fields = skimSkillFrontmatter(text);
+    out.push({
+      id,
+      name: fields.name || id,
+      description: fields.description,
+      path,
+      source,
+    });
+  }
+  return out;
+}
+
+export interface ListSkillCatalogOptions {
+  projectRoot?: string;
+  revskillsRoot?: string;
+}
+
+/** Content tree wins over revskills for the same id. */
+export function listSkillCatalog(options: ListSkillCatalogOptions = {}): SkillCatalogEntry[] {
+  const byId = new Map<string, SkillCatalogEntry>();
+  if (options.revskillsRoot) {
+    for (const entry of listSkillDir(join(options.revskillsRoot, 'skills'), 'revskills')) {
+      byId.set(entry.id, entry);
+    }
+  }
+  if (options.projectRoot) {
+    const contentDir = join(options.projectRoot, '.revealui', 'content', 'skills');
+    for (const entry of listSkillDir(contentDir, 'content')) {
+      byId.set(entry.id, entry);
+    }
+  }
+  return [...byId.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}

--- a/packages/daemon/src/skills-rpc.ts
+++ b/packages/daemon/src/skills-rpc.ts
@@ -1,0 +1,44 @@
+/**
+ * GAP-293 Phase B — skills.list
+ *
+ * Read-only catalog of SKILL.md trees RevDev should see (project
+ * `.revealui/content/skills` + optional revskills root). No execution.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { registerHandler } from './server.js';
+import { listSkillCatalog } from './skill-catalog.js';
+
+function asDir(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.length > 0) return value;
+  return undefined;
+}
+
+export function resolveSkillRoots(params: Record<string, unknown> | undefined): {
+  projectRoot: string;
+  revskillsRoot: string | undefined;
+} {
+  const projectRoot =
+    asDir(params?.projectRoot) ??
+    (process.env.REVDEV_PROJECT_ROOT && process.env.REVDEV_PROJECT_ROOT.length > 0
+      ? process.env.REVDEV_PROJECT_ROOT
+      : process.cwd());
+  const fromParam = asDir(params?.revskillsRoot);
+  const fromEnv =
+    process.env.REVDEV_REVSKILLS_ROOT && process.env.REVDEV_REVSKILLS_ROOT.length > 0
+      ? process.env.REVDEV_REVSKILLS_ROOT
+      : undefined;
+  const revskillsRoot = fromParam ?? fromEnv ?? join(homedir(), 'revfleet', 'revskills');
+  return { projectRoot, revskillsRoot };
+}
+
+registerHandler('skills.list', async (params) => {
+  const roots = resolveSkillRoots(params);
+  return {
+    skills: listSkillCatalog({
+      projectRoot: roots.projectRoot,
+      revskillsRoot: roots.revskillsRoot,
+    }),
+  };
+});

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -167,4 +167,7 @@ export const RPC_METHODS = {
   // GAP-474 — operational workflows (registry under REVDEV_JV_ROOT / workflows)
   'workflow.list': 'workflow.list',
   'workflow.run': 'workflow.run',
+
+  // GAP-293 Phase B — read-only skill catalog (no execution)
+  'skills.list': 'skills.list',
 } as const;


### PR DESCRIPTION
## Summary

GAP-293 Phase B. JSON-RPC \`skills.list\` returns name, path, description, source from \`.revealui/content/skills\` and an optional revskills tree. No execution.

- routine + license-exempt (same class as \`workflow.list\`)
- Roots: \`projectRoot\` / \`REVDEV_PROJECT_ROOT\`, \`revskillsRoot\` / \`REVDEV_REVSKILLS_ROOT\`

Companion: revealui \`listSkillCatalog\` + \`revealui-harnesses skills list\`.

## Test plan

- [x] daemon skill-catalog + permission + rpc-contract + protocol methods tests