### PR TITLE
feat(daemon): GAP-349 P5a knowledge-graph replica and graph.* RPC

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -55,6 +55,8 @@
     "@revdev/protocol": "workspace:*",
     "@revealui/contracts": "^1.4.0",
     "@revealui/core": "^0.10.2",
+    "@revealui/db": "^0.10.0",
+    "@revealui/knowledge-graph": "^0.1.8",
     "@revealui/utils": "^0.3.5",
     "drizzle-orm": "^0.45.2",
     "node-pty": "^1.0.0",

--- a/packages/daemon/src/__tests__/graph.test.ts
+++ b/packages/daemon/src/__tests__/graph.test.ts
@@ -1,0 +1,162 @@
+/**
+ * GAP-349 P5 — local knowledge-graph replica on daemon PGlite.
+ *
+ * Migration 0014 installs portable kg_* DDL. ingestEpisode records kg_outbox.
+ * graph.outbox.push is a no-op without a hub URL (does not invent a second store).
+ */
+
+import { PGlite } from '@electric-sql/pglite';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  graphAddEpisode,
+  graphAt,
+  graphContext,
+  graphNeighbors,
+  graphNode,
+  graphOutboxPush,
+  graphSearch,
+  graphStatus,
+} from '../graph.js';
+import { MIGRATIONS } from '../migrations/index.js';
+import { migrate } from '../storage/migrate.js';
+
+const DB_TEST_TIMEOUT = 60_000;
+
+async function boot(): Promise<PGlite> {
+  const db = new PGlite();
+  await migrate(db);
+  return db;
+}
+
+describe('knowledge-graph replica (GAP-349 P5)', () => {
+  let db: PGlite;
+
+  afterEach(async () => {
+    await db?.close().catch(() => {});
+  });
+
+  it(
+    'migration 0014 creates kg_* tables on a full migrate()',
+    async () => {
+      db = await boot();
+      expect(MIGRATIONS.at(-1)?.version).toBe(14);
+      expect(MIGRATIONS.at(-1)?.name).toBe('knowledge-graph-replica');
+      const tables = await db.query<{ table_name: string }>(
+        `SELECT table_name FROM information_schema.tables
+         WHERE table_schema = 'public' AND table_name LIKE 'kg_%'
+         ORDER BY table_name`,
+      );
+      expect(tables.rows.map((r) => r.table_name)).toEqual([
+        'kg_edge_episodes',
+        'kg_edges',
+        'kg_episodes',
+        'kg_node_aliases',
+        'kg_nodes',
+        'kg_outbox',
+      ]);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'addEpisode writes nodes/edges, search/neighbors/at/context read them, outbox stays pending without hub',
+    async () => {
+      db = await boot();
+      const before = await graphStatus(db);
+      expect(before.replica).toBe('pglite');
+      expect(before.nodes).toBe(0);
+      expect(before.hubConfigured).toBe(false);
+
+      const ingested = await graphAddEpisode(
+        db,
+        {
+          episodeType: 'agent-fact',
+          source: 'test',
+          content: 'electric proxy retries on 5xx',
+          nodes: [
+            {
+              kind: 'file',
+              name: 'electric-proxy.ts',
+              naturalKey: 'revealui/apps/admin/src/lib/api/electric-proxy.ts',
+              repo: 'revealui',
+            },
+            {
+              kind: 'concept',
+              name: 'Electric proxy retry',
+              naturalKey: 'concept:electric-proxy-retry',
+            },
+          ],
+          edges: [
+            {
+              source: {
+                kind: 'concept',
+                naturalKey: 'concept:electric-proxy-retry',
+              },
+              target: {
+                kind: 'file',
+                naturalKey: 'revealui/apps/admin/src/lib/api/electric-proxy.ts',
+              },
+              relation: 'documents',
+              fact: 'electric-proxy.ts retries with exponential backoff on 5xx',
+            },
+          ],
+        },
+        'test-site',
+      );
+      expect(ingested).toMatchObject({ nodeCount: 2, edgeCount: 1 });
+
+      const status = await graphStatus(db);
+      expect(status.nodes).toBe(2);
+      expect(status.edges).toBe(1);
+      expect(status.episodes).toBe(1);
+      expect(status.outboxPending).toBeGreaterThan(0);
+
+      const found = await graphSearch(db, { query: 'electric proxy' });
+      const search = found as {
+        nodes: Array<{ naturalKey: string }>;
+        facts: Array<{ fact: string }>;
+      };
+      expect(
+        search.nodes.some((n) => n.naturalKey.includes('electric-proxy')) ||
+          search.facts.some((f) => f.fact.includes('backoff')),
+      ).toBe(true);
+
+      const node = await graphNode(db, {
+        naturalKey: 'revealui/apps/admin/src/lib/api/electric-proxy.ts',
+      });
+      expect(node.node?.naturalKey).toBe('revealui/apps/admin/src/lib/api/electric-proxy.ts');
+      expect(node.facts.length).toBeGreaterThan(0);
+
+      const neighbors = (await graphNeighbors(db, {
+        naturalKey: 'concept:electric-proxy-retry',
+        depth: 2,
+      })) as { nodes: Array<{ naturalKey: string }>; edges: Array<{ relation: string }> };
+      expect(neighbors.nodes.length).toBeGreaterThan(0);
+      expect(neighbors.edges.some((e) => e.relation === 'documents')).toBe(true);
+
+      const at = await graphAt(db, {
+        naturalKey: 'concept:electric-proxy-retry',
+        at: new Date().toISOString(),
+      });
+      expect(Array.isArray(at)).toBe(true);
+
+      const packed = await graphContext(db, {
+        naturalKey: 'concept:electric-proxy-retry',
+        depth: 2,
+        charBudget: 500,
+      });
+      expect(packed.anchor?.naturalKey).toBe('concept:electric-proxy-retry');
+      expect(packed.charsUsed).toBeLessThanOrEqual(500);
+      expect(packed.context.includes('electric-proxy') || packed.factCount >= 0).toBe(true);
+
+      const push = await graphOutboxPush(db);
+      expect(push.hub).toBe(false);
+      expect(push.pushed).toBe(0);
+      expect(push.pending).toBeGreaterThan(0);
+
+      const still = await graphStatus(db);
+      expect(still.outboxPending).toBe(push.pending);
+    },
+    DB_TEST_TIMEOUT,
+  );
+});

--- a/packages/daemon/src/graph.ts
+++ b/packages/daemon/src/graph.ts
@@ -1,0 +1,450 @@
+/**
+ * graph.* handlers — offline-first knowledge-graph replica on daemon PGlite.
+ *
+ * GAP-349 P5 / spec §8.2: local kg_* tables + kg_outbox; reads and
+ * ingestEpisode run against PGlite. graph.outbox.push replays unpushed ops
+ * to the Neon hub when POSTGRES_URL is set (class-1/2 merge, no extra CRDT
+ * library). Communities and Electric down-sync stay later P5 slices.
+ *
+ * Extends `@revealui/knowledge-graph` (published 0.1.8; 0.1.9 pulls unpublished
+ * `@revealui/ts-strada`). Do not fork DDL.
+ */
+
+import { hostname } from 'node:os';
+import type { PGlite } from '@electric-sql/pglite';
+import {
+  applyOp,
+  EDGE_RELATIONS,
+  type EdgeInput,
+  type EdgeRelation,
+  ingestEpisode,
+  type KgExecutor,
+  type KgOp,
+  kgAtTime,
+  kgNeighbors,
+  kgSearch,
+  makeExecutor,
+  makePoolExecutor,
+  NODE_KINDS,
+  type NodeInput,
+  type NodeKind,
+} from '@revealui/knowledge-graph';
+import { resolveNaturalKey } from '@revealui/knowledge-graph/ingest';
+import { createLogger } from '@revealui/utils/logger';
+import { resolvePostgresUrl } from './neon.js';
+import { registerHandler } from './server.js';
+
+/** Lockstep with @revealui/knowledge-graph EpisodeType (0.1.8 has no EPISODE_TYPES export). */
+const EPISODE_TYPES = [
+  'code-scan',
+  'git-commit',
+  'doc',
+  'agent-fact',
+  'memory',
+  'json',
+  'manual',
+] as const;
+type EpisodeType = (typeof EPISODE_TYPES)[number];
+
+const log = createLogger({ service: 'revdev-daemon-graph' });
+
+const DEFAULT_CONTEXT_CHAR_BUDGET = 16_000;
+const MAX_CONTEXT_CHAR_BUDGET = 200_000;
+const MAX_BFS_DEPTH = 6;
+const MAX_SEARCH_LIMIT = 100;
+
+export function kgExecutorFromPglite(db: PGlite): KgExecutor {
+  return makeExecutor({
+    query: (text: string, params?: unknown[]) => db.query(text, params),
+  });
+}
+
+export function resolveGraphSiteId(
+  params: Record<string, unknown>,
+  ctx?: { agentId?: string | null },
+): string {
+  const fromEnv = process.env.REVDEV_KG_SITE_ID?.trim();
+  if (fromEnv) return fromEnv;
+  if (typeof params.siteId === 'string' && params.siteId.trim()) return params.siteId.trim();
+  if (ctx?.agentId) return `daemon:${ctx.agentId}`;
+  return `daemon:${hostname()}`;
+}
+
+function asIsoDate(value: unknown): Date | undefined {
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+export async function graphStatus(db: PGlite): Promise<{
+  replica: 'pglite';
+  tables: string[];
+  nodes: number;
+  edges: number;
+  episodes: number;
+  outboxPending: number;
+  hubConfigured: boolean;
+  siteId: string;
+}> {
+  const exec = kgExecutorFromPglite(db);
+  const [nodes, edges, episodes, pending] = await Promise.all([
+    exec.query<{ n: number }>('SELECT count(*)::int AS n FROM kg_nodes'),
+    exec.query<{ n: number }>('SELECT count(*)::int AS n FROM kg_edges'),
+    exec.query<{ n: number }>('SELECT count(*)::int AS n FROM kg_episodes'),
+    exec.query<{ n: number }>('SELECT count(*)::int AS n FROM kg_outbox WHERE pushed_at IS NULL'),
+  ]);
+  return {
+    replica: 'pglite',
+    tables: [
+      'kg_episodes',
+      'kg_nodes',
+      'kg_edges',
+      'kg_edge_episodes',
+      'kg_node_aliases',
+      'kg_outbox',
+    ],
+    nodes: nodes[0]?.n ?? 0,
+    edges: edges[0]?.n ?? 0,
+    episodes: episodes[0]?.n ?? 0,
+    outboxPending: pending[0]?.n ?? 0,
+    hubConfigured: Boolean(resolvePostgresUrl()),
+    siteId: resolveGraphSiteId({}),
+  };
+}
+
+export async function graphSearch(db: PGlite, params: Record<string, unknown>): Promise<unknown> {
+  const exec = kgExecutorFromPglite(db);
+  const query = typeof params.query === 'string' ? params.query : '';
+  const limit =
+    typeof params.limit === 'number' ? Math.min(Math.max(1, params.limit), MAX_SEARCH_LIMIT) : 20;
+  const bfsDepth =
+    typeof params.bfsDepth === 'number'
+      ? Math.min(Math.max(1, params.bfsDepth), MAX_BFS_DEPTH)
+      : undefined;
+  const anchor =
+    typeof params.anchor === 'string'
+      ? params.anchor
+      : typeof params.naturalKey === 'string'
+        ? ((await resolveNaturalKey(exec, params.naturalKey)) ?? undefined)
+        : undefined;
+  return kgSearch(exec, {
+    query,
+    anchor,
+    kinds: asKindList(params.kinds),
+    relations: asRelationList(params.relations),
+    at: asIsoDate(params.at),
+    limit,
+    bfsDepth,
+  });
+}
+
+export async function graphNode(
+  db: PGlite,
+  params: Record<string, unknown>,
+): Promise<{ node: Record<string, unknown> | null; facts: unknown[] }> {
+  const exec = kgExecutorFromPglite(db);
+  const naturalKey = typeof params.naturalKey === 'string' ? params.naturalKey : '';
+  const id = await resolveNaturalKey(exec, naturalKey);
+  if (!id) return { node: null, facts: [] };
+  const rows = await exec.query<{
+    id: string;
+    kind: string;
+    name: string;
+    natural_key: string;
+    repo: string | null;
+    summary: string | null;
+  }>('SELECT id, kind, name, natural_key, repo, summary FROM kg_nodes WHERE id = $1', [id]);
+  const row = rows[0];
+  const at = asIsoDate(params.at) ?? new Date();
+  const facts = await kgAtTime(exec, id, at);
+  return {
+    node: row
+      ? {
+          id: row.id,
+          kind: row.kind,
+          name: row.name,
+          naturalKey: row.natural_key,
+          repo: row.repo,
+          summary: row.summary,
+        }
+      : null,
+    facts,
+  };
+}
+
+export async function graphNeighbors(
+  db: PGlite,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const exec = kgExecutorFromPglite(db);
+  const naturalKey = typeof params.naturalKey === 'string' ? params.naturalKey : '';
+  const id = await resolveNaturalKey(exec, naturalKey);
+  if (!id) return { nodes: [], edges: [] };
+  const depth =
+    typeof params.depth === 'number' ? Math.min(Math.max(1, params.depth), MAX_BFS_DEPTH) : 1;
+  return kgNeighbors(exec, id, {
+    depth,
+    relations: asRelationList(params.relations),
+    at: asIsoDate(params.at),
+  });
+}
+
+export async function graphAt(db: PGlite, params: Record<string, unknown>): Promise<unknown> {
+  const exec = kgExecutorFromPglite(db);
+  const naturalKey = typeof params.naturalKey === 'string' ? params.naturalKey : '';
+  const at = asIsoDate(params.at);
+  if (!at) throw new Error('graph.at requires at (ISO-8601)');
+  const id = await resolveNaturalKey(exec, naturalKey);
+  if (!id) return [];
+  return kgAtTime(exec, id, at);
+}
+
+export async function graphContext(
+  db: PGlite,
+  params: Record<string, unknown>,
+): Promise<{
+  context: string;
+  anchor: { id: string; naturalKey: string } | null;
+  nodeCount: number;
+  factCount: number;
+  charBudget: number;
+  charsUsed: number;
+  truncated: boolean;
+}> {
+  const exec = kgExecutorFromPglite(db);
+  const naturalKey = typeof params.naturalKey === 'string' ? params.naturalKey : '';
+  const charBudget =
+    typeof params.charBudget === 'number'
+      ? Math.min(Math.max(1, params.charBudget), MAX_CONTEXT_CHAR_BUDGET)
+      : DEFAULT_CONTEXT_CHAR_BUDGET;
+  const depth =
+    typeof params.depth === 'number' ? Math.min(Math.max(1, params.depth), MAX_BFS_DEPTH) : 2;
+  const id = await resolveNaturalKey(exec, naturalKey);
+  if (!id) {
+    return {
+      context: '',
+      anchor: null,
+      nodeCount: 0,
+      factCount: 0,
+      charBudget,
+      charsUsed: 0,
+      truncated: false,
+    };
+  }
+  const neighbors = await kgNeighbors(exec, id, { depth, at: asIsoDate(params.at) });
+  const lines: string[] = [`# Context for ${naturalKey} (depth=${depth})`, '', '## Nodes'];
+  for (const n of neighbors.nodes) {
+    lines.push(`- [${n.kind}] ${n.naturalKey} (${n.distance} hop)`);
+  }
+  lines.push('', '## Facts');
+  for (const e of neighbors.edges) {
+    lines.push(`- (${e.relation}) ${e.fact}`);
+  }
+  let charsUsed = 0;
+  let truncated = false;
+  const packed: string[] = [];
+  for (const line of lines) {
+    const added = line.length + 1;
+    if (charsUsed + added > charBudget) {
+      truncated = true;
+      break;
+    }
+    packed.push(line);
+    charsUsed += added;
+  }
+  return {
+    context: packed.join('\n'),
+    anchor: { id, naturalKey },
+    nodeCount: neighbors.nodes.length,
+    factCount: neighbors.edges.length,
+    charBudget,
+    charsUsed,
+    truncated,
+  };
+}
+
+export async function graphAddEpisode(
+  db: PGlite,
+  params: Record<string, unknown>,
+  siteId: string,
+): Promise<unknown> {
+  const exec = kgExecutorFromPglite(db);
+  const episodeType = parseEpisodeType(params.episodeType);
+  const source = typeof params.source === 'string' ? params.source : 'daemon';
+  const content = typeof params.content === 'string' ? params.content : '';
+  const nodes = parseNodes(params.nodes);
+  const edges = parseEdges(params.edges);
+  const referenceTime = asIsoDate(params.referenceTime) ?? new Date();
+  return ingestEpisode(
+    exec,
+    {
+      episode: {
+        episodeType,
+        source,
+        siteId,
+        content,
+        contentRef: isRecord(params.contentRef) ? params.contentRef : {},
+        referenceTime,
+      },
+      nodes,
+      edges,
+    },
+    { recordOutbox: true },
+  );
+}
+
+export async function graphOutboxPush(db: PGlite): Promise<{
+  pushed: number;
+  pending: number;
+  hub: boolean;
+  error?: string;
+}> {
+  const exec = kgExecutorFromPglite(db);
+  const pendingRows = await exec.query<{ seq: number; op: unknown }>(
+    'SELECT seq, op FROM kg_outbox WHERE pushed_at IS NULL ORDER BY seq',
+  );
+  const hub = await tryHubExecutor();
+  if (!hub) {
+    return { pushed: 0, pending: pendingRows.length, hub: false };
+  }
+  let pushed = 0;
+  for (const row of pendingRows) {
+    try {
+      await applyOp(hub, asKgOp(row.op), { recordOutbox: false });
+      await exec.query('UPDATE kg_outbox SET pushed_at = now() WHERE seq = $1', [row.seq]);
+      pushed += 1;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn('kg_outbox push stopped', { seq: row.seq, error: message });
+      return {
+        pushed,
+        pending: pendingRows.length - pushed,
+        hub: true,
+        error: message,
+      };
+    }
+  }
+  return { pushed, pending: 0, hub: true };
+}
+
+let cachedHub: KgExecutor | null | undefined;
+
+async function tryHubExecutor(): Promise<KgExecutor | null> {
+  if (cachedHub !== undefined) return cachedHub;
+  const url = resolvePostgresUrl();
+  if (!url) {
+    cachedHub = null;
+    return null;
+  }
+  try {
+    const { createPool } = await import('@revealui/db/pool');
+    const pool = createPool({
+      connectionTimeoutMillis: 30_000,
+      queryTimeoutMillis: 60_000,
+      statementTimeoutMillis: 60_000,
+      max: 2,
+    });
+    cachedHub = makePoolExecutor(pool);
+    return cachedHub;
+  } catch (err) {
+    log.warn('knowledge-graph hub pool unavailable', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    cachedHub = null;
+    return null;
+  }
+}
+
+function asKgOp(value: unknown): KgOp {
+  if (!value || typeof value !== 'object' || !('t' in value)) {
+    throw new Error('kg_outbox.op is not a KgOp');
+  }
+  return value as KgOp;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+const NODE_KIND_SET = new Set<string>(NODE_KINDS);
+const EDGE_RELATION_SET = new Set<string>(EDGE_RELATIONS);
+const EPISODE_TYPE_SET = new Set<string>(EPISODE_TYPES);
+
+function parseEpisodeType(value: unknown): EpisodeType {
+  if (typeof value === 'string' && EPISODE_TYPE_SET.has(value)) return value as EpisodeType;
+  return 'agent-fact';
+}
+
+function asKindList(value: unknown): NodeKind[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const kinds = value.filter((k): k is NodeKind => typeof k === 'string' && NODE_KIND_SET.has(k));
+  return kinds.length > 0 ? kinds : undefined;
+}
+
+function asRelationList(value: unknown): EdgeRelation[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const rels = value.filter(
+    (r): r is EdgeRelation => typeof r === 'string' && EDGE_RELATION_SET.has(r),
+  );
+  return rels.length > 0 ? rels : undefined;
+}
+
+function parseNodes(value: unknown): NodeInput[] {
+  if (!Array.isArray(value)) return [];
+  const nodes: NodeInput[] = [];
+  for (const raw of value) {
+    if (!isRecord(raw)) continue;
+    if (typeof raw.kind !== 'string' || !NODE_KIND_SET.has(raw.kind)) continue;
+    if (typeof raw.name !== 'string' || typeof raw.naturalKey !== 'string') continue;
+    nodes.push({
+      kind: raw.kind as NodeKind,
+      name: raw.name,
+      naturalKey: raw.naturalKey,
+      repo: typeof raw.repo === 'string' ? raw.repo : null,
+      summary: typeof raw.summary === 'string' ? raw.summary : null,
+      attributes: isRecord(raw.attributes) ? raw.attributes : {},
+    });
+  }
+  return nodes;
+}
+
+function parseEdges(value: unknown): EdgeInput[] {
+  if (!Array.isArray(value)) return [];
+  const edges: EdgeInput[] = [];
+  for (const raw of value) {
+    if (!isRecord(raw) || !isRecord(raw.source) || !isRecord(raw.target)) continue;
+    if (typeof raw.relation !== 'string' || !EDGE_RELATION_SET.has(raw.relation)) continue;
+    if (typeof raw.source.kind !== 'string' || !NODE_KIND_SET.has(raw.source.kind)) continue;
+    if (typeof raw.target.kind !== 'string' || !NODE_KIND_SET.has(raw.target.kind)) continue;
+    if (typeof raw.source.naturalKey !== 'string' || typeof raw.target.naturalKey !== 'string') {
+      continue;
+    }
+    if (typeof raw.fact !== 'string') continue;
+    edges.push({
+      source: { kind: raw.source.kind as NodeKind, naturalKey: raw.source.naturalKey },
+      target: { kind: raw.target.kind as NodeKind, naturalKey: raw.target.naturalKey },
+      relation: raw.relation as EdgeRelation,
+      fact: raw.fact,
+      repo: typeof raw.repo === 'string' ? raw.repo : null,
+    });
+  }
+  return edges;
+}
+
+registerHandler('graph.status', async (_params, db) => graphStatus(db));
+
+registerHandler('graph.search', async (params, db) => graphSearch(db, params));
+
+registerHandler('graph.node', async (params, db) => graphNode(db, params));
+
+registerHandler('graph.neighbors', async (params, db) => graphNeighbors(db, params));
+
+registerHandler('graph.at', async (params, db) => graphAt(db, params));
+
+registerHandler('graph.context', async (params, db) => graphContext(db, params));
+
+registerHandler('graph.addEpisode', async (params, db, ctx) =>
+  graphAddEpisode(db, params, resolveGraphSiteId(params, ctx)),
+);
+
+registerHandler('graph.outbox.push', async (_params, db) => graphOutboxPush(db));

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -77,6 +77,8 @@ import './workflow-rpc.js';
 import './skills-rpc.js';
 // GAP-323 — design-pack watch (design.pack.* + auto-watch on start)
 import './design-pack-watch.js';
+// GAP-349 P5 — local knowledge-graph replica + graph.* RPC
+import './graph.js';
 
 export { DAEMON_DEFAULTS, type DaemonConfig } from './config.js';
 export { SCHEMA_SQL } from './storage/schema.js';

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -137,6 +137,15 @@ const EXEMPT_METHODS = new Set([
   'design.pack.watch',
   'design.pack.unwatch',
   'design.pack.scan',
+  // GAP-349 P5: local graph replica is a daily-driver inspect/write surface
+  // (query-before-grep). Hub replay (graph.outbox.push) stays Pro-floor.
+  'graph.status',
+  'graph.search',
+  'graph.node',
+  'graph.neighbors',
+  'graph.at',
+  'graph.context',
+  'graph.addEpisode',
 ]);
 
 /**
@@ -173,8 +182,8 @@ export const METHOD_MIN_TIER = new Map<string, LicenseTier>([
  * free-file/git claims so help cannot re-drift (INIT-002 Phase 0).
  */
 export const LICENSE_TIER_HELP = `License tiers (method gate; source: EXEMPT_METHODS + METHOD_MIN_TIER):
-  free         Sessions, single-repo file/git, local inference run, harness.health
-  pro          Multi-agent coordination (mail, tasks, files.*, goal.*, agent.*, merge.*, worktree, events, harness.prune, …)
+  free         Sessions, single-repo file/git, local inference run, harness.health, graph.* replica (except outbox.push)
+  pro          Multi-agent coordination (mail, tasks, files.*, goal.*, agent.*, merge.*, worktree, events, harness.prune, graph.outbox.push, …)
   max          + full AI memory (memory.*) and local-model management (inference.pull/delete/start/stop)
   enterprise   Same method surface as max; commercial terms differ (founder daily-driver JWT for goal spine)`;
 

--- a/packages/daemon/src/migrations/0014-knowledge-graph-replica.ts
+++ b/packages/daemon/src/migrations/0014-knowledge-graph-replica.ts
@@ -1,0 +1,19 @@
+/**
+ * Migration 0014 — PGlite knowledge-graph site replica (GAP-349 P5).
+ *
+ * Portable DDL (embedding as real[], no HNSW) from
+ * `@revealui/knowledge-graph/ddl`. Same tables as Neon 0021+0022 so
+ * ingest/search/outbox APIs run locally. Spec called this "migration 0007";
+ * 0007 is already permission-approvals in this daemon.
+ */
+
+import { kgDdlStatements } from '@revealui/knowledge-graph/ddl';
+import type { Migration } from '../storage/migrate.js';
+
+const SQL = `${kgDdlStatements({ variant: 'portable' }).join(';\n')};`;
+
+export const MIGRATION_0014: Migration = {
+  version: 14,
+  name: 'knowledge-graph-replica',
+  sql: SQL,
+};

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -29,6 +29,7 @@ import { MIGRATION_0010 } from './0010-agent-messages-uuid.js';
 import { MIGRATION_0011 } from './0011-spawned-agent-identity.js';
 import { MIGRATION_0012 } from './0012-session-fidelity-snapshots.js';
 import { MIGRATION_0013 } from './0013-goals.js';
+import { MIGRATION_0014 } from './0014-knowledge-graph-replica.js';
 
 export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0001,
@@ -44,4 +45,5 @@ export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0011,
   MIGRATION_0012,
   MIGRATION_0013,
+  MIGRATION_0014,
 ];

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -154,6 +154,15 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['workflow.run', 'consequential'],
   ['skills.list', 'routine'],
   ['skills.invoke', 'routine'],
+  // GAP-349 P5 — local replica reads/writes are routine; hub push is consequential
+  ['graph.status', 'routine'],
+  ['graph.search', 'routine'],
+  ['graph.node', 'routine'],
+  ['graph.neighbors', 'routine'],
+  ['graph.at', 'routine'],
+  ['graph.context', 'routine'],
+  ['graph.addEpisode', 'routine'],
+  ['graph.outbox.push', 'consequential'],
   // Inner tools of skills.invoke (not standalone RPCs). Bash is a shell, so
   // critical: auto mode still requires approval (policy floor). Reads stay routine.
   ['skills.tool.Read', 'routine'],

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -175,6 +175,15 @@ const IDENTITY_EXEMPT = new Set([
   'inference.stop',
   'inference.chat',
   'inference.generate',
+  // GAP-349 P5: local graph replica is a 0600-socket diagnostic/query surface
+  // (same class as harness.health / inference.status). Writes still go through
+  // graph.addEpisode / graph.outbox.push which are not identity-exempt.
+  'graph.status',
+  'graph.search',
+  'graph.node',
+  'graph.neighbors',
+  'graph.at',
+  'graph.context',
 ]);
 
 /**

--- a/packages/daemon/src/validation/limits.ts
+++ b/packages/daemon/src/validation/limits.ts
@@ -34,6 +34,9 @@ export const MAX_PAYLOAD_SIZE = 100_000;
 /** Maximum memory content length (500KB) */
 export const MAX_MEMORY_LENGTH = 500_000;
 
+/** GAP-349 episode content cap (lockstep with @revealui/mcp kg_add_episode). */
+export const MAX_EPISODE_CONTENT_CHARS = 64_000;
+
 /** Maximum TTL for file reservations (24 hours in seconds) */
 export const MAX_TTL_SECONDS = 86_400;
 

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -19,6 +19,7 @@ import { isValidAgentId } from '@revdev/protocol/did';
 import { z } from 'zod';
 import {
   MAX_BODY_LENGTH,
+  MAX_EPISODE_CONTENT_CHARS,
   MAX_FILE_WRITE_BYTES,
   MAX_IDS_BATCH,
   MAX_MEMORY_LENGTH,
@@ -493,6 +494,68 @@ export const schemas: Record<string, z.ZodType> = {
       actorAgentId,
     })
     .passthrough(),
+
+  // GAP-349 P5 — local knowledge-graph replica
+  'graph.status': z.object({ actorAgentId }).passthrough(),
+  'graph.search': z
+    .object({
+      query: z.string().min(1).max(MAX_NAME_LENGTH),
+      anchor: z.string().min(1).max(1024).optional(),
+      naturalKey: z.string().min(1).max(1024).optional(),
+      kinds: z.array(z.string().max(64)).max(32).optional(),
+      relations: z.array(z.string().max(64)).max(32).optional(),
+      at: z.string().max(64).optional(),
+      limit: z.number().int().min(1).max(MAX_QUERY_LIMIT).optional(),
+      bfsDepth: z.number().int().min(1).max(6).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+  'graph.node': z
+    .object({
+      naturalKey: z.string().min(1).max(1024),
+      at: z.string().max(64).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+  'graph.neighbors': z
+    .object({
+      naturalKey: z.string().min(1).max(1024),
+      depth: z.number().int().min(1).max(6).optional(),
+      relations: z.array(z.string().max(64)).max(32).optional(),
+      at: z.string().max(64).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+  'graph.at': z
+    .object({
+      naturalKey: z.string().min(1).max(1024),
+      at: z.string().min(1).max(64),
+      actorAgentId,
+    })
+    .passthrough(),
+  'graph.context': z
+    .object({
+      naturalKey: z.string().min(1).max(1024),
+      depth: z.number().int().min(1).max(6).optional(),
+      charBudget: z.number().int().min(1).max(200_000).optional(),
+      at: z.string().max(64).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+  'graph.addEpisode': z
+    .object({
+      episodeType: z.string().max(64).optional(),
+      source: z.string().min(1).max(MAX_NAME_LENGTH).optional(),
+      content: z.string().max(MAX_EPISODE_CONTENT_CHARS).optional(),
+      contentRef: z.record(z.string(), z.unknown()).optional(),
+      referenceTime: z.string().max(64).optional(),
+      siteId: z.string().max(MAX_NAME_LENGTH).optional(),
+      nodes: z.array(z.record(z.string(), z.unknown())).max(200).optional(),
+      edges: z.array(z.record(z.string(), z.unknown())).max(400).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+  'graph.outbox.push': z.object({ actorAgentId }).passthrough(),
 
   // -- Health -----------------------------------------------------------------
   // Both handlers (`server.ts:registerHandler('harness.health', ...)` and

--- a/packages/daemon/tsup.config.ts
+++ b/packages/daemon/tsup.config.ts
@@ -13,5 +13,13 @@ export default defineConfig({
   clean: true,
   target: 'node24',
   banner: { js: '' },
-  external: ['@electric-sql/pglite', /^@revealui\/ai/],
+  external: [
+    '@electric-sql/pglite',
+    /^@revealui\/ai/,
+    '@revealui/knowledge-graph',
+    '@revealui/knowledge-graph/ddl',
+    '@revealui/knowledge-graph/ingest',
+    '@revealui/db',
+    '@revealui/db/pool',
+  ],
 });

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -172,4 +172,14 @@ export const RPC_METHODS = {
   'skills.list': 'skills.list',
   // GAP-293 Phase C — native workflow generate on product default snap
   'skills.invoke': 'skills.invoke',
+
+  // GAP-349 P5 — local knowledge-graph replica (PGlite) + outbox push to Neon
+  'graph.status': 'graph.status',
+  'graph.search': 'graph.search',
+  'graph.node': 'graph.node',
+  'graph.neighbors': 'graph.neighbors',
+  'graph.at': 'graph.at',
+  'graph.context': 'graph.context',
+  'graph.addEpisode': 'graph.addEpisode',
+  'graph.outbox.push': 'graph.outbox.push',
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,12 @@ importers:
       '@revealui/core':
         specifier: ^0.10.2
         version: 0.10.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
+      '@revealui/db':
+        specifier: ^0.10.0
+        version: 0.10.0(@electric-sql/pglite@0.5.4)
+      '@revealui/knowledge-graph':
+        specifier: ^0.1.8
+        version: 0.1.8(@electric-sql/pglite@0.5.4)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(pg@8.22.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@revealui/utils':
         specifier: ^0.3.5
         version: 0.3.5


### PR DESCRIPTION
## Summary

GAP-349 P5a: offline-first knowledge-graph replica on the RevDev daemon.

- Migration 0014 applies portable `kg_*` DDL from `@revealui/knowledge-graph` 0.1.8 (spec said 0007; that version is already permission-approvals).
- RPC: `graph.status`, `graph.search`, `graph.node`, `graph.neighbors`, `graph.at`, `graph.context`, `graph.addEpisode`, `graph.outbox.push`.
- Local `ingestEpisode` records `kg_outbox`. Push replays unpushed ops to Neon when `POSTGRES_URL` is set (class-1/2 `applyOp`). No hub URL: pending stays local.
- Pin 0.1.8: published 0.1.9 depends on unpublished `@revealui/ts-strada`.

Not in this PR: Electric down-sync, communities, Layer-3 reconciliation.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/graph.test.ts` (daemon)
- [x] rpc-contract, migrate (schema version 14), permission, signature-gate, guard
- [x] `pnpm typecheck` in `@revdev/daemon`
