### PR TITLE
feat(daemon): enforce GAP-294 on skills.invoke tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Dates are ISO 8601 (UTC).
   reject-with-receipt (`-32004`, `pending_approvals` queue). `permission.pending`
   + signed `permission.decide` (no self-approval). Migration 0007. Default remains
   shadow until the operator sets the env.
+- **GAP-294 skill-tool enforce.** `skills.invoke` inner tools use the same
+  queue. `skills.tool.Read` / `Grep` / `Glob` are routine. `skills.tool.Bash`
+  is critical (auto still requires approval). Install default stays shadow.
 
 ### Fixed
 

--- a/apps/studio/src-tauri/tests/daemon_ctl_integration.rs
+++ b/apps/studio/src-tauri/tests/daemon_ctl_integration.rs
@@ -91,9 +91,20 @@ async fn daemon_lifecycle_start_status_stop() {
     let pid = daemon_ctl::daemon_start().await.expect("daemon_start succeeds");
     assert!(pid > 0);
 
-    // Up: pid file + process + reachable socket.
-    let during = daemon_ctl::daemon_status().await.expect("status (up)");
-    assert!(during.running, "daemon should be running");
+    // Up: pid file + process + reachable socket. Poll briefly: start
+    // returns on ping, and status.running is the pid file.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let during = loop {
+        let status = daemon_ctl::daemon_status().await.expect("status (up)");
+        if status.running {
+            break status;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "daemon should be running"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
     assert_eq!(during.pid, Some(pid), "pid file matches the spawned pid");
     assert!(during.reachable, "daemon should answer ping");
 

--- a/packages/daemon/src/__tests__/permission.test.ts
+++ b/packages/daemon/src/__tests__/permission.test.ts
@@ -8,8 +8,11 @@ import { RPC_METHODS } from '@revdev/protocol';
 import { afterEach, describe, expect, it } from 'vitest';
 import { MIGRATIONS } from '../migrations/index.js';
 import {
+  ApprovalRequiredError,
   classifyMethod,
+  decideApproval,
   decideEnforcement,
+  enforceSkillTool,
   evaluateShadow,
   expectedClassifiedMethods,
   grantCoversMethod,
@@ -101,6 +104,13 @@ describe('evaluateShadow', () => {
     expect(r.actionClass).toBe('critical');
     expect(r.would).toBe('require_approval');
   });
+
+  it('skills.tool.Bash is critical under auto shadow-as', () => {
+    process.env.REVDEV_PERMISSION_SHADOW_AS = 'auto';
+    const r = evaluateShadow('skills.tool.Bash');
+    expect(r.actionClass).toBe('critical');
+    expect(r.would).toBe('require_approval');
+  });
 });
 
 describe('owner-countersigned judgment calls', () => {
@@ -117,6 +127,13 @@ describe('owner-countersigned judgment calls', () => {
   });
   it('memory.store is routine', () => {
     expect(classifyMethod('memory.store')).toBe('routine');
+  });
+  it('skills.invoke stays routine; Bash tool is critical; Read/Grep/Glob are routine', () => {
+    expect(classifyMethod('skills.invoke')).toBe('routine');
+    expect(classifyMethod('skills.tool.Read')).toBe('routine');
+    expect(classifyMethod('skills.tool.Grep')).toBe('routine');
+    expect(classifyMethod('skills.tool.Glob')).toBe('routine');
+    expect(classifyMethod('skills.tool.Bash')).toBe('critical');
   });
 });
 
@@ -139,6 +156,8 @@ describe('decideEnforcement (Phase 1)', () => {
   it('auto allows consequential and requires approval for critical', () => {
     expect(decideEnforcement('file.write', 'auto').action).toBe('allow');
     expect(decideEnforcement('agent.spawn', 'auto').action).toBe('require_approval');
+    expect(decideEnforcement('skills.tool.Bash', 'auto').action).toBe('require_approval');
+    expect(decideEnforcement('skills.tool.Read', 'manual').action).toBe('allow');
   });
 
   it('deny-list absorbs', () => {
@@ -217,6 +236,53 @@ describe('parseSessionPermissionMode (Phase 2)', () => {
     expect(classifyMethod('permission.grant')).toBe('critical');
     expect(classifyMethod('permission.revokeGrant')).toBe('critical');
     expect(classifyMethod('permission.listGrants')).toBe('routine');
+  });
+});
+
+describe('enforceSkillTool (GAP-294 skill tools)', () => {
+  let db: PGlite;
+
+  afterEach(async () => {
+    delete process.env.REVDEV_PERMISSION_MODE;
+    await db?.close().catch(() => {});
+  });
+
+  it(
+    'shadow allows Bash; manual queues then consumes a single-use approval',
+    async () => {
+      db = new PGlite();
+      await migrate(db, [...MIGRATIONS]);
+      const params = { command: 'echo skill-ok' };
+
+      process.env.REVDEV_PERMISSION_MODE = 'shadow';
+      await enforceSkillTool('Bash', params, { db, agentId: 'agent-a' });
+
+      process.env.REVDEV_PERMISSION_MODE = 'manual';
+      await expect(
+        enforceSkillTool('Bash', params, { db, agentId: 'agent-a' }),
+      ).rejects.toBeInstanceOf(ApprovalRequiredError);
+
+      const pending = await db.query<{ id: string }>(
+        `SELECT id FROM pending_approvals WHERE agent_id = $1 AND method = $2 AND status = 'pending'`,
+        ['agent-a', 'skills.tool.Bash'],
+      );
+      expect(pending.rows[0]?.id).toBeTruthy();
+      await decideApproval(db, pending.rows[0].id, 'approved', 'op-1');
+
+      await enforceSkillTool('Bash', params, { db, agentId: 'agent-a' });
+
+      await expect(
+        enforceSkillTool('Bash', params, { db, agentId: 'agent-a' }),
+      ).rejects.toBeInstanceOf(ApprovalRequiredError);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it('Read stays allowed in manual without an approval', async () => {
+    db = new PGlite();
+    await migrate(db, [...MIGRATIONS]);
+    process.env.REVDEV_PERMISSION_MODE = 'manual';
+    await enforceSkillTool('Read', { path: 'note.txt' }, { db, agentId: 'agent-a' });
   });
 });
 

--- a/packages/daemon/src/__tests__/permission.test.ts
+++ b/packages/daemon/src/__tests__/permission.test.ts
@@ -266,8 +266,12 @@ describe('enforceSkillTool (GAP-294 skill tools)', () => {
         `SELECT id FROM pending_approvals WHERE agent_id = $1 AND method = $2 AND status = 'pending'`,
         ['agent-a', 'skills.tool.Bash'],
       );
-      expect(pending.rows[0]?.id).toBeTruthy();
-      await decideApproval(db, pending.rows[0].id, 'approved', 'op-1');
+      const pendingId = pending.rows[0]?.id;
+      expect(pendingId).toBeTruthy();
+      if (!pendingId) {
+        throw new Error('expected a pending skills.tool.Bash approval');
+      }
+      await decideApproval(db, pendingId, 'approved', 'op-1');
 
       await enforceSkillTool('Bash', params, { db, agentId: 'agent-a' });
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -206,10 +206,19 @@ console.log('');
 console.log('  RevDev Daemon v0.1.0');
 console.log('  ────────────────────');
 
+// Write the PID file BEFORE listen. Studio liveness is the pid file
+// (`daemon_status.running`). startDaemon accepts ping as soon as the
+// socket binds, so a post-listen write races: start returns, status
+// reads a missing pid, CI reports "daemon should be running".
+await mkdir(dirname(pidFile), { recursive: true });
+await writeFile(pidFile, String(process.pid));
+console.log(`[daemon] PID ${process.pid} written to ${pidFile}`);
+
 let daemon: Awaited<ReturnType<typeof startDaemon>>;
 try {
   daemon = await startDaemon(config);
 } catch (err) {
+  await unlink(pidFile).catch(() => {});
   // Fail-closed license errors are operator-actionable, not crashes:
   // initLicenseGuard already logged the CRITICAL detail for an expired
   // license; surface a config error then exit non-zero with no stack trace.
@@ -222,11 +231,6 @@ try {
   }
   throw err;
 }
-
-// Write PID file so supervisors and Studio can find us
-await mkdir(dirname(pidFile), { recursive: true });
-await writeFile(pidFile, String(process.pid));
-console.log(`[daemon] PID ${process.pid} written to ${pidFile}`);
 
 // Graceful shutdown — clean up PID file and socket
 for (const signal of ['SIGINT', 'SIGTERM'] as const) {

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -154,7 +154,26 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['workflow.run', 'consequential'],
   ['skills.list', 'routine'],
   ['skills.invoke', 'routine'],
+  // Inner tools of skills.invoke (not standalone RPCs). Bash is a shell, so
+  // critical: auto mode still requires approval (policy floor). Reads stay routine.
+  ['skills.tool.Read', 'routine'],
+  ['skills.tool.Grep', 'routine'],
+  ['skills.tool.Glob', 'routine'],
+  ['skills.tool.Bash', 'critical'],
 ]);
+
+export const SKILL_TOOL_METHODS = {
+  Read: 'skills.tool.Read',
+  Grep: 'skills.tool.Grep',
+  Glob: 'skills.tool.Glob',
+  Bash: 'skills.tool.Bash',
+} as const;
+
+export type SkillToolName = keyof typeof SKILL_TOOL_METHODS;
+
+export function skillToolMethod(name: SkillToolName): string {
+  return SKILL_TOOL_METHODS[name];
+}
 
 /** Fail closed: unmapped method is critical (spec §5 / I2). */
 export function classifyMethod(method: string): ActionClass {
@@ -725,6 +744,16 @@ export function summarizeParams(
   return bits.join(' ').slice(0, 240);
 }
 
+export class PermissionDeniedError extends Error {
+  readonly code = APPROVAL_REQUIRED_CODE;
+  readonly data: { kind: 'permission-denied'; method: string; reason: string };
+  constructor(method: string, reason: string) {
+    super(`Permission denied for ${method}`);
+    this.name = 'PermissionDeniedError';
+    this.data = { kind: 'permission-denied', method, reason };
+  }
+}
+
 export class ApprovalRequiredError extends Error {
   readonly code = APPROVAL_REQUIRED_CODE;
   readonly data: {
@@ -950,10 +979,54 @@ export function parseSessionPermissionMode(raw: unknown): SessionPermissionMode 
   return null;
 }
 
+export interface SkillPermissionCtx {
+  db: PGlite;
+  agentId: string;
+}
+
 /**
- * Effective mode for a call: session `permission_mode` override, else daemon default.
- * Spec §3: effective = per-session override ?? daemon default.
+ * GAP-294 enforce for skills.invoke inner tools. Shadow observes only.
+ * Missing session + non-shadow + non-routine fails closed.
  */
+export async function enforceSkillTool(
+  toolName: SkillToolName,
+  params: Record<string, unknown>,
+  ctx: SkillPermissionCtx | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const method = skillToolMethod(toolName);
+  const mode = ctx
+    ? await resolveEffectiveMode(ctx.db, ctx.agentId, env)
+    : resolvePermissionMode(env);
+
+  if (ctx) {
+    emitPermissionShadowEvent(ctx.db, ctx.agentId, method, evaluateShadow(method, env));
+  }
+
+  if (mode === 'shadow') return;
+
+  const decision = decideEnforcement(method, mode, env);
+  if (decision.action === 'allow') return;
+
+  if (!ctx) {
+    throw new PermissionDeniedError(method, 'no-session');
+  }
+
+  if (decision.action === 'deny') {
+    throw new PermissionDeniedError(method, decision.reason);
+  }
+
+  if (mode === 'agent-scoped' || decision.reason === 'agent_scoped') {
+    const grantHit = await tryConsumeGrant(ctx.db, ctx.agentId, method, params);
+    if (grantHit) return;
+  }
+  const consumed = await tryConsumeApproval(ctx.db, ctx.agentId, method, params);
+  if (!consumed) {
+    await queueApprovalRequired(ctx.db, ctx.agentId, method, params);
+  }
+}
+
+/** Effective mode: session permission_mode override, else daemon default (spec §3). */
 export async function resolveEffectiveMode(
   db: PGlite,
   agentId: string | null | undefined,

--- a/packages/daemon/src/skill-invoke-runtime.ts
+++ b/packages/daemon/src/skill-invoke-runtime.ts
@@ -9,6 +9,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { z } from 'zod/v4';
+import { ApprovalRequiredError, PermissionDeniedError } from './permission.js';
 import {
   type NativeWorkflowToolName,
   PHASE_C_INFERENCE_SNAP,
@@ -172,6 +173,9 @@ export async function runSkillInvokeRuntime(
       if (chunk.type === 'error' && chunk.error) outputParts.push(`[error] ${chunk.error}`);
     }
   } catch (err) {
+    if (err instanceof ApprovalRequiredError || err instanceof PermissionDeniedError) {
+      throw err;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return {
       skillId: prepared.skillId,

--- a/packages/daemon/src/skill-invoke-tools.ts
+++ b/packages/daemon/src/skill-invoke-tools.ts
@@ -8,6 +8,7 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { isAbsolute, join, resolve, sep } from 'node:path';
 import { promisify } from 'node:util';
+import { enforceSkillTool, type SkillPermissionCtx, type SkillToolName } from './permission.js';
 import {
   isNativeWorkflowToolName,
   type NativeWorkflowToolName,
@@ -22,6 +23,7 @@ const CMD_TIMEOUT_MS = 30_000;
 export interface SkillToolContext {
   projectRoot: string;
   revskillsRoot?: string;
+  permission?: SkillPermissionCtx;
 }
 
 export interface SkillToolResult {
@@ -202,6 +204,7 @@ export async function executeSkillInvokeTool(
     return { name: call.name, ok: false, text: `tool ${call.name} is not on this skill allowlist` };
   }
   const args = parseArgs(call.arguments);
+  await enforceSkillTool(call.name as SkillToolName, args, ctx.permission);
   if (call.name === 'Read') return runRead(args, ctx);
   if (call.name === 'Grep') return runGrep(args, ctx);
   if (call.name === 'Glob') return runGlob(args, ctx);

--- a/packages/daemon/src/skills-rpc.ts
+++ b/packages/daemon/src/skills-rpc.ts
@@ -48,7 +48,7 @@ function asBool(value: unknown): boolean {
   return value === true;
 }
 
-registerHandler('skills.invoke', async (params) => {
+registerHandler('skills.invoke', async (params, db, ctx) => {
   const skillId = typeof params?.skillId === 'string' ? params.skillId : '';
   const dryRun = asBool(params?.dryRun);
   const roots = resolveSkillRoots(params);
@@ -63,8 +63,11 @@ registerHandler('skills.invoke', async (params) => {
   if (dryRun) {
     return { ...prepared, dryRun: true, ran: false };
   }
+  const agentId =
+    ctx.agentId ?? (typeof params?.actorAgentId === 'string' ? params.actorAgentId : undefined);
   return runSkillInvokeRuntime(prepared, {
     projectRoot: roots.projectRoot,
     revskillsRoot: roots.revskillsRoot,
+    permission: agentId ? { db, agentId } : undefined,
   });
 });


### PR DESCRIPTION
## Summary

Inner tools of `skills.invoke` now use the GAP-294 permission queue.

- `skills.tool.Read` / `Grep` / `Glob` = routine
- `skills.tool.Bash` = critical (auto still requires approval)
- Shadow default is unchanged. No install-default flip.
- Tool-guard still runs. Approvals are single-use and bound to the command bytes.

Throws `-32004` from the invoke handler when Bash needs approval so the operator can `permission.decide` and retry the same command.

## Review

Invoke + permission surface. Treat as review-pending until a non-author verdict.

## Test plan

- [x] classify + enforceSkillTool PGlite (queue, consume once, Read allowed)
- [x] existing skill-invoke-tools / runtime tests
- [ ] CI

GAP-294 / GAP-293 Phase C residual. Does not close GAP-294 (Phase 3 owner default flip remains).