### PR TITLE
feat(daemon): complete skills.invoke text and timeout

### DIFF
--- a/packages/daemon/src/__tests__/skill-invoke.test.ts
+++ b/packages/daemon/src/__tests__/skill-invoke.test.ts
@@ -2,7 +2,14 @@ import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { PHASE_C_INFERENCE_SNAP, prepareInvoke } from '../skill-invoke.js';
+import {
+  classifySkillInvokeFailure,
+  extractSkillInvokeText,
+  PHASE_C_INFERENCE_SNAP,
+  prepareInvoke,
+  skillInvokeTimeoutMs,
+  SKILL_INVOKE_MIN_TIMEOUT_MS,
+} from '../skill-invoke.js';
 
 describe('prepareInvoke (GAP-293 Phase C)', () => {
   it('rejects unknown skills', () => {
@@ -22,5 +29,28 @@ describe('prepareInvoke (GAP-293 Phase C)', () => {
     if ('error' in result) return;
     expect(result.model).toBe(PHASE_C_INFERENCE_SNAP);
     expect(result.user).toContain('cannot execute tools');
+  });
+
+  it('reads reasoning_content when content is empty', () => {
+    expect(
+      extractSkillInvokeText({
+        choices: [{ message: { content: '', reasoning_content: 'traffic-light report' } }],
+      }),
+    ).toBe('traffic-light report');
+  });
+
+  it('does not use the 120s invoke cap for a doctor-sized prompt', () => {
+    const timeout = skillInvokeTimeoutMs('# doctor\n'.repeat(400), 'run doctor');
+    expect(timeout).toBeGreaterThan(120_000);
+    expect(timeout).toBeGreaterThanOrEqual(SKILL_INVOKE_MIN_TIMEOUT_MS);
+  });
+
+  it('classifies abort-as-timeout separately from connect failure', () => {
+    const abort = new Error('The operation was aborted due to timeout');
+    abort.name = 'AbortError';
+    expect(classifySkillInvokeFailure(abort)).toBe('timeout');
+    expect(classifySkillInvokeFailure(new Error('connect ECONNREFUSED 127.0.0.1:9090'))).toBe(
+      'connect',
+    );
   });
 });

--- a/packages/daemon/src/__tests__/skill-invoke.test.ts
+++ b/packages/daemon/src/__tests__/skill-invoke.test.ts
@@ -7,8 +7,8 @@ import {
   extractSkillInvokeText,
   PHASE_C_INFERENCE_SNAP,
   prepareInvoke,
-  skillInvokeTimeoutMs,
   SKILL_INVOKE_MIN_TIMEOUT_MS,
+  skillInvokeTimeoutMs,
 } from '../skill-invoke.js';
 
 describe('prepareInvoke (GAP-293 Phase C)', () => {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -91,6 +91,8 @@ Environment:
   REVDEV_DAEMON_SHUTDOWN_GRACE_MS  Max wait for in-flight handlers during close() (default: ${DAEMON_DEFAULTS.shutdownGracePeriodMs} ms = ${DAEMON_DEFAULTS.shutdownGracePeriodMs / 1000} s)
   REVDEV_PERMISSION_MODE       GAP-294 mode: shadow (default) | manual | auto | agent-scoped
                                shadow = would_* events only (no block). Flip only after soak review.
+  REVDEV_SKILLS_INVOKE_TIMEOUT_MS  Override skills.invoke wall-clock (default: prompt-sized, min 300s)
+  INFERENCE_SNAPS_BASE_URL     OpenAI-compat snap base (default: http://localhost:9090/v1)
 
 ${LICENSE_TIER_HELP}
 `);

--- a/packages/daemon/src/skill-invoke.ts
+++ b/packages/daemon/src/skill-invoke.ts
@@ -70,3 +70,56 @@ export function prepareInvoke(
     ].join(' '),
   };
 }
+
+/** OpenAI-compat text. nemotron-3-nano fills reasoning_content, not content. */
+export function extractSkillInvokeText(payload: unknown): string {
+  if (!payload || typeof payload !== 'object') return '';
+  const choices = (payload as { choices?: unknown }).choices;
+  if (!Array.isArray(choices) || choices.length === 0) return '';
+  const first = choices[0];
+  if (!first || typeof first !== 'object') return '';
+  const message = (first as { message?: unknown }).message;
+  if (!message || typeof message !== 'object') return '';
+  const rec = message as { content?: unknown; reasoning_content?: unknown };
+  const content = typeof rec.content === 'string' ? rec.content.trim() : '';
+  if (content.length > 0) return rec.content as string;
+  const reasoning = typeof rec.reasoning_content === 'string' ? rec.reasoning_content.trim() : '';
+  if (reasoning.length > 0) return rec.reasoning_content as string;
+  return '';
+}
+
+export const SKILL_INVOKE_MS_PER_PROMPT_TOKEN = 1_200;
+export const SKILL_INVOKE_DECODE_BUDGET_MS = 180_000;
+export const SKILL_INVOKE_MIN_TIMEOUT_MS = 300_000;
+export const SKILL_INVOKE_MAX_TIMEOUT_MS = 14_400_000;
+
+export function parseSkillInvokeTimeoutOverride(raw: string | undefined): number | null {
+  if (!raw || raw.trim().length === 0) return null;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+export function skillInvokeTimeoutMs(
+  system: string,
+  user: string,
+  overrideMs?: number | null,
+): number {
+  if (overrideMs !== undefined && overrideMs !== null && overrideMs > 0) return overrideMs;
+  const approxTokens = Math.max(1, Math.ceil((system.length + user.length) / 4));
+  const sized = approxTokens * SKILL_INVOKE_MS_PER_PROMPT_TOKEN + SKILL_INVOKE_DECODE_BUDGET_MS;
+  return Math.min(SKILL_INVOKE_MAX_TIMEOUT_MS, Math.max(SKILL_INVOKE_MIN_TIMEOUT_MS, sized));
+}
+
+export type SkillInvokeFailureKind = 'timeout' | 'connect' | 'other';
+
+export function classifySkillInvokeFailure(err: unknown): SkillInvokeFailureKind {
+  if (!(err instanceof Error)) return 'other';
+  if (err.name === 'TimeoutError' || err.name === 'AbortError') return 'timeout';
+  const msg = err.message;
+  if (/aborted due to timeout|The operation was aborted/i.test(msg)) return 'timeout';
+  if (/ECONNREFUSED|ENOTFOUND|ECONNRESET|fetch failed|Failed to parse URL/i.test(msg)) {
+    return 'connect';
+  }
+  return 'other';
+}

--- a/packages/daemon/src/skills-rpc.ts
+++ b/packages/daemon/src/skills-rpc.ts
@@ -12,8 +12,8 @@ import { listSkillCatalog } from './skill-catalog.js';
 import {
   classifySkillInvokeFailure,
   extractSkillInvokeText,
-  parseSkillInvokeTimeoutOverride,
   PHASE_C_INFERENCE_SNAP,
+  parseSkillInvokeTimeoutOverride,
   prepareInvoke,
   skillInvokeTimeoutMs,
 } from './skill-invoke.js';

--- a/packages/daemon/src/skills-rpc.ts
+++ b/packages/daemon/src/skills-rpc.ts
@@ -9,7 +9,14 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { registerHandler } from './server.js';
 import { listSkillCatalog } from './skill-catalog.js';
-import { PHASE_C_INFERENCE_SNAP, prepareInvoke } from './skill-invoke.js';
+import {
+  classifySkillInvokeFailure,
+  extractSkillInvokeText,
+  parseSkillInvokeTimeoutOverride,
+  PHASE_C_INFERENCE_SNAP,
+  prepareInvoke,
+  skillInvokeTimeoutMs,
+} from './skill-invoke.js';
 
 function asDir(value: unknown): string | undefined {
   if (typeof value === 'string' && value.length > 0) return value;
@@ -45,7 +52,6 @@ registerHandler('skills.list', async (params) => {
 });
 
 const SNAPS_BASE = process.env.INFERENCE_SNAPS_BASE_URL ?? 'http://localhost:9090/v1';
-const INVOKE_TIMEOUT_MS = 120_000;
 
 function asBool(value: unknown): boolean {
   return value === true;
@@ -66,11 +72,16 @@ registerHandler('skills.invoke', async (params) => {
   if (dryRun) {
     return { ...prepared, dryRun: true, ran: false };
   }
+  const timeoutMs = skillInvokeTimeoutMs(
+    prepared.system,
+    prepared.user,
+    parseSkillInvokeTimeoutOverride(process.env.REVDEV_SKILLS_INVOKE_TIMEOUT_MS),
+  );
   try {
     const res = await fetch(`${SNAPS_BASE}/chat/completions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      signal: AbortSignal.timeout(INVOKE_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
       body: JSON.stringify({
         model: PHASE_C_INFERENCE_SNAP,
         messages: [
@@ -84,26 +95,41 @@ registerHandler('skills.invoke', async (params) => {
       return {
         error: `Inference Snap ${PHASE_C_INFERENCE_SNAP} failed (${res.status}): ${text}`,
         model: PHASE_C_INFERENCE_SNAP,
-        hint: `Install/start: sudo snap install ${PHASE_C_INFERENCE_SNAP} && check ${SNAPS_BASE}`,
+        hint: `Check ${SNAPS_BASE} (nemotron-3-nano status). HTTP ${String(res.status)} is not a missing-snap signal.`,
       };
     }
-    const payload = (await res.json()) as {
-      choices?: Array<{ message?: { content?: string } }>;
-    };
-    const text = payload.choices?.[0]?.message?.content ?? '';
+    const payload: unknown = await res.json();
+    const text = extractSkillInvokeText(payload);
     return {
       skillId: prepared.skillId,
       model: PHASE_C_INFERENCE_SNAP,
       text,
       ran: true,
       toolsExecuted: false,
+      timeoutMs,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    const kind = classifySkillInvokeFailure(err);
+    if (kind === 'timeout') {
+      return {
+        error: `skills.invoke timed out after ${timeoutMs}ms waiting on ${SNAPS_BASE}`,
+        model: PHASE_C_INFERENCE_SNAP,
+        timeoutMs,
+        hint: `Snap is reachable but the generate exceeded the prompt-sized budget. Raise REVDEV_SKILLS_INVOKE_TIMEOUT_MS (ms).`,
+      };
+    }
+    if (kind === 'connect') {
+      return {
+        error: `Cannot reach Inference Snaps at ${SNAPS_BASE}: ${msg}`,
+        model: PHASE_C_INFERENCE_SNAP,
+        hint: `sudo snap install ${PHASE_C_INFERENCE_SNAP} && ${PHASE_C_INFERENCE_SNAP} set http.port=9090 --assume-yes`,
+      };
+    }
     return {
-      error: `Cannot reach Inference Snaps at ${SNAPS_BASE}: ${msg}`,
+      error: `Inference Snap request failed: ${msg}`,
       model: PHASE_C_INFERENCE_SNAP,
-      hint: `sudo snap install ${PHASE_C_INFERENCE_SNAP}`,
+      hint: `Check ${SNAPS_BASE} and daemon logs.`,
     };
   }
 });


### PR DESCRIPTION
## Summary

GAP-293 invoke-complete: live `skills.invoke doctor` reached the product default snap and then failed two proven ways.

1. 120s `AbortSignal` is shorter than a CPU 30B prompt of the doctor SKILL.md.
2. The snap writes `message.reasoning_content` and leaves `content` empty.

This PR:

- Extracts `content`, then `reasoning_content`
- Sizes the deadline from prompt length (min 300s, env `REVDEV_SKILLS_INVOKE_TIMEOUT_MS`)
- Classifies timeout vs connect so a timeout no longer says "install the snap"

Companion: revealui harnesses (same helpers) + jv spec note.

## Test plan

- [x] `vitest run src/__tests__/skill-invoke.test.ts` (5)
- [ ] CI Test / Typecheck