### PR TITLE
ci(backflow): pin auto-land reusable like revealui

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -5,13 +5,11 @@ name: backflow-main-into-test
 # Requires the BACKFLOW_APP_ID / BACKFLOW_APP_PRIVATE_KEY secrets + the
 # revfleet-backflow App installed on this repo (Contents + Pull requests r/w).
 # Triggers on push to BOTH main and test:
-#   - push:main — main moved forward; open a backflow PR so test catches up.
-#   - push:test — self-heal: if a backflow PR was squash-merged (which strips
-#     main's parentage and leaves `test` not containing `main`), the next push
-#     to test re-detects the broken ancestry and re-opens a correct --no-ff
-#     backflow, instead of the gap lurking until the next promotion (where
-#     promotion-gate would then block it). The reusable no-ops when test already
-#     contains main, so the push:test path is a cheap guard.
+#   - push:main — main moved forward; land main into test via merges API.
+#   - push:test — self-heal: if ancestry is still broken (legacy squash of a
+#     backflow PR), re-run lands main into test via merges API (two-parent).
+#     Primary path no longer opens a human-squashable PR. No-ops when test
+#     already contains main.
 on:
   push:
     branches: [main, test]
@@ -27,7 +25,7 @@ jobs:
     # Pinned to an immutable SHA (RevealUIStudio/.github main @ 2026-06-12) so a
     # later push to the shared repo cannot silently change this production gate.
     # Bump via Dependabot (github-actions) like every other pinned ref.
-    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@e895ec57294c24089e3a0c7238d6c34ebb5fdf95 # main @ 2026-07-25 (backflow applies backflow:merge-commit label — .github#12)
+    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@d0c9c99e243874a028c9d94d02726f73832c5968 # feat/auto-land (org .github#13) — merges API base=test; no human squash
     # Scope to ONLY the two secrets the reusable declares (its workflow_call.secrets
     # block documents this exact form) instead of `secrets: inherit`, which would
     # forward every caller secret into it.


### PR DESCRIPTION
## Summary

Pin the org-shared backflow reusable to the auto-land SHA already used on revealui (`d0c9c99`, .github#13).

After this lands on `test` (and later on `main` via the next promotion), a push to `main` lands `main` into `test` with a two-parent merges API commit. No human squash button.

revcon/revkit also gain `push: test` + scoped `BACKFLOW_APP_*` secrets (they previously fired only on `main` and used `secrets: inherit`).

## Test plan

- [ ] Confirm the workflow file pins `d0c9c99e243874a028c9d94d02726f73832c5968`
- [ ] After merge to `test`, next `main` push should auto-land (once this file is also on `main`)
- [ ] `test` still contains `main` (ancestry)