### PR TITLE
fix(studio): refuse to start when WSLg cannot present a window

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -1,6 +1,8 @@
 # RevealUI Studio
 
-> **Status:** Functional — connects to the harness daemon, 506 frontend tests passing. **Prebuilt binaries are published** on [GitHub Releases](https://github.com/RevealUIStudio/revdev/releases) (first release `studio-v0.1.0`, 2026-07-02; macOS · Linux · Windows). macOS builds are currently **unsigned / ad-hoc**, so Gatekeeper blocks the first launch — **right-click the app → Open** (or `System Settings → Privacy & Security → Open Anyway`) once to run it. In-app auto-update is **configured but not yet live** (the `releases.revealui.com` update endpoint is not serving manifests yet), so update by downloading the latest release manually for now. To run from source instead: `pnpm tauri:dev`.
+> **Status:** Functional — connects to the harness daemon, 506 frontend tests passing. **Prebuilt binaries are published** on [GitHub Releases](https://github.com/RevealUIStudio/revdev/releases) (first release `studio-v0.1.0`, 2026-07-02; macOS · Linux · Windows). macOS builds are currently **unsigned / ad-hoc**, so Gatekeeper blocks the first launch — **right-click the app → Open** (or `System Settings → Privacy & Security → Open Anyway`) once to run it. In-app auto-update is **configured but not yet live** (the `releases.revealui.com` update endpoint is not serving manifests yet), so update by downloading the latest release manually for now.
+>
+> Two launch paths, two binaries. The Windows Start Menu app is the last installed release. `pnpm tauri:dev` in WSL is this source tree. They do not share UI. On WSL, Studio refuses to start if WSLg cannot put a window on the Windows desktop (RDP/msrdc down, or a 640x480 stub display).
 
 Native AI experience — agent coordination hub, local inference management, visual agent dashboard, DevPod manager, and secret vault.
 

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod harness_watcher;
 mod inference;
 mod local_shell;
 mod platform;
+mod presentment;
 pub mod signing;
 mod spawner;
 pub mod ssh;
@@ -55,6 +56,10 @@ pub fn run() {
         .setup(|app| {
             tray::setup_tray(&app.handle())?;
             harness_watcher::start(app.handle().clone());
+            presentment::present_main_window(&app.handle()).map_err(|err| {
+                eprintln!("{err}");
+                Box::<dyn std::error::Error>::from(err)
+            })?;
 
             // Register the tile-gallery hotkey dynamically so registration
             // failures (e.g. a stale WSLg compositor claim) degrade to a

--- a/apps/studio/src-tauri/src/presentment.rs
+++ b/apps/studio/src-tauri/src/presentment.rs
@@ -1,0 +1,199 @@
+//! Window presentment: refuse to look "up" when the operator cannot see Studio.
+//!
+//! On this machine the failure class was: `pnpm tauri:dev` created a GTK
+//! window on a WSLg compositor whose Windows RDP client (msrdc) was down.
+//! The process stayed running. The Start Menu app is a different Windows
+//! install and does not load this source tree.
+//!
+//! Detection is pure so it can be locked in unit tests. The weston log
+//! misspells "initialized" as "initalized"; match that string as written.
+
+use tauri::{AppHandle, Manager, PhysicalPosition};
+
+/// Why a WSL Studio window will not appear on the Windows desktop.
+pub const WSL_UNPRESENTABLE: &str = "Studio cannot put a window on your desktop. \
+WSLg's RDP display (msrdc) is not connected, so Linux GUI windows stay on a \
+hidden 640x480 compositor. Repair WSLg, then launch this source tree again. \
+The Windows Start Menu app is a separate install and will not pick up this tree.";
+
+/// Last weston/RDP signal in a log: missing peer vs a live one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WestonRdpState {
+    Missing,
+    Live,
+    Unknown,
+}
+
+pub fn weston_rdp_state(log: &str) -> WestonRdpState {
+    let mut state = WestonRdpState::Unknown;
+    for line in log.lines() {
+        if line.contains("rdp_peer is not initalized") {
+            state = WestonRdpState::Missing;
+        } else if line.contains("rdp_rail_notify_app_list(): rdp_peer 0x") {
+            state = WestonRdpState::Live;
+        }
+    }
+    state
+}
+
+/// True when a WSL session cannot present a desktop window to Windows.
+pub fn wsl_display_unpresentable(
+    is_wsl: bool,
+    monitor_width: u32,
+    monitor_height: u32,
+    weston_log: Option<&str>,
+) -> bool {
+    if !is_wsl {
+        return false;
+    }
+    let stub = monitor_width <= 640 && monitor_height <= 480;
+    let rdp_dead = matches!(
+        weston_log.map(weston_rdp_state),
+        Some(WestonRdpState::Missing)
+    );
+    stub || rdp_dead
+}
+
+/// Keep the window inside the monitor. If it is larger than the monitor,
+/// pin it to the monitor origin so a later display resize can show it.
+pub fn clamp_position(
+    x: i32,
+    y: i32,
+    win_w: u32,
+    win_h: u32,
+    mon_x: i32,
+    mon_y: i32,
+    mon_w: u32,
+    mon_h: u32,
+) -> (i32, i32) {
+    if mon_w == 0 || mon_h == 0 {
+        return (x, y);
+    }
+    let max_x = mon_x + mon_w as i32 - win_w.min(mon_w) as i32;
+    let max_y = mon_y + mon_h as i32 - win_h.min(mon_h) as i32;
+    let nx = x.clamp(mon_x, max_x.max(mon_x));
+    let ny = y.clamp(mon_y, max_y.max(mon_y));
+    (nx, ny)
+}
+
+pub fn running_in_wsl() -> bool {
+    std::env::var_os("WSL_DISTRO_NAME").is_some()
+}
+
+/// Center and clamp the main window, or refuse to start on an unpresentable WSL display.
+pub fn present_main_window<R: tauri::Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    let Some(win) = app.get_webview_window("main") else {
+        return Ok(());
+    };
+
+    if cfg!(debug_assertions) {
+        let _ = win.set_title("RevealUI Studio (dev)");
+    }
+
+    let monitor = win
+        .current_monitor()
+        .map_err(|err| err.to_string())?
+        .or(win.primary_monitor().map_err(|err| err.to_string())?);
+
+    if let Some(monitor) = monitor {
+        let size = monitor.size();
+        let weston = std::fs::read_to_string("/mnt/wslg/weston.log").ok();
+        if wsl_display_unpresentable(
+            running_in_wsl(),
+            size.width,
+            size.height,
+            weston.as_deref(),
+        ) {
+            return Err(WSL_UNPRESENTABLE.to_string());
+        }
+
+        let _ = win.center();
+        if let (Ok(pos), Ok(outer)) = (win.outer_position(), win.outer_size()) {
+            let mon_pos = monitor.position();
+            let (x, y) = clamp_position(
+                pos.x,
+                pos.y,
+                outer.width,
+                outer.height,
+                mon_pos.x,
+                mon_pos.y,
+                size.width,
+                size.height,
+            );
+            if x != pos.x || y != pos.y {
+                let _ = win.set_position(PhysicalPosition::new(x, y));
+            }
+        }
+    }
+
+    let _ = win.show();
+    let _ = win.set_focus();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_wsl_is_always_presentable() {
+        assert!(!wsl_display_unpresentable(
+            false,
+            640,
+            480,
+            Some("CreateWndow(): rdp_peer is not initalized"),
+        ));
+    }
+
+    #[test]
+    fn wsl_stub_resolution_is_unpresentable() {
+        assert!(wsl_display_unpresentable(true, 640, 480, None));
+        assert!(wsl_display_unpresentable(true, 320, 240, None));
+    }
+
+    #[test]
+    fn wsl_real_resolution_without_log_is_presentable() {
+        assert!(!wsl_display_unpresentable(true, 1920, 1200, None));
+    }
+
+    #[test]
+    fn weston_last_missing_peer_wins() {
+        let log = "\
+[18:20] CreateWndow(): rdp_peer is not initalized
+[20:25] rdp_rail_notify_app_list(): rdp_peer 0x5a9bb49395b0
+[20:27] CreateWndow(): rdp_peer is not initalized
+";
+        assert_eq!(weston_rdp_state(log), WestonRdpState::Missing);
+        assert!(wsl_display_unpresentable(true, 1920, 1200, Some(log)));
+    }
+
+    #[test]
+    fn weston_last_live_peer_wins() {
+        let log = "\
+[18:20] CreateWndow(): rdp_peer is not initalized
+[20:25] rdp_rail_notify_app_list(): rdp_peer 0x5a9bb49395b0
+";
+        assert_eq!(weston_rdp_state(log), WestonRdpState::Live);
+        assert!(!wsl_display_unpresentable(true, 1920, 1200, Some(log)));
+    }
+
+    #[test]
+    fn clamp_moves_offscreen_coords_onto_the_monitor() {
+        assert_eq!(
+            clamp_position(-32730, -32709, 1100, 750, 0, 0, 1920, 1200),
+            (0, 0)
+        );
+        assert_eq!(
+            clamp_position(2000, 50, 1100, 750, 0, 0, 1920, 1200),
+            (820, 50)
+        );
+    }
+
+    #[test]
+    fn clamp_pins_oversized_window_to_origin() {
+        assert_eq!(
+            clamp_position(86, 107, 1100, 750, 0, 0, 640, 480),
+            (0, 0)
+        );
+    }
+}

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -15,6 +15,7 @@
         "title": "RevealUI Studio",
         "width": 1100,
         "height": 750,
+        "center": true,
         "resizable": true,
         "fullscreen": false
       }


### PR DESCRIPTION
## Why

Opening Studio on this machine showed the old sign-in because two different binaries share the same name:

- Windows Start Menu is the last installed release (June/July 0.2.0). It does not load this source tree. Auto-update is configured but the release endpoint is not live.
- `pnpm tauri:dev` in WSL creates a GTK window. When WSLg's RDP client (msrdc) is down, that window stays on a hidden 640x480 compositor and the process looks like it launched.

Session window moves and msrdc restarts do not close that class.

## What

- Detect an unpresentable WSL display (640x480 stub, or weston log last signal is a missing RDP peer).
- Refuse to start with a stderr error that names WSLg RDP. Do not leave a hidden process.
- Center and clamp the window when a real monitor exists.
- Document that Start Menu and `tauri:dev` are two binaries.

## Not in this PR

A current Windows build. That is the Start Menu path. It needs a `studio-v*` release from `test` (or a draft from `studio-release.yml`) and an install of that artifact.