### PR TITLE
fix(studio): mut WslLaunch pipe handles in spawn_blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+## [0.2.11] — 2026-08-16
+
+### Fixed
+
+- **Windows release compile.** `spawn_blocking` pipe write/read needs
+  `mut` stdin and stdout. That path is Windows-only so Linux CI missed it.
+
+[0.2.11]: https://github.com/RevealUIStudio/revdev/releases/tag/studio-v0.2.11
+
 ## [0.2.10] — 2026-08-16
 
 ### Fixed

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Native AI experience — agent coordination hub, local inference management, visual agent dashboard (Tauri 2 + React 19)",
   "private": true,
   "dependencies": {

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "age",
  "arboard",

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]

--- a/apps/studio/src-tauri/src/harness.rs
+++ b/apps/studio/src-tauri/src/harness.rs
@@ -559,7 +559,7 @@ async fn rpc_call_once(
 
     // WslLaunch anonymous pipes are not overlapped. Drive them with blocking
     // std I/O on a worker so Tokio IOCP does not see EOF / invalid parameter.
-    let stdin = slot
+    let mut stdin = slot
         .as_mut()
         .expect("relay just inserted")
         .stdin
@@ -579,7 +579,7 @@ async fn rpc_call_once(
         return Err(format!("Write failed: {e}"));
     }
 
-    let stdout = slot
+    let mut stdout = slot
         .as_mut()
         .expect("relay still held")
         .stdout

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "RevealUI Studio",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "identifier": "dev.revealui.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Why

`studio-v0.2.10` Windows ts-rs got past the ELF check, then failed:

```
error[E0596]: cannot borrow stdin as mutable
harness.rs:569 stdin.write_all / stdin.flush
harness.rs:590 stdout.read_line
```

That module is \`cfg(not(unix))\`. Linux CI never compiles it.

## What

- \`let mut stdin\` / \`let mut stdout\` before \`spawn_blocking\`
- Bump **0.2.11**. Leave \`studio-v0.2.10\` alone.

## After merge

Tag \`studio-v0.2.11\` from \`origin/test\`.