### PR TITLE
chore(studio): bump 0.2.2 for quit-on-close release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+## [0.2.2] — 2026-08-14
+
+### Fixed
+
+- **Console flashes after close.** Window X quits the process instead of
+  hiding to the tray. Windows `wsl.exe` / `cmd` / `pwsh` spawns use
+  `CREATE_NO_WINDOW` so daemon polls do not flash a terminal.
+
+[0.2.2]: https://github.com/RevealUIStudio/revdev/releases/tag/studio-v0.2.2
+
 ## [0.2.1] — 2026-08-14
 
 ### Added

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Native AI experience — agent coordination hub, local inference management, visual agent dashboard (Tauri 2 + React 19)",
   "private": true,
   "dependencies": {

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "age",
  "arboard",

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "RevealUI Studio",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "dev.revealui.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Version bump so \`studio-v0.2.2\` matches the binary. Includes #412 (quit on close + hidden Windows console spawns).

Tag \`studio-v0.2.2\` is pushed with this commit and will run \`studio-release.yml\`.