### PR TITLE
test(daemon): lock GAP-389 npx --yes package vs package --yes

### DIFF
--- a/packages/daemon/src/__tests__/tool-guard.test.ts
+++ b/packages/daemon/src/__tests__/tool-guard.test.ts
@@ -354,9 +354,14 @@ describe('GAP-384 command-position scoping (prose false-positives)', () => {
     );
   });
 
-  it('allows npx package --yes but blocks npx -y package (GAP-388)', () => {
+  it('allows npx package --yes but blocks npx -y / --yes package (GAP-388 / GAP-389)', () => {
     expect(evaluateCommand('npx create-revealui@latest --yes', manifest)).toBeNull();
-    expect(evaluateCommand('npx -y cowsay moo', manifest)).not.toBeNull();
+    expect(evaluateCommand('npx create-revealui app --yes', manifest)).toBeNull();
+    expect(evaluateCommand('cd ~/x && npx create-revealui app --yes', manifest)).toBeNull();
+    expect(evaluateCommand('npx -y cowsay moo', manifest)?.reason).toContain('npx');
+    expect(evaluateCommand('npx --yes cowsay moo', manifest)?.reason).toContain('npx');
+    expect(evaluateCommand('cd ~/x && npx -y some-pkg', manifest)?.reason).toContain('npx');
+    expect(evaluateCommand('npx foo && npx -y bar', manifest)?.reason).toContain('npx');
   });
 });
 


### PR DESCRIPTION
## Summary

GAP-389 lock-in only. `npxYesFlag` already shipped in #345 (token-walk, no authored regex).

Adds the remaining acceptance cases:
- `npx --yes pkg` blocks
- `npx pkg --yes` / `create-revealui … --yes` allow
- compound `cd && npx -y` blocks; `cd && npx pkg --yes` allows
- `npx foo && npx -y bar` blocks the second invocation

## Test plan

- [x] `vitest run src/__tests__/tool-guard.test.ts` 45/45
- [x] `node ~/.claude/hooks/lib/guard-patterns-check.js` silent (no drift)
