### PR TITLE
fix(studio): make first-run local-first and one-click

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -1,5 +1,6 @@
 import { listen } from '@tauri-apps/api/event';
 import { useEffect, useState } from 'react';
+import Button from './components/adapters/Button';
 import AgentPanel from './components/agent/AgentPanel';
 import LoginScreen from './components/auth/LoginScreen';
 import Dashboard from './components/dashboard/Dashboard';
@@ -75,7 +76,7 @@ function MainApp() {
   // whereas completing setup persists. Conflating the two used to mark setup
   // permanently complete on any close gesture (UX-durability audit, Theme 3).
   const [wizardDismissed, setWizardDismissed] = useState(false);
-  const { config, loading, setIntent, updateConfig } = useConfig();
+  const { config, loading, error, reload, setIntent, updateConfig } = useConfig();
 
   // Listen for tray-click navigation events from Rust
   useEffect(() => {
@@ -93,10 +94,32 @@ function MainApp() {
     setPage('editor');
   }
 
-  if (loading || !config) {
+  if (loading) {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center gap-2 bg-surface-0">
+        <div className="text-fg-muted">Loading your Studio setup</div>
+        <p className="text-sm text-fg-subtle">Reading the local config for this machine.</p>
+      </div>
+    );
+  }
+
+  if (!config) {
     return (
       <div className="flex h-screen items-center justify-center bg-surface-0">
-        <div className="text-fg-muted">Loading...</div>
+        <div className="w-full max-w-sm space-y-3 px-6 text-center">
+          <h1 className="text-lg font-semibold text-fg">Studio could not read its local config</h1>
+          <p className="text-sm text-fg-muted">
+            {error ?? 'The config file is missing or unreadable.'}
+          </p>
+          <Button
+            variant="primary"
+            onClick={() => {
+              reload().catch(() => undefined);
+            }}
+          >
+            Try again
+          </Button>
+        </div>
       </div>
     );
   }

--- a/apps/studio/src/__tests__/components/DeployWizard.test.tsx
+++ b/apps/studio/src/__tests__/components/DeployWizard.test.tsx
@@ -11,11 +11,26 @@ const MOCK_CONFIG: StudioConfig = {
   develop: null,
 };
 
+function mockUseConfigReturn(
+  overrides: { config?: StudioConfig | null; loading?: boolean; error?: string | null } = {},
+) {
+  return {
+    config: null as StudioConfig | null,
+    loading: true,
+    error: null as string | null,
+    reload: vi.fn(),
+    updateConfig: vi.fn(),
+    setIntent: vi.fn(),
+    ...overrides,
+  };
+}
+
 vi.mock('../../hooks/use-config', () => ({
   useConfig: vi.fn().mockReturnValue({
     config: null,
     loading: true,
     error: null,
+    reload: vi.fn(),
     updateConfig: vi.fn(),
     setIntent: vi.fn(),
   }),
@@ -79,13 +94,9 @@ describe('DeployWizard', () => {
   });
 
   it('renders wizard title and step navigation when config is loaded', () => {
-    vi.mocked(useConfig).mockReturnValue({
-      config: MOCK_CONFIG,
-      loading: false,
-      error: null,
-      updateConfig: vi.fn(),
-      setIntent: vi.fn(),
-    });
+    vi.mocked(useConfig).mockReturnValue(
+      mockUseConfigReturn({ config: MOCK_CONFIG, loading: false }),
+    );
 
     render(<DeployWizard onComplete={vi.fn()} />);
 
@@ -96,13 +107,9 @@ describe('DeployWizard', () => {
   });
 
   it('renders the current step component', () => {
-    vi.mocked(useConfig).mockReturnValue({
-      config: MOCK_CONFIG,
-      loading: false,
-      error: null,
-      updateConfig: vi.fn(),
-      setIntent: vi.fn(),
-    });
+    vi.mocked(useConfig).mockReturnValue(
+      mockUseConfigReturn({ config: MOCK_CONFIG, loading: false }),
+    );
 
     render(<DeployWizard onComplete={vi.fn()} />);
 
@@ -110,13 +117,9 @@ describe('DeployWizard', () => {
   });
 
   it('shows step counter', () => {
-    vi.mocked(useConfig).mockReturnValue({
-      config: MOCK_CONFIG,
-      loading: false,
-      error: null,
-      updateConfig: vi.fn(),
-      setIntent: vi.fn(),
-    });
+    vi.mocked(useConfig).mockReturnValue(
+      mockUseConfigReturn({ config: MOCK_CONFIG, loading: false }),
+    );
 
     render(<DeployWizard onComplete={vi.fn()} />);
 
@@ -124,13 +127,9 @@ describe('DeployWizard', () => {
   });
 
   it('disables Back button on first step', () => {
-    vi.mocked(useConfig).mockReturnValue({
-      config: MOCK_CONFIG,
-      loading: false,
-      error: null,
-      updateConfig: vi.fn(),
-      setIntent: vi.fn(),
-    });
+    vi.mocked(useConfig).mockReturnValue(
+      mockUseConfigReturn({ config: MOCK_CONFIG, loading: false }),
+    );
 
     render(<DeployWizard onComplete={vi.fn()} />);
 

--- a/apps/studio/src/__tests__/components/IntentScreen.test.tsx
+++ b/apps/studio/src/__tests__/components/IntentScreen.test.tsx
@@ -10,48 +10,40 @@ function clickHeadingButton(name: string): void {
 }
 
 describe('IntentScreen', () => {
-  it('renders welcome heading and description', () => {
+  it('renders a path question and next-step copy', () => {
     render(<IntentScreen onSelect={vi.fn()} />);
 
-    expect(screen.getByText('Welcome to RevealUI Studio')).toBeInTheDocument();
-    expect(screen.getByText('How would you like to use RevealUI?')).toBeInTheDocument();
+    expect(screen.getByText('How will you use Studio?')).toBeInTheDocument();
+    expect(screen.getByText(/Pick a path. One click opens that workspace/)).toBeInTheDocument();
+    expect(screen.getByText(/open Agent in the sidebar/)).toBeInTheDocument();
   });
 
-  it('renders Deploy and Develop options', () => {
+  it('renders Develop and Deploy options', () => {
     render(<IntentScreen onSelect={vi.fn()} />);
 
     expect(screen.getByRole('heading', { name: 'Deploy' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Develop' })).toBeInTheDocument();
   });
 
-  it('Continue button is disabled when nothing is selected', () => {
-    render(<IntentScreen onSelect={vi.fn()} />);
-
-    expect(screen.getByText('Continue')).toBeDisabled();
-  });
-
-  it('enables Continue after selecting Deploy', () => {
-    render(<IntentScreen onSelect={vi.fn()} />);
-
-    clickHeadingButton('Deploy');
-    expect(screen.getByText('Continue')).not.toBeDisabled();
-  });
-
-  it('calls onSelect with "deploy" when Deploy is selected and Continue clicked', () => {
-    const onSelect = vi.fn();
-    render(<IntentScreen onSelect={onSelect} />);
-
-    clickHeadingButton('Deploy');
-    fireEvent.click(screen.getByText('Continue'));
-    expect(onSelect).toHaveBeenCalledWith('deploy');
-  });
-
-  it('calls onSelect with "develop" when Develop is selected and Continue clicked', () => {
+  it('calls onSelect with "develop" when the Develop card is clicked', () => {
     const onSelect = vi.fn();
     render(<IntentScreen onSelect={onSelect} />);
 
     clickHeadingButton('Develop');
-    fireEvent.click(screen.getByText('Continue'));
     expect(onSelect).toHaveBeenCalledWith('develop');
+  });
+
+  it('calls onSelect with "deploy" when the Deploy card is clicked', () => {
+    const onSelect = vi.fn();
+    render(<IntentScreen onSelect={onSelect} />);
+
+    clickHeadingButton('Deploy');
+    expect(onSelect).toHaveBeenCalledWith('deploy');
+  });
+
+  it('does not leave a disabled Continue trap', () => {
+    render(<IntentScreen onSelect={vi.fn()} />);
+
+    expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
   });
 });

--- a/apps/studio/src/__tests__/components/LoginScreen.test.tsx
+++ b/apps/studio/src/__tests__/components/LoginScreen.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import LoginScreen from '../../components/auth/LoginScreen';
+import type { AuthContextValue } from '../../hooks/use-auth';
+import { AuthContext } from '../../hooks/use-auth';
+import { SettingsContext } from '../../hooks/use-settings';
+
+const updateSettings = vi.fn();
+
+const defaultSettings = {
+  settings: {
+    theme: 'system' as const,
+    apiUrl: 'https://api.revealui.com',
+    pollingIntervalMs: 30_000,
+    localMode: false,
+  },
+  updateSettings,
+  resetSettings: vi.fn(),
+};
+
+const defaultAuth: AuthContextValue = {
+  step: 'email',
+  user: null,
+  tokenExpiresAt: null,
+  loading: false,
+  error: null,
+  sendOtp: vi.fn().mockResolvedValue(true),
+  submitOtp: vi.fn().mockResolvedValue(true),
+  signOut: vi.fn().mockResolvedValue(undefined),
+  recheck: vi.fn().mockResolvedValue(undefined),
+  getToken: vi.fn().mockReturnValue(null),
+};
+
+function renderGate(auth: Partial<AuthContextValue> = {}) {
+  return render(
+    <SettingsContext.Provider value={defaultSettings}>
+      <AuthContext.Provider value={{ ...defaultAuth, ...auth }}>
+        <LoginScreen />
+      </AuthContext.Provider>
+    </SettingsContext.Provider>,
+  );
+}
+
+describe('LoginScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('leads with local work, not a cloud login wall', () => {
+    renderGate();
+
+    expect(screen.getByText('RevealUI Studio')).toBeInTheDocument();
+    expect(screen.getByText(/start locally without an account/)).toBeInTheDocument();
+    expect(screen.getByText('Work on this machine')).toBeInTheDocument();
+    expect(screen.getByText('Sign in with email')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Email')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Connecting to/)).not.toBeInTheDocument();
+  });
+
+  it('starts local mode from the primary action', () => {
+    renderGate();
+
+    fireEvent.click(screen.getByText('Work on this machine'));
+    expect(updateSettings).toHaveBeenCalledWith({ localMode: true });
+  });
+
+  it('reveals email sign-in only after that path is chosen', () => {
+    renderGate();
+
+    fireEvent.click(screen.getByText('Sign in with email'));
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByText('Send verification code')).toBeInTheDocument();
+    expect(screen.getByText(/Sign-in contacts https:\/\/api.revealui.com/)).toBeInTheDocument();
+  });
+
+  it('explains an empty email submit instead of doing nothing', () => {
+    renderGate();
+
+    fireEvent.click(screen.getByText('Sign in with email'));
+    const form = screen.getByText('Send verification code').closest('form');
+    if (!form) throw new Error('missing email form');
+    fireEvent.submit(form);
+
+    expect(screen.getByText('Enter the email that should receive the code.')).toBeInTheDocument();
+    expect(defaultAuth.sendOtp).not.toHaveBeenCalled();
+  });
+});

--- a/apps/studio/src/__tests__/components/SetupWizard.test.tsx
+++ b/apps/studio/src/__tests__/components/SetupWizard.test.tsx
@@ -54,6 +54,7 @@ describe('SetupWizard', () => {
   it('renders "Setup RevealUI Studio" title', () => {
     renderWizard();
     expect(screen.getByText('Setup RevealUI Studio')).toBeInTheDocument();
+    expect(screen.getByText(/Agent Approvals live under Agent in the sidebar/)).toBeInTheDocument();
   });
 
   it('renders Skip button', () => {

--- a/apps/studio/src/__tests__/components/WelcomeBanner.test.tsx
+++ b/apps/studio/src/__tests__/components/WelcomeBanner.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import WelcomeBanner from '../../components/dashboard/WelcomeBanner';
+import { SettingsContext } from '../../hooks/use-settings';
+
+function renderBanner(localMode: boolean) {
+  return render(
+    <SettingsContext.Provider
+      value={{
+        settings: {
+          theme: 'system',
+          apiUrl: 'http://localhost:3004',
+          pollingIntervalMs: 30_000,
+          localMode,
+        },
+        updateSettings: vi.fn(),
+        resetSettings: vi.fn(),
+      }}
+    >
+      <WelcomeBanner />
+    </SettingsContext.Provider>,
+  );
+}
+
+describe('WelcomeBanner', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows local next steps when local mode is on', () => {
+    renderBanner(true);
+
+    expect(screen.getByText('You are working on this machine')).toBeInTheDocument();
+    expect(screen.getByText('Open Agent in the sidebar.')).toBeInTheDocument();
+    expect(screen.getByText('Open the Approvals tab on the right.')).toBeInTheDocument();
+  });
+
+  it('keeps the account-mode welcome when local mode is off', () => {
+    renderBanner(false);
+
+    expect(screen.getByText('Run your agents on your own infrastructure')).toBeInTheDocument();
+    expect(screen.queryByText('You are working on this machine')).not.toBeInTheDocument();
+  });
+});

--- a/apps/studio/src/__tests__/hooks/use-config.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-config.test.ts
@@ -64,6 +64,28 @@ describe('useConfig', () => {
     expect(result.current.error).toContain('Config read failed');
   });
 
+  it('reload retries getConfig after a failure', async () => {
+    vi.mocked(getConfig)
+      .mockRejectedValueOnce(new Error('Config read failed'))
+      .mockResolvedValueOnce(MOCK_CONFIG);
+
+    const { result } = renderHook(() => useConfig());
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(result.current.config).toBeNull();
+
+    await act(async () => {
+      await result.current.reload();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.config).toEqual(MOCK_CONFIG);
+    expect(result.current.error).toBeNull();
+  });
+
   it('updateConfig merges and persists changes', async () => {
     const { result } = renderHook(() => useConfig());
 

--- a/apps/studio/src/components/auth/LoginScreen.tsx
+++ b/apps/studio/src/components/auth/LoginScreen.tsx
@@ -1,27 +1,32 @@
 /**
- * LoginScreen — Device Authentication Flow
+ * LoginScreen — first-run gate
  *
- * Two-step flow:
- * 1. Enter email → OTP sent to inbox
- * 2. Enter 6-digit OTP code → bearer token issued
- *
- * Matches the Studio visual style (dark theme, orange accent).
+ * Local Studio is the primary path. Account sign-in is optional and only
+ * needed for API-backed features. The previous layout led with email OTP
+ * and buried local mode under a ghost button, so a first click felt like
+ * a no-op.
  */
 
 import { useEffect, useRef, useState } from 'react';
 import { useAuthContext } from '../../hooks/use-auth';
 import { useSettingsContext } from '../../hooks/use-settings';
 import Button from '../adapters/Button';
+import ErrorAlert from '../adapters/ErrorAlert';
 import Input from '../adapters/Input';
 
 const RESEND_COOLDOWN_SECONDS = 30;
 
+type GateView = 'choose' | 'signin';
+
 export default function LoginScreen() {
   const { step, loading, error, sendOtp, submitOtp } = useAuthContext();
   const { settings, updateSettings } = useSettingsContext();
+  const [view, setView] = useState<GateView>('choose');
+  const [startingLocal, setStartingLocal] = useState(false);
   const [email, setEmail] = useState('');
   const [code, setCode] = useState('');
   const [otpSent, setOtpSent] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
   const [resendCooldown, setResendCooldown] = useState(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -38,8 +43,11 @@ export default function LoginScreen() {
     intervalRef.current = setInterval(() => {
       setResendCooldown((prev) => {
         if (prev <= 1) {
-          clearInterval(intervalRef.current!);
-          intervalRef.current = null;
+          const timer = intervalRef.current;
+          if (timer !== null) {
+            clearInterval(timer);
+            intervalRef.current = null;
+          }
           return 0;
         }
         return prev - 1;
@@ -47,9 +55,19 @@ export default function LoginScreen() {
     }, 1000);
   }
 
+  function startLocalMode(): void {
+    setFormError(null);
+    setStartingLocal(true);
+    updateSettings({ localMode: true });
+  }
+
   async function handleSendOtp(e: React.FormEvent): Promise<void> {
     e.preventDefault();
-    if (!email.trim()) return;
+    if (!email.trim()) {
+      setFormError('Enter the email that should receive the code.');
+      return;
+    }
+    setFormError(null);
     const ok = await sendOtp(settings.apiUrl, email.trim());
     if (ok) {
       setOtpSent(true);
@@ -59,38 +77,94 @@ export default function LoginScreen() {
 
   async function handleVerify(e: React.FormEvent): Promise<void> {
     e.preventDefault();
-    if (!code.trim() || code.length !== 6) return;
+    if (!code.trim() || code.length !== 6) {
+      setFormError('Enter the 6-digit code from the email.');
+      return;
+    }
+    setFormError(null);
     await submitOtp(settings.apiUrl, email.trim(), code.trim());
   }
 
   async function handleResend(): Promise<void> {
     setCode('');
+    setFormError(null);
     await sendOtp(settings.apiUrl, email.trim());
     startCooldown();
   }
 
   const showOtp = step === 'otp' || otpSent;
+  const showSignIn = view === 'signin' || showOtp;
   const resendBlocked = resendCooldown > 0;
+  const gateError = formError ?? error;
+
+  if (!showSignIn) {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-surface-0">
+        <div className="w-full max-w-md space-y-6 rounded-xl border border-edge bg-surface-1 p-8">
+          <div className="text-center">
+            <h1 className="text-lg font-semibold text-fg">RevealUI Studio</h1>
+            <p className="mt-2 text-sm leading-relaxed text-fg-muted">
+              Studio is the desktop app for the RevDev daemon on this machine. You can start locally
+              without an account.
+            </p>
+          </div>
+
+          <ErrorAlert message={gateError} />
+
+          <div className="space-y-3">
+            <Button
+              type="button"
+              variant="primary"
+              size="lg"
+              loading={startingLocal}
+              disabled={startingLocal}
+              onClick={startLocalMode}
+              className="h-auto w-full flex-col items-start gap-1 rounded-lg px-4 py-3 text-left"
+            >
+              <span className="text-sm font-semibold">Work on this machine</span>
+              <span className="text-xs font-normal opacity-90">
+                Opens terminal, git, vault, and Agent Approvals. No RevealUI account needed.
+              </span>
+            </Button>
+
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={startingLocal}
+              onClick={() => {
+                setFormError(null);
+                setView('signin');
+              }}
+              className="h-auto w-full flex-col items-start gap-1 rounded-lg border border-edge px-4 py-3 text-left"
+            >
+              <span className="text-sm font-semibold text-fg">Sign in with email</span>
+              <span className="text-xs font-normal text-fg-muted">
+                Connect Studio to a RevealUI API for account features. You will get a one-time code.
+              </span>
+            </Button>
+          </div>
+
+          <p className="text-center text-[11px] leading-relaxed text-fg-subtle">
+            After local start, Studio asks whether you want to develop in repos or deploy a
+            business. You can skip the setup checklist and open Agent → Approvals from there.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-screen w-screen items-center justify-center bg-surface-0">
       <div className="w-full max-w-sm space-y-6 rounded-xl border border-edge bg-surface-1 p-8">
-        {/* Header */}
         <div className="text-center">
           <h1 className="text-lg font-semibold text-fg">RevealUI Studio</h1>
           <p className="mt-1 text-sm text-fg-muted">
-            {showOtp ? 'Enter verification code' : 'Sign in to your account'}
+            {showOtp ? 'Enter the 6-digit code from your email' : 'Sign in to a RevealUI account'}
           </p>
         </div>
 
-        {/* Error */}
-        {error ? (
-          <div className="rounded-md border border-error/40 bg-error-subtle px-3 py-2 text-xs text-error">
-            {error}
-          </div>
-        ) : null}
+        <ErrorAlert message={gateError} />
 
-        {/* Email Step */}
         {showOtp ? null : (
           <form onSubmit={handleSendOtp} className="space-y-4">
             <Input
@@ -109,7 +183,6 @@ export default function LoginScreen() {
           </form>
         )}
 
-        {/* OTP Step */}
         {showOtp ? (
           <form onSubmit={handleVerify} className="space-y-4">
             <p className="text-xs text-fg-subtle">
@@ -144,7 +217,9 @@ export default function LoginScreen() {
                 type="button"
                 variant="ghost"
                 size="sm"
-                onClick={handleResend}
+                onClick={() => {
+                  handleResend().catch(() => undefined);
+                }}
                 disabled={loading || resendBlocked}
                 className="h-auto p-0 text-fg-subtle hover:text-accent disabled:cursor-not-allowed disabled:opacity-50"
               >
@@ -157,35 +232,31 @@ export default function LoginScreen() {
                 onClick={() => {
                   setOtpSent(false);
                   setCode('');
+                  setFormError(null);
                 }}
                 className="h-auto p-0 text-fg-subtle hover:text-fg-muted"
               >
-                Use different email
+                Use a different email
               </Button>
             </div>
           </form>
         ) : null}
 
-        {/* Local mode escape hatch (email step only) */}
-        {showOtp ? null : (
-          <div className="space-y-2 border-t border-edge pt-4">
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => updateSettings({ localMode: true })}
-              className="w-full rounded-md border border-edge px-3 py-2 text-sm text-fg-muted transition-colors hover:border-brand hover:text-fg"
-            >
-              Continue in local mode
-            </Button>
-            <p className="text-center text-[11px] text-fg-subtle">
-              Use local tools (terminal, shell, git) without signing in. Account features stay
-              disabled until you sign in.
-            </p>
-          </div>
-        )}
-
-        {/* Footer */}
-        <p className="text-center text-[11px] text-fg-subtle">Connecting to {settings.apiUrl}</p>
+        <div className="space-y-2 border-t border-edge pt-4">
+          <Button
+            type="button"
+            variant="ghost"
+            loading={startingLocal}
+            disabled={startingLocal}
+            onClick={startLocalMode}
+            className="w-full rounded-md border border-edge px-3 py-2 text-sm text-fg-muted transition-colors hover:border-brand hover:text-fg"
+          >
+            Work on this machine instead
+          </Button>
+          <p className="text-center text-[11px] text-fg-subtle">
+            Sign-in contacts {settings.apiUrl}. Local mode does not.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/apps/studio/src/components/dashboard/WelcomeBanner.tsx
+++ b/apps/studio/src/components/dashboard/WelcomeBanner.tsx
@@ -1,10 +1,12 @@
 import { IconClose } from '@revealui/presentation';
 import { useCallback, useState } from 'react';
+import { useSettingsContext } from '../../hooks/use-settings';
 import Button from '../adapters/Button';
 
 const STORAGE_KEY = 'revealui-welcome-dismissed';
 
 export default function WelcomeBanner() {
+  const { settings } = useSettingsContext();
   const [dismissed, setDismissed] = useState(() => localStorage.getItem(STORAGE_KEY) === '1');
 
   const dismiss = useCallback(() => {
@@ -27,13 +29,27 @@ export default function WelcomeBanner() {
         <IconClose size="sm" />
       </Button>
       <h2 className="text-sm font-semibold text-brand-text">
-        Run your agents on your own infrastructure
+        {settings.localMode
+          ? 'You are working on this machine'
+          : 'Run your agents on your own infrastructure'}
       </h2>
-      <p className="mt-1 text-xs leading-relaxed text-fg-muted">
-        Studio is where you start your agents and watch them work. Each one runs as a user you
-        govern, and every action it takes is recorded so you can check it. This is an early preview,
-        so expect a few rough edges.
-      </p>
+      {settings.localMode ? (
+        <div className="mt-1 space-y-2 text-xs leading-relaxed text-fg-muted">
+          <p>Account features stay off until you sign in from Settings.</p>
+          <p className="font-medium text-fg">Next</p>
+          <ol className="list-decimal space-y-1 pl-4">
+            <li>Skip the setup checklist if it covers the window.</li>
+            <li>Open Agent in the sidebar.</li>
+            <li>Open the Approvals tab on the right.</li>
+          </ol>
+        </div>
+      ) : (
+        <p className="mt-1 text-xs leading-relaxed text-fg-muted">
+          Studio is where you start your agents and watch them work. Each one runs as a user you
+          govern, and every action it takes is recorded so you can check it. This is an early
+          preview, so expect a few rough edges.
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/studio/src/components/intent/IntentScreen.tsx
+++ b/apps/studio/src/components/intent/IntentScreen.tsx
@@ -7,21 +7,20 @@ interface IntentScreenProps {
 }
 
 export default function IntentScreen({ onSelect }: IntentScreenProps) {
-  const [selected, setSelected] = useState<'deploy' | 'develop' | null>(null);
-  const [pending, setPending] = useState(false);
+  const [pending, setPending] = useState<'deploy' | 'develop' | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  async function handleContinue(): Promise<void> {
-    if (!selected) return;
+  async function handleSelect(intent: 'deploy' | 'develop'): Promise<void> {
+    if (pending) return;
     setError(null);
-    setPending(true);
+    setPending(intent);
     try {
-      await onSelect(selected);
+      await onSelect(intent);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to save your selection. Please try again.',
       );
-      setPending(false);
+      setPending(null);
     }
   }
 
@@ -32,58 +31,55 @@ export default function IntentScreen({ onSelect }: IntentScreenProps) {
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-brand text-2xl font-bold text-on-brand">
             R
           </div>
-          <h1 className="text-3xl font-bold text-fg">Welcome to RevealUI Studio</h1>
-          <p className="mt-2 text-fg-muted">How would you like to use RevealUI?</p>
+          <h1 className="text-3xl font-bold text-fg">How will you use Studio?</h1>
+          <p className="mt-2 text-fg-muted">
+            Pick a path. One click opens that workspace. You can change this later in Settings.
+          </p>
         </div>
 
         <div className="grid grid-cols-2 gap-6">
           <Button
             type="button"
             variant="ghost"
-            onClick={() => setSelected('deploy')}
-            className={`h-auto rounded-xl border-2 p-6 text-left ${
-              selected === 'deploy'
-                ? 'border-brand bg-surface-2'
-                : 'border-edge bg-surface-1 hover:border-edge'
-            }`}
+            loading={pending === 'develop'}
+            disabled={pending !== null}
+            onClick={() => {
+              handleSelect('develop').catch(() => undefined);
+            }}
+            className="h-auto rounded-xl border-2 border-edge bg-surface-1 p-6 text-left hover:border-brand"
           >
-            <div className="mb-2 text-2xl">&#x1F680;</div>
-            <h2 className="text-lg font-semibold text-fg">Deploy</h2>
+            <div className="mb-2 text-2xl">&#x1F6E0;&#xFE0F;</div>
+            <h2 className="text-lg font-semibold text-fg">Develop</h2>
             <p className="mt-1 text-sm text-fg-muted">
-              I want to run RevealUI for my business. Set up Vercel, database, Stripe, and go live.
+              Work in local repos. This opens the dashboard, then terminal, git, and Agent
+              Approvals.
             </p>
           </Button>
 
           <Button
             type="button"
             variant="ghost"
-            onClick={() => setSelected('develop')}
-            className={`h-auto rounded-xl border-2 p-6 text-left ${
-              selected === 'develop'
-                ? 'border-brand bg-surface-2'
-                : 'border-edge bg-surface-1 hover:border-edge'
-            }`}
+            loading={pending === 'deploy'}
+            disabled={pending !== null}
+            onClick={() => {
+              handleSelect('deploy').catch(() => undefined);
+            }}
+            className="h-auto rounded-xl border-2 border-edge bg-surface-1 p-6 text-left hover:border-brand"
           >
-            <div className="mb-2 text-2xl">&#x1F6E0;&#xFE0F;</div>
-            <h2 className="text-lg font-semibold text-fg">Develop</h2>
+            <div className="mb-2 text-2xl">&#x1F680;</div>
+            <h2 className="text-lg font-semibold text-fg">Deploy</h2>
             <p className="mt-1 text-sm text-fg-muted">
-              I want to contribute to RevealUI. Set up the dev environment with WSL, Nix, and tools.
+              Run the guided business setup for Vercel, a database, and Stripe.
             </p>
           </Button>
         </div>
 
-        <div className="mt-8 flex flex-col items-center gap-4">
+        <div className="mt-8 flex flex-col items-center gap-3">
           <ErrorAlert message={error} className="w-full" />
-          <Button
-            variant="primary"
-            size="lg"
-            disabled={!selected || pending}
-            onClick={() => {
-              void handleContinue();
-            }}
-          >
-            {pending ? 'Saving…' : 'Continue'}
-          </Button>
+          <p className="max-w-lg text-center text-sm text-fg-subtle">
+            For this machine, choose Develop. A setup checklist may appear next. You can skip it and
+            open Agent in the sidebar, then the Approvals tab.
+          </p>
         </div>
       </div>
     </div>

--- a/apps/studio/src/components/setup/SetupWizard.tsx
+++ b/apps/studio/src/components/setup/SetupWizard.tsx
@@ -63,6 +63,10 @@ export default function SetupWizard({ onComplete, onDismiss }: SetupWizardProps)
         }
       >
         <div className="space-y-4">
+          <p className="text-sm leading-relaxed text-fg-muted">
+            This checklist sets up WSL, Nix, DevPod, and git identity. It is optional. Skip to use
+            Studio now. Agent Approvals live under Agent in the sidebar.
+          </p>
           {setup.loading && !setup.status && (
             <p className="text-sm text-fg-muted">Checking environment...</p>
           )}
@@ -83,7 +87,7 @@ export default function SetupWizard({ onComplete, onDismiss }: SetupWizardProps)
       <ConfirmDialog
         open={confirmingDismiss}
         title="Dismiss setup?"
-        body="Setup isn't finished. Dismiss anyway? You can reopen setup later."
+        body="Setup is not finished. Dismiss anyway? You can reopen Setup from the sidebar. Agent Approvals are under Agent."
         confirmLabel="Dismiss setup"
         cancelLabel="Keep going"
         onConfirm={() => {

--- a/apps/studio/src/hooks/use-config.ts
+++ b/apps/studio/src/hooks/use-config.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { getConfig, setConfig } from '../lib/config';
 import type { StudioConfig } from '../types';
 
@@ -6,6 +6,7 @@ interface UseConfigReturn {
   config: StudioConfig | null;
   loading: boolean;
   error: string | null;
+  reload: () => Promise<void>;
   updateConfig: (updates: Partial<StudioConfig>) => Promise<void>;
   setIntent: (intent: 'deploy' | 'develop') => Promise<void>;
 }
@@ -15,12 +16,21 @@ export function useConfig(): UseConfigReturn {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    getConfig()
-      .then(setConfigState)
-      .catch((e) => setError(String(e)))
-      .finally(() => setLoading(false));
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setConfigState(await getConfig());
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    reload().catch(() => undefined);
+  }, [reload]);
 
   const updateConfig = async (updates: Partial<StudioConfig>) => {
     if (!config) return;
@@ -37,5 +47,5 @@ export function useConfig(): UseConfigReturn {
     await updateConfig({ intent });
   };
 
-  return { config, loading, error, updateConfig, setIntent };
+  return { config, loading, error, reload, updateConfig, setIntent };
 }


### PR DESCRIPTION
## Why

The first Studio screen was a cloud login. Local mode sat on a ghost button, and the next screen’s Continue button did nothing until a card was selected. That made a first click look like a no-op.

## What

- Welcome leads with **Work on this machine**. Sign-in is a second path, not the default frame.
- Develop and Deploy are one-click cards. There is no disabled Continue.
- Setup checklist and dashboard banner say the next step: Agent → Approvals.
- Config load failure shows an error and retry instead of a stuck Loading screen.

## Test

`pnpm --filter studio exec vitest run` on the first-run files: 35 passed.