### PR TITLE
fix(studio): keep skip hover readable and stringify agent errors

### DIFF
--- a/apps/studio/src-tauri/src/harness.rs
+++ b/apps/studio/src-tauri/src/harness.rs
@@ -23,6 +23,18 @@ use tokio::time::{timeout, Duration};
 
 const SOCKET_REL_PATH: &str = ".local/share/revealui/harness.sock";
 
+/// User-facing copy when the Windows WSL relay exits before a JSON-RPC line.
+/// Kept off the `not(unix)` gate so Linux CI can lock the wording.
+#[cfg_attr(unix, allow(dead_code))]
+pub(crate) fn relay_closed_message(stderr: &str) -> String {
+    let hint = stderr.trim();
+    let base = "Relay closed without response. The agent daemon in WSL is not running. Open Setup from the sidebar, then try Agent again.";
+    if hint.is_empty() {
+        return base.to_string();
+    }
+    format!("{base} ({hint})")
+}
+
 /// Per-attempt timeout for daemon RPC calls. Shared by both transports.
 const RPC_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -452,7 +464,7 @@ async fn rpc_call_once(
     params: &serde_json::Value,
     signature: &Option<String>,
 ) -> Result<serde_json::Value, String> {
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
     use tokio::process::Command;
 
     // The socket path is resolved WSL-side against the daemon's $HOME so Studio
@@ -511,7 +523,16 @@ async fn rpc_call_once(
         .map_err(|e| format!("Read failed: {e}"))?;
     if n == 0 {
         // EOF before any response — relay or daemon died. Transient → respawn.
-        return Err("Relay closed without response".to_string());
+        let mut err_buf = String::new();
+        if let Some(stderr) = child.stderr.take() {
+            let mut err_reader = BufReader::new(stderr);
+            let _ = timeout(
+                Duration::from_millis(250),
+                err_reader.read_to_string(&mut err_buf),
+            )
+            .await;
+        }
+        return Err(relay_closed_message(&err_buf));
     }
 
     // child is killed + reaped on drop (kill_on_drop) at function exit.
@@ -522,4 +543,26 @@ async fn rpc_call_once(
         return Err(error.message);
     }
     Ok(response.result.unwrap_or(serde_json::Value::Null))
+}
+
+#[cfg(test)]
+mod relay_closed_tests {
+    use super::relay_closed_message;
+
+    #[test]
+    fn empty_stderr_points_at_setup() {
+        let msg = relay_closed_message("  ");
+        assert!(msg.starts_with("Relay closed without response"));
+        assert!(msg.contains("Open Setup from the sidebar"));
+        assert!(!msg.contains('('));
+    }
+
+    #[test]
+    fn includes_relay_stderr_hint() {
+        let msg = relay_closed_message(
+            "revdev-relay: connect /home/x/.local/share/revealui/harness.sock: No such file or directory\n",
+        );
+        assert!(msg.starts_with("Relay closed without response"));
+        assert!(msg.contains("No such file or directory"));
+    }
 }

--- a/apps/studio/src/__tests__/components/Button.test.tsx
+++ b/apps/studio/src/__tests__/components/Button.test.tsx
@@ -53,10 +53,11 @@ describe('Button', () => {
     expect(button.className).toContain('bg-secondary');
   });
 
-  it('maps ghost → neutral ghost appearance', () => {
-    render(<Button variant="ghost">Ghost</Button>);
+  it('maps ghost → readable hover ink (body text, not ink-on-accent)', () => {
+    render(<Button variant="ghost">Skip</Button>);
     const button = screen.getByRole('button');
-    expect(button.className).toContain('hover:text-accent-foreground');
+    expect(button.className).toContain('hover:text-fg!');
+    expect(button.className).toContain('text-fg');
   });
 
   it('maps danger → danger solid (bg-destructive)', () => {

--- a/apps/studio/src/__tests__/lib/invoke.test.ts
+++ b/apps/studio/src/__tests__/lib/invoke.test.ts
@@ -475,3 +475,65 @@ describe('pairWithDaemon (GAP-397 challenge-response)', () => {
     expect(localStorage.getItem('revdev-daemon-token')).toBeNull();
   });
 });
+
+describe('formatInvokeError', () => {
+  it('keeps a real Error', async () => {
+    const { formatInvokeError } = await import('../../lib/invoke');
+    const err = new Error('already an error');
+    expect(formatInvokeError(err)).toBe(err);
+  });
+
+  it('unwraps StudioError { kind, message }', async () => {
+    const { invokeErrorMessage } = await import('../../lib/invoke');
+    expect(invokeErrorMessage({ kind: 'Other', message: 'git status failed' })).toBe(
+      'git status failed',
+    );
+  });
+
+  it('unwraps a nested Tauri { message: StudioError } envelope', async () => {
+    const { invokeErrorMessage } = await import('../../lib/invoke');
+    expect(
+      invokeErrorMessage({
+        message: { kind: 'Process', message: 'Relay closed without response' },
+      }),
+    ).toBe('Relay closed without response');
+  });
+
+  it('never renders [object Object]', async () => {
+    const { invokeErrorMessage } = await import('../../lib/invoke');
+    expect(invokeErrorMessage({ kind: 'Io' })).toBe('Studio command failed');
+    expect(invokeErrorMessage({})).toBe('Studio command failed');
+  });
+
+  it('rewrites relay/daemon failures into one Setup line', async () => {
+    const { formatDaemonUnreachable, isDaemonUnreachable } = await import('../../lib/invoke');
+    expect(isDaemonUnreachable('Relay closed without response')).toBe(true);
+    expect(formatDaemonUnreachable('Relay closed without response')).toMatch(/Open Setup/);
+    expect(formatDaemonUnreachable('permission denied')).toBe('permission denied');
+  });
+});
+
+describe('invoke bridge (Tauri reject payload)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+  });
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+    vi.restoreAllMocks();
+  });
+
+  it('throws Error.message from a StudioError object reject', async () => {
+    const { invoke: tauriInvoke } = await import('@tauri-apps/api/core');
+    vi.mocked(tauriInvoke).mockRejectedValue({
+      kind: 'Other',
+      message: 'Relay closed without response',
+    });
+
+    const { gitStatus } = await import('../../lib/invoke');
+    await expect(gitStatus('/repo')).rejects.toSatisfy((err: unknown) => {
+      return err instanceof Error && err.message === 'Relay closed without response';
+    });
+  });
+});

--- a/apps/studio/src/components/adapters/Button.tsx
+++ b/apps/studio/src/components/adapters/Button.tsx
@@ -55,7 +55,15 @@ export default function Button({
   ...props
 }: ButtonProps) {
   const intent = intentMap[variant];
-  const overrideClassName = [compactSizeOverride[size], className].filter(Boolean).join(' ');
+  // Ghost chrome stays body ink on a raised surface. Presentation 0.13
+  // ghost+neutral still hovers to accent-foreground (ink-on-amber), which
+  // vanishes on Studio's dark card. Drop this override when Studio depends
+  // on a presentation release that ships hover:text-foreground for ghost.
+  const ghostContrast =
+    variant === 'ghost' ? 'text-fg hover:bg-surface-2! hover:text-fg!' : undefined;
+  const overrideClassName = [compactSizeOverride[size], ghostContrast, className]
+    .filter(Boolean)
+    .join(' ');
 
   return (
     <PresentationButton

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -26,10 +26,13 @@ import type { AgentCard } from '../../lib/a2a-api';
 import { fetchAgentCards } from '../../lib/a2a-api';
 import {
   agentReadWorkboard,
+  formatDaemonUnreachable,
   gitDiscardFile,
   gitStageFile,
   gitStatus,
   gitUnstageFile,
+  invokeErrorMessage,
+  isDaemonUnreachable,
 } from '../../lib/invoke';
 import type { AgentSession, GitFileEntry, GitStatusResult } from '../../types';
 import Button from '../adapters/Button';
@@ -342,7 +345,7 @@ export default function AgentPanel() {
       setSessions(parseWorkboard(md));
       setWorkboardError(null);
     } catch (e) {
-      setWorkboardError(e instanceof Error ? e.message : String(e));
+      setWorkboardError(formatDaemonUnreachable(invokeErrorMessage(e)));
       setSessions([]);
     }
   }
@@ -354,7 +357,7 @@ export default function AgentPanel() {
       const s = await gitStatus(repoPath);
       setGitState(s);
     } catch (e) {
-      setGitError(e instanceof Error ? e.message : String(e));
+      setGitError(formatDaemonUnreachable(invokeErrorMessage(e)));
       setGitState(null);
     } finally {
       setLoading(false);
@@ -413,7 +416,7 @@ export default function AgentPanel() {
       await gitStageFile(repoPath, path);
       await loadChanges();
     } catch (e) {
-      setGitError(e instanceof Error ? e.message : String(e));
+      setGitError(formatDaemonUnreachable(invokeErrorMessage(e)));
     }
   };
 
@@ -422,7 +425,7 @@ export default function AgentPanel() {
       await gitUnstageFile(repoPath, path);
       await loadChanges();
     } catch (e) {
-      setGitError(e instanceof Error ? e.message : String(e));
+      setGitError(formatDaemonUnreachable(invokeErrorMessage(e)));
     }
   };
 
@@ -431,7 +434,7 @@ export default function AgentPanel() {
       await gitDiscardFile(repoPath, path);
       await loadChanges();
     } catch (e) {
-      setGitError(e instanceof Error ? e.message : String(e));
+      setGitError(formatDaemonUnreachable(invokeErrorMessage(e)));
     }
   };
 
@@ -444,7 +447,7 @@ export default function AgentPanel() {
       );
       await loadChanges();
     } catch (e) {
-      setGitError(e instanceof Error ? e.message : String(e));
+      setGitError(formatDaemonUnreachable(invokeErrorMessage(e)));
     } finally {
       setStagingAll(false);
     }
@@ -457,11 +460,17 @@ export default function AgentPanel() {
       await Promise.all(gitState.unstaged.map((f) => gitDiscardFile(repoPath, f.path)));
       await loadChanges();
     } catch (e) {
-      setGitError(e instanceof Error ? e.message : String(e));
+      setGitError(formatDaemonUnreachable(invokeErrorMessage(e)));
     } finally {
       setDiscardingAll(false);
     }
   };
+
+  const daemonUnreachable =
+    isDaemonUnreachable(workboardError ?? '') || isDaemonUnreachable(gitError ?? '');
+  const daemonBanner = daemonUnreachable
+    ? formatDaemonUnreachable(workboardError ?? gitError ?? '')
+    : null;
 
   const totalChanges =
     (gitState?.staged.length ?? 0) +
@@ -512,7 +521,12 @@ export default function AgentPanel() {
         </div>
 
         <div className="max-h-48 flex-1 overflow-y-auto px-2 py-2 md:max-h-none">
-          {workboardError ? (
+          {daemonBanner ? (
+            <div className="mb-2 rounded border border-error/40 bg-error-subtle px-2.5 py-2 text-[10px] text-error">
+              {daemonBanner}
+            </div>
+          ) : null}
+          {workboardError && !isDaemonUnreachable(workboardError) ? (
             <div className="rounded border border-error/40 bg-error-subtle px-2.5 py-2 text-[10px] text-error">
               {workboardError}
             </div>
@@ -756,7 +770,7 @@ export default function AgentPanel() {
 
             {/* File list */}
             <div className="flex-1 overflow-y-auto px-3 py-2">
-              {gitError ? (
+              {gitError && !isDaemonUnreachable(gitError) ? (
                 <div className="rounded border border-error/40 bg-error-subtle px-2.5 py-2 text-[10px] text-error">
                   {gitError}
                 </div>

--- a/apps/studio/src/components/agent/ApprovalQueue.tsx
+++ b/apps/studio/src/components/agent/ApprovalQueue.tsx
@@ -8,9 +8,11 @@
 import { Select } from '@revealui/presentation';
 import { useCallback, useEffect, useState } from 'react';
 import {
+  formatDaemonUnreachable,
   harnessPermissionDecide,
   harnessPermissionPending,
   harnessPermissionSetMode,
+  invokeErrorMessage,
 } from '../../lib/invoke';
 import type { HarnessApproval, HarnessSession } from '../../types';
 import Button from '../adapters/Button';
@@ -63,7 +65,7 @@ export default function ApprovalQueue({ sessions, connected, onChanged }: Approv
       setApprovals(rows);
       setError(null);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(formatDaemonUnreachable(invokeErrorMessage(e)));
     } finally {
       setLoading(false);
     }
@@ -84,7 +86,7 @@ export default function ApprovalQueue({ sessions, connected, onChanged }: Approv
       await refresh();
       onChanged?.();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(formatDaemonUnreachable(invokeErrorMessage(e)));
     } finally {
       setBusyId(null);
     }
@@ -106,7 +108,7 @@ export default function ApprovalQueue({ sessions, connected, onChanged }: Approv
       );
       onChanged?.();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(formatDaemonUnreachable(invokeErrorMessage(e)));
     } finally {
       setModeBusy(false);
     }

--- a/apps/studio/src/components/agent/SpawnerPanel.tsx
+++ b/apps/studio/src/components/agent/SpawnerPanel.tsx
@@ -10,10 +10,12 @@ import { Textarea } from '@revealui/presentation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSpawner } from '../../hooks/use-spawner';
 import {
+  formatDaemonUnreachable,
   harnessAgentList,
   harnessAgentRemove,
   harnessAgentSpawn,
   harnessAgentStop,
+  invokeErrorMessage,
 } from '../../lib/invoke';
 import type { AgentBackend, HarnessAgentProcess } from '../../types';
 import Button from '../adapters/Button';
@@ -79,7 +81,7 @@ export default function SpawnerPanel() {
       setHarnessProcs(list);
       setHarnessError(null);
     } catch (e) {
-      setHarnessError(e instanceof Error ? e.message : String(e));
+      setHarnessError(formatDaemonUnreachable(invokeErrorMessage(e)));
     } finally {
       setHarnessLoading(false);
     }

--- a/apps/studio/src/hooks/use-harness.ts
+++ b/apps/studio/src/hooks/use-harness.ts
@@ -14,6 +14,7 @@ import {
   harnessSessions,
   harnessTasks,
   harnessWaitForWorkCompleted,
+  invokeErrorMessage,
 } from '../lib/invoke';
 import { runWorkCompletedRefreshLoop } from '../lib/work-completed-refresh';
 import type {
@@ -115,7 +116,7 @@ export function useHarness(agentId?: string): UseHarnessReturn {
       setReservations(state.reservations);
       setError(state.connected ? null : 'Harness daemon not running');
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(invokeErrorMessage(e));
       setConnected(false);
     } finally {
       setLoading(false);
@@ -182,12 +183,12 @@ export function useHarness(agentId?: string): UseHarnessReturn {
     }
 
     setupListeners().catch((e: unknown) => {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(invokeErrorMessage(e));
     });
 
     // Do one initial fetch so we don't wait for the first watcher tick
     loadAllRef.current().catch((e: unknown) => {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(invokeErrorMessage(e));
     });
 
     return () => {
@@ -237,7 +238,7 @@ export function useHarness(agentId?: string): UseHarnessReturn {
       if (!isTauri()) await loadAll();
       return msg;
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(invokeErrorMessage(e));
       throw e;
     }
   }
@@ -247,7 +248,7 @@ export function useHarness(agentId?: string): UseHarnessReturn {
       await harnessMarkRead(messageIds);
       if (!isTauri()) await loadAll();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(invokeErrorMessage(e));
       throw e;
     }
   }
@@ -258,7 +259,7 @@ export function useHarness(agentId?: string): UseHarnessReturn {
       if (!isTauri()) await loadAll();
       return task;
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(invokeErrorMessage(e));
       throw e;
     }
   }
@@ -269,7 +270,7 @@ export function useHarness(agentId?: string): UseHarnessReturn {
       if (!isTauri()) await loadAll();
       return result;
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(invokeErrorMessage(e));
       throw e;
     }
   }
@@ -280,7 +281,7 @@ export function useHarness(agentId?: string): UseHarnessReturn {
       if (!isTauri()) await loadAll();
       return ok;
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(invokeErrorMessage(e));
       throw e;
     }
   }
@@ -291,7 +292,7 @@ export function useHarness(agentId?: string): UseHarnessReturn {
       if (!isTauri()) await loadAll();
       return ok;
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(invokeErrorMessage(e));
       throw e;
     }
   }
@@ -307,7 +308,7 @@ export function useHarness(agentId?: string): UseHarnessReturn {
       if (!isTauri()) await loadAll();
       return result;
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(invokeErrorMessage(e));
       throw e;
     }
   }

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -908,11 +908,64 @@ async function httpRpc<T>(method: string, params: Record<string, unknown>): Prom
   return body.result as T;
 }
 
+function extractInvokeMessage(err: unknown, depth = 0): string | null {
+  if (depth > 4) return null;
+  if (typeof err === 'string') {
+    const trimmed = err.trim();
+    if (trimmed.length > 0 && trimmed !== '[object Object]') return trimmed;
+    return null;
+  }
+  if (err instanceof Error) {
+    if (err.message && err.message !== '[object Object]') return err.message;
+    return extractInvokeMessage((err as { cause?: unknown }).cause, depth + 1);
+  }
+  if (err && typeof err === 'object') {
+    const rec = err as Record<string, unknown>;
+    for (const key of ['message', 'error', 'msg'] as const) {
+      const nested = extractInvokeMessage(rec[key], depth + 1);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+/** Turn a Tauri/IPC reject value into an Error with a readable message. */
+export function formatInvokeError(err: unknown): Error {
+  if (err instanceof Error && err.message && err.message !== '[object Object]') {
+    return err;
+  }
+  const message = extractInvokeMessage(err);
+  return new Error(message ?? 'Studio command failed');
+}
+
+/** String form for UI catch sites. Never returns `[object Object]`. */
+export function invokeErrorMessage(err: unknown): string {
+  return formatInvokeError(err).message;
+}
+
+export function isDaemonUnreachable(message: string): boolean {
+  return (
+    message.startsWith('Relay closed') ||
+    message.startsWith('Relay spawn failed:') ||
+    message.startsWith('Harness daemon not running') ||
+    message.startsWith('The agent daemon in WSL') ||
+    message.startsWith('RPC timeout')
+  );
+}
+
+/** One actionable line when the WSL daemon/relay is down. */
+export function formatDaemonUnreachable(message: string): string {
+  if (!isDaemonUnreachable(message)) return message;
+  return 'The agent daemon in WSL is not running. Open Setup from the sidebar, then try Agent again.';
+}
+
 /** Guarded invoke — returns mock data in browser, real IPC in Tauri */
 function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   // Tauri native mode — use IPC
   if (isTauri()) {
-    return tauriInvoke<T>(cmd, args);
+    return tauriInvoke<T>(cmd, args).catch((err: unknown) => {
+      throw formatInvokeError(err);
+    });
   }
 
   // Browser mode with remote daemon — route harness commands over HTTP


### PR DESCRIPTION
## What

Desktop Setup/Agent dogfood defects on Windows 0.2.2:

1. **Skip hover** vanishes. Presentation ghost+neutral still hovers to `accent-foreground` (ink on amber) over a dark card. Studio ghost chrome now keeps body ink (`text-fg` / `hover:text-fg!`) until a presentation release ships the same pairing.
2. **`[object Object]`** on Agent. Tauri rejects `StudioError` as `{ kind, message }`. `String(err)` is `[object Object]`. `invoke()` now unwraps that payload to a real `Error`, and Agent catch sites use `invokeErrorMessage`.
3. **Relay closed without response**. Skipping Setup leaves the WSL daemon/relay down. The Windows transport now attaches relay stderr and keeps the `Relay closed without response` prefix (retries stay transient). Agent shows **one** Setup line instead of three raw boxes.

Dismiss-setup confirm copy is unchanged. It is the intended unfinished-setup gate.

## Why this shape

- Ghost contrast: owning token pair is presentation. Studio adapter is the consume-side pin until `@revealui/presentation` ships `hover:text-foreground` for ghost/outline neutral (companion PR).
- Error string: owning unwrap is the invoke bridge, not per-panel `String(e)`.
- Relay: owning copy is the WSL transport. UI collapses the same failure class to one banner.

## Test

- `pnpm --filter studio exec vitest run src/__tests__/lib/invoke.test.ts src/__tests__/components/Button.test.tsx` (57 pass)
- `cargo test --offline --lib relay_closed` (2 pass)

## Out of scope

- Apple/Windows certs, Android, GAP-479 first-run rebuild, 0.2.1 reopen.
- Multiplexed long-lived relay (still one `wsl.exe` per RPC; CREATE_NO_WINDOW already hides those consoles).

Does not need a Studio version bump until you want this on the installed Windows build.