### PR TITLE
feat(daemon): bind skills.invoke to gemma3 product default

### DIFF
--- a/packages/daemon/src/skill-invoke.ts
+++ b/packages/daemon/src/skill-invoke.ts
@@ -1,6 +1,6 @@
 /**
  * GAP-293 Phase C — native workflow allowlist + prompt bind.
- * Snap: product default `nemotron-3-nano` (US-origin catalog SSOT).
+ * Snap: product default `gemma3` (US-origin catalog SSOT).
  */
 
 import { readFileSync } from 'node:fs';
@@ -12,7 +12,7 @@ export const NATIVE_WORKFLOW_SKILL_IDS = [
   'revealui-checkpoint',
 ] as const;
 
-export const PHASE_C_INFERENCE_SNAP = 'nemotron-3-nano';
+export const PHASE_C_INFERENCE_SNAP = 'gemma3';
 
 const ALIASES: Record<string, (typeof NATIVE_WORKFLOW_SKILL_IDS)[number]> = {
   doctor: 'revealui-doctor',


### PR DESCRIPTION
## Summary

`PHASE_C_INFERENCE_SNAP` follows the product default (`gemma3`). Nemotron remains allowlisted for capable hosts.

Companion: revealui SSOT flip + jv ADR.