### PR TITLE
fix(studio): wire Setup to install the WSL agent relay

### DIFF
--- a/.github/workflows/studio-release.yml
+++ b/.github/workflows/studio-release.yml
@@ -20,7 +20,20 @@ env:
   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
 jobs:
+  linux-relay:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Build WSL revdev-relay
+        run: cargo build --release --manifest-path apps/studio/relay/Cargo.toml
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: revdev-relay
+          path: apps/studio/relay/target/release/revdev-relay
+
   build:
+    needs: linux-relay
     strategy:
       fail-fast: false
       matrix:
@@ -37,6 +50,14 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: revdev-relay
+          path: apps/studio/src-tauri/wsl
+      - name: Mark relay executable
+        if: matrix.platform != 'windows-latest'
+        run: chmod +x apps/studio/src-tauri/wsl/revdev-relay
 
       - name: Install Linux system dependencies
         if: matrix.platform == 'ubuntu-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ target/
 *.tsbuildinfo
 
 # Tauri
+apps/studio/src-tauri/wsl/revdev-relay
 apps/studio/src-tauri/target/
 apps/studio/src-tauri/gen/
 apps/studio/src-tauri/bindings/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Agent Setup actually installs the WSL relay.** Complete Setup calls
+  `daemon_setup` (it was registered and never invoked). Studio Release
+  bundles the Linux `revdev-relay` so Setup can copy it. A missing relay
+  is no longer described as a down daemon.
+
 ## [0.2.6] — 2026-08-15
 
 ### Fixed

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -45,6 +45,7 @@
       "icons/icon.ico"
     ],
     "resources": {
+      "wsl/revdev-relay": "wsl/revdev-relay",
       "../../../config/terminal/alacritty-revealui.toml": "terminal/alacritty-revealui.toml",
       "../../../config/terminal/gnome-terminal-revealui.dconf": "terminal/gnome-terminal-revealui.dconf",
       "../../../config/terminal/iterm2-revealui.json": "terminal/iterm2-revealui.json",

--- a/apps/studio/src-tauri/wsl/README.md
+++ b/apps/studio/src-tauri/wsl/README.md
@@ -1,0 +1,10 @@
+# WSL payload
+
+`revdev-relay` is the Linux ELF Setup copies to `$HOME/.local/bin` on
+Windows. The file is produced by Studio Release (`linux-relay` job) and
+is gitignored. Build locally with:
+
+```bash
+cargo build --release --manifest-path apps/studio/relay/Cargo.toml
+cp apps/studio/relay/target/release/revdev-relay apps/studio/src-tauri/wsl/revdev-relay
+```

--- a/apps/studio/src/__tests__/components/SetupWizard.test.tsx
+++ b/apps/studio/src/__tests__/components/SetupWizard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // NOTE: vitest hoists vi.mock above all imports/consts, so the factory must not
@@ -34,10 +34,13 @@ vi.mock('@tauri-apps/plugin-shell', () => ({
 vi.mock('../../lib/invoke', () => ({
   vaultInit: vi.fn(),
   vaultIsInitialized: vi.fn().mockResolvedValue(true),
+  daemonSetup: vi.fn().mockResolvedValue('ok'),
+  invokeErrorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
 }));
 
 import SetupWizard from '../../components/setup/SetupWizard';
 import { markSetupComplete, useSetup } from '../../hooks/use-setup';
+import { daemonSetup } from '../../lib/invoke';
 
 function renderWizard(overrides?: { onComplete?: () => void; onDismiss?: () => void }) {
   const onComplete = overrides?.onComplete ?? vi.fn();
@@ -49,6 +52,7 @@ function renderWizard(overrides?: { onComplete?: () => void; onDismiss?: () => v
 describe('SetupWizard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(daemonSetup).mockResolvedValue('ok');
   });
 
   it('renders "Setup RevealUI Studio" title', () => {
@@ -83,12 +87,24 @@ describe('SetupWizard', () => {
     expect(completeButton).not.toBeDisabled();
   });
 
-  it('completing setup calls onComplete and markSetupComplete, not onDismiss', () => {
+  it('completing setup installs the WSL relay then marks complete', async () => {
     const { onComplete, onDismiss } = renderWizard();
     fireEvent.click(screen.getByText('Complete Setup'));
-    expect(markSetupComplete).toHaveBeenCalled();
-    expect(onComplete).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(daemonSetup).toHaveBeenCalledTimes(1);
+      expect(markSetupComplete).toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
     expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('does not mark complete when relay install fails', async () => {
+    daemonSetup.mockRejectedValueOnce(new Error('wslpath failed'));
+    const { onComplete } = renderWizard();
+    fireEvent.click(screen.getByText('Complete Setup'));
+    expect(await screen.findByText('wslpath failed')).toBeInTheDocument();
+    expect(markSetupComplete).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
   });
 
   it('skipping with all checks passing dismisses directly without a confirm', () => {

--- a/apps/studio/src/__tests__/lib/invoke.test.ts
+++ b/apps/studio/src/__tests__/lib/invoke.test.ts
@@ -508,7 +508,14 @@ describe('formatInvokeError', () => {
   it('rewrites relay/daemon failures into one Setup line', async () => {
     const { formatDaemonUnreachable, isDaemonUnreachable } = await import('../../lib/invoke');
     expect(isDaemonUnreachable('Relay closed without response')).toBe(true);
-    expect(formatDaemonUnreachable('Relay closed without response')).toMatch(/Open Setup/);
+    expect(formatDaemonUnreachable('Relay closed without response')).toMatch(
+      /daemon in WSL is not running/,
+    );
+    expect(
+      formatDaemonUnreachable(
+        'Relay closed without response. The agent daemon in WSL is not running. Open Setup from the sidebar, then try Agent again. (revdev-relay: connect /home/x/.local/share/revealui/harness.sock: No such file or directory)',
+      ),
+    ).toMatch(/relay is not installed/);
     expect(formatDaemonUnreachable('permission denied')).toBe('permission denied');
   });
 });

--- a/apps/studio/src/components/setup/SetupWizard.tsx
+++ b/apps/studio/src/components/setup/SetupWizard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { markSetupComplete, useSetup } from '../../hooks/use-setup';
+import { daemonSetup, invokeErrorMessage } from '../../lib/invoke';
 import Button from '../adapters/Button';
 import ConfirmDialog from '../adapters/ConfirmDialog';
 import ErrorAlert from '../adapters/ErrorAlert';
@@ -23,6 +24,8 @@ interface SetupWizardProps {
 export default function SetupWizard({ onComplete, onDismiss }: SetupWizardProps) {
   const setup = useSetup();
   const [confirmingDismiss, setConfirmingDismiss] = useState(false);
+  const [provisioning, setProvisioning] = useState(false);
+  const [provisionError, setProvisionError] = useState<string | null>(null);
 
   const allDone =
     setup.status?.wsl_running &&
@@ -32,8 +35,19 @@ export default function SetupWizard({ onComplete, onDismiss }: SetupWizardProps)
     !!setup.status?.git_email;
 
   const handleComplete = () => {
-    markSetupComplete();
-    onComplete();
+    setProvisioning(true);
+    setProvisionError(null);
+    void daemonSetup()
+      .then(() => {
+        markSetupComplete();
+        onComplete();
+      })
+      .catch((err: unknown) => {
+        setProvisionError(invokeErrorMessage(err));
+      })
+      .finally(() => {
+        setProvisioning(false);
+      });
   };
 
   const handleSkip = () => {
@@ -56,7 +70,13 @@ export default function SetupWizard({ onComplete, onDismiss }: SetupWizardProps)
             <Button variant="ghost" onClick={handleSkip}>
               Skip
             </Button>
-            <Button variant="primary" size="lg" onClick={handleComplete} disabled={!allDone}>
+            <Button
+              variant="primary"
+              size="lg"
+              onClick={handleComplete}
+              disabled={!allDone || provisioning}
+              loading={provisioning}
+            >
               Complete Setup
             </Button>
           </>
@@ -64,14 +84,15 @@ export default function SetupWizard({ onComplete, onDismiss }: SetupWizardProps)
       >
         <div className="space-y-4">
           <p className="text-sm leading-relaxed text-fg-muted">
-            This checklist sets up WSL, Nix, DevPod, and git identity. It is optional. Skip to use
-            Studio now. Agent Approvals live under Agent in the sidebar.
+            This checklist sets up WSL, Nix, DevPod, and git identity. Completing Setup installs the
+            agent relay in WSL. Skip hides the wizard for this launch. Agent Approvals live under
+            Agent in the sidebar.
           </p>
           {setup.loading && !setup.status && (
             <p className="text-sm text-fg-muted">Checking environment...</p>
           )}
 
-          <ErrorAlert message={setup.error} />
+          <ErrorAlert message={setup.error ?? provisionError} />
 
           <WslRow setup={setup} />
           <NixRow setup={setup} />

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -949,6 +949,7 @@ export function isDaemonUnreachable(message: string): boolean {
     message.startsWith('Relay spawn failed:') ||
     message.startsWith('Harness daemon not running') ||
     message.startsWith('The agent daemon in WSL') ||
+    message.startsWith('The WSL agent relay') ||
     message.startsWith('RPC timeout')
   );
 }
@@ -956,6 +957,9 @@ export function isDaemonUnreachable(message: string): boolean {
 /** One actionable line when the WSL daemon/relay is down. */
 export function formatDaemonUnreachable(message: string): string {
   if (!isDaemonUnreachable(message)) return message;
+  if (message.includes('revdev-relay') || message.includes('No such file or directory')) {
+    return 'The WSL agent relay is not installed. Open Setup from the sidebar, then try Agent again.';
+  }
   return 'The agent daemon in WSL is not running. Open Setup from the sidebar, then try Agent again.';
 }
 
@@ -1051,6 +1055,11 @@ export function readAppLog(name: string, lines?: number): Promise<string> {
 
 export function checkSetup(): Promise<SetupStatus> {
   return invoke<SetupStatus>('check_setup');
+}
+
+/** Stage `revdev-relay`, enable the WSL daemon unit, provision this install's trust entry. */
+export function daemonSetup(): Promise<string> {
+  return invoke<string>('daemon_setup');
 }
 
 export function setGitIdentity(name: string, email: string): Promise<void> {


### PR DESCRIPTION
## Why

On 0.2.6 the Agent tab said the daemon was down. The daemon was **up** and answered `ping`. `$HOME/.local/bin/revdev-relay` was missing.

`daemon_setup` already copies that binary and provisions the trust anchor. The frontend never called it. Complete Setup only set `setupComplete`. The Windows installer also did not bundle the Linux ELF, so even a manual `daemon_setup` would have failed.

## What

- Complete Setup awaits `daemon_setup` and does not mark complete if it fails
- Studio Release builds `revdev-relay` on Ubuntu and stages it at `src-tauri/wsl/` before the Tauri bundle
- Agent copy says the relay is missing when stderr names `revdev-relay` / `No such file`

This machine already has the relay at `$HOME/.local/bin/revdev-relay` and this install's trust entry. Click Agent again on the running 0.2.6 window.

## Proof

`vitest` SetupWizard (9) + `rewrites relay` (1) passed.