### PR TITLE
fix(studio): one process, one hidden WSL relay, one Agent error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+## [0.2.4] — 2026-08-15
+
+### Fixed
+
+- **One Studio process.** A second launch focuses the existing window
+  instead of opening another copy.
+- **Agent terminal flash.** Windows reuses one hidden WSL relay and does
+  not spawn `wsl.exe` again for 20s after a failed connect. Agent click
+  no longer launches a stack of consoles.
+- **Agent daemon-down copy.** One Setup line. The spawn panel and the
+  offline chip do not repeat it.
+
+[0.2.4]: https://github.com/RevealUIStudio/revdev/releases/tag/studio-v0.2.4
+
 ## [0.2.3] — 2026-08-14
 
 ### Fixed

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Native AI experience — agent coordination hub, local inference management, visual agent dashboard (Tauri 2 + React 19)",
   "private": true,
   "dependencies": {

--- a/apps/studio/relay/src/main.rs
+++ b/apps/studio/relay/src/main.rs
@@ -8,8 +8,9 @@
 //!
 //! The daemon therefore only ever sees an ordinary local Unix-socket
 //! connection — the wire protocol, framing, and handlers are byte-identical
-//! across platforms. Studio's per-call model spawns one relay per request
-//! (mirroring its fresh-`UnixStream`-per-call on native Unix).
+//! across platforms. Windows Studio keeps one relay child and writes many
+//! newline-framed requests on stdin. Native Unix still opens a fresh
+//! `UnixStream` per call.
 //!
 //! Pure std, zero dependencies — a fully-owned, auditable byte pump.
 

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -188,6 +188,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +500,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -694,6 +827,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1460,12 +1602,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1509,6 +1678,26 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -1785,6 +1974,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2276,6 +2478,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -3708,6 +3916,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3815,6 +4033,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4118,6 +4342,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4225,6 +4460,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4836,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "age",
  "arboard",
@@ -4865,6 +5114,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "thiserror 2.0.18",
  "tokio",
@@ -6099,6 +6349,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6426,6 +6687,22 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]
@@ -6958,7 +7235,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7041,6 +7330,17 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -8322,6 +8622,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.1",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.1",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8447,4 +8817,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.1",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow 1.0.1",
 ]

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]
@@ -23,6 +23,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 revvault-core = { git = "https://github.com/RevealUIStudio/revvault.git", package = "revvault-core" }

--- a/apps/studio/src-tauri/src/harness.rs
+++ b/apps/studio/src-tauri/src/harness.rs
@@ -35,6 +35,14 @@ pub(crate) fn relay_closed_message(stderr: &str) -> String {
     format!("{base} ({hint})")
 }
 
+/// After a failed WSL relay spawn, skip new `wsl.exe` children until `until`.
+pub(crate) fn relay_spawn_on_cooldown(
+    now: std::time::Instant,
+    until: Option<std::time::Instant>,
+) -> bool {
+    until.is_some_and(|t| now < t)
+}
+
 /// Per-attempt timeout for daemon RPC calls. Shared by both transports.
 const RPC_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -416,11 +424,52 @@ fn wsl_distro() -> String {
 }
 
 #[cfg(not(unix))]
+const RELAY_DOWN_COOLDOWN: Duration = Duration::from_secs(20);
+
+#[cfg(not(unix))]
+static RELAY_COOLDOWN_UNTIL: std::sync::Mutex<Option<std::time::Instant>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(not(unix))]
+struct LiveRelay {
+    child: tokio::process::Child,
+    stdin: tokio::process::ChildStdin,
+    stdout: tokio::io::BufReader<tokio::process::ChildStdout>,
+}
+
+#[cfg(not(unix))]
+impl Drop for LiveRelay {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+#[cfg(not(unix))]
+static LIVE_RELAY: tokio::sync::Mutex<Option<LiveRelay>> = tokio::sync::Mutex::const_new(None);
+
+#[cfg(not(unix))]
+fn mark_relay_down() {
+    if let Ok(mut guard) = RELAY_COOLDOWN_UNTIL.lock() {
+        *guard = Some(std::time::Instant::now() + RELAY_DOWN_COOLDOWN);
+    }
+}
+
+#[cfg(not(unix))]
+fn relay_is_cooling_down() -> bool {
+    let until = RELAY_COOLDOWN_UNTIL.lock().ok().and_then(|g| *g);
+    relay_spawn_on_cooldown(std::time::Instant::now(), until)
+}
+
+#[cfg(not(unix))]
 async fn rpc_call_raw(
     method: &str,
     params: serde_json::Value,
     signature: Option<String>,
 ) -> Result<serde_json::Value, String> {
+    if relay_is_cooling_down() {
+        return Err(relay_closed_message(""));
+    }
+
     let mut last_err = String::new();
 
     for attempt in 0..MAX_RETRIES {
@@ -442,6 +491,9 @@ async fn rpc_call_raw(
         }
     }
 
+    if last_err.starts_with("Relay closed") || last_err.starts_with("Relay spawn failed:") {
+        mark_relay_down();
+    }
     Err(last_err)
 }
 
@@ -457,30 +509,68 @@ fn is_transient_error(err: &str) -> bool {
         || err.starts_with("RPC timeout")
 }
 
-/// Execute a single RPC over a freshly-spawned relay child.
+#[cfg(not(unix))]
+async fn spawn_live_relay() -> Result<LiveRelay, String> {
+    use tokio::io::BufReader;
+    use tokio::process::Command;
+
+    // `--shell-type none` + `bash -c` (not `-lc`) so WSL does not open a
+    // login console. `$HOME` is still set. CREATE_NO_WINDOW is applied by
+    // hide_tokio. One child is reused for every RPC on this process.
+    let relay_cmd = format!(r#"exec "$HOME/.local/bin/revdev-relay" "$HOME/{SOCKET_REL_PATH}""#);
+    let mut relay = Command::new("wsl.exe");
+    crate::win_process::hide_tokio(&mut relay);
+    let mut child = relay
+        .args([
+            "-d",
+            &wsl_distro(),
+            "--shell-type",
+            "none",
+            "-e",
+            "bash",
+            "-c",
+            &relay_cmd,
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(false)
+        .spawn()
+        .map_err(|e| format!("Relay spawn failed: {e}"))?;
+
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "Relay spawn failed: stdin unavailable".to_string())?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Relay spawn failed: stdout unavailable".to_string())?;
+    Ok(LiveRelay {
+        child,
+        stdin,
+        stdout: BufReader::new(stdout),
+    })
+}
+
+/// Execute one RPC on the long-lived WSL relay. The daemon already accepts
+/// many newline-framed requests on one Unix socket; we keep stdin open so
+/// the relay child stays up across Agent/git/workboard/watcher calls.
 #[cfg(not(unix))]
 async fn rpc_call_once(
     method: &str,
     params: &serde_json::Value,
     signature: &Option<String>,
 ) -> Result<serde_json::Value, String> {
-    use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
-    use tokio::process::Command;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 
-    // The socket path is resolved WSL-side against the daemon's $HOME so Studio
-    // never needs to know the WSL username; `exec` hands stdio straight to the
-    // relay. A login shell (`-lc`) ensures $HOME is set.
-    let relay_cmd = format!(r#"exec "$HOME/.local/bin/revdev-relay" "$HOME/{SOCKET_REL_PATH}""#);
-    let mut relay = Command::new("wsl.exe");
-    crate::win_process::hide_tokio(&mut relay);
-    let mut child = relay
-        .args(["-d", &wsl_distro(), "-e", "bash", "-lc", &relay_cmd])
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .map_err(|e| format!("Relay spawn failed: {e}"))?;
+    let mut slot = LIVE_RELAY.lock().await;
+    if slot.is_none() {
+        *slot = Some(spawn_live_relay().await.map_err(|e| {
+            mark_relay_down();
+            e
+        })?);
+    }
 
     let id = REQUEST_ID.fetch_add(1, Ordering::Relaxed);
     let request = JsonRpcRequest {
@@ -493,49 +583,58 @@ async fn rpc_call_once(
     let mut payload = serde_json::to_vec(&request).map_err(|e| e.to_string())?;
     payload.push(b'\n');
 
-    // Write the request, then close stdin so the relay half-closes the socket
-    // write side — the daemon has the complete (newline-framed) request and can
-    // respond. The response comes back over the child's stdout.
-    {
-        let mut stdin = child
+    let write_err = {
+        let relay = slot.as_mut().expect("relay just inserted");
+        relay
             .stdin
-            .take()
-            .ok_or_else(|| "Relay spawn failed: stdin unavailable".to_string())?;
-        stdin
             .write_all(&payload)
             .await
-            .map_err(|e| format!("Write failed: {e}"))?;
-        stdin
-            .flush()
-            .await
-            .map_err(|e| format!("Write failed: {e}"))?;
+            .err()
+            .map(|e| format!("Write failed: {e}"))
+    };
+    if let Some(err) = write_err {
+        *slot = None;
+        return Err(err);
+    }
+    if let Some(relay) = slot.as_mut() {
+        if let Err(e) = relay.stdin.flush().await {
+            *slot = None;
+            return Err(format!("Write failed: {e}"));
+        }
     }
 
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| "Read failed: stdout unavailable".to_string())?;
-    let mut reader = BufReader::new(stdout);
     let mut line = String::new();
-    let n = reader
-        .read_line(&mut line)
-        .await
-        .map_err(|e| format!("Read failed: {e}"))?;
-    if n == 0 {
-        // EOF before any response — relay or daemon died. Transient → respawn.
-        let mut err_buf = String::new();
-        if let Some(stderr) = child.stderr.take() {
-            let mut err_reader = BufReader::new(stderr);
-            let _ = timeout(
-                Duration::from_millis(250),
-                err_reader.read_to_string(&mut err_buf),
-            )
-            .await;
+    let n = {
+        let relay = slot.as_mut().expect("relay still held");
+        relay
+            .stdout
+            .read_line(&mut line)
+            .await
+            .map_err(|e| format!("Read failed: {e}"))
+    };
+    let n = match n {
+        Ok(n) => n,
+        Err(err) => {
+            *slot = None;
+            return Err(err);
         }
+    };
+    if n == 0 {
+        let mut err_buf = String::new();
+        if let Some(mut relay) = slot.take() {
+            if let Some(stderr) = relay.child.stderr.take() {
+                let mut err_reader = tokio::io::BufReader::new(stderr);
+                let _ = timeout(
+                    Duration::from_millis(250),
+                    tokio::io::AsyncReadExt::read_to_string(&mut err_reader, &mut err_buf),
+                )
+                .await;
+            }
+        }
+        mark_relay_down();
         return Err(relay_closed_message(&err_buf));
     }
 
-    // child is killed + reaped on drop (kill_on_drop) at function exit.
     let response: JsonRpcResponse =
         serde_json::from_str(&line).map_err(|e| format!("Parse failed: {e}"))?;
 
@@ -547,7 +646,7 @@ async fn rpc_call_once(
 
 #[cfg(test)]
 mod relay_closed_tests {
-    use super::relay_closed_message;
+    use super::{relay_closed_message, relay_spawn_on_cooldown};
 
     #[test]
     fn empty_stderr_points_at_setup() {
@@ -564,5 +663,17 @@ mod relay_closed_tests {
         );
         assert!(msg.starts_with("Relay closed without response"));
         assert!(msg.contains("No such file or directory"));
+    }
+
+    #[test]
+    fn cooldown_skips_spawn_until_deadline() {
+        let start = std::time::Instant::now();
+        let until = Some(start + std::time::Duration::from_secs(20));
+        assert!(relay_spawn_on_cooldown(start, until));
+        assert!(!relay_spawn_on_cooldown(
+            start + std::time::Duration::from_secs(21),
+            until
+        ));
+        assert!(!relay_spawn_on_cooldown(start, None));
     }
 }

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -19,9 +19,9 @@ mod updater;
 mod win_process;
 
 use commands::{
-    agent as agent_cmds, apps, config as config_cmds, deploy, git as git_cmds,
+    agent as agent_cmds, apps, config as config_cmds, deploy, fleet_map, git as git_cmds,
     harness as harness_cmds, inference as inference_cmds, launcher, local_shell as shell_cmds,
-    fleet_map, mount, setup, spawner as spawner_cmds, ssh as ssh_cmds, status, sync, terminal, vault,
+    mount, setup, spawner as spawner_cmds, ssh as ssh_cmds, status, sync, terminal, vault,
 };
 use config::ConfigState;
 use local_shell::LocalShellState;
@@ -38,6 +38,13 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            if let Some(win) = app.get_webview_window("main") {
+                let _ = win.unminimize();
+                let _ = win.show();
+                let _ = win.set_focus();
+            }
+        }))
         .plugin(
             tauri_plugin_global_shortcut::Builder::new()
                 .with_handler(|app, _shortcut, _event| {

--- a/apps/studio/src-tauri/src/win_process.rs
+++ b/apps/studio/src-tauri/src/win_process.rs
@@ -1,6 +1,6 @@
 //! Windows console programs (`wsl.exe`, `cmd.exe`, `pwsh.exe`) open a visible
-//! terminal unless CREATE_NO_WINDOW is set. Studio polls some of these every
-//! few seconds, so a missing flag looks like terminals flashing forever.
+//! terminal unless CREATE_NO_WINDOW is set. Do not add DETACHED_PROCESS here:
+//! it can drop redirected stdin/stdout, which the WSL relay needs.
 
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "RevealUI Studio",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "identifier": "dev.revealui.studio",
   "build": {
     "frontendDist": "../dist",

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -556,7 +556,7 @@ export default function AgentPanel() {
                 ))}
               </div>
             </div>
-          ) : (
+          ) : daemonBanner ? null : (
             <div className="mt-4 rounded border border-edge bg-surface-1/40 px-2.5 py-2 text-[10px] text-fg-subtle">
               Harness daemon offline
             </div>

--- a/apps/studio/src/components/agent/SpawnerPanel.tsx
+++ b/apps/studio/src/components/agent/SpawnerPanel.tsx
@@ -16,6 +16,7 @@ import {
   harnessAgentSpawn,
   harnessAgentStop,
   invokeErrorMessage,
+  isDaemonUnreachable,
 } from '../../lib/invoke';
 import type { AgentBackend, HarnessAgentProcess } from '../../types';
 import Button from '../adapters/Button';
@@ -179,7 +180,7 @@ export default function SpawnerPanel() {
         />
       ) : null}
 
-      {error ? (
+      {error && !isDaemonUnreachable(error) ? (
         <div className="mb-2 rounded border border-error/40 bg-error-subtle px-2.5 py-2 text-[10px] text-error">
           {error}
         </div>


### PR DESCRIPTION
## What

Windows dogfood after 0.2.3:

- Two Studio windows (no single-instance lock).
- Clicking Agent spawned a `wsl.exe` per RPC (workboard, git, ping, spawn list) plus the watcher every 2s. That is the terminal flash. `CREATE_NO_WINDOW` cannot hide a stack of WSL attaches.
- Agent showed the same daemon-down line twice, plus "Harness daemon offline".

Owning fixes:

1. **`tauri-plugin-single-instance`** — a second launch focuses the existing window.
2. **One long-lived hidden `revdev-relay`** — the daemon already accepts many newline frames on one Unix socket. After a failed connect, skip new `wsl.exe` children for 20s. Spawn uses `--shell-type none` and `bash -c` (not a login shell).
3. **One Agent empty state** — spawn panel and the offline chip do not repeat the Setup line.

The 0.2.3 exe already embeds the Circuit-R mark. The orange taskbar tile was the old cube process sitting next to the new one (and Windows icon cache). Single-instance is the product fix for that class.

Bumps Studio to **0.2.4**.

## Test

`cargo test --offline --lib relay_closed` (3 pass)

## After merge

```bash
git tag -s studio-v0.2.4 -m 'studio 0.2.4'
git push origin studio-v0.2.4
```

Tag from `origin/test` after the merge, not from a stale local `test`.