### PR TITLE
feat(daemon): run skills.invoke through AgentRuntime

### DIFF
--- a/packages/daemon/src/__tests__/skill-invoke-runtime.test.ts
+++ b/packages/daemon/src/__tests__/skill-invoke-runtime.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { runSkillInvokeRuntime, setSkillInvokeAiLoaderForTests } from '../skill-invoke-runtime.js';
+
+describe('runSkillInvokeRuntime', () => {
+  afterEach(() => {
+    setSkillInvokeAiLoaderForTests();
+  });
+
+  it('fails closed when AgentRuntime cannot load', async () => {
+    setSkillInvokeAiLoaderForTests(async () => {
+      throw new Error('missing @revealui/ai');
+    });
+    const result = await runSkillInvokeRuntime(
+      {
+        skillId: 'revealui-doctor',
+        model: 'gemma3',
+        system: '# doctor',
+        user: 'run',
+        allowedTools: [],
+      },
+      { projectRoot: '/tmp' },
+    );
+    expect(result.ran).toBe(false);
+    expect(result.error).toContain('@revealui/ai');
+  });
+
+  it('streams AgentRuntime text and records tool starts', async () => {
+    setSkillInvokeAiLoaderForTests(async () => ({
+      StreamingAgentRuntime: class {
+        async *streamTask() {
+          yield { type: 'tool_call_start', toolCall: { name: 'Read' } };
+          yield { type: 'tool_call_result', toolResult: { success: true, content: 'ok' } };
+          yield { type: 'text', content: 'report' };
+        }
+        async cleanup() {}
+      },
+      createLLMClientFromEnv: () => ({}),
+    }));
+    const result = await runSkillInvokeRuntime(
+      {
+        skillId: 'revealui-doctor',
+        model: 'gemma3',
+        system: '# doctor',
+        user: 'run',
+        allowedTools: ['Read'],
+      },
+      { projectRoot: '/tmp' },
+    );
+    expect(result.ran).toBe(true);
+    expect(result.text).toContain('report');
+    expect(result.toolsExecuted).toBe(true);
+    expect(result.toolTrace).toEqual([{ name: 'Read', ok: true }]);
+  });
+});

--- a/packages/daemon/src/skill-invoke-runtime.ts
+++ b/packages/daemon/src/skill-invoke-runtime.ts
@@ -1,0 +1,199 @@
+/**
+ * GAP-293 Phase C — skills.invoke through StreamingAgentRuntime.
+ *
+ * Same loop as `@revealui/harnesses` `runNativeSkillInvoke`. Tools execute
+ * via tool-guard (`executeSkillInvokeTool`), not a second HTTP chat loop.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { z } from 'zod/v4';
+import {
+  type NativeWorkflowToolName,
+  PHASE_C_INFERENCE_SNAP,
+  SKILL_INVOKE_MAX_TOOL_ROUNDS,
+  skillInvokeTimeoutMs,
+} from './skill-invoke.js';
+import { executeSkillInvokeTool, type SkillToolContext } from './skill-invoke-tools.js';
+
+export interface PreparedSkillInvoke {
+  skillId: string;
+  model: string;
+  system: string;
+  user: string;
+  allowedTools: NativeWorkflowToolName[];
+}
+
+export interface RuntimeInvokeResult {
+  skillId: string;
+  model: string;
+  text: string;
+  ran: boolean;
+  toolsExecuted: boolean;
+  toolTrace: Array<{ name: string; ok: boolean }>;
+  timeoutMs: number;
+  error?: string;
+}
+
+type AiLoader = () => Promise<{
+  StreamingAgentRuntime: new (config: {
+    maxIterations?: number;
+    timeout?: number;
+  }) => {
+    streamTask(
+      agent: unknown,
+      task: unknown,
+      llmClient: unknown,
+    ): AsyncGenerator<{
+      type: string;
+      content?: string;
+      toolCall?: { name: string };
+      toolResult?: { content?: string; success?: boolean };
+      error?: string;
+    }>;
+    cleanup(): Promise<void>;
+  };
+  createLLMClientFromEnv: () => unknown;
+}>;
+
+const PARAMS: Record<NativeWorkflowToolName, z.ZodType> = {
+  Read: z.object({ path: z.string() }),
+  Grep: z.object({ pattern: z.string(), path: z.string().optional() }),
+  Glob: z.object({ pattern: z.string(), path: z.string().optional() }),
+  Bash: z.object({ command: z.string() }),
+};
+
+function toolsForGuard(allowed: readonly NativeWorkflowToolName[], ctx: SkillToolContext) {
+  return allowed.map((name) => ({
+    name,
+    description: `${name} (tool-guarded native workflow tool)`,
+    parameters: PARAMS[name],
+    async execute(params: unknown): Promise<{ success: boolean; content: string }> {
+      const result = await executeSkillInvokeTool(
+        { id: name, name, arguments: JSON.stringify(params ?? {}) },
+        allowed,
+        ctx,
+      );
+      return { success: result.ok, content: result.text };
+    },
+  }));
+}
+
+async function importAiSubpath(subpath: string): Promise<Record<string, unknown>> {
+  try {
+    return (await import(`@revealui/ai/${subpath}`)) as Record<string, unknown>;
+  } catch {
+    const root = process.env.REVEALUI_MONOREPO ?? join(homedir(), 'revfleet', 'revealui');
+    const file = join(root, 'packages', 'ai', 'dist', `${subpath}.js`);
+    return (await import(pathToFileURL(file).href)) as Record<string, unknown>;
+  }
+}
+
+const defaultLoadAi: AiLoader = async () => {
+  const [runtimeMod, clientMod] = await Promise.all([
+    importAiSubpath('orchestration/streaming-runtime'),
+    importAiSubpath('llm/client'),
+  ]);
+  return {
+    StreamingAgentRuntime: runtimeMod.StreamingAgentRuntime as Awaited<
+      ReturnType<AiLoader>
+    >['StreamingAgentRuntime'],
+    createLLMClientFromEnv: clientMod.createLLMClientFromEnv as Awaited<
+      ReturnType<AiLoader>
+    >['createLLMClientFromEnv'],
+  };
+};
+
+let loadAi: AiLoader = defaultLoadAi;
+
+/** Test seam. Restores the real loader when passed undefined. */
+export function setSkillInvokeAiLoaderForTests(loader?: AiLoader): void {
+  loadAi = loader ?? defaultLoadAi;
+}
+
+export async function runSkillInvokeRuntime(
+  prepared: PreparedSkillInvoke,
+  ctx: SkillToolContext,
+): Promise<RuntimeInvokeResult> {
+  const timeoutMs = skillInvokeTimeoutMs(prepared.system, prepared.user);
+  let ai: Awaited<ReturnType<AiLoader>>;
+  try {
+    ai = await loadAi();
+  } catch {
+    return {
+      skillId: prepared.skillId,
+      model: prepared.model,
+      text: '',
+      ran: false,
+      toolsExecuted: false,
+      toolTrace: [],
+      timeoutMs,
+      error:
+        '@revealui/ai is not installed next to the daemon. Install the optional dependency so skills.invoke can use AgentRuntime.',
+    };
+  }
+
+  const tools = toolsForGuard(prepared.allowedTools, ctx);
+  const llmClient = ai.createLLMClientFromEnv();
+  const runtime = new ai.StreamingAgentRuntime({
+    maxIterations: SKILL_INVOKE_MAX_TOOL_ROUNDS,
+    timeout: timeoutMs,
+  });
+  const agent = {
+    id: 'revdev-native-skill',
+    name: prepared.skillId,
+    instructions: prepared.system,
+    tools,
+    config: {},
+    getContext: () => ({
+      projectRoot: ctx.projectRoot,
+      workingDirectory: ctx.projectRoot,
+    }),
+  };
+  const task = {
+    id: `skill-${prepared.skillId}-${String(Date.now())}`,
+    type: 'native-skill',
+    description: prepared.user,
+  };
+
+  const outputParts: string[] = [];
+  const toolTrace: Array<{ name: string; ok: boolean }> = [];
+  try {
+    for await (const chunk of runtime.streamTask(agent, task, llmClient)) {
+      if (chunk.type === 'text' && chunk.content) outputParts.push(chunk.content);
+      if (chunk.type === 'tool_call_start' && chunk.toolCall?.name) {
+        toolTrace.push({ name: chunk.toolCall.name, ok: true });
+      }
+      if (chunk.type === 'tool_call_result' && chunk.toolResult) {
+        const last = toolTrace[toolTrace.length - 1];
+        if (last && chunk.toolResult.success === false) last.ok = false;
+      }
+      if (chunk.type === 'error' && chunk.error) outputParts.push(`[error] ${chunk.error}`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      skillId: prepared.skillId,
+      model: prepared.model,
+      text: outputParts.join('\n'),
+      ran: false,
+      toolsExecuted: toolTrace.length > 0,
+      toolTrace,
+      timeoutMs,
+      error: msg,
+    };
+  } finally {
+    await runtime.cleanup();
+  }
+
+  return {
+    skillId: prepared.skillId,
+    model: PHASE_C_INFERENCE_SNAP,
+    text: outputParts.join('\n'),
+    ran: true,
+    toolsExecuted: toolTrace.length > 0,
+    toolTrace,
+    timeoutMs,
+  };
+}

--- a/packages/daemon/src/skills-rpc.ts
+++ b/packages/daemon/src/skills-rpc.ts
@@ -1,28 +1,15 @@
 /**
- * GAP-293 Phase B — skills.list
+ * GAP-293 Phase B/C — skills.list (read) and skills.invoke (AgentRuntime).
  *
- * Read-only catalog of SKILL.md trees RevDev should see (project
- * `.revealui/content/skills` + optional revskills root). No execution.
+ * Invoke uses StreamingAgentRuntime + tool-guard tools. No parallel HTTP loop.
  */
 
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { Agent } from 'undici';
 import { registerHandler } from './server.js';
 import { listSkillCatalog } from './skill-catalog.js';
-import {
-  classifySkillInvokeFailure,
-  extractSkillInvokeText,
-  extractSkillInvokeToolCalls,
-  PHASE_C_INFERENCE_SNAP,
-  parseSkillInvokeTimeoutOverride,
-  prepareInvoke,
-  SKILL_INVOKE_MAX_TOOL_ROUNDS,
-  type SkillInvokeMessage,
-  skillInvokeCompletionBody,
-  skillInvokeTimeoutMs,
-} from './skill-invoke.js';
-import { executeSkillInvokeTool } from './skill-invoke-tools.js';
+import { PHASE_C_INFERENCE_SNAP, prepareInvoke } from './skill-invoke.js';
+import { runSkillInvokeRuntime } from './skill-invoke-runtime.js';
 
 function asDir(value: unknown): string | undefined {
   if (typeof value === 'string' && value.length > 0) return value;
@@ -57,8 +44,6 @@ registerHandler('skills.list', async (params) => {
   };
 });
 
-const SNAPS_BASE = process.env.INFERENCE_SNAPS_BASE_URL ?? 'http://localhost:9090/v1';
-
 function asBool(value: unknown): boolean {
   return value === true;
 }
@@ -78,104 +63,8 @@ registerHandler('skills.invoke', async (params) => {
   if (dryRun) {
     return { ...prepared, dryRun: true, ran: false };
   }
-  const timeoutMs = skillInvokeTimeoutMs(
-    prepared.system,
-    prepared.user,
-    parseSkillInvokeTimeoutOverride(process.env.REVDEV_SKILLS_INVOKE_TIMEOUT_MS),
-  );
-  const dispatcher = new Agent({
-    headersTimeout: timeoutMs,
-    bodyTimeout: timeoutMs,
-    connectTimeout: 30_000,
+  return runSkillInvokeRuntime(prepared, {
+    projectRoot: roots.projectRoot,
+    revskillsRoot: roots.revskillsRoot,
   });
-  const messages: SkillInvokeMessage[] = [
-    { role: 'system', content: prepared.system },
-    { role: 'user', content: prepared.user },
-  ];
-  const toolTrace: Array<{ name: string; ok: boolean }> = [];
-  try {
-    for (let round = 0; round < SKILL_INVOKE_MAX_TOOL_ROUNDS; round += 1) {
-      const res = await fetch(`${SNAPS_BASE}/chat/completions`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        signal: AbortSignal.timeout(timeoutMs),
-        dispatcher,
-        body: JSON.stringify(skillInvokeCompletionBody(messages, prepared.allowedTools)),
-      });
-      if (!res.ok) {
-        const text = await res.text();
-        return {
-          error: `Inference Snap ${PHASE_C_INFERENCE_SNAP} failed (${res.status}): ${text}`,
-          model: PHASE_C_INFERENCE_SNAP,
-          hint: `Check ${SNAPS_BASE} (${PHASE_C_INFERENCE_SNAP} status). HTTP ${String(res.status)} is not a missing-snap signal.`,
-          toolsExecuted: toolTrace.length > 0,
-          toolTrace,
-        };
-      }
-      const payload: unknown = await res.json();
-      const calls = extractSkillInvokeToolCalls(payload);
-      if (calls.length === 0) {
-        return {
-          skillId: prepared.skillId,
-          model: PHASE_C_INFERENCE_SNAP,
-          text: extractSkillInvokeText(payload),
-          ran: true,
-          toolsExecuted: toolTrace.length > 0,
-          toolTrace,
-          timeoutMs,
-        };
-      }
-      messages.push({
-        role: 'assistant',
-        content: extractSkillInvokeText(payload),
-        tool_calls: calls,
-      });
-      for (const call of calls) {
-        const result = await executeSkillInvokeTool(call, prepared.allowedTools, {
-          projectRoot: roots.projectRoot,
-          revskillsRoot: roots.revskillsRoot,
-        });
-        toolTrace.push({ name: result.name, ok: result.ok });
-        messages.push({
-          role: 'tool',
-          tool_call_id: call.id,
-          content: result.text,
-        });
-      }
-    }
-    return {
-      skillId: prepared.skillId,
-      model: PHASE_C_INFERENCE_SNAP,
-      text: 'Tool loop reached SKILL_INVOKE_MAX_TOOL_ROUNDS without a final report.',
-      ran: true,
-      toolsExecuted: toolTrace.length > 0,
-      toolTrace,
-      timeoutMs,
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    const kind = classifySkillInvokeFailure(err);
-    if (kind === 'timeout') {
-      return {
-        error: `skills.invoke timed out after ${timeoutMs}ms waiting on ${SNAPS_BASE}`,
-        model: PHASE_C_INFERENCE_SNAP,
-        timeoutMs,
-        hint: `Snap is reachable but the generate exceeded the prompt-sized budget. Raise REVDEV_SKILLS_INVOKE_TIMEOUT_MS (ms).`,
-      };
-    }
-    if (kind === 'connect') {
-      return {
-        error: `Cannot reach Inference Snaps at ${SNAPS_BASE}: ${msg}`,
-        model: PHASE_C_INFERENCE_SNAP,
-        hint: `sudo snap install ${PHASE_C_INFERENCE_SNAP} && ${PHASE_C_INFERENCE_SNAP} set http.port=9090 --assume-yes`,
-      };
-    }
-    return {
-      error: `Inference Snap request failed: ${msg}`,
-      model: PHASE_C_INFERENCE_SNAP,
-      hint: `Check ${SNAPS_BASE} and daemon logs.`,
-    };
-  } finally {
-    await dispatcher.close();
-  }
 });

--- a/packages/daemon/tsup.config.ts
+++ b/packages/daemon/tsup.config.ts
@@ -13,5 +13,5 @@ export default defineConfig({
   clean: true,
   target: 'node24',
   banner: { js: '' },
-  external: ['@electric-sql/pglite'],
+  external: ['@electric-sql/pglite', /^@revealui\/ai/],
 });


### PR DESCRIPTION
## Summary

Collapse the daemon HTTP chat loop onto `StreamingAgentRuntime` (same loop class as `revealui-harnesses skills invoke`).

- Tools still execute through tool-guard (`executeSkillInvokeTool`)
- Fail closed if `@revealui/ai` cannot load (package or `REVEALUI_MONOREPO` / `~/revfleet/revealui` dist)
- No second fetch/`undici` Agent loop on `skills.invoke`

Companion: revealui export of `runNativeSkillInvoke`, jv spec progress.

## Review

Invoke surface. Treat as review-pending until a non-author verdict.

## Test plan

- [x] skill-invoke-runtime tests (fail-closed + mocked stream)
- [x] existing skill-invoke / skill-invoke-tools tests
- [ ] CI
- [ ] After merge: rebuild systemd daemon

GAP-293. Does not close GAP-294.