### PR TITLE
fix(studio): connect Agent without sending the operator to Setup

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Native AI experience — agent coordination hub, local inference management, visual agent dashboard (Tauri 2 + React 19)",
   "private": true,
   "dependencies": {

--- a/apps/studio/src-tauri/Cargo.lock
+++ b/apps/studio/src-tauri/Cargo.lock
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "revealui-studio"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "age",
  "arboard",

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revealui-studio"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]

--- a/apps/studio/src-tauri/src/commands/harness.rs
+++ b/apps/studio/src-tauri/src/commands/harness.rs
@@ -114,10 +114,10 @@ pub struct HarnessReserveResult {
 
 #[tauri::command]
 pub async fn harness_ping() -> Result<bool, StudioError> {
-    match harness::rpc_call("ping", serde_json::json!({})).await {
-        Ok(_) => Ok(true),
-        Err(_) => Ok(false),
-    }
+    harness::rpc_call("ping", serde_json::json!({}))
+        .await
+        .map(|_| true)
+        .map_err(StudioError::Other)
 }
 
 // ── Sessions ────────────────────────────────────────────────────────────────

--- a/apps/studio/src-tauri/src/daemon_ctl.rs
+++ b/apps/studio/src-tauri/src/daemon_ctl.rs
@@ -414,6 +414,9 @@ fn build_trust_anchor_provision_script(agent_id: &str, fp: &str) -> String {
 pub async fn daemon_setup(app: tauri::AppHandle) -> Result<String, String> {
     use tauri::Manager;
 
+    // Drop a dead relay and the 20s spawn cooldown so Agent can retry now.
+    crate::harness::reset_live_relay().await;
+
     // Gate: stops here with actionable `wsl --shutdown` guidance if systemd-user
     // isn't available yet.
     wsl::ensure_systemd().await?;
@@ -497,6 +500,7 @@ pub async fn daemon_setup(app: tauri::AppHandle) -> Result<String, String> {
 #[cfg(unix)]
 #[tauri::command]
 pub async fn daemon_setup(_app: tauri::AppHandle) -> Result<String, String> {
+    crate::harness::reset_live_relay().await;
     Ok("No WSL setup required on this platform.".to_string())
 }
 

--- a/apps/studio/src-tauri/src/harness.rs
+++ b/apps/studio/src-tauri/src/harness.rs
@@ -25,14 +25,27 @@ const SOCKET_REL_PATH: &str = ".local/share/revealui/harness.sock";
 
 /// User-facing copy when the Windows WSL relay exits before a JSON-RPC line.
 /// Kept off the `not(unix)` gate so Linux CI can lock the wording.
+/// Do not claim the daemon is down here: EOF on the pipe is not a process check.
 #[cfg_attr(unix, allow(dead_code))]
 pub(crate) fn relay_closed_message(stderr: &str) -> String {
     let hint = stderr.trim();
-    let base = "Relay closed without response. The agent daemon in WSL is not running. Open Setup from the sidebar, then try Agent again.";
+    let base = "Relay closed without response.";
     if hint.is_empty() {
         return base.to_string();
     }
     format!("{base} ({hint})")
+}
+
+/// Drop a dead WslLaunch child and clear the spawn cooldown so Connect Agent
+/// can retry immediately. Unix has no relay child.
+pub async fn reset_live_relay() {
+    #[cfg(not(unix))]
+    {
+        *LIVE_RELAY.lock().await = None;
+        if let Ok(mut guard) = RELAY_COOLDOWN_UNTIL.lock() {
+            *guard = None;
+        }
+    }
 }
 
 /// After a failed WSL relay spawn, skip new `wsl.exe` children until `until`.
@@ -624,11 +637,11 @@ mod relay_closed_tests {
     use super::{relay_closed_message, relay_spawn_on_cooldown};
 
     #[test]
-    fn empty_stderr_points_at_setup() {
+    fn empty_stderr_does_not_claim_the_daemon_is_down() {
         let msg = relay_closed_message("  ");
-        assert!(msg.starts_with("Relay closed without response"));
-        assert!(msg.contains("Open Setup from the sidebar"));
-        assert!(!msg.contains('('));
+        assert_eq!(msg, "Relay closed without response.");
+        assert!(!msg.contains("daemon"));
+        assert!(!msg.contains("Open Setup"));
     }
 
     #[test]

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "RevealUI Studio",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "identifier": "dev.revealui.studio",
   "build": {
     "frontendDist": "../dist",

--- a/apps/studio/src/__tests__/components/AgentConnectBanner.test.tsx
+++ b/apps/studio/src/__tests__/components/AgentConnectBanner.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import AgentConnectBanner from '../../components/agent/AgentConnectBanner';
+
+describe('AgentConnectBanner', () => {
+  it('shows the real message and Connect Agent', () => {
+    const onConnect = vi.fn();
+    render(
+      <AgentConnectBanner
+        message="Studio lost the WSL agent relay. Connect Agent to open it again."
+        connecting={false}
+        onConnect={onConnect}
+      />,
+    );
+    expect(
+      screen.getByText('Studio lost the WSL agent relay. Connect Agent to open it again.'),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Agent' }));
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables Connect Agent while connecting', () => {
+    render(
+      <AgentConnectBanner
+        message="Studio lost the WSL agent relay. Connect Agent to open it again."
+        connecting={true}
+        onConnect={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Connect Agent' })).toBeDisabled();
+  });
+});

--- a/apps/studio/src/__tests__/lib/invoke.test.ts
+++ b/apps/studio/src/__tests__/lib/invoke.test.ts
@@ -505,17 +505,26 @@ describe('formatInvokeError', () => {
     expect(invokeErrorMessage({})).toBe('Studio command failed');
   });
 
-  it('rewrites relay/daemon failures into one Setup line', async () => {
+  it('rewrites relay/daemon failures into a Connect Agent line', async () => {
     const { formatDaemonUnreachable, isDaemonUnreachable } = await import('../../lib/invoke');
     expect(isDaemonUnreachable('Relay closed without response')).toBe(true);
-    expect(formatDaemonUnreachable('Relay closed without response')).toMatch(
-      /daemon in WSL is not running/,
+    expect(formatDaemonUnreachable('Relay closed without response')).toBe(
+      'Studio lost the WSL agent relay. Connect Agent to open it again.',
+    );
+    expect(formatDaemonUnreachable('Relay spawn failed: WslLaunch HRESULT 0x80070002')).toBe(
+      'Studio could not start the WSL agent relay. Connect Agent to try again.',
+    );
+    expect(formatDaemonUnreachable('RPC timeout after 10s: ping')).toBe(
+      'The WSL agent did not answer in time. Connect Agent to try again.',
+    );
+    expect(formatDaemonUnreachable('Harness daemon not running')).toBe(
+      'The agent daemon in WSL is not running. Connect Agent to start it.',
     );
     expect(
       formatDaemonUnreachable(
-        'Relay closed without response. The agent daemon in WSL is not running. Open Setup from the sidebar, then try Agent again. (revdev-relay: connect /home/x/.local/share/revealui/harness.sock: No such file or directory)',
+        'Relay closed without response. (revdev-relay: connect /home/x/.local/share/revealui/harness.sock: No such file or directory)',
       ),
-    ).toMatch(/relay is not installed/);
+    ).toBe('The WSL agent relay is not installed. Connect Agent to install it.');
     expect(formatDaemonUnreachable('permission denied')).toBe('permission denied');
   });
 });

--- a/apps/studio/src/components/agent/AgentConnectBanner.tsx
+++ b/apps/studio/src/components/agent/AgentConnectBanner.tsx
@@ -1,0 +1,31 @@
+import Button from '../adapters/Button';
+
+interface AgentConnectBannerProps {
+  message: string;
+  connecting: boolean;
+  onConnect: () => void;
+}
+
+/** Agent empty-state action: connect here, do not send the operator to Setup. */
+export default function AgentConnectBanner({
+  message,
+  connecting,
+  onConnect,
+}: AgentConnectBannerProps) {
+  return (
+    <div className="mb-2 rounded border border-error/40 bg-error-subtle px-2.5 py-2 text-[10px] text-error">
+      <p>{message}</p>
+      <Button
+        type="button"
+        variant="primary"
+        size="sm"
+        className="mt-2"
+        onClick={onConnect}
+        disabled={connecting}
+        loading={connecting}
+      >
+        Connect Agent
+      </Button>
+    </div>
+  );
+}

--- a/apps/studio/src/components/agent/AgentPanel.tsx
+++ b/apps/studio/src/components/agent/AgentPanel.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import ConfirmDialog from '../adapters/ConfirmDialog';
 import AgentChat from './AgentChat';
+import AgentConnectBanner from './AgentConnectBanner';
 import ApprovalQueue from './ApprovalQueue';
 import FileReservations from './FileReservations';
 import MessageInbox from './MessageInbox';
@@ -26,6 +27,7 @@ import type { AgentCard } from '../../lib/a2a-api';
 import { fetchAgentCards } from '../../lib/a2a-api';
 import {
   agentReadWorkboard,
+  daemonSetup,
   formatDaemonUnreachable,
   gitDiscardFile,
   gitStageFile,
@@ -320,6 +322,7 @@ export default function AgentPanel() {
 
   const [sessions, setSessions] = useState<AgentSession[]>([]);
   const [workboardError, setWorkboardError] = useState<string | null>(null);
+  const [connecting, setConnecting] = useState(false);
 
   const [gitState, setGitState] = useState<GitStatusResult | null>(null);
   const [gitError, setGitError] = useState<string | null>(null);
@@ -371,6 +374,18 @@ export default function AgentPanel() {
 
   async function refresh() {
     await Promise.all([loadWorkboard(), loadChanges(), loadRemoteAgents()]);
+  }
+
+  async function connectAgent() {
+    setConnecting(true);
+    try {
+      await daemonSetup();
+      await Promise.all([refresh(), harness.refresh()]);
+    } catch (e) {
+      setWorkboardError(formatDaemonUnreachable(invokeErrorMessage(e)));
+    } finally {
+      setConnecting(false);
+    }
   }
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: refresh on mount + path changes
@@ -522,9 +537,11 @@ export default function AgentPanel() {
 
         <div className="max-h-48 flex-1 overflow-y-auto px-2 py-2 md:max-h-none">
           {daemonBanner ? (
-            <div className="mb-2 rounded border border-error/40 bg-error-subtle px-2.5 py-2 text-[10px] text-error">
-              {daemonBanner}
-            </div>
+            <AgentConnectBanner
+              message={daemonBanner}
+              connecting={connecting}
+              onConnect={() => void connectAgent()}
+            />
           ) : null}
           {workboardError && !isDaemonUnreachable(workboardError) ? (
             <div className="rounded border border-error/40 bg-error-subtle px-2.5 py-2 text-[10px] text-error">

--- a/apps/studio/src/hooks/use-harness.ts
+++ b/apps/studio/src/hooks/use-harness.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  formatDaemonUnreachable,
   harnessCheckFile,
   harnessClaimTask,
   harnessCompleteTask,
@@ -116,7 +117,7 @@ export function useHarness(agentId?: string): UseHarnessReturn {
       setReservations(state.reservations);
       setError(state.connected ? null : 'Harness daemon not running');
     } catch (e) {
-      setError(invokeErrorMessage(e));
+      setError(formatDaemonUnreachable(invokeErrorMessage(e)));
       setConnected(false);
     } finally {
       setLoading(false);

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -956,17 +956,29 @@ export function isDaemonUnreachable(message: string): boolean {
     message.startsWith('Harness daemon not running') ||
     message.startsWith('The agent daemon in WSL') ||
     message.startsWith('The WSL agent relay') ||
+    message.startsWith('The WSL agent did not answer') ||
+    message.startsWith('Studio lost the WSL agent relay') ||
+    message.startsWith('Studio could not start the WSL agent relay') ||
     message.startsWith('RPC timeout')
   );
 }
 
-/** One actionable line when the WSL daemon/relay is down. */
+/** One actionable line. Do not send the operator to Setup for a pipe failure. */
 export function formatDaemonUnreachable(message: string): string {
   if (!isDaemonUnreachable(message)) return message;
   if (message.includes('revdev-relay') || message.includes('No such file or directory')) {
-    return 'The WSL agent relay is not installed. Open Setup from the sidebar, then try Agent again.';
+    return 'The WSL agent relay is not installed. Connect Agent to install it.';
   }
-  return 'The agent daemon in WSL is not running. Open Setup from the sidebar, then try Agent again.';
+  if (message.startsWith('Relay spawn failed:') || message.startsWith('Studio could not start')) {
+    return 'Studio could not start the WSL agent relay. Connect Agent to try again.';
+  }
+  if (message.startsWith('Relay closed') || message.startsWith('Studio lost the WSL agent relay')) {
+    return 'Studio lost the WSL agent relay. Connect Agent to open it again.';
+  }
+  if (message.startsWith('RPC timeout') || message.startsWith('The WSL agent did not answer')) {
+    return 'The WSL agent did not answer in time. Connect Agent to try again.';
+  }
+  return 'The agent daemon in WSL is not running. Connect Agent to start it.';
 }
 
 /** Guarded invoke — returns mock data in browser, real IPC in Tauri */


### PR DESCRIPTION
## Why

Installed 0.2.11 still shows **Agent Sessions** as "The agent daemon in WSL is not running. Open Setup..." whenever the WslLaunch pipe EOFs, spawn fails, or ping times out. The daemon is often already `active`. Setup was already completed, so that instruction is a dead end.

## What

- `relay_closed_message` no longer claims the daemon is down.
- `formatDaemonUnreachable` classifies relay-missing / spawn-failed / pipe-lost / timeout / daemon-down and tells the operator to **Connect Agent**.
- `harness_ping` returns the real error instead of `Ok(false)`.
- **Connect Agent** runs `daemon_setup` (clears the 20s WslLaunch cooldown and drops the dead child), then retries workboard + harness.

## Version

0.2.12. Do not retag 0.2.11.

## Proof

- `cargo test --lib relay_closed` — 4 passed
- `vitest` invoke + AgentConnectBanner + SetupWizard — 53 passed