### PR TITLE
docs: align README/status with public releases and license split

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Pre-1.0 across the board:
 
 | Component | Status | How to use it today |
 |---|---|---|
-| **Studio** | Buildable, unsigned | `pnpm --filter studio tauri build` → local binary. Signed/notarized auto-update pipeline defined in `.github/workflows/studio-release.yml`; not yet cutting public releases. Dogfooding `@revealui/presentation` Phase 1+2 done; Phase 3+4 in flight. |
-| **Console** | Buildable | `cd apps/console && go build -o ../../rvui .` — no release automation yet. |
+| **Studio** | Buildable, unsigned | Local: `pnpm --filter studio tauri build`. Public GitHub Releases are live — latest `studio-v0.2.11` (2026-08-16; macOS · Linux · Windows). Tag pipeline: `.github/workflows/studio-release.yml`. macOS/Windows OS code-signing is still unsigned/ad-hoc (Tauri updater `.sig` files are not Apple/Microsoft signatures). Dogfooding `@revealui/presentation` Phase 1+2 done; Phase 3+4 in flight. |
+| **Console** | Buildable | `cd apps/console && go build -o ../../rvui .`. Tag pipeline: `.github/workflows/console-release.yml`. Public tag `console-v0.2.0` (2026-07-17). |
 | **Harness Daemon** | Buildable, not published | Build with `pnpm --filter @revdev/daemon build`. `node packages/daemon/dist/cli.js --detach` returns in <1s; child runs in its own session and PGID. Boot survival via `pnpm --filter @revdev/daemon setup:systemd` (systemd-user unit; requires `loginctl enable-linger` on WSL). |
 
 Integration test coverage is thin on the Studio↔daemon Tauri bridge (`vault.rs`, `spawner.rs`, `harness.rs`). Treat Studio as development-preview quality until those land.
@@ -96,8 +96,12 @@ pnpm test
 
 ## License
 
-| Component | License |
-|---|---|
-| Studio | LicenseRef-RevealUI-Commercial |
-| Console | MIT |
-| Harness Daemon | FSL-1.1-MIT (Fair Source, converts to MIT after 2 years) |
+The root [`LICENSE`](./LICENSE) is MIT and is the default for this repository. It does **not** relicense components that declare a different license:
+
+| Component | License | Where declared |
+|---|---|---|
+| Studio | LicenseRef-RevealUI-Commercial | `apps/studio/src-tauri/Cargo.toml` |
+| Console | MIT | root `LICENSE` (no component override) |
+| Harness Daemon | FSL-1.1-MIT (Fair Source, converts to MIT after 2 years) | `packages/daemon/LICENSE` |
+
+`@revdev/bridge` is also FSL-1.1-MIT; `@revdev/protocol` and `@revdev/theme` are MIT.

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -1,15 +1,15 @@
 ---
 type: master-plan
 repo: revdev
-last-updated: 2026-07-23
+last-updated: 2026-08-19
 owner: RevealUI Studio
 staleness-status: FRESH
 ---
 
 # RevDev — Master Plan
 
-**Last Updated:** 2026-07-23
-**Status:** Pre-1.0 — Studio + Console + harness daemon all buildable; no public releases yet
+**Last Updated:** 2026-08-19
+**Status:** Pre-1.0 — Studio + Console + harness daemon all buildable; public tags `studio-v0.2.11` and `console-v0.2.0` exist
 **Owner:** RevealUI Studio (`founder@revealui.com`)
 **Repo:** [RevealUIStudio/revdev](https://github.com/RevealUIStudio/revdev)
 

--- a/docs/MASTER_SPEC.md
+++ b/docs/MASTER_SPEC.md
@@ -1,15 +1,15 @@
 ---
 type: master-spec
 repo: revdev
-last-updated: 2026-07-23
+last-updated: 2026-08-19
 owner: RevealUI Studio
 staleness-status: FRESH
 ---
 
 # RevDev — Master Spec
 
-**Last Updated:** 2026-07-23
-**Status:** Pre-1.0 — daemon production-grade for internal use; Studio + Console builds clean; no public releases
+**Last Updated:** 2026-08-19
+**Status:** Pre-1.0 — daemon production-grade for internal use; Studio + Console build clean; public tags `studio-v0.2.11` and `console-v0.2.0` exist
 **Repo:** [RevealUIStudio/revdev](https://github.com/RevealUIStudio/revdev)
 
 > **The spec lives in one place: [`docs/SPEC.md`](./SPEC.md)** — surface area, architecture, JSON-RPC contract, license model, identity. This file is the stable entry point; it carries no spec content of its own. (Consolidated 2026-06-11; the licensing model previously specced in the internal coordination hub was absorbed into `SPEC.md` §License model.)

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,15 +1,15 @@
 ---
 type: plan
 repo: revdev
-last-updated: 2026-07-21
+last-updated: 2026-08-19
 owner: RevealUI Studio
 staleness-status: FRESH
 ---
 
 # RevDev — Plan
 
-**Last Updated:** 2026-07-21 (Phase 0 honesty pass — W4/W8–W13 + dogfood re-verified against `origin/test` code; earlier body below still carries 2026-06-11 detail where unchanged)
-**Status:** Pre-1.0 — Studio + Console + harness daemon buildable; tags `v0.1.1` / `v0.2.0` exist; auto-update customer loop still gated on H4
+**Last Updated:** 2026-08-19 (docs honesty: public `studio-v0.2.11` / `console-v0.2.0` exist; earlier body below still carries 2026-06-11 / 2026-07-21 detail where unchanged)
+**Status:** Pre-1.0 — Studio + Console + harness daemon buildable; public tags `studio-v0.2.11` and `console-v0.2.0` exist; auto-update customer loop still gated on H4 (`releases.revealui.com` 404s)
 **Owner:** RevealUI Studio
 
 > **The single RevDev plan.** [`MASTER_PLAN.md`](./MASTER_PLAN.md) is the stable entry point that references this file; the spec counterpart is [`SPEC.md`](./SPEC.md) (referenced by [`MASTER_SPEC.md`](./MASTER_SPEC.md)). This file absorbs and supersedes the former `PRODUCTION_LAUNCH_PLAN.md` (removed 2026-06-11) with every task status re-verified.
@@ -20,8 +20,8 @@ staleness-status: FRESH
 
 | Component | Status | How to get it today |
 |---|---|---|
-| Studio | Buildable; signing configured | `pnpm --filter studio tauri build` — local binary. `studio-release.yml` defined; updater pubkey + signing secrets configured 2026-06-11 (H1); no public releases cut yet — remaining gates are the H4 release endpoint + first `studio-v*` tag. |
-| Console | Buildable | `cd apps/console && go build -o ../../rvui .` — no root `go.mod`; module lives under `apps/console/`. `console-release.yml` defined; no releases cut. |
+| Studio | Buildable; OS-unsigned | Local: `pnpm --filter studio tauri build`. `studio-release.yml` is cutting public tags — latest `studio-v0.2.11` (2026-08-16). Updater pubkey + signing secrets configured 2026-06-11 (H1). Remaining: H4 custom-domain mirror (`releases.revealui.com` still 404s) and Apple/Microsoft OS code-signing (H7/H8). |
+| Console | Buildable | `cd apps/console && go build -o ../../rvui .` — no root `go.mod`; module lives under `apps/console/`. `console-release.yml` has cut public tag `console-v0.2.0` (2026-07-17). |
 | Harness daemon | Buildable, not published | `pnpm --filter @revdev/daemon build`; CLI at `packages/daemon/dist/cli.js`. Runs locally under systemd-user. |
 
 What is true today (each item verified, not carried forward):

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,15 +1,15 @@
 ---
 type: spec
 repo: revdev
-last-updated: 2026-06-11
+last-updated: 2026-08-19
 owner: RevealUI Studio
 staleness-status: FRESH
 ---
 
 # RevDev — Spec
 
-**Last Updated:** 2026-06-11
-**Status:** Pre-1.0 — daemon production-grade for internal use; Studio + Console builds clean; no public releases
+**Last Updated:** 2026-08-19
+**Status:** Pre-1.0 — daemon production-grade for internal use; Studio + Console build clean; public tags `studio-v0.2.11` and `console-v0.2.0` exist
 
 > **The single RevDev spec** — surface area, architecture, JSON-RPC contract, license model, identity. [`MASTER_SPEC.md`](./MASTER_SPEC.md) is the stable entry point that references this file. Plan counterpart: [`PLAN.md`](./PLAN.md).
 
@@ -201,7 +201,7 @@ Tier is the pricing axis; principal type is orthogonal — staff-ness is **not**
 
 ## CI surface
 
-`.github/workflows/`: `ci.yml` (quality, typecheck, build, test, Console Go job, secret scanning), `codeql.yml` (js-ts + go), `dependency-review.yml` (PR-only), `promotion-gate.yml` (test→main gate), `backflow.yml` (auto main→test backflow PR, shared reusable workflow), gitleaks via pinned CLI, `studio-release.yml` (tag-triggered Tauri build; defined, not yet cutting public releases), `console-release.yml` (tag-triggered Go release). All third-party actions SHA-pinned.
+`.github/workflows/`: `ci.yml` (quality, typecheck, build, test, Console Go job, secret scanning), `codeql.yml` (js-ts + go), `dependency-review.yml` (PR-only), `promotion-gate.yml` (test→main gate), `backflow.yml` (auto main→test backflow PR, shared reusable workflow), gitleaks via pinned CLI, `studio-release.yml` (tag-triggered Tauri build; latest public tag `studio-v0.2.11`), `console-release.yml` (tag-triggered Go release; public tag `console-v0.2.0`). All third-party actions SHA-pinned.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs honesty only. No product-code changes.

Verified against `origin/test` plus live GitHub Releases (`gh release view studio-v0.2.11` / `console-v0.2.0`). Did not invent tags.

## Before → after

### Studio releases
**Before:** README (and SPEC/PLAN) said Studio was buildable unsigned and the `studio-release.yml` pipeline was “not yet cutting public releases.” PLAN still said remaining gates were “H4 + first `studio-v*` tag.”

**After:** Public tag **`studio-v0.2.11`** exists (2026-08-16, latest, 17 uploaded assets + GitHub source zip/tar). Local builds remain unsigned; macOS/Windows OS code-signing is still ad-hoc (updater `.sig` ≠ Apple/Microsoft). First `studio-v*` tag is no longer a remaining gate.

### Console releases
**Before:** README said “no release automation yet.” PLAN said `console-release.yml` defined, no releases cut.

**After:** Tag pipeline exists and has cut public **`console-v0.2.0`** (2026-07-17).

### License split
**Before:** README table listed Studio commercial / Console MIT / daemon FSL, while root `LICENSE` is MIT — readers could take the whole tree as MIT.

**After:** Root `LICENSE` is MIT and is the default. It does **not** relicense Studio (`LicenseRef-RevealUI-Commercial` in `apps/studio/src-tauri/Cargo.toml`) or the daemon (`FSL-1.1-MIT` in `packages/daemon/LICENSE`). Console stays MIT via the root file. Bridge/protocol/theme SPDX noted in one line.

### Kept (still true)
- Studio↔daemon bridge tests are still thin: `vault.rs` has no unit tests; `spawner.rs` / `harness.rs` have local unit tests only. Treat Studio as development-preview.
- Pre-1.0. Daemon still “buildable, not published.”
- H4 custom-domain auto-update (`releases.revealui.com`) still 404s.

## Out of scope
- Product code
- New releases or version bumps
- Promotion to `main`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe2d4d1d-3582-4f2e-a5b3-55a93cffe04c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe2d4d1d-3582-4f2e-a5b3-55a93cffe04c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

