### PR TITLE
fix(studio): quit on close and hide Windows console flashes

### DIFF
--- a/apps/studio/src-tauri/src/commands/apps.rs
+++ b/apps/studio/src-tauri/src/commands/apps.rs
@@ -61,7 +61,9 @@ pub fn read_app_log(name: String, lines: Option<u32>) -> Result<String, StudioEr
 
     #[cfg(target_os = "windows")]
     {
-        let output = Command::new("wsl.exe")
+        let mut cmd = Command::new("wsl.exe");
+        crate::win_process::hide_std(&mut cmd);
+        let output = cmd
             .args(["-e", "tail", "-n", &n.to_string(), &log_path])
             .output()
             .map_err(|e| StudioError::Process(format!("Failed to read log: {e}")))?;

--- a/apps/studio/src-tauri/src/commands/launcher.rs
+++ b/apps/studio/src-tauri/src/commands/launcher.rs
@@ -22,7 +22,9 @@ fn focus_window_platform(process_name: &str) -> Result<bool, StudioError> {
         clean_name
     );
 
-    let output = Command::new("powershell.exe")
+    let mut cmd = Command::new("powershell.exe");
+    crate::win_process::hide_std(&mut cmd);
+    let output = cmd
         .args(["-NoProfile", "-NonInteractive", "-Command", &script])
         .output()
         .map_err(|e| StudioError::Process(e.to_string()))?;

--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -86,6 +86,7 @@ mod wsl {
     pub async fn run(args: &[&str]) -> Result<std::process::Output, String> {
         let distro = distro();
         let mut cmd = Command::new("wsl.exe");
+        crate::win_process::hide_tokio(&mut cmd);
         cmd.args(["-d", &distro, "-e"]).args(args);
         cmd.output()
             .await

--- a/apps/studio/src-tauri/src/harness.rs
+++ b/apps/studio/src-tauri/src/harness.rs
@@ -459,7 +459,9 @@ async fn rpc_call_once(
     // never needs to know the WSL username; `exec` hands stdio straight to the
     // relay. A login shell (`-lc`) ensures $HOME is set.
     let relay_cmd = format!(r#"exec "$HOME/.local/bin/revdev-relay" "$HOME/{SOCKET_REL_PATH}""#);
-    let mut child = Command::new("wsl.exe")
+    let mut relay = Command::new("wsl.exe");
+    crate::win_process::hide_tokio(&mut relay);
+    let mut child = relay
         .args(["-d", &wsl_distro(), "-e", "bash", "-lc", &relay_cmd])
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub mod ssh;
 mod state;
 mod tray;
 mod updater;
+mod win_process;
 
 use commands::{
     agent as agent_cmds, apps, config as config_cmds, deploy, git as git_cmds,

--- a/apps/studio/src-tauri/src/platform/windows.rs
+++ b/apps/studio/src-tauri/src/platform/windows.rs
@@ -14,8 +14,14 @@ impl WindowsPlatform {
         }
     }
 
+    fn hidden(program: &str) -> Command {
+        let mut cmd = Command::new(program);
+        crate::win_process::hide_std(&mut cmd);
+        cmd
+    }
+
     fn wsl_exec(&self, cmd: &str) -> Result<String, String> {
-        let output = Command::new("wsl.exe")
+        let output = Self::hidden("wsl.exe")
             .args(["-d", &self.distribution, "-e", "bash", "-c", cmd])
             .output()
             .map_err(|e| format!("Failed to run wsl.exe: {e}"))?;
@@ -39,7 +45,7 @@ impl WindowsPlatform {
 
         // Check if repo exists
         let git_dir = format!("{}/.git", full_path.replace('\\', "/"));
-        if Command::new("cmd")
+        if Self::hidden("cmd")
             .args(["/C", &format!("if exist \"{}\" echo EXISTS", git_dir.replace('/', "\\"))])
             .output()
             .map(|o| !String::from_utf8_lossy(&o.stdout).contains("EXISTS"))
@@ -185,7 +191,7 @@ impl WindowsPlatform {
 impl PlatformOps for WindowsPlatform {
     fn get_system_status(&self) -> Result<SystemStatus, String> {
         // Check if WSL is running
-        let wsl_check = Command::new("wsl.exe")
+        let wsl_check = Self::hidden("wsl.exe")
             .args(["--list", "--running"])
             .output()
             .map_err(|e| format!("Failed to check WSL: {e}"))?;
@@ -261,7 +267,7 @@ impl PlatformOps for WindowsPlatform {
 
     fn mount_devbox(&self) -> Result<String, String> {
         // Spawn elevated PowerShell to run Mount-WSLDev
-        let output = Command::new("pwsh.exe")
+        let output = Self::hidden("pwsh.exe")
             .args([
                 "-NoProfile",
                 "-Command",
@@ -290,7 +296,7 @@ impl PlatformOps for WindowsPlatform {
 
     fn unmount_devbox(&self) -> Result<String, String> {
         // Find the physical drive number first, then unmount
-        let output = Command::new("pwsh.exe")
+        let output = Self::hidden("pwsh.exe")
             .args([
                 "-NoProfile",
                 "-Command",
@@ -365,7 +371,7 @@ impl PlatformOps for WindowsPlatform {
             "cd ~/projects/RevealUI && nohup {dev_cmd} > /tmp/revealui-{name}.log 2>&1 &"
         );
 
-        Command::new("wsl.exe")
+        Self::hidden("wsl.exe")
             .args(["-d", &self.distribution, "-e", "bash", "-c", &bash_cmd])
             .spawn()
             .map_err(|e| format!("Failed to start {name}: {e}"))?;
@@ -386,7 +392,7 @@ impl PlatformOps for WindowsPlatform {
 
     fn check_setup(&self) -> Result<SetupStatus, String> {
         // Check WSL running
-        let wsl_check = Command::new("wsl.exe")
+        let wsl_check = Self::hidden("wsl.exe")
             .args(["--list", "--running"])
             .output()
             .map_err(|e| format!("Failed to check WSL: {e}"))?;
@@ -415,13 +421,13 @@ impl PlatformOps for WindowsPlatform {
             .unwrap_or(false);
 
         // Read git config (pass args directly — no shell injection risk)
-        let git_name = Command::new("wsl.exe")
+        let git_name = Self::hidden("wsl.exe")
             .args(["-d", &self.distribution, "-e", "git", "config", "--global", "user.name"])
             .output()
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
             .unwrap_or_default();
 
-        let git_email = Command::new("wsl.exe")
+        let git_email = Self::hidden("wsl.exe")
             .args(["-d", &self.distribution, "-e", "git", "config", "--global", "user.email"])
             .output()
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
@@ -431,12 +437,12 @@ impl PlatformOps for WindowsPlatform {
     }
 
     fn set_git_identity(&self, name: &str, email: &str) -> Result<(), String> {
-        Command::new("wsl.exe")
+        Self::hidden("wsl.exe")
             .args(["-d", &self.distribution, "-e", "git", "config", "--global", "user.name", name])
             .output()
             .map_err(|e| format!("Failed to set git name: {e}"))?;
 
-        Command::new("wsl.exe")
+        Self::hidden("wsl.exe")
             .args(["-d", &self.distribution, "-e", "git", "config", "--global", "user.email", email])
             .output()
             .map_err(|e| format!("Failed to set git email: {e}"))?;

--- a/apps/studio/src-tauri/src/tray.rs
+++ b/apps/studio/src-tauri/src/tray.rs
@@ -41,14 +41,13 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         })
         .build(app)?;
 
-    // Hide to tray when the user clicks the window's X button.
-    // The only way to fully quit is via the tray "Quit" menu item.
+    // X means quit. Hiding to tray left the harness watcher polling wsl.exe
+    // every 2s, which flashes a console on Windows after the window is gone.
     if let Some(win) = app.get_webview_window("main") {
-        let win_clone = win.clone();
+        let app_handle = app.clone();
         win.on_window_event(move |event| {
-            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                api.prevent_close();
-                let _ = win_clone.hide();
+            if let tauri::WindowEvent::CloseRequested { .. } = event {
+                app_handle.exit(0);
             }
         });
     }

--- a/apps/studio/src-tauri/src/win_process.rs
+++ b/apps/studio/src-tauri/src/win_process.rs
@@ -1,0 +1,35 @@
+//! Windows console programs (`wsl.exe`, `cmd.exe`, `pwsh.exe`) open a visible
+//! terminal unless CREATE_NO_WINDOW is set. Studio polls some of these every
+//! few seconds, so a missing flag looks like terminals flashing forever.
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+pub fn hide_std(cmd: &mut std::process::Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let _ = cmd;
+}
+
+#[cfg_attr(unix, allow(dead_code))]
+pub fn hide_tokio(cmd: &mut tokio::process::Command) {
+    #[cfg(windows)]
+    {
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let _ = cmd;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hide_std_accepts_a_command() {
+        let mut cmd = std::process::Command::new("true");
+        hide_std(&mut cmd);
+    }
+}

--- a/apps/studio/src/hooks/use-settings.ts
+++ b/apps/studio/src/hooks/use-settings.ts
@@ -1,4 +1,4 @@
-import { createContext, use, useEffect, useState } from 'react';
+import { createContext, use, useState } from 'react';
 
 export type Theme = 'dark' | 'light' | 'system';
 
@@ -75,12 +75,7 @@ export function useSettingsContext(): SettingsContextValue {
 }
 
 export function useSettings(): SettingsContextValue {
-  const [settings, setSettings] = useState<StudioSettings>(DEFAULT_SETTINGS);
-
-  // Load from localStorage on mount (client-only)
-  useEffect(() => {
-    setSettings(loadSettings());
-  }, []);
+  const [settings, setSettings] = useState<StudioSettings>(loadSettings);
 
   function updateSettings(patch: Partial<StudioSettings>) {
     setSettings((prev) => {


### PR DESCRIPTION
## Summary

Closing Studio hid the window to the tray. The harness watcher kept polling the daemon through `wsl.exe` every 2s, which opens a visible console on Windows. That is the flash-after-quit.

- Window X now quits the process.
- `wsl.exe` / `cmd` / `pwsh` / `powershell` get `CREATE_NO_WINDOW`.
- Local-mode settings load synchronously so Work on this machine does not sit on a spinner waiting for a second render.

I already killed the leftover `revealui-studio.exe` on this machine so flashes should have stopped immediately.