### PR TITLE
feat(releases): return updater JSON instead of a GitHub 302

### DIFF
--- a/apps/releases/api/latest.js
+++ b/apps/releases/api/latest.js
@@ -1,0 +1,36 @@
+const UPSTREAM =
+  'https://github.com/RevealUIStudio/revdev/releases/download/studio-latest/latest.json';
+
+export const config = { runtime: 'edge' };
+
+/**
+ * Baked-in Studio updater URL must return JSON, not a GitHub asset 302.
+ * GitHub `studio-latest` stays the authored feed. This host is the stable edge.
+ */
+export default async function handler() {
+  const upstream = await fetch(UPSTREAM, {
+    headers: { 'user-agent': 'revealui-studio-releases' },
+    redirect: 'follow',
+  });
+  if (!upstream.ok) {
+    return Response.json(
+      { error: 'updater feed unavailable', status: upstream.status },
+      { status: 502 },
+    );
+  }
+
+  const body = await upstream.text();
+  try {
+    JSON.parse(body);
+  } catch {
+    return Response.json({ error: 'updater feed was not JSON' }, { status: 502 });
+  }
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'public, max-age=60, s-maxage=60',
+    },
+  });
+}

--- a/apps/releases/vercel.json
+++ b/apps/releases/vercel.json
@@ -3,16 +3,7 @@
   "rewrites": [
     {
       "source": "/studio/:target/:arch/latest.json",
-      "destination": "https://github.com/RevealUIStudio/revdev/releases/download/studio-latest/latest.json"
-    }
-  ],
-  "headers": [
-    {
-      "source": "/studio/:target/:arch/latest.json",
-      "headers": [
-        { "key": "Content-Type", "value": "application/json; charset=utf-8" },
-        { "key": "Cache-Control", "value": "public, max-age=60" }
-      ]
+      "destination": "/api/latest"
     }
   ]
 }

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -177,7 +177,7 @@ The daemon stores all events, messages, and memory in PGlite. If the database ex
 
 Studio checks `releases.revealui.com` first, then the GitHub `studio-latest` updater feed. If this fails:
 - Check internet connectivity
-- `releases.revealui.com` may 404 until the owner aliases it; the GitHub fallback should still work after a `studio-v*` publish
+- The custom host should return JSON (HTTP 200), not a 404. GitHub fallback still works after a `studio-v*` publish
 - Studio continues working normally without updates
 
 ### Update signature verification failed


### PR DESCRIPTION
## Summary

Durable shape for the baked-in updater URL:

- GitHub `studio-latest` remains the authored feed (CI already writes it).
- `releases.revealui.com` stays its own Vercel project so marketing deploys cannot take down updates.
- This host now **fetches that feed and returns HTTP 200 JSON**. The previous rewrite passed through GitHub's short-lived 302, which is not a stable edge.

Already live on production (verified 200 + `version` 0.2.1 with no client-side redirect).

## Why not marketing

Marketing has a SPA catch-all. Updater availability must not share that deploy path.