### PR TITLE
fix(studio): read WslLaunch pipes with blocking std I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+## [0.2.9] — 2026-08-16
+
+### Fixed
+
+- **Agent over a live WSL daemon.** `WslLaunch` stdio uses anonymous
+  pipes. Those handles are not overlapped, so `tokio::fs::File` never
+  delivered a ping line. Studio now writes and reads them with blocking
+  std I/O on a worker thread.
+
+[0.2.9]: https://github.com/RevealUIStudio/revdev/releases/tag/studio-v0.2.9
+
 ## [0.2.8] — 2026-08-16
 
 ### Fixed

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Native AI experience — agent coordination hub, local inference management, visual agent dashboard (Tauri 2 + React 19)",
   "private": true,
   "dependencies": {

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "age",
  "arboard",

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]
@@ -35,7 +35,7 @@ arboard = "3"
 russh = "0.62.5"
 # "process" + "time" power the Windows wsl.exe relay transport (harness.rs);
 # "time" also backs the shared retry/timeout loop on every platform.
-tokio = { version = "1", features = ["sync", "net", "io-util", "time", "process"] }
+tokio = { version = "1", features = ["sync", "net", "io-util", "time", "process", "rt"] }
 uuid = { version = "1", features = ["v4"] }
 base64 = "0.22"
 sha2 = "0.10"

--- a/apps/studio/src-tauri/src/harness.rs
+++ b/apps/studio/src-tauri/src/harness.rs
@@ -430,8 +430,8 @@ static RELAY_COOLDOWN_UNTIL: std::sync::Mutex<Option<std::time::Instant>> =
 #[cfg(not(unix))]
 struct LiveRelay {
     child: crate::win_process::HiddenWslChild,
-    stdin: tokio::fs::File,
-    stdout: tokio::io::BufReader<tokio::fs::File>,
+    stdin: Option<std::fs::File>,
+    stdout: Option<std::io::BufReader<std::fs::File>>,
 }
 
 #[cfg(not(unix))]
@@ -508,8 +508,6 @@ fn is_transient_error(err: &str) -> bool {
 
 #[cfg(not(unix))]
 async fn spawn_live_relay() -> Result<LiveRelay, String> {
-    use tokio::io::BufReader;
-
     if relay_is_cooling_down() {
         return Err(relay_closed_message(""));
     }
@@ -524,8 +522,8 @@ async fn spawn_live_relay() -> Result<LiveRelay, String> {
     let stdout = child.take_stdout()?;
     Ok(LiveRelay {
         child,
-        stdin,
-        stdout: BufReader::new(stdout),
+        stdin: Some(stdin),
+        stdout: Some(std::io::BufReader::new(stdout)),
     })
 }
 
@@ -538,7 +536,7 @@ async fn rpc_call_once(
     params: &serde_json::Value,
     signature: &Option<String>,
 ) -> Result<serde_json::Value, String> {
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+    use std::io::{BufRead, Write};
 
     let mut slot = LIVE_RELAY.lock().await;
     if slot.is_none() {
@@ -559,56 +557,57 @@ async fn rpc_call_once(
     let mut payload = serde_json::to_vec(&request).map_err(|e| e.to_string())?;
     payload.push(b'\n');
 
-    let write_err = {
-        let relay = slot.as_mut().expect("relay just inserted");
-        relay
-            .stdin
-            .write_all(&payload)
-            .await
-            .err()
-            .map(|e| format!("Write failed: {e}"))
-    };
-    if let Some(err) = write_err {
-        *slot = None;
-        return Err(err);
-    }
+    // WslLaunch anonymous pipes are not overlapped. Drive them with blocking
+    // std I/O on a worker so Tokio IOCP does not see EOF / invalid parameter.
+    let stdin = slot
+        .as_mut()
+        .expect("relay just inserted")
+        .stdin
+        .take()
+        .ok_or_else(|| "Relay spawn failed: stdin unavailable".to_string())?;
+    let (stdin, write_err) = tokio::task::spawn_blocking(move || {
+        let result = stdin.write_all(&payload).and_then(|()| stdin.flush());
+        (stdin, result)
+    })
+    .await
+    .map_err(|e| format!("Write failed: {e}"))?;
     if let Some(relay) = slot.as_mut() {
-        if let Err(e) = relay.stdin.flush().await {
-            *slot = None;
-            return Err(format!("Write failed: {e}"));
-        }
+        relay.stdin = Some(stdin);
+    }
+    if let Err(e) = write_err {
+        *slot = None;
+        return Err(format!("Write failed: {e}"));
     }
 
-    let mut line = String::new();
-    let n = {
-        let relay = slot.as_mut().expect("relay still held");
-        relay
-            .stdout
-            .read_line(&mut line)
-            .await
-            .map_err(|e| format!("Read failed: {e}"))
-    };
+    let stdout = slot
+        .as_mut()
+        .expect("relay still held")
+        .stdout
+        .take()
+        .ok_or_else(|| "Relay spawn failed: stdout unavailable".to_string())?;
+    let (stdout, line, n) = tokio::task::spawn_blocking(move || {
+        let mut line = String::new();
+        let n = stdout.read_line(&mut line);
+        (stdout, line, n)
+    })
+    .await
+    .map_err(|e| format!("Read failed: {e}"))?;
+    if let Some(relay) = slot.as_mut() {
+        relay.stdout = Some(stdout);
+    }
     let n = match n {
         Ok(n) => n,
         Err(err) => {
             *slot = None;
-            return Err(err);
+            return Err(format!("Read failed: {err}"));
         }
     };
     if n == 0 {
-        let mut err_buf = String::new();
-        if let Some(mut relay) = slot.take() {
-            if let Some(stderr) = relay.child.take_stderr() {
-                let mut err_reader = tokio::io::BufReader::new(stderr);
-                let _ = timeout(
-                    Duration::from_millis(250),
-                    tokio::io::AsyncReadExt::read_to_string(&mut err_reader, &mut err_buf),
-                )
-                .await;
-            }
-        }
+        // Do not read stderr here: the anonymous pipe blocks if the child
+        // is still alive with an empty buffer.
+        *slot = None;
         mark_relay_down();
-        return Err(relay_closed_message(&err_buf));
+        return Err(relay_closed_message(""));
     }
 
     let response: JsonRpcResponse =

--- a/apps/studio/src-tauri/src/win_process.rs
+++ b/apps/studio/src-tauri/src/win_process.rs
@@ -39,26 +39,26 @@ pub fn relay_shell_command(socket_rel_path: &str) -> String {
 #[cfg(windows)]
 pub struct HiddenWslChild {
     process: isize,
-    stdin: Option<tokio::fs::File>,
-    stdout: Option<tokio::fs::File>,
-    stderr: Option<tokio::fs::File>,
+    stdin: Option<std::fs::File>,
+    stdout: Option<std::fs::File>,
+    stderr: Option<std::fs::File>,
 }
 
 #[cfg(windows)]
 impl HiddenWslChild {
-    pub fn take_stdin(&mut self) -> Result<tokio::fs::File, String> {
+    pub fn take_stdin(&mut self) -> Result<std::fs::File, String> {
         self.stdin
             .take()
             .ok_or_else(|| "Relay spawn failed: stdin unavailable".to_string())
     }
 
-    pub fn take_stdout(&mut self) -> Result<tokio::fs::File, String> {
+    pub fn take_stdout(&mut self) -> Result<std::fs::File, String> {
         self.stdout
             .take()
             .ok_or_else(|| "Relay spawn failed: stdout unavailable".to_string())
     }
 
-    pub fn take_stderr(&mut self) -> Option<tokio::fs::File> {
+    pub fn take_stderr(&mut self) -> Option<std::fs::File> {
         self.stderr.take()
     }
 
@@ -135,9 +135,12 @@ pub fn spawn_wsl_hidden(distro: &str, command: &str) -> Result<HiddenWslChild, S
         Ok(())
     }
 
-    unsafe fn to_tokio(handle: HANDLE) -> tokio::fs::File {
+    // Anonymous CreatePipe handles are not FILE_FLAG_OVERLAPPED. Do not wrap
+    // them in tokio::fs::File; IOCP read/write fails or returns EOF. The
+    // caller drives these with blocking std I/O (spawn_blocking).
+    unsafe fn to_std(handle: HANDLE) -> std::fs::File {
         let owned = OwnedHandle::from_raw_handle(handle as _);
-        tokio::fs::File::from_std(std::fs::File::from(owned))
+        std::fs::File::from(owned)
     }
 
     let distro_w = to_wide(distro);
@@ -198,9 +201,9 @@ pub fn spawn_wsl_hidden(distro: &str, command: &str) -> Result<HiddenWslChild, S
 
     Ok(HiddenWslChild {
         process: process as isize,
-        stdin: Some(unsafe { to_tokio(stdin_w) }),
-        stdout: Some(unsafe { to_tokio(stdout_r) }),
-        stderr: Some(unsafe { to_tokio(stderr_r) }),
+        stdin: Some(unsafe { to_std(stdin_w) }),
+        stdout: Some(unsafe { to_std(stdout_r) }),
+        stderr: Some(unsafe { to_std(stderr_r) }),
     })
 }
 

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "RevealUI Studio",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "identifier": "dev.revealui.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Why

0.2.8 is installed. The daemon is active. \`revdev-relay\` pings from WSL. A Python \`WslLaunch\` probe with **blocking** \`WriteFile\`/\`ReadFile\` returns \`pong\`. Studio has **no** \`revdev-relay\` child.

\`WslLaunch\` stdio is \`CreatePipe\`. Those handles are not \`FILE_FLAG_OVERLAPPED\`. \`tokio::fs::File\` on them returns EOF / never a line. \`formatDaemonUnreachable\` turns that into “The agent daemon in WSL is not running.”

## What

- Keep \`WslLaunch\` (no \`wsl.exe\` console)
- Hold \`std::fs::File\` ends and read/write them in \`spawn_blocking\`
- Bump **0.2.9** (do not move \`studio-v0.2.8\`)

## Proof

\`cargo test --offline --lib -- presentment cooldown empty_stderr includes_relay relay_command hide_std\` → 13 passed.

The Windows pipe path is \`cfg(windows)\`. Empirically: blocking \`WslLaunch\` ping works; 0.2.8 tokio File does not leave a relay process.

## After merge

Tag \`studio-v0.2.9\` from \`origin/test\`.