### PR TITLE
fix(studio): do not compile the Linux relay on Windows ts-rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+## [0.2.10] — 2026-08-16
+
+### Fixed
+
+- **Windows release ts-rs.** `generate-types.sh` treated a non-executable
+  Linux `revdev-relay` as missing and tried to compile it on Windows
+  (`UnixStream` is Linux-only). Use the downloaded ELF if the file exists.
+
+[0.2.10]: https://github.com/RevealUIStudio/revdev/releases/tag/studio-v0.2.10
+
 ## [0.2.9] — 2026-08-16
 
 ### Fixed

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Native AI experience — agent coordination hub, local inference management, visual agent dashboard (Tauri 2 + React 19)",
   "private": true,
   "dependencies": {

--- a/apps/studio/scripts/generate-types.sh
+++ b/apps/studio/scripts/generate-types.sh
@@ -15,7 +15,15 @@ TAURI_DIR="$STUDIO_DIR/src-tauri"
 GENERATED_DIR="$STUDIO_DIR/src/generated"
 
 RELAY_BIN="$TAURI_DIR/wsl/revdev-relay"
-if [ ! -x "$RELAY_BIN" ]; then
+# Existence, not -x: the Linux ELF from Studio Release is not executable
+# on Windows, and cargo-building the relay there fails (UnixStream).
+if [ ! -f "$RELAY_BIN" ]; then
+  if [ "$(uname -s)" != "Linux" ]; then
+    echo "error: $RELAY_BIN is missing and this host cannot build the Linux ELF."
+    echo "       On Linux: cargo build --release --manifest-path apps/studio/relay/Cargo.toml"
+    echo "       On Windows release: the linux-relay job must download it first."
+    exit 1
+  fi
   echo "==> Building gitignored wsl/revdev-relay for tauri-build..."
   cargo build --release --manifest-path "$STUDIO_DIR/relay/Cargo.toml"
   mkdir -p "$(dirname "$RELAY_BIN")"

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "age",
  "arboard",

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "RevealUI Studio",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "identifier": "dev.revealui.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Why

`studio-v0.2.9` Windows release died in Generate ts-rs:

```
error[E0433]: cannot find unix in os
 --> apps/studio/relay/src/main.rs:19
use std::os::unix::net::UnixStream
```

`generate-types.sh` used `[ ! -x wsl/revdev-relay ]`. The linux-relay job downloads a Linux ELF; Windows does not mark it executable, so the script rebuilt the relay on MSVC.

## What

- Treat the payload as present if the file exists (`-f`)
- Only `cargo build` the relay on Linux
- Bump **0.2.10** (leave `studio-v0.2.9` alone)

## After merge

Tag `studio-v0.2.10` from `origin/test`.