### PR TITLE
fix(studio): compile Windows 0.2.6 and skip icon SVG lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+## [0.2.6] — 2026-08-15
+
+### Fixed
+
+- **Windows release compile.** `SHChangeNotify` takes `i32`.
+  `CommandExt::show_window` is still unstable on CI rustc, so leftover
+  console children keep CREATE_NO_WINDOW only. Agent uses `WslLaunch`.
+- **Quality lint.** Biome no longer treats ICO source SVGs as DOM.
+
+[0.2.6]: https://github.com/RevealUIStudio/revdev/releases/tag/studio-v0.2.6
+
 ## [0.2.5] — 2026-08-15
 
 ### Fixed
@@ -15,9 +26,8 @@ Dates are ISO 8601 (UTC).
   Explorer to drop the cached Tauri cube. 16/24px icons use the untiled
   mark so the pin is not a smudge.
 - **Agent flash after 0.2.4.** The relay starts with `WslLaunch` (no
-  `wsl.exe` console). Remaining `wsl.exe` / `cmd.exe` / `pwsh.exe`
-  children set SW_HIDE as well as CREATE_NO_WINDOW. Parallel Agent RPCs
-  no longer race past the spawn cooldown.
+  `wsl.exe` console). Parallel Agent RPCs no longer race past the
+  spawn cooldown.
 
 [0.2.5]: https://github.com/RevealUIStudio/revdev/releases/tag/studio-v0.2.5
 

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Native AI experience — agent coordination hub, local inference management, visual agent dashboard (Tauri 2 + React 19)",
   "private": true,
   "dependencies": {

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "age",
  "arboard",

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]

--- a/apps/studio/src-tauri/src/presentment.rs
+++ b/apps/studio/src-tauri/src/presentment.rs
@@ -141,7 +141,7 @@ fn notify_shell_icon_changed() {
         };
         unsafe {
             SHChangeNotify(
-                SHCNE_ASSOCCHANGED,
+                SHCNE_ASSOCCHANGED as i32,
                 SHCNF_IDLIST | SHCNF_FLUSH,
                 std::ptr::null(),
                 std::ptr::null(),

--- a/apps/studio/src-tauri/src/win_process.rs
+++ b/apps/studio/src-tauri/src/win_process.rs
@@ -1,23 +1,21 @@
 //! Hide Windows console programs and launch WSL without `wsl.exe`.
 //!
 //! `wsl.exe`, `cmd.exe`, and `pwsh.exe` are console-subsystem binaries. They
-//! flash a terminal unless CREATE_NO_WINDOW and SW_HIDE are both set. Do not
-//! add DETACHED_PROCESS: it can drop redirected stdin/stdout.
+//! flash a terminal unless CREATE_NO_WINDOW is set. Do not add
+//! DETACHED_PROCESS: it can drop redirected stdin/stdout. Do not call
+//! `CommandExt::show_window`: it is still unstable on the rustc CI uses.
 //!
 //! The Agent relay must not spawn `wsl.exe` at all. Use [`spawn_wsl_hidden`]
 //! (`WslLaunch` in wslapi) so the Linux process starts with no console host.
 
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-#[cfg(windows)]
-const SW_HIDE: u16 = 0;
 
 pub fn hide_std(cmd: &mut std::process::Command) {
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
         cmd.creation_flags(CREATE_NO_WINDOW);
-        cmd.show_window(SW_HIDE);
     }
     let _ = cmd;
 }
@@ -26,9 +24,7 @@ pub fn hide_std(cmd: &mut std::process::Command) {
 pub fn hide_tokio(cmd: &mut tokio::process::Command) {
     #[cfg(windows)]
     {
-        use std::os::windows::process::CommandExt;
         cmd.creation_flags(CREATE_NO_WINDOW);
-        cmd.as_std_mut().show_window(SW_HIDE);
     }
     let _ = cmd;
 }

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "RevealUI Studio",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "dev.revealui.studio",
   "build": {
     "frontendDist": "../dist",

--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,7 @@
       "!**/node_modules",
       "!**/.next",
       "!**/src-tauri/target",
+      "!**/src-tauri/icons",
       "!**/bindings",
       "!**/pnpm-lock.yaml"
     ]


### PR DESCRIPTION
## Why

`studio-v0.2.5` Windows release failed at ts-rs:

- `SHChangeNotify` takes `i32`; `SHCNE_ASSOCCHANGED` is `u32`
- `CommandExt::show_window` is still unstable on CI rustc (`windows_process_extensions_show_window`)
- Biome `noSvgWithoutTitle` failed Quality on `src-tauri/icons/*.svg`

Do not retag 0.2.5. This is **0.2.6**.

## What

- Cast the shell notify event id
- Drop `show_window`; leftover console children keep `CREATE_NO_WINDOW`. Agent relay is still `WslLaunch`
- Exclude `**/src-tauri/icons` from Biome
- Bump Studio to 0.2.6

## Proof

`cargo test --offline --lib -- presentment cooldown relay_command hide_std` → 11 passed.

Windows `WslLaunch` / `SHChangeNotify` still compile only on `cfg(windows)`.

## After merge

Tag `studio-v0.2.6` from `origin/test`. Leave `studio-v0.2.5` in place.