### PR TITLE
fix(console): fail-closed agents ssh, contain static, drop shell execute

### DIFF
--- a/.github/workflows/studio-rust-tests.yml
+++ b/.github/workflows/studio-rust-tests.yml
@@ -79,6 +79,15 @@ jobs:
       - name: Satisfy tauri-build frontendDist
         run: mkdir -p apps/studio/dist
 
+      # tauri.conf.json bundles gitignored wsl/revdev-relay. Release CI builds
+      # it; this job must too or tauri-build fails on a missing resource.
+      - name: Build WSL relay payload for tauri-build
+        run: |
+          cargo build --release --manifest-path apps/studio/relay/Cargo.toml
+          mkdir -p apps/studio/src-tauri/wsl
+          cp apps/studio/relay/target/release/revdev-relay apps/studio/src-tauri/wsl/revdev-relay
+          chmod +x apps/studio/src-tauri/wsl/revdev-relay
+
       # --test-threads=1: both test binaries route the harness client through
       # process-global env (REVDEV_TEST_SOCKET / REVDEV_DAEMON_*); parallel
       # tests would race each other's socket overrides.
@@ -180,6 +189,13 @@ jobs:
       # tauri-build's codegen requires the configured frontendDist path to exist.
       - name: Satisfy tauri-build frontendDist
         run: mkdir -p apps/studio/dist
+
+      - name: Build WSL relay payload for tauri-build
+        run: |
+          cargo build --release --manifest-path apps/studio/relay/Cargo.toml
+          mkdir -p apps/studio/src-tauri/wsl
+          cp apps/studio/relay/target/release/revdev-relay apps/studio/src-tauri/wsl/revdev-relay
+          chmod +x apps/studio/src-tauri/wsl/revdev-relay
 
       # Reverts the changed Rust source to base, then runs each changed
       # integration test (`cargo test --test <name>`) and requires >=1 red.

--- a/apps/console/authz/authorized.go
+++ b/apps/console/authz/authorized.go
@@ -1,0 +1,66 @@
+// Package authz implements fail-closed public-key allowlisting for agents mode.
+package authz
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// LoadAuthorizedKeys reads an OpenSSH authorized_keys file and returns the
+// public keys it contains. Missing files and unreadable paths return an error
+// (callers treat that as deny). An empty or comment-only file returns a nil
+// slice and a nil error — also a deny for agents mode.
+func LoadAuthorizedKeys(path string) ([]ssh.PublicKey, error) {
+	if path == "" {
+		return nil, fmt.Errorf("authorized keys path is empty")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAuthorizedKeys(data)
+}
+
+// ParseAuthorizedKeys parses the full contents of an authorized_keys file.
+func ParseAuthorizedKeys(data []byte) ([]ssh.PublicKey, error) {
+	var keys []ssh.PublicKey
+	rest := data
+	for len(rest) > 0 {
+		var key ssh.PublicKey
+		var err error
+		key, _, _, rest, err = ssh.ParseAuthorizedKey(rest)
+		if err != nil {
+			// Remaining lines are comments, blanks, or unparseable — stop.
+			break
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+// KeysEqual reports whether two SSH public keys are the same key material.
+// x/crypto/ssh has no exported KeysEqual in current modules; equality is the
+// wire-form Marshal comparison used throughout that package's tests.
+func KeysEqual(a, b ssh.PublicKey) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return bytes.Equal(a.Marshal(), b.Marshal())
+}
+
+// KeyAuthorized reports whether candidate matches any key in authorized.
+// A nil candidate never matches.
+func KeyAuthorized(candidate ssh.PublicKey, authorized []ssh.PublicKey) bool {
+	if candidate == nil || len(authorized) == 0 {
+		return false
+	}
+	for _, k := range authorized {
+		if KeysEqual(candidate, k) {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/console/authz/authorized_test.go
+++ b/apps/console/authz/authorized_test.go
@@ -1,0 +1,141 @@
+package authz
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func mustKeyPair(t *testing.T) (ssh.PublicKey, ssh.Signer) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	return signer.PublicKey(), signer
+}
+
+func writeAuthorizedKeys(t *testing.T, path string, keys ...ssh.PublicKey) {
+	t.Helper()
+	var body []byte
+	for _, k := range keys {
+		body = append(body, ssh.MarshalAuthorizedKey(k)...)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write authorized_keys: %v", err)
+	}
+}
+
+func TestLoadAuthorizedKeys_MissingFileDenies(t *testing.T) {
+	keys, err := LoadAuthorizedKeys(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if keys != nil {
+		t.Fatalf("keys = %v, want nil on error", keys)
+	}
+}
+
+func TestLoadAuthorizedKeys_EmptyPathDenies(t *testing.T) {
+	keys, err := LoadAuthorizedKeys("")
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+	if keys != nil {
+		t.Fatalf("keys = %v, want nil on error", keys)
+	}
+}
+
+func TestLoadAuthorizedKeys_EmptyFileDenies(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := LoadAuthorizedKeys(path)
+	if err != nil {
+		t.Fatalf("empty file should parse, got %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("len(keys) = %d, want 0", len(keys))
+	}
+	pub, _ := mustKeyPair(t)
+	if KeyAuthorized(pub, keys) {
+		t.Fatal("empty authorized set must deny any key")
+	}
+}
+
+func TestLoadAuthorizedKeys_CommentOnlyDenies(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+	if err := os.WriteFile(path, []byte("# only a comment\n\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := LoadAuthorizedKeys(path)
+	if err != nil {
+		t.Fatalf("comment-only file should parse, got %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("len(keys) = %d, want 0", len(keys))
+	}
+}
+
+func TestKeyAuthorized_MatchingKeyAllows(t *testing.T) {
+	pub, _ := mustKeyPair(t)
+	other, _ := mustKeyPair(t)
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+	writeAuthorizedKeys(t, path, other, pub)
+
+	keys, err := LoadAuthorizedKeys(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !KeyAuthorized(pub, keys) {
+		t.Fatal("matching key must be authorized")
+	}
+}
+
+func TestKeyAuthorized_NonMatchingDenies(t *testing.T) {
+	allowed, _ := mustKeyPair(t)
+	intruder, _ := mustKeyPair(t)
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+	writeAuthorizedKeys(t, path, allowed)
+
+	keys, err := LoadAuthorizedKeys(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if KeyAuthorized(intruder, keys) {
+		t.Fatal("non-matching key must be denied")
+	}
+}
+
+func TestKeyAuthorized_NilCandidateDenies(t *testing.T) {
+	pub, _ := mustKeyPair(t)
+	if KeyAuthorized(nil, []ssh.PublicKey{pub}) {
+		t.Fatal("nil candidate must be denied")
+	}
+}
+
+func TestKeysEqual(t *testing.T) {
+	a, _ := mustKeyPair(t)
+	b, _ := mustKeyPair(t)
+	if !KeysEqual(a, a) {
+		t.Fatal("key must equal itself")
+	}
+	if KeysEqual(a, b) {
+		t.Fatal("distinct keys must not equal")
+	}
+	if KeysEqual(nil, a) || KeysEqual(a, nil) {
+		t.Fatal("nil must not equal a real key")
+	}
+	if !KeysEqual(nil, nil) {
+		t.Fatal("nil equals nil")
+	}
+}

--- a/apps/console/main.go
+++ b/apps/console/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/charmbracelet/ssh"
 
 	"github.com/RevealUIStudio/revdev/apps/console/api"
+	"github.com/RevealUIStudio/revdev/apps/console/authz"
 	"github.com/RevealUIStudio/revdev/apps/console/proxy"
 	"github.com/RevealUIStudio/revdev/apps/console/tui"
 )
@@ -54,11 +55,16 @@ func main() {
 			return true // Accept all keys — fingerprint used for account lookup, not auth
 		}),
 		wish.WithMiddleware(
-			// Route to agent proxy or payment TUI based on SSH command
+			// Route to agent proxy or payment TUI based on SSH command.
+			// Payment TUI keeps accept-all public keys (fingerprint lookup).
+			// Agents mode is fail-closed against CONSOLE_AUTHORIZED_KEYS.
 			func(next ssh.Handler) ssh.Handler {
 				return func(s ssh.Session) {
 					cmd := strings.Join(s.Command(), " ")
 					if strings.TrimSpace(cmd) == "agents" || defaultMode == "agents" {
+						if !authorizeAgentsSession(s) {
+							return
+						}
 						termProxy.Handle(s)
 						return
 					}
@@ -98,4 +104,21 @@ func envOrDefault(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// authorizeAgentsSession fails closed: only keys listed in the OpenSSH
+// authorized_keys file at CONSOLE_AUTHORIZED_KEYS may reach the agent proxy
+// (and therefore any REVEALUI_API_TOKEN attached to API calls).
+func authorizeAgentsSession(s ssh.Session) bool {
+	path := os.Getenv("CONSOLE_AUTHORIZED_KEYS")
+	keys, err := authz.LoadAuthorizedKeys(path)
+	if err != nil || len(keys) == 0 {
+		fmt.Fprintf(s, "\r\nagents mode denied: authorized keys unavailable\r\n")
+		return false
+	}
+	if !authz.KeyAuthorized(s.PublicKey(), keys) {
+		fmt.Fprintf(s, "\r\nagents mode denied: public key not authorized\r\n")
+		return false
+	}
+	return true
 }

--- a/apps/console/proxy/proxy.go
+++ b/apps/console/proxy/proxy.go
@@ -102,10 +102,17 @@ func short(id string) string {
 
 // spawnSession creates a new agent session via the API.
 func (p *Proxy) spawnSession(name string) (string, error) {
-	body := fmt.Sprintf(`{"name":"%s","cols":120,"rows":30}`, name)
+	payload, err := json.Marshal(struct {
+		Name string `json:"name"`
+		Cols int    `json:"cols"`
+		Rows int    `json:"rows"`
+	}{Name: name, Cols: 120, Rows: 30})
+	if err != nil {
+		return "", fmt.Errorf("encode spawn body: %w", err)
+	}
 	endpoint := fmt.Sprintf("%s/api/terminal/sessions", p.apiURL)
 
-	resp, err := p.client.HTTPClient().Post(endpoint, "application/json", strings.NewReader(body))
+	resp, err := p.client.HTTPClient().Post(endpoint, "application/json", strings.NewReader(string(payload)))
 	if err != nil {
 		return "", fmt.Errorf("spawn failed: %w", err)
 	}

--- a/apps/console/proxy/proxy_test.go
+++ b/apps/console/proxy/proxy_test.go
@@ -1,7 +1,9 @@
 package proxy
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -75,5 +77,44 @@ func TestSpawnSession_Succeeds(t *testing.T) {
 	}
 	if id != "abc123xyz" {
 		t.Errorf("sessionID = %q, want %q", id, "abc123xyz")
+	}
+}
+
+func TestSpawnSession_NameWithQuoteIsValidJSON(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		gotBody = string(raw)
+		fmt.Fprint(w, `{"sessionId":"quoted-ok"}`)
+	}))
+	defer srv.Close()
+
+	name := `evil","cols":1,"x":"`
+	id, err := newTestProxy(srv.URL).spawnSession(name)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "quoted-ok" {
+		t.Errorf("sessionID = %q, want quoted-ok", id)
+	}
+
+	// Body must be valid JSON with the name as a single string field — not
+	// broken open by sprintf injection.
+	var body struct {
+		Name string `json:"name"`
+		Cols int    `json:"cols"`
+		Rows int    `json:"rows"`
+	}
+	if err := json.Unmarshal([]byte(gotBody), &body); err != nil {
+		t.Fatalf("request body is not valid JSON: %v\nbody=%q", err, gotBody)
+	}
+	if body.Name != name {
+		t.Errorf("name = %q, want %q", body.Name, name)
+	}
+	if body.Cols != 120 || body.Rows != 30 {
+		t.Errorf("cols/rows = %d/%d, want 120/30", body.Cols, body.Rows)
 	}
 }

--- a/apps/studio/scripts/generate-types.sh
+++ b/apps/studio/scripts/generate-types.sh
@@ -14,6 +14,15 @@ STUDIO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TAURI_DIR="$STUDIO_DIR/src-tauri"
 GENERATED_DIR="$STUDIO_DIR/src/generated"
 
+RELAY_BIN="$TAURI_DIR/wsl/revdev-relay"
+if [ ! -x "$RELAY_BIN" ]; then
+  echo "==> Building gitignored wsl/revdev-relay for tauri-build..."
+  cargo build --release --manifest-path "$STUDIO_DIR/relay/Cargo.toml"
+  mkdir -p "$(dirname "$RELAY_BIN")"
+  cp "$STUDIO_DIR/relay/target/release/revdev-relay" "$RELAY_BIN"
+  chmod +x "$RELAY_BIN"
+fi
+
 echo "==> Running cargo test to generate ts-rs bindings..."
 cd "$TAURI_DIR"
 cargo test --lib

--- a/apps/studio/src-tauri/capabilities/default.json
+++ b/apps/studio/src-tauri/capabilities/default.json
@@ -5,7 +5,6 @@
   "permissions": [
     "core:default",
     "shell:allow-open",
-    "shell:allow-execute",
     "core:event:default",
     "dialog:default",
     "updater:default"

--- a/apps/studio/src-tauri/src/commands/mod.rs
+++ b/apps/studio/src-tauri/src/commands/mod.rs
@@ -15,5 +15,6 @@ pub mod ssh;
 pub mod status;
 pub mod sync;
 pub mod terminal;
+pub mod tiles;
 pub mod vault;
 pub mod fleet_map;

--- a/apps/studio/src-tauri/src/commands/tiles.rs
+++ b/apps/studio/src-tauri/src/commands/tiles.rs
@@ -1,0 +1,274 @@
+//! Trusted-host tile helpers: browser profile discovery and process listing.
+//! These replace frontend `shell:allow-execute` / `Command.create('exec-sh')`.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde::Serialize;
+
+use super::error::StudioError;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserProfile {
+    pub directory: String,
+    pub name: String,
+    /// `"chrome"` or `"edge"`
+    pub browser: String,
+}
+
+/// Detect Chrome/Edge user profiles by reading Preferences under known data dirs.
+#[tauri::command]
+pub fn detect_browser_profiles() -> Result<Vec<BrowserProfile>, StudioError> {
+    let mut profiles = Vec::new();
+    for (browser, base) in browser_data_dirs() {
+        if !base.is_dir() {
+            continue;
+        }
+        let Ok(entries) = fs::read_dir(&base) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let dir_name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            if dir_name != "Default" && !dir_name.starts_with("Profile ") {
+                continue;
+            }
+            if !path.is_dir() {
+                continue;
+            }
+            let prefs_path = path.join("Preferences");
+            let Ok(raw) = fs::read_to_string(&prefs_path) else {
+                continue;
+            };
+            let Ok(prefs) = serde_json::from_str::<serde_json::Value>(&raw) else {
+                continue;
+            };
+            let Some(name) = prefs
+                .get("profile")
+                .and_then(|p| p.get("name"))
+                .and_then(|n| n.as_str())
+            else {
+                continue;
+            };
+            if name.is_empty() {
+                continue;
+            }
+            profiles.push(BrowserProfile {
+                directory: dir_name,
+                name: name.to_string(),
+                browser: browser.to_string(),
+            });
+        }
+    }
+    Ok(profiles)
+}
+
+/// Return running process names (best-effort) for tile "running" indicators.
+/// On Linux/WSL this includes `ps -eo comm` plus Windows `tasklist` when available.
+#[tauri::command]
+pub fn list_running_processes() -> Result<Vec<String>, StudioError> {
+    let mut names = Vec::new();
+
+    // Native process list (Linux/macOS/Windows host).
+    if let Ok(output) = native_process_list() {
+        names.extend(parse_process_names(&output));
+    }
+
+    // When Studio runs under WSL/Linux, also sample Windows processes.
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(output) = Command::new("tasklist.exe")
+            .args(["/FO", "CSV", "/NH"])
+            .output()
+        {
+            if output.status.success() {
+                names.extend(parse_tasklist_csv(&String::from_utf8_lossy(&output.stdout)));
+            }
+        }
+    }
+
+    Ok(names)
+}
+
+fn native_process_list() -> Result<String, StudioError> {
+    #[cfg(target_os = "windows")]
+    {
+        let mut cmd = Command::new("tasklist.exe");
+        crate::win_process::hide_std(&mut cmd);
+        let output = cmd
+            .args(["/FO", "CSV", "/NH"])
+            .output()
+            .map_err(|e| StudioError::Process(e.to_string()))?;
+        if !output.status.success() {
+            return Err(StudioError::Process("tasklist failed".into()));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let output = Command::new("ps")
+            .args(["-eo", "comm"])
+            .output()
+            .map_err(|e| StudioError::Process(e.to_string()))?;
+        if !output.status.success() {
+            return Err(StudioError::Process("ps failed".into()));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+}
+
+fn parse_process_names(raw: &str) -> Vec<String> {
+    // CSV tasklist on Windows: "Image Name","PID",...
+    if raw.contains("\",\"") || raw.lines().next().map(|l| l.starts_with('"')).unwrap_or(false) {
+        return parse_tasklist_csv(raw);
+    }
+    raw.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && *l != "COMMAND" && *l != "COMM")
+        .map(|l| l.to_string())
+        .collect()
+}
+
+fn parse_tasklist_csv(raw: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for line in raw.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // "name.exe","1234",...
+        if let Some(rest) = line.strip_prefix('"') {
+            if let Some(end) = rest.find('"') {
+                names.push(rest[..end].to_string());
+            }
+        }
+    }
+    names
+}
+
+fn browser_data_dirs() -> Vec<(&'static str, PathBuf)> {
+    let mut dirs = Vec::new();
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(profile) = std::env::var("USERPROFILE") {
+            let base = PathBuf::from(profile);
+            dirs.push((
+                "chrome",
+                base.join("AppData/Local/Google/Chrome/User Data"),
+            ));
+            dirs.push((
+                "edge",
+                base.join("AppData/Local/Microsoft/Edge/User Data"),
+            ));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(home) = home_dir() {
+            dirs.push((
+                "chrome",
+                home.join("Library/Application Support/Google/Chrome"),
+            ));
+            dirs.push((
+                "edge",
+                home.join("Library/Application Support/Microsoft Edge"),
+            ));
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // Native Linux Chromium paths
+        if let Some(home) = home_dir() {
+            dirs.push(("chrome", home.join(".config/google-chrome")));
+            dirs.push(("edge", home.join(".config/microsoft-edge")));
+        }
+        // WSL: Windows browser profiles via /mnt/<drive>/Users/...
+        if let Some(win_home) = wsl_windows_userprofile() {
+            dirs.push((
+                "chrome",
+                win_home.join("AppData/Local/Google/Chrome/User Data"),
+            ));
+            dirs.push((
+                "edge",
+                win_home.join("AppData/Local/Microsoft/Edge/User Data"),
+            ));
+        }
+    }
+
+    dirs
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+/// Resolve Windows %USERPROFILE% from WSL and map to `/mnt/<drive>/...`.
+#[cfg(target_os = "linux")]
+fn wsl_windows_userprofile() -> Option<PathBuf> {
+    let output = Command::new("cmd.exe")
+        .args(["/c", "echo %USERPROFILE%"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let win = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .trim_end_matches('\r')
+        .to_string();
+    if win.is_empty() || win.contains('%') {
+        return None;
+    }
+    windows_path_to_wsl(&win)
+}
+
+#[cfg(target_os = "linux")]
+fn windows_path_to_wsl(win: &str) -> Option<PathBuf> {
+    // C:\Users\name → /mnt/c/Users/name
+    let bytes = win.as_bytes();
+    if bytes.len() < 3 || bytes[1] != b':' || (bytes[2] != b'\\' && bytes[2] != b'/') {
+        return None;
+    }
+    let drive = (bytes[0] as char).to_ascii_lowercase();
+    if !drive.is_ascii_alphabetic() {
+        return None;
+    }
+    let rest = win[3..].replace('\\', "/");
+    Some(PathBuf::from(format!("/mnt/{drive}/{rest}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ps_comm_lines() {
+        let names = parse_process_names("COMMAND\nzed\ntmux\nchrome\n");
+        assert!(names.contains(&"zed".into()));
+        assert!(names.contains(&"tmux".into()));
+        assert!(!names.iter().any(|n| n == "COMMAND"));
+    }
+
+    #[test]
+    fn parse_tasklist_image_names() {
+        let raw = "\"chrome.exe\",\"1234\",\"Console\",\"1\",\"100 K\"\r\n\"Zed.exe\",\"99\",\"Console\",\"1\",\"50 K\"\r\n";
+        let names = parse_tasklist_csv(raw);
+        assert_eq!(names, vec!["chrome.exe".to_string(), "Zed.exe".to_string()]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn maps_windows_userprofile() {
+        let p = windows_path_to_wsl(r"C:\Users\josh").unwrap();
+        assert_eq!(p, PathBuf::from("/mnt/c/Users/josh"));
+    }
+}

--- a/apps/studio/src-tauri/src/commands/tiles.rs
+++ b/apps/studio/src-tauri/src/commands/tiles.rs
@@ -233,7 +233,7 @@ fn wsl_windows_userprofile() -> Option<PathBuf> {
 
 #[cfg(target_os = "linux")]
 fn windows_path_to_wsl(win: &str) -> Option<PathBuf> {
-    // C:\Users\name → /mnt/c/Users/name
+    // Windows drive letter path → /mnt/<drive>/…
     let bytes = win.as_bytes();
     if bytes.len() < 3 || bytes[1] != b':' || (bytes[2] != b'\\' && bytes[2] != b'/') {
         return None;
@@ -268,7 +268,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn maps_windows_userprofile() {
-        let p = windows_path_to_wsl(r"C:\Users\josh").unwrap();
-        assert_eq!(p, PathBuf::from("/mnt/c/Users/josh"));
+        let p = windows_path_to_wsl(r"C:\Temp\profile").unwrap();
+        assert_eq!(p, PathBuf::from("/mnt/c/Temp/profile"));
     }
 }

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -21,7 +21,8 @@ mod win_process;
 use commands::{
     agent as agent_cmds, apps, config as config_cmds, deploy, fleet_map, git as git_cmds,
     harness as harness_cmds, inference as inference_cmds, launcher, local_shell as shell_cmds,
-    mount, setup, spawner as spawner_cmds, ssh as ssh_cmds, status, sync, terminal, vault,
+    mount, setup, spawner as spawner_cmds, ssh as ssh_cmds, status, sync, terminal, tiles,
+    vault,
 };
 use config::ConfigState;
 use local_shell::LocalShellState;
@@ -192,6 +193,8 @@ pub fn run() {
             inference_cmds::inference_profile_apply,
             terminal::terminal_detect,
             terminal::terminal_install,
+            tiles::detect_browser_profiles,
+            tiles::list_running_processes,
             launcher::focus_window,
             daemon_ctl::daemon_status,
             daemon_ctl::daemon_start,

--- a/apps/studio/src/hooks/use-tiles.ts
+++ b/apps/studio/src/hooks/use-tiles.ts
@@ -1,6 +1,5 @@
-import { Command } from '@tauri-apps/plugin-shell';
 import { useCallback, useEffect, useState } from 'react';
-import { focusWindow } from '../lib/invoke';
+import { focusWindow, listRunningProcesses } from '../lib/invoke';
 import {
   type BrowserProfile,
   CATEGORIES,
@@ -55,22 +54,9 @@ async function detectRunningProcesses(): Promise<Set<string>> {
   const running = new Set<string>();
 
   try {
-    // On WSL, use tasklist.exe to detect Windows processes + pgrep for Linux
-    const [winResult, linuxResult] = await Promise.allSettled([
-      Command.create('exec-sh', ['-c', 'tasklist.exe /FO CSV /NH 2>/dev/null']).execute(),
-      Command.create('exec-sh', ['-c', 'ps -eo comm 2>/dev/null']).execute(),
-    ]);
-
-    const winProcesses =
-      winResult.status === 'fulfilled' && winResult.value.code === 0
-        ? winResult.value.stdout.toLowerCase()
-        : '';
-    const linuxProcesses =
-      linuxResult.status === 'fulfilled' && linuxResult.value.code === 0
-        ? linuxResult.value.stdout.toLowerCase()
-        : '';
-
-    const combined = `${winProcesses}\n${linuxProcesses}`;
+    // Trusted-host process list (Rust command — no shell:allow-execute).
+    const names = await listRunningProcesses();
+    const combined = names.join('\n').toLowerCase();
 
     for (const [tileId, processNames] of Object.entries(PROCESS_NAMES)) {
       for (const name of processNames) {

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -230,6 +230,12 @@ const MOCK_DATA: Record<string, unknown> = {
   agent_remove: undefined,
   agent_input: undefined,
   agent_resize: undefined,
+  detect_browser_profiles: [] as Array<{
+    directory: string;
+    name: string;
+    browser: string;
+  }>,
+  list_running_processes: [] as string[],
   inference_profile_get: {
     tier: 'idle',
     provider: null,
@@ -1399,6 +1405,22 @@ export function focusWindow(processName: string): Promise<boolean> {
     return Promise.resolve(false);
   }
   return invoke<boolean>('focus_window', { processName });
+}
+
+// ── Tile gallery (trusted-host process / browser profile discovery) ─────────
+
+export interface BrowserProfileRow {
+  directory: string;
+  name: string;
+  browser: string;
+}
+
+export function detectBrowserProfiles(): Promise<BrowserProfileRow[]> {
+  return invoke<BrowserProfileRow[]>('detect_browser_profiles');
+}
+
+export function listRunningProcesses(): Promise<string[]> {
+  return invoke<string[]>('list_running_processes');
 }
 
 // ── Harness Daemon ─────────────────────────────────────────────────────────

--- a/apps/studio/src/lib/tiles.ts
+++ b/apps/studio/src/lib/tiles.ts
@@ -303,71 +303,20 @@ export interface BrowserProfile {
 }
 
 export async function detectBrowserProfiles(): Promise<BrowserProfile[]> {
-  const { Command } = await import('@tauri-apps/plugin-shell');
-  const platform = detectPlatform();
-  const profiles: BrowserProfile[] = [];
-
-  // Resolve the browser data directory per platform
-  let baseDirs: { name: 'chrome' | 'edge'; path: string }[] = [];
-
-  if (platform === 'windows') {
-    // WSL: convert Windows path to WSL mount
-    const whoami = await Command.create('exec-sh', [
-      '-c',
-      'cmd.exe /c "echo %USERPROFILE%" 2>/dev/null',
-    ]).execute();
-    if (whoami.code !== 0) return profiles;
-    const winProfile = whoami.stdout.trim().replace(/\r/g, '');
-    const wslBase = winProfile
-      .replace(/^([A-Z]):\\/, (_m, drive: string) => `/mnt/${drive.toLowerCase()}/`)
-      .split('\\')
-      .join('/');
-    baseDirs = [
-      { name: 'chrome', path: `${wslBase}/AppData/Local/Google/Chrome/User Data` },
-      { name: 'edge', path: `${wslBase}/AppData/Local/Microsoft/Edge/User Data` },
-    ];
-  } else if (platform === 'macos') {
-    const home = (await Command.create('exec-sh', ['-c', 'echo $HOME']).execute()).stdout.trim();
-    baseDirs = [
-      { name: 'chrome', path: `${home}/Library/Application Support/Google/Chrome` },
-      { name: 'edge', path: `${home}/Library/Application Support/Microsoft Edge` },
-    ];
-  } else {
-    const home = (await Command.create('exec-sh', ['-c', 'echo $HOME']).execute()).stdout.trim();
-    baseDirs = [
-      { name: 'chrome', path: `${home}/.config/google-chrome` },
-      { name: 'edge', path: `${home}/.config/microsoft-edge` },
-    ];
+  // Trusted-host discovery via Tauri command (no shell:allow-execute).
+  const { detectBrowserProfiles: invokeDetect } = await import('./invoke');
+  try {
+    const rows = await invokeDetect();
+    return rows
+      .filter((r): r is BrowserProfile => r.browser === 'chrome' || r.browser === 'edge')
+      .map((r) => ({
+        directory: r.directory,
+        name: r.name,
+        browser: r.browser,
+      }));
+  } catch {
+    return [];
   }
-
-  for (const browser of baseDirs) {
-    const lsResult = await Command.create('exec-sh', [
-      '-c',
-      `ls -d "${browser.path}"/Default "${browser.path}"/Profile\\ * 2>/dev/null`,
-    ]).execute();
-    if (lsResult.code !== 0) continue;
-
-    const dirs = lsResult.stdout.trim().split('\n').filter(Boolean);
-    for (const dir of dirs) {
-      const catResult = await Command.create('exec-sh', [
-        '-c',
-        `cat "${dir}/Preferences" 2>/dev/null`,
-      ]).execute();
-      if (catResult.code !== 0) continue;
-      try {
-        const prefs = JSON.parse(catResult.stdout);
-        const name = prefs?.profile?.name;
-        if (name) {
-          const directory = dir.split('/').pop() ?? 'Default';
-          profiles.push({ directory, name, browser: browser.name });
-        }
-      } catch {
-        // Skip unparseable profiles
-      }
-    }
-  }
-
-  return profiles;
 }
 
 // ── Launch ───────────────────────────────────────────────────────────────────
@@ -377,7 +326,7 @@ export function launchTile(tile: TileDefinition): void {
   if (action.type === 'url') {
     open(action.url);
   } else {
-    // shell:allow-execute is enabled in capabilities/default.json
+    // shell:allow-open only — open the program/path, never arbitrary shell execute.
     const args = action.args ? [action.program, ...action.args] : [action.program];
     open(args.join(' '));
   }

--- a/packages/daemon/src/__tests__/resolve-static-path.test.ts
+++ b/packages/daemon/src/__tests__/resolve-static-path.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for resolveStaticPath containment (absolute URL paths must not
+ * escape staticDir — Node's path.join replaces the base when given an abs path).
+ */
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve, sep } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveStaticPath } from '../http-gateway.js';
+
+describe('resolveStaticPath', () => {
+  let staticDir: string;
+
+  beforeEach(async () => {
+    staticDir = await mkdtemp(join(tmpdir(), 'revdev-static-'));
+    await writeFile(join(staticDir, 'index.html'), '<html></html>');
+    await writeFile(join(staticDir, 'app.js'), 'console.log(1)');
+  });
+
+  afterEach(async () => {
+    await rm(staticDir, { recursive: true, force: true });
+  });
+
+  it('serves files under staticDir', () => {
+    const p = resolveStaticPath(staticDir, '/app.js');
+    expect(p).toBe(resolve(staticDir, 'app.js'));
+  });
+
+  it('maps / and empty to index.html', () => {
+    expect(resolveStaticPath(staticDir, '/')).toBe(resolve(staticDir, 'index.html'));
+    expect(resolveStaticPath(staticDir, '')).toBe(resolve(staticDir, 'index.html'));
+  });
+
+  it('does not escape staticDir for absolute-looking URL paths', () => {
+    // Historical bug: path.join(staticDir, '/etc/passwd') === '/etc/passwd'
+    // After the fix, leading slashes are stripped so the path stays under staticDir
+    // (or is rejected) — never the real OS /etc/passwd.
+    const base = resolve(staticDir);
+    for (const candidate of ['/etc/passwd', '////etc/passwd', '/etc/shadow']) {
+      const p = resolveStaticPath(staticDir, candidate);
+      expect(p).not.toBe(candidate);
+      expect(p).not.toBe('/etc/passwd');
+      expect(p).not.toBe('/etc/shadow');
+      if (p !== null) {
+        expect(p === base || p.startsWith(base + sep)).toBe(true);
+      }
+    }
+  });
+
+  it('rejects .. traversal segments', () => {
+    expect(resolveStaticPath(staticDir, '/../etc/passwd')).toBeNull();
+    expect(resolveStaticPath(staticDir, 'foo/../../etc/passwd')).toBeNull();
+    expect(resolveStaticPath(staticDir, 'foo/../../../etc/passwd')).toBeNull();
+  });
+
+  it('rejects NUL bytes', () => {
+    expect(resolveStaticPath(staticDir, 'app.js\0/etc/passwd')).toBeNull();
+  });
+
+  it('rejects empty staticDir', () => {
+    expect(resolveStaticPath('', '/app.js')).toBeNull();
+  });
+
+  it('never returns a path outside the resolved static root', () => {
+    const candidates = [
+      '/etc/passwd',
+      '/etc/shadow',
+      '///var/log/syslog',
+      '..',
+      '../',
+      '../../',
+      'a/../../b',
+      `${'../'.repeat(20)}etc/passwd`,
+    ];
+    const base = resolve(staticDir);
+    for (const c of candidates) {
+      const p = resolveStaticPath(staticDir, c);
+      if (p !== null) {
+        expect(p === base || p.startsWith(base + sep)).toBe(true);
+      }
+    }
+  });
+});

--- a/packages/daemon/src/http-gateway.ts
+++ b/packages/daemon/src/http-gateway.ts
@@ -12,7 +12,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
-import { dirname, extname, join, normalize } from 'node:path';
+import { dirname, extname, normalize, resolve, sep } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
 import {
   findValidToken,
@@ -831,26 +831,21 @@ export class HttpGateway {
       return;
     }
 
-    // Default to index.html for SPA routing
-    const filePath = urlPath === '/' ? '/index.html' : urlPath;
-
-    // Security: prevent directory traversal
-    const normalized = normalize(filePath);
-    if (normalized.includes('..')) {
+    const resolved = resolveStaticPath(this.config.staticDir, urlPath);
+    if (!resolved) {
       res.writeHead(400);
       res.end('Bad request');
       return;
     }
 
-    const fullPath = join(this.config.staticDir, normalized);
-
-    // If file doesn't exist, serve index.html (SPA fallback)
+    // If file doesn't exist, serve index.html (SPA fallback) — still contained.
+    const indexPath = resolveStaticPath(this.config.staticDir, 'index.html');
     const targetPath =
-      existsSync(fullPath) && statSync(fullPath).isFile()
-        ? fullPath
-        : join(this.config.staticDir, 'index.html');
+      existsSync(resolved) && statSync(resolved).isFile()
+        ? resolved
+        : indexPath;
 
-    if (!existsSync(targetPath)) {
+    if (!targetPath || !existsSync(targetPath)) {
       res.writeHead(404);
       res.end('Not found');
       return;
@@ -866,6 +861,71 @@ export class HttpGateway {
   private logAuth(message: string): void {
     process.stderr.write(`[http-gateway auth] ${message}\n`);
   }
+}
+
+/**
+ * Resolve a URL path to a file under staticDir, or null if it escapes.
+ *
+ * Node's `join(staticDir, '/etc/passwd')` replaces the base with the absolute
+ * segment — so every path is treated as relative-only (leading slashes stripped),
+ * NUL/`..` segments are rejected, and the final resolved path must stay under
+ * `resolve(staticDir)`.
+ */
+export function resolveStaticPath(staticDir: string, urlPath: string): string | null {
+  if (!staticDir || urlPath.includes('\0')) {
+    return null;
+  }
+
+  let relative = urlPath;
+  // Drop query/hash if a raw URL ever lands here.
+  const q = relative.indexOf('?');
+  if (q !== -1) relative = relative.slice(0, q);
+  const h = relative.indexOf('#');
+  if (h !== -1) relative = relative.slice(0, h);
+
+  // Relative only — strip every leading slash so join/resolve cannot reset.
+  while (relative.startsWith('/') || relative.startsWith('\\')) {
+    relative = relative.slice(1);
+  }
+
+  if (relative === '' || relative === '.') {
+    relative = 'index.html';
+  }
+
+  // Reject .. segments before and after normalize (Windows + POSIX separators).
+  const rawSegments = relative.split(/[/\\]/);
+  if (rawSegments.some((seg) => seg === '..')) {
+    return null;
+  }
+
+  const normalized = normalize(relative);
+  if (
+    normalized === '..' ||
+    normalized.startsWith(`..${sep}`) ||
+    normalized.startsWith('../') ||
+    normalized.startsWith('..\\') ||
+    normalized.includes(`${sep}..${sep}`) ||
+    normalized.includes('/../') ||
+    normalized.includes('\\..\\')
+  ) {
+    return null;
+  }
+
+  // Reject absolute-looking forms that survived the strip (drive letters, UNC).
+  if (
+    normalized.startsWith('/') ||
+    normalized.startsWith('\\') ||
+    /^[a-zA-Z]:/.test(normalized)
+  ) {
+    return null;
+  }
+
+  const base = resolve(staticDir);
+  const fullPath = resolve(base, normalized);
+  if (fullPath !== base && !fullPath.startsWith(base + sep)) {
+    return null;
+  }
+  return fullPath;
 }
 
 /** SHA-256 hex digest of a string. */

--- a/packages/daemon/src/http-gateway.ts
+++ b/packages/daemon/src/http-gateway.ts
@@ -840,10 +840,7 @@ export class HttpGateway {
 
     // If file doesn't exist, serve index.html (SPA fallback) — still contained.
     const indexPath = resolveStaticPath(this.config.staticDir, 'index.html');
-    const targetPath =
-      existsSync(resolved) && statSync(resolved).isFile()
-        ? resolved
-        : indexPath;
+    const targetPath = existsSync(resolved) && statSync(resolved).isFile() ? resolved : indexPath;
 
     if (!targetPath || !existsSync(targetPath)) {
       res.writeHead(404);
@@ -912,11 +909,7 @@ export function resolveStaticPath(staticDir: string, urlPath: string): string | 
   }
 
   // Reject absolute-looking forms that survived the strip (drive letters, UNC).
-  if (
-    normalized.startsWith('/') ||
-    normalized.startsWith('\\') ||
-    /^[a-zA-Z]:/.test(normalized)
-  ) {
+  if (normalized.startsWith('/') || normalized.startsWith('\\') || /^[a-zA-Z]:/.test(normalized)) {
     return null;
   }
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -42,6 +42,7 @@ export {
   type HttpGatewayConfig,
   isPreAuthRoute,
   PRE_AUTH_ROUTES,
+  resolveStaticPath,
 } from './http-gateway.js';
 export { checkLicense, LICENSE_TIERS, type LicenseTier } from './license.js';
 export {


### PR DESCRIPTION
## Summary
- Agents SSH requires `CONSOLE_AUTHORIZED_KEYS` (OpenSSH authorized_keys). Missing, empty, or non-matching key fails closed. Payment TUI stays accept-all + fingerprint lookup.
- `spawnSession` uses `json.Marshal` instead of sprintf.
- HTTP gateway static serving resolves only under `staticDir` (absolute URL paths cannot escape).
- Studio drops `shell:allow-execute`. Browser profile and process detection moved to Rust. `shell:allow-open` remains.

## Test
- `go test ./...` in apps/console
- daemon `resolve-static-path` + http-gateway focused suites green

Review-pending (SSH / spawn / Tauri host surface). Do not merge until the recorded verdict lands.

## Owner after merge
If Console agents mode is deployed, set `CONSOLE_AUTHORIZED_KEYS` to a real authorized_keys file or agents connections all fail closed.