### PR TITLE
fix(daemon): honor invoke budget past undici 300s header timeout

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -58,6 +58,7 @@
     "@revealui/utils": "^0.3.5",
     "drizzle-orm": "^0.45.2",
     "node-pty": "^1.0.0",
+    "undici": "^7.29.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -58,7 +58,7 @@
     "@revealui/utils": "^0.3.5",
     "drizzle-orm": "^0.45.2",
     "node-pty": "^1.0.0",
-    "undici": "^7.29.0",
+    "undici": ">=7.29.0 <8",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/daemon/src/__tests__/skill-invoke.test.ts
+++ b/packages/daemon/src/__tests__/skill-invoke.test.ts
@@ -53,4 +53,13 @@ describe('prepareInvoke (GAP-293 Phase C)', () => {
       'connect',
     );
   });
+
+  it('classifies undici fetch-failed header timeouts as timeout not connect', () => {
+    const cause = new Error('Headers Timeout Error');
+    cause.name = 'HeadersTimeoutError';
+    (cause as Error & { code?: string }).code = 'UND_ERR_HEADERS_TIMEOUT';
+    const wrapped = new Error('fetch failed', { cause });
+    wrapped.name = 'TypeError';
+    expect(classifySkillInvokeFailure(wrapped)).toBe('timeout');
+  });
 });

--- a/packages/daemon/src/skill-invoke.ts
+++ b/packages/daemon/src/skill-invoke.ts
@@ -113,11 +113,51 @@ export function skillInvokeTimeoutMs(
 
 export type SkillInvokeFailureKind = 'timeout' | 'connect' | 'other';
 
+const TIMEOUT_NAMES = new Set([
+  'TimeoutError',
+  'AbortError',
+  'HeadersTimeoutError',
+  'BodyTimeoutError',
+  'ConnectTimeoutError',
+]);
+
+const TIMEOUT_CODES = new Set([
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+]);
+
+function walkErrorChain(err: unknown, visit: (e: Error) => boolean): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    if (current instanceof Error) {
+      if (visit(current)) return true;
+      current = current.cause;
+      continue;
+    }
+    break;
+  }
+  return false;
+}
+
+/** Undici wraps 300s header timeouts as TypeError: fetch failed + cause. */
+export function isSkillInvokeTimeoutError(err: unknown): boolean {
+  return walkErrorChain(err, (e) => {
+    if (TIMEOUT_NAMES.has(e.name)) return true;
+    const code = (e as Error & { code?: string }).code;
+    if (code && TIMEOUT_CODES.has(code)) return true;
+    return /aborted due to timeout|The operation was aborted|Headers Timeout|Body Timeout/i.test(
+      e.message,
+    );
+  });
+}
+
 export function classifySkillInvokeFailure(err: unknown): SkillInvokeFailureKind {
+  if (isSkillInvokeTimeoutError(err)) return 'timeout';
   if (!(err instanceof Error)) return 'other';
-  if (err.name === 'TimeoutError' || err.name === 'AbortError') return 'timeout';
   const msg = err.message;
-  if (/aborted due to timeout|The operation was aborted/i.test(msg)) return 'timeout';
   if (/ECONNREFUSED|ENOTFOUND|ECONNRESET|fetch failed|Failed to parse URL/i.test(msg)) {
     return 'connect';
   }

--- a/packages/daemon/src/skills-rpc.ts
+++ b/packages/daemon/src/skills-rpc.ts
@@ -7,6 +7,7 @@
 
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { Agent } from 'undici';
 import { registerHandler } from './server.js';
 import { listSkillCatalog } from './skill-catalog.js';
 import {
@@ -77,11 +78,17 @@ registerHandler('skills.invoke', async (params) => {
     prepared.user,
     parseSkillInvokeTimeoutOverride(process.env.REVDEV_SKILLS_INVOKE_TIMEOUT_MS),
   );
+  const dispatcher = new Agent({
+    headersTimeout: timeoutMs,
+    bodyTimeout: timeoutMs,
+    connectTimeout: 30_000,
+  });
   try {
     const res = await fetch(`${SNAPS_BASE}/chat/completions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       signal: AbortSignal.timeout(timeoutMs),
+      dispatcher,
       body: JSON.stringify({
         model: PHASE_C_INFERENCE_SNAP,
         messages: [
@@ -131,5 +138,7 @@ registerHandler('skills.invoke', async (params) => {
       model: PHASE_C_INFERENCE_SNAP,
       hint: `Check ${SNAPS_BASE} and daemon logs.`,
     };
+  } finally {
+    await dispatcher.close();
   }
 });

--- a/packages/daemon/tsup.config.ts
+++ b/packages/daemon/tsup.config.ts
@@ -14,6 +14,4 @@ export default defineConfig({
   target: 'node24',
   banner: { js: '' },
   external: ['@electric-sql/pglite'],
-  // Bundle undici so systemd `node dist/cli.js` does not need a hoisted install.
-  noExternal: ['undici'],
 });

--- a/packages/daemon/tsup.config.ts
+++ b/packages/daemon/tsup.config.ts
@@ -14,4 +14,6 @@ export default defineConfig({
   target: 'node24',
   banner: { js: '' },
   external: ['@electric-sql/pglite'],
+  // Bundle undici so systemd `node dist/cli.js` does not need a hoisted install.
+  noExternal: ['undici'],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       node-pty:
         specifier: ^1.0.0
         version: 1.1.0
+      undici:
+        specifier: ^7.29.0
+        version: 7.29.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,7 +205,7 @@ importers:
         specifier: ^1.0.0
         version: 1.1.0
       undici:
-        specifier: ^7.29.0
+        specifier: '>=7.29.0 <8'
         version: 7.29.0
       zod:
         specifier: ^4.4.3


### PR DESCRIPTION
## Summary

Live `skills.invoke doctor` reached the snap (1423 prompt tokens, prompt done at 3.5 min) then the daemon aborted at ~291s. Node `fetch` / undici defaults `headersTimeout` to 300s, wraps that as `TypeError: fetch failed`, and we classified it as a missing snap.

- `undici.Agent` headers/body timeout = prompt-sized budget
- Walk `error.cause` so `HeadersTimeoutError` is timeout, not connect

Companion: revealui harnesses classify lockstep (same PR title family).

## Test plan

- [x] `vitest run src/__tests__/skill-invoke.test.ts` (6)
- [ ] CI Quality / Test