### PR TITLE
chore(studio): bump 0.2.1 for updater-feed release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-08-14
+
+### Added
+
+- **Auto-update feed.** Studio bundles updater artifacts. New `studio-v*` tags
+  publish `latest.json` to the rolling `studio-latest` GitHub release. The
+  client tries `releases.revealui.com` first, then that GitHub feed.
+- **Deploy-wizard Gmail probe (revdev#15).** Send-test uses the service account
+  and domain-wide delegation, returns a Gmail message id, and rate-limits at
+  5/min. Next stays disabled until the send succeeds.
+
+### Fixed
+
+- **Deploy wizard honesty.** Draft (including generated secrets) persists in
+  local config (mode 0600). Sidebar cannot skip past the first incomplete
+  step. Verify fails when email was not probed or the API project id is
+  missing. Deploy poll can be cancelled. Config load failure shows Retry.
+- **First-run and WSLg.** Local-first first-run and refuse-to-start when WSLg
+  cannot present a window (revdev#405, #406), included in this desktop tag.
+
+[0.2.1]: https://github.com/RevealUIStudio/revdev/releases/tag/studio-v0.2.1
+
+
 ### Added
 
 - **GAP-269 spawned agent identity.** `agent.spawn` mints a distinct

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Native AI experience — agent coordination hub, local inference management, visual agent dashboard (Tauri 2 + React 19)",
   "private": true,
   "dependencies": {

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "age",
  "arboard",

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.2.1",
+version = "0.2.1"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.2.0"
+version = "0.2.1",
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "RevealUI Studio",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "dev.revealui.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Version bump so the `studio-v0.2.1` tag matches the binary. #408 is already on `test` at 0.2.0 labels; without this bump the updater would treat 0.2.1 artifacts as still 0.2.0.

Tag `studio-v0.2.1` is pushed with this commit and will run `studio-release.yml` (artifacts + `studio-latest` feed).

## Owner

- Alias `releases.revealui.com` when you want the primary URL (GitHub fallback is live after the release job).
- GAP-273 / H9 unchanged.