### PR TITLE
fix(studio): keep SetupWizard mocks out of release tsc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+## [0.2.8] — 2026-08-16
+
+### Fixed
+
+- **Windows NSIS build.** `pnpm build` (`tsc -b`) no longer typechecks
+  `__tests__`. The SetupWizard mock uses `vi.mocked` so a rejected
+  `daemonSetup` is typed.
+
+[0.2.8]: https://github.com/RevealUIStudio/revdev/releases/tag/studio-v0.2.8
+
 ## [0.2.7] — 2026-08-15
 
 ### Fixed

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Native AI experience — agent coordination hub, local inference management, visual agent dashboard (Tauri 2 + React 19)",
   "private": true,
   "dependencies": {

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "age",
  "arboard",

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "RevealUI Studio",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "identifier": "dev.revealui.studio",
   "build": {
     "frontendDist": "../dist",

--- a/apps/studio/src/__tests__/components/SetupWizard.test.tsx
+++ b/apps/studio/src/__tests__/components/SetupWizard.test.tsx
@@ -99,7 +99,7 @@ describe('SetupWizard', () => {
   });
 
   it('does not mark complete when relay install fails', async () => {
-    daemonSetup.mockRejectedValueOnce(new Error('wslpath failed'));
+    vi.mocked(daemonSetup).mockRejectedValueOnce(new Error('wslpath failed'));
     const { onComplete } = renderWizard();
     fireEvent.click(screen.getByText('Complete Setup'));
     expect(await screen.findByText('wslpath failed')).toBeInTheDocument();

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -21,5 +21,6 @@
     },
     "types": ["@testing-library/jest-dom"]
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
 }


### PR DESCRIPTION
## Why

`studio-v0.2.7` release failed on every platform at `beforeBuildCommand` (`pnpm build` → `tsc -b`):

```
SetupWizard.test.tsx:102 mockRejectedValueOnce does not exist on type () => Promise<string>
```

Do not retag `studio-v0.2.7`. This is **0.2.8**.

## What

- Exclude `src/__tests__` from the app `tsconfig` so release tsc does not compile mocks
- Use `vi.mocked(daemonSetup)` in the fail-path test
- Bump 0.2.8 (no TOML comma)

## After merge

Tag `studio-v0.2.8` from `origin/test`.