### PR TITLE
feat(daemon): skills.invoke on product default snap

### DIFF
--- a/packages/daemon/src/__tests__/skill-invoke.test.ts
+++ b/packages/daemon/src/__tests__/skill-invoke.test.ts
@@ -1,0 +1,26 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { PHASE_C_INFERENCE_SNAP, prepareInvoke } from '../skill-invoke.js';
+
+describe('prepareInvoke (GAP-293 Phase C)', () => {
+  it('rejects unknown skills', () => {
+    const result = prepareInvoke('preflight', []);
+    expect('error' in result).toBe(true);
+  });
+
+  it('uses product default snap and forbids tool claims', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'inv-'));
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, 'SKILL.md');
+    writeFileSync(path, '---\nname: Doc\ndescription: d\n---\n# doctor\n');
+    const result = prepareInvoke('doctor', [
+      { id: 'revealui-doctor', name: 'Doc', description: 'd', path, source: 'revskills' },
+    ]);
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.model).toBe(PHASE_C_INFERENCE_SNAP);
+    expect(result.user).toContain('cannot execute tools');
+  });
+});

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -130,6 +130,7 @@ const EXEMPT_METHODS = new Set([
   'workflow.run',
   // GAP-293 Phase B: catalog read is a daily-driver inspect (no execution)
   'skills.list',
+  'skills.invoke',
   // GAP-323: design-pack advisory (native pair of GAP-322 SessionStart warn).
   // Free-tier daily-driver surface — no multi-agent coordination required.
   'design.pack.status',

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -153,6 +153,7 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['workflow.list', 'routine'],
   ['workflow.run', 'consequential'],
   ['skills.list', 'routine'],
+  ['skills.invoke', 'routine'],
 ]);
 
 /** Fail closed: unmapped method is critical (spec §5 / I2). */

--- a/packages/daemon/src/skill-invoke.ts
+++ b/packages/daemon/src/skill-invoke.ts
@@ -1,0 +1,72 @@
+/**
+ * GAP-293 Phase C — native workflow allowlist + prompt bind.
+ * Snap: product default `nemotron-3-nano` (US-origin catalog SSOT).
+ */
+
+import { readFileSync } from 'node:fs';
+import type { SkillCatalogEntry } from './skill-catalog.js';
+
+export const NATIVE_WORKFLOW_SKILL_IDS = [
+  'revealui-doctor',
+  'revealui-recover',
+  'revealui-checkpoint',
+] as const;
+
+export const PHASE_C_INFERENCE_SNAP = 'nemotron-3-nano';
+
+const ALIASES: Record<string, (typeof NATIVE_WORKFLOW_SKILL_IDS)[number]> = {
+  doctor: 'revealui-doctor',
+  recover: 'revealui-recover',
+  checkpoint: 'revealui-checkpoint',
+};
+
+export function resolveNativeWorkflowSkillId(
+  raw: string,
+): (typeof NATIVE_WORKFLOW_SKILL_IDS)[number] | null {
+  const key = raw.trim();
+  if (key in ALIASES) return ALIASES[key] ?? null;
+  for (const id of NATIVE_WORKFLOW_SKILL_IDS) {
+    if (id === key) return id;
+  }
+  return null;
+}
+
+export function prepareInvoke(
+  skillId: string,
+  catalog: SkillCatalogEntry[],
+):
+  | { skillId: string; model: string; path: string; system: string; user: string }
+  | { error: string } {
+  const resolved = resolveNativeWorkflowSkillId(skillId);
+  if (!resolved) {
+    return {
+      error: `skills.invoke allowlist is ${NATIVE_WORKFLOW_SKILL_IDS.join(', ')} (or doctor/recover/checkpoint). Got: ${skillId}`,
+    };
+  }
+  const entry = catalog.find((s) => s.id === resolved);
+  if (!entry) {
+    return {
+      error: `skill ${resolved} is not in the catalog (materialize content or set REVDEV_REVSKILLS_ROOT)`,
+    };
+  }
+  let body: string;
+  try {
+    body = readFileSync(entry.path, 'utf-8');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { error: `cannot read ${entry.path}: ${msg}` };
+  }
+  return {
+    skillId: resolved,
+    model: PHASE_C_INFERENCE_SNAP,
+    path: entry.path,
+    system: body,
+    user: [
+      `Run the ${resolved} workflow as a RevDev-native pass.`,
+      `Local model is the product default Inference Snap: ${PHASE_C_INFERENCE_SNAP}.`,
+      'You cannot execute tools or git commits from this invoke.',
+      'Produce the structured report the skill specifies.',
+      'Name any command you would have run; do not claim you ran it.',
+    ].join(' '),
+  };
+}

--- a/packages/daemon/src/skills-rpc.ts
+++ b/packages/daemon/src/skills-rpc.ts
@@ -9,6 +9,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { registerHandler } from './server.js';
 import { listSkillCatalog } from './skill-catalog.js';
+import { PHASE_C_INFERENCE_SNAP, prepareInvoke } from './skill-invoke.js';
 
 function asDir(value: unknown): string | undefined {
   if (typeof value === 'string' && value.length > 0) return value;
@@ -41,4 +42,68 @@ registerHandler('skills.list', async (params) => {
       revskillsRoot: roots.revskillsRoot,
     }),
   };
+});
+
+const SNAPS_BASE = process.env.INFERENCE_SNAPS_BASE_URL ?? 'http://localhost:9090/v1';
+const INVOKE_TIMEOUT_MS = 120_000;
+
+function asBool(value: unknown): boolean {
+  return value === true;
+}
+
+registerHandler('skills.invoke', async (params) => {
+  const skillId = typeof params?.skillId === 'string' ? params.skillId : '';
+  const dryRun = asBool(params?.dryRun);
+  const roots = resolveSkillRoots(params);
+  const catalog = listSkillCatalog({
+    projectRoot: roots.projectRoot,
+    revskillsRoot: roots.revskillsRoot,
+  });
+  const prepared = prepareInvoke(skillId, catalog);
+  if ('error' in prepared) {
+    return { error: prepared.error, model: PHASE_C_INFERENCE_SNAP };
+  }
+  if (dryRun) {
+    return { ...prepared, dryRun: true, ran: false };
+  }
+  try {
+    const res = await fetch(`${SNAPS_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      signal: AbortSignal.timeout(INVOKE_TIMEOUT_MS),
+      body: JSON.stringify({
+        model: PHASE_C_INFERENCE_SNAP,
+        messages: [
+          { role: 'system', content: prepared.system },
+          { role: 'user', content: prepared.user },
+        ],
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      return {
+        error: `Inference Snap ${PHASE_C_INFERENCE_SNAP} failed (${res.status}): ${text}`,
+        model: PHASE_C_INFERENCE_SNAP,
+        hint: `Install/start: sudo snap install ${PHASE_C_INFERENCE_SNAP} && check ${SNAPS_BASE}`,
+      };
+    }
+    const payload = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const text = payload.choices?.[0]?.message?.content ?? '';
+    return {
+      skillId: prepared.skillId,
+      model: PHASE_C_INFERENCE_SNAP,
+      text,
+      ran: true,
+      toolsExecuted: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      error: `Cannot reach Inference Snaps at ${SNAPS_BASE}: ${msg}`,
+      model: PHASE_C_INFERENCE_SNAP,
+      hint: `sudo snap install ${PHASE_C_INFERENCE_SNAP}`,
+    };
+  }
 });

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -170,4 +170,6 @@ export const RPC_METHODS = {
 
   // GAP-293 Phase B — read-only skill catalog (no execution)
   'skills.list': 'skills.list',
+  // GAP-293 Phase C — native workflow generate on product default snap
+  'skills.invoke': 'skills.invoke',
 } as const;


### PR DESCRIPTION
## Summary

GAP-293 Phase C first slice. Snap is the existing product default \`nemotron-3-nano\` (US-origin catalog), not a new name.

- \`skills.invoke\` allowlists doctor / recover / checkpoint
- Single generate against Inference Snaps (\`:9090\`)
- **No tools, no git commits**
- \`dryRun: true\` returns the prompt without calling the snap

## Test plan

- [x] skill-invoke + catalog + rpc-contract + permission tests