### PR TITLE
chore(studio): bump 0.2.7 for relay flush and Setup wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+## [0.2.7] — 2026-08-15
+
 ### Fixed
 
 - **Agent Setup actually installs the WSL relay.** Complete Setup calls
@@ -16,6 +18,8 @@ Dates are ISO 8601 (UTC).
 - **Agent ping over a live daemon.** `revdev-relay` now flushes each
   pipe write. Piped stdout was fully buffered, so Studio never saw a
   response while the daemon kept the socket open.
+
+[0.2.7]: https://github.com/RevealUIStudio/revdev/releases/tag/studio-v0.2.7
 
 ## [0.2.6] — 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Dates are ISO 8601 (UTC).
   `daemon_setup` (it was registered and never invoked). Studio Release
   bundles the Linux `revdev-relay` so Setup can copy it. A missing relay
   is no longer described as a down daemon.
+- **Agent ping over a live daemon.** `revdev-relay` now flushes each
+  pipe write. Piped stdout was fully buffered, so Studio never saw a
+  response while the daemon kept the socket open.
 
 ## [0.2.6] — 2026-08-15
 

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Native AI experience — agent coordination hub, local inference management, visual agent dashboard (Tauri 2 + React 19)",
   "private": true,
   "dependencies": {

--- a/apps/studio/relay/src/main.rs
+++ b/apps/studio/relay/src/main.rs
@@ -14,11 +14,26 @@
 //!
 //! Pure std, zero dependencies — a fully-owned, auditable byte pump.
 
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::net::Shutdown;
 use std::os::unix::net::UnixStream;
 use std::process::ExitCode;
 use std::thread;
+
+/// Copy `from` to `to`, flushing after every read. Piped stdout is fully
+/// buffered; `io::copy` would hold a daemon line until the socket closed.
+fn pump_and_flush(mut from: impl Read, mut to: impl Write) -> io::Result<()> {
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = from.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        to.write_all(&buf[..n])?;
+        to.flush()?;
+    }
+    Ok(())
+}
 
 fn main() -> ExitCode {
     let socket_path = match std::env::args().nth(1) {
@@ -47,19 +62,18 @@ fn main() -> ExitCode {
             return ExitCode::from(1);
         }
     };
-    let mut from_socket = stream;
+    let from_socket = stream;
 
     let pump_in = thread::spawn(move || {
-        let mut stdin = io::stdin().lock();
-        let _ = io::copy(&mut stdin, &mut to_socket);
+        let stdin = io::stdin().lock();
+        let _ = pump_and_flush(stdin, &mut to_socket);
         // Half-close so the daemon observes EOF and can finish responding even
         // if the client closed its stdin right after sending the request.
         let _ = to_socket.shutdown(Shutdown::Write);
     });
 
-    let mut stdout = io::stdout().lock();
-    let _ = io::copy(&mut from_socket, &mut stdout);
-    let _ = stdout.flush();
+    let stdout = io::stdout().lock();
+    let _ = pump_and_flush(from_socket, stdout);
     let _ = pump_in.join();
 
     ExitCode::SUCCESS

--- a/apps/studio/relay/tests/bridge.rs
+++ b/apps/studio/relay/tests/bridge.rs
@@ -57,6 +57,72 @@ fn relay_bridges_stdin_to_socket_and_socket_to_stdout() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// Studio keeps the WSL relay's stdin open (one child, many RPCs). The mock
+/// daemon must also keep the socket open. stdout is a pipe, so libc will
+/// block-buffer unless the relay flushes after each write.
+#[test]
+fn relay_flushes_stdout_while_both_sides_stay_open() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let dir = std::env::temp_dir().join(format!("revdev-relay-flush-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let sock = dir.join("t.sock");
+    let _ = std::fs::remove_file(&sock);
+
+    let listener = UnixListener::bind(&sock).unwrap();
+    let (release_tx, release_rx) = mpsc::channel::<()>();
+    let server = thread::spawn(move || {
+        let (conn, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(conn.try_clone().unwrap());
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        let mut writer = conn;
+        writer
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"pong\":true}}\n")
+            .unwrap();
+        writer.flush().unwrap();
+        let _ = release_rx.recv();
+    });
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_revdev-relay"))
+        .arg(&sock)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n")
+        .unwrap();
+
+    let stdout = child.stdout.take().unwrap();
+    let (line_tx, line_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut line = String::new();
+        let _ = BufReader::new(stdout).read_line(&mut line);
+        let _ = line_tx.send(line);
+    });
+
+    let line = line_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("relay did not flush the daemon line while the socket stayed open");
+    assert!(
+        line.contains("pong"),
+        "expected a ping result, got {line:?}"
+    );
+
+    drop(child.stdin.take());
+    let _ = release_tx.send(());
+    let _ = child.wait();
+    let _ = server.join();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn relay_exits_nonzero_when_socket_missing() {
     let missing = std::env::temp_dir().join("revdev-relay-does-not-exist.sock");

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.2.6"
+version = "0.2.7",
 dependencies = [
  "age",
  "arboard",

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.2.7",
+version = "0.2.7"
 dependencies = [
  "age",
  "arboard",

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.2.6"
+version = "0.2.7",
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.2.7",
+version = "0.2.7"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "RevealUI Studio",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "identifier": "dev.revealui.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Why

You merged #420. GitHub squashed the first commit only. `origin/test` still has the unflushed `revdev-relay` (`io::copy`, no flush). Tagging `studio-v0.2.6` again would collide. The installed app is still 0.2.6.

## What

- Cherry-pick the flush + the test that keeps both sides open
- Bump Studio to **0.2.7**

## After merge

Tag `studio-v0.2.7` from `origin/test`. Leave `studio-v0.2.6` alone.