### PR TITLE
fix(daemon): cap skills.invoke completion at 2048 tokens

### DIFF
--- a/packages/daemon/src/__tests__/skill-invoke.test.ts
+++ b/packages/daemon/src/__tests__/skill-invoke.test.ts
@@ -7,7 +7,9 @@ import {
   extractSkillInvokeText,
   PHASE_C_INFERENCE_SNAP,
   prepareInvoke,
+  SKILL_INVOKE_MAX_COMPLETION_TOKENS,
   SKILL_INVOKE_MIN_TIMEOUT_MS,
+  skillInvokeCompletionBody,
   skillInvokeTimeoutMs,
 } from '../skill-invoke.js';
 
@@ -37,6 +39,18 @@ describe('prepareInvoke (GAP-293 Phase C)', () => {
         choices: [{ message: { content: '', reasoning_content: 'traffic-light report' } }],
       }),
     ).toBe('traffic-light report');
+  });
+
+  it('caps completion tokens so a small snap cannot decode without bound', () => {
+    const body = skillInvokeCompletionBody('# doctor\n', 'run doctor');
+    expect(body.model).toBe(PHASE_C_INFERENCE_SNAP);
+    expect(body.max_tokens).toBe(SKILL_INVOKE_MAX_COMPLETION_TOKENS);
+    expect(body.max_tokens).toBe(2_048);
+    expect(body.stream).toBe(false);
+    expect(body.messages).toEqual([
+      { role: 'system', content: '# doctor\n' },
+      { role: 'user', content: 'run doctor' },
+    ]);
   });
 
   it('does not use the 120s invoke cap for a doctor-sized prompt', () => {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -91,7 +91,7 @@ Environment:
   REVDEV_DAEMON_SHUTDOWN_GRACE_MS  Max wait for in-flight handlers during close() (default: ${DAEMON_DEFAULTS.shutdownGracePeriodMs} ms = ${DAEMON_DEFAULTS.shutdownGracePeriodMs / 1000} s)
   REVDEV_PERMISSION_MODE       GAP-294 mode: shadow (default) | manual | auto | agent-scoped
                                shadow = would_* events only (no block). Flip only after soak review.
-  REVDEV_SKILLS_INVOKE_TIMEOUT_MS  Override skills.invoke wall-clock (default: prompt-sized, min 300s)
+  REVDEV_SKILLS_INVOKE_TIMEOUT_MS  Override skills.invoke wall-clock (default: prompt-sized, min 300s; completion is also capped at 2048 tokens)
   INFERENCE_SNAPS_BASE_URL     OpenAI-compat snap base (default: http://localhost:9090/v1)
 
 ${LICENSE_TIER_HELP}

--- a/packages/daemon/src/skill-invoke.ts
+++ b/packages/daemon/src/skill-invoke.ts
@@ -108,10 +108,7 @@ export interface SkillInvokeCompletionBody {
 }
 
 /** OpenAI-compat POST body for skills.invoke. Always bounded. */
-export function skillInvokeCompletionBody(
-  system: string,
-  user: string,
-): SkillInvokeCompletionBody {
+export function skillInvokeCompletionBody(system: string, user: string): SkillInvokeCompletionBody {
   return {
     model: PHASE_C_INFERENCE_SNAP,
     messages: [

--- a/packages/daemon/src/skill-invoke.ts
+++ b/packages/daemon/src/skill-invoke.ts
@@ -93,6 +93,36 @@ export const SKILL_INVOKE_DECODE_BUDGET_MS = 180_000;
 export const SKILL_INVOKE_MIN_TIMEOUT_MS = 300_000;
 export const SKILL_INVOKE_MAX_TIMEOUT_MS = 14_400_000;
 
+/**
+ * Hard cap on completion tokens. Unbounded decode lets a 270m CPU snap
+ * ramble until the wall-clock budget (minutes) while the client is gone.
+ * 2048 is enough for a Phase C traffic-light / diagnostic / checkpoint report.
+ */
+export const SKILL_INVOKE_MAX_COMPLETION_TOKENS = 2_048;
+
+export interface SkillInvokeCompletionBody {
+  model: typeof PHASE_C_INFERENCE_SNAP;
+  messages: Array<{ role: 'system' | 'user'; content: string }>;
+  max_tokens: typeof SKILL_INVOKE_MAX_COMPLETION_TOKENS;
+  stream: false;
+}
+
+/** OpenAI-compat POST body for skills.invoke. Always bounded. */
+export function skillInvokeCompletionBody(
+  system: string,
+  user: string,
+): SkillInvokeCompletionBody {
+  return {
+    model: PHASE_C_INFERENCE_SNAP,
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content: user },
+    ],
+    max_tokens: SKILL_INVOKE_MAX_COMPLETION_TOKENS,
+    stream: false,
+  };
+}
+
 export function parseSkillInvokeTimeoutOverride(raw: string | undefined): number | null {
   if (!raw || raw.trim().length === 0) return null;
   const parsed = Number.parseInt(raw, 10);

--- a/packages/daemon/src/skills-rpc.ts
+++ b/packages/daemon/src/skills-rpc.ts
@@ -16,6 +16,7 @@ import {
   PHASE_C_INFERENCE_SNAP,
   parseSkillInvokeTimeoutOverride,
   prepareInvoke,
+  skillInvokeCompletionBody,
   skillInvokeTimeoutMs,
 } from './skill-invoke.js';
 
@@ -89,20 +90,14 @@ registerHandler('skills.invoke', async (params) => {
       headers: { 'Content-Type': 'application/json' },
       signal: AbortSignal.timeout(timeoutMs),
       dispatcher,
-      body: JSON.stringify({
-        model: PHASE_C_INFERENCE_SNAP,
-        messages: [
-          { role: 'system', content: prepared.system },
-          { role: 'user', content: prepared.user },
-        ],
-      }),
+      body: JSON.stringify(skillInvokeCompletionBody(prepared.system, prepared.user)),
     });
     if (!res.ok) {
       const text = await res.text();
       return {
         error: `Inference Snap ${PHASE_C_INFERENCE_SNAP} failed (${res.status}): ${text}`,
         model: PHASE_C_INFERENCE_SNAP,
-        hint: `Check ${SNAPS_BASE} (nemotron-3-nano status). HTTP ${String(res.status)} is not a missing-snap signal.`,
+        hint: `Check ${SNAPS_BASE} (${PHASE_C_INFERENCE_SNAP} status). HTTP ${String(res.status)} is not a missing-snap signal.`,
       };
     }
     const payload: unknown = await res.json();


### PR DESCRIPTION
## Summary

`skills.invoke` sent chat completions with no `max_tokens`. On gemma3-270m (the product default) that decoded without bound until the prompt-sized wall-clock budget (~minutes). A Phase C doctor dry-run then hung the snap at 300% CPU after the client left.

This caps the OpenAI-compat body at 2048 completion tokens (`skillInvokeCompletionBody`). That is enough for a traffic-light / diagnostic / checkpoint report. Wall-clock budget is unchanged.

Also uses the product default snap name in the HTTP-error hint (was still hard-coded `nemotron-3-nano`).

## Test plan

- [x] `vitest run src/__tests__/skill-invoke.test.ts` (7 tests)
- [ ] CI
- [ ] Live doctor invoke on gemma3:9090 after this daemon is running

GAP-293 Phase C. Does not close GAP-294 / 300 / 360 / 260 / 479.