### PR TITLE
fix: P0 Console SSH allowlist/loopback and P0 Studio Tauri exec scope

### DIFF
--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -30,26 +30,40 @@ Until then, run locally via the [Development](#development) section.
 
 ## Development
 
+Public-key auth is a required allowlist. The process refuses to start without
+`CONSOLE_AUTHORIZED_KEYS` pointing at an OpenSSH `authorized_keys` file that
+contains at least one key. Default bind is loopback.
+
 ```bash
 cd apps/console
+export CONSOLE_AUTHORIZED_KEYS="$HOME/.ssh/authorized_keys"
 go run .
 ```
 
 ## Deployment
 
-Requires persistent TCP (SSH), not serverless. Deploy to Fly.io or a VPS:
+Requires persistent TCP (SSH), not serverless. This binary is experimental and
+is not a hosted public Console. Default bind is `127.0.0.1`. Publishing the
+container port still requires an authorized_keys file; set `HOST` only when you
+intentionally expose the listener inside the container:
 
 ```bash
 docker build -t revealui-console .
-docker run -p 2222:2222 revealui-console
+docker run \
+  -e CONSOLE_AUTHORIZED_KEYS=/keys \
+  -v "$HOME/.ssh/authorized_keys:/keys:ro" \
+  -p 127.0.0.1:2222:2222 \
+  -e HOST=0.0.0.0 \
+  revealui-console
 ```
 
 ## Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `HOST` | `0.0.0.0` | Bind address |
+| `HOST` | `127.0.0.1` | Bind address (loopback unless set) |
 | `PORT` | `2222` | SSH port |
 | `HOST_KEY_PATH` | `.ssh/term_ed25519` | SSH host key |
+| `CONSOLE_AUTHORIZED_KEYS` | — | Required OpenSSH authorized_keys allowlist; refuse to start if missing or empty |
 | `REVEALUI_API_URL` | `https://api.revealui.com` | API endpoint |
 | `REVEALUI_API_TOKEN` | — | Optional API token |

--- a/apps/console/main.go
+++ b/apps/console/main.go
@@ -1,13 +1,15 @@
 // RevealUI Terminal — SSH payment + agent terminal service
 //
 // Usage:
-//   ssh terminal.revealui.com              — payment TUI (default)
-//   ssh terminal.revealui.com -t agents    — agent terminal proxy
+//
+//	ssh terminal.revealui.com              — payment TUI (default)
+//	ssh terminal.revealui.com -t agents    — agent terminal proxy
 //
 // Mode selection:
-//   TERMINAL_MODE=agents env var forces agent mode (no SSH command parsing).
-//   Otherwise, if the SSH client sends "agents" as the command, agent mode.
-//   Default: payment TUI.
+//
+//	TERMINAL_MODE=agents env var forces agent mode (no SSH command parsing).
+//	Otherwise, if the SSH client sends "agents" as the command, agent mode.
+//	Default: payment TUI.
 //
 // Built with the Charm ecosystem:
 //   - Wish (SSH server)
@@ -31,19 +33,31 @@ import (
 	bm "charm.land/wish/v2/bubbletea"
 	"github.com/charmbracelet/ssh"
 
+	gossh "golang.org/x/crypto/ssh"
+
 	"github.com/RevealUIStudio/revdev/apps/console/api"
 	"github.com/RevealUIStudio/revdev/apps/console/authz"
 	"github.com/RevealUIStudio/revdev/apps/console/proxy"
 	"github.com/RevealUIStudio/revdev/apps/console/tui"
 )
 
+// Loopback by default so an unconfigured binary is not reachable on LAN.
+// Set HOST explicitly only when you intend to publish the port.
+const defaultListenHost = "127.0.0.1"
+const defaultListenPort = "2222"
+
 func main() {
-	host := envOrDefault("HOST", "0.0.0.0")
-	port := envOrDefault("PORT", "2222")
+	host := envOrDefault("HOST", defaultListenHost)
+	port := envOrDefault("PORT", defaultListenPort)
 	hostKeyPath := envOrDefault("HOST_KEY_PATH", ".ssh/term_ed25519")
 	apiURL := envOrDefault("REVEALUI_API_URL", "https://api.revealui.com")
 	apiToken := os.Getenv("REVEALUI_API_TOKEN") // optional — empty for public-only
 	defaultMode := envOrDefault("TERMINAL_MODE", "tui")
+
+	allowed, err := requiredAuthorizedKeys(os.Getenv("CONSOLE_AUTHORIZED_KEYS"))
+	if err != nil {
+		log.Fatalf("refusing to start: %v", err)
+	}
 
 	client := api.NewClient(apiURL, apiToken)
 	termProxy := proxy.New(client, apiURL)
@@ -51,13 +65,13 @@ func main() {
 	s, err := wish.NewServer(
 		wish.WithAddress(fmt.Sprintf("%s:%s", host, port)),
 		wish.WithHostKeyPath(hostKeyPath),
-		wish.WithPublicKeyAuth(func(_ ssh.Context, _ ssh.PublicKey) bool {
-			return true // Accept all keys — fingerprint used for account lookup, not auth
+		wish.WithPublicKeyAuth(func(_ ssh.Context, key ssh.PublicKey) bool {
+			return authorizePublicKey(key, allowed)
 		}),
 		wish.WithMiddleware(
-			// Route to agent proxy or payment TUI based on SSH command.
-			// Payment TUI keeps accept-all public keys (fingerprint lookup).
-			// Agents mode is fail-closed against CONSOLE_AUTHORIZED_KEYS.
+			// Handshake already allowlists CONSOLE_AUTHORIZED_KEYS. Agents
+			// mode re-checks the file (fail-closed) so an emptied allowlist
+			// cannot keep driving the proxy / REVEALUI_API_TOKEN.
 			func(next ssh.Handler) ssh.Handler {
 				return func(s ssh.Session) {
 					cmd := strings.Join(s.Command(), " ")
@@ -104,6 +118,33 @@ func envOrDefault(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// requiredAuthorizedKeys loads an OpenSSH authorized_keys file and refuses
+// an empty or missing allowlist. The SSH server must not start without one:
+// billing TUI and the agent proxy both inherit REVEALUI_API_TOKEN.
+func requiredAuthorizedKeys(path string) ([]gossh.PublicKey, error) {
+	keys, err := authz.LoadAuthorizedKeys(path)
+	if err != nil {
+		return nil, fmt.Errorf("CONSOLE_AUTHORIZED_KEYS: %w", err)
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("CONSOLE_AUTHORIZED_KEYS has no keys; refusing to start")
+	}
+	return keys, nil
+}
+
+// authorizePublicKey is the Wish public-key callback: only allowlisted keys
+// get a session (payment TUI or agents). Unknown / nil keys are rejected.
+func authorizePublicKey(key ssh.PublicKey, allowed []gossh.PublicKey) bool {
+	if key == nil || len(allowed) == 0 {
+		return false
+	}
+	parsed, err := gossh.ParsePublicKey(key.Marshal())
+	if err != nil {
+		return false
+	}
+	return authz.KeyAuthorized(parsed, allowed)
 }
 
 // authorizeAgentsSession fails closed: only keys listed in the OpenSSH

--- a/apps/console/main_test.go
+++ b/apps/console/main_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"os"
+	"path/filepath"
 	"testing"
+
+	gossh "golang.org/x/crypto/ssh"
 )
 
 func TestEnvOrDefault_ReturnsEnvValue(t *testing.T) {
@@ -35,17 +40,118 @@ func TestEnvOrDefault_ReturnsFallbackWhenEmpty(t *testing.T) {
 func TestEnvOrDefault_DefaultPortValue(t *testing.T) {
 	os.Unsetenv("PORT")
 
-	got := envOrDefault("PORT", "2222")
+	got := envOrDefault("PORT", defaultListenPort)
 	if got != "2222" {
 		t.Errorf("envOrDefault() = %q, want %q", got, "2222")
+	}
+}
+
+func TestDefaultListenHost_IsLoopback(t *testing.T) {
+	if defaultListenHost != "127.0.0.1" {
+		t.Errorf("defaultListenHost = %q, want 127.0.0.1", defaultListenHost)
 	}
 }
 
 func TestEnvOrDefault_DefaultHostValue(t *testing.T) {
 	os.Unsetenv("HOST")
 
-	got := envOrDefault("HOST", "0.0.0.0")
-	if got != "0.0.0.0" {
-		t.Errorf("envOrDefault() = %q, want %q", got, "0.0.0.0")
+	got := envOrDefault("HOST", defaultListenHost)
+	if got != "127.0.0.1" {
+		t.Errorf("envOrDefault() = %q, want %q", got, "127.0.0.1")
+	}
+}
+
+func mustTestKey(t *testing.T) gossh.PublicKey {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	signer, err := gossh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	return signer.PublicKey()
+}
+
+func writeTestAuthorizedKeys(t *testing.T, path string, keys ...gossh.PublicKey) {
+	t.Helper()
+	var body []byte
+	for _, k := range keys {
+		body = append(body, gossh.MarshalAuthorizedKey(k)...)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write authorized_keys: %v", err)
+	}
+}
+
+func TestRequiredAuthorizedKeys_MissingRefusesStart(t *testing.T) {
+	_, err := requiredAuthorizedKeys(filepath.Join(t.TempDir(), "missing"))
+	if err == nil {
+		t.Fatal("expected error when authorized_keys is missing")
+	}
+}
+
+func TestRequiredAuthorizedKeys_EmptyRefusesStart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := requiredAuthorizedKeys(path)
+	if err == nil {
+		t.Fatal("expected error when authorized_keys is empty")
+	}
+}
+
+func TestRequiredAuthorizedKeys_EmptyPathRefusesStart(t *testing.T) {
+	_, err := requiredAuthorizedKeys("")
+	if err == nil {
+		t.Fatal("expected error when CONSOLE_AUTHORIZED_KEYS is unset")
+	}
+}
+
+func TestAuthorizePublicKey_RejectsUnknownKey(t *testing.T) {
+	allowed := mustTestKey(t)
+	intruder := mustTestKey(t)
+	if authorizePublicKey(intruder, []gossh.PublicKey{allowed}) {
+		t.Fatal("unknown public key must be rejected")
+	}
+}
+
+func TestAuthorizePublicKey_AcceptsAllowlistedKey(t *testing.T) {
+	allowed := mustTestKey(t)
+	if !authorizePublicKey(allowed, []gossh.PublicKey{allowed}) {
+		t.Fatal("allowlisted public key must be accepted")
+	}
+}
+
+func TestAuthorizePublicKey_RejectsNilKey(t *testing.T) {
+	allowed := mustTestKey(t)
+	if authorizePublicKey(nil, []gossh.PublicKey{allowed}) {
+		t.Fatal("nil public key must be rejected")
+	}
+}
+
+func TestAuthorizePublicKey_RejectsEmptyAllowlist(t *testing.T) {
+	pub := mustTestKey(t)
+	if authorizePublicKey(pub, nil) {
+		t.Fatal("empty allowlist must reject every key")
+	}
+}
+
+func TestRequiredAuthorizedKeys_MatchingKeyLoads(t *testing.T) {
+	pub := mustTestKey(t)
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+	writeTestAuthorizedKeys(t, path, pub)
+
+	keys, err := requiredAuthorizedKeys(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !authorizePublicKey(pub, keys) {
+		t.Fatal("key from the loaded file must authorize")
+	}
+	if authorizePublicKey(mustTestKey(t), keys) {
+		t.Fatal("unknown key must still be rejected after a real load")
 	}
 }

--- a/apps/studio/src-tauri/capabilities/default.json
+++ b/apps/studio/src-tauri/capabilities/default.json
@@ -4,7 +4,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "shell:allow-open",
+    "shell:default",
     "core:event:default",
     "dialog:default",
     "updater:default"

--- a/apps/studio/src-tauri/src/commands/local_shell.rs
+++ b/apps/studio/src-tauri/src/commands/local_shell.rs
@@ -6,19 +6,17 @@ use tauri::State;
 use super::error::StudioError;
 use crate::local_shell::LocalShellState;
 
-/// Open a local PTY shell. Returns session ID. When `shell_program` is
-/// omitted the backend picks a platform default (`wsl.exe` on Windows,
-/// `$SHELL` elsewhere).
+/// Open a local PTY shell. Returns session ID. The host picks the program
+/// (`wsl.exe` on Windows, `$SHELL` elsewhere) — the frontend cannot supply one.
 #[tauri::command]
 pub fn shell_open(
     cols: u16,
     rows: u16,
     cwd: Option<String>,
-    shell_program: Option<String>,
     app_handle: tauri::AppHandle,
     state: State<'_, LocalShellState>,
 ) -> Result<String, StudioError> {
-    crate::local_shell::open(cols, rows, cwd, shell_program, app_handle, state.sessions.clone())
+    crate::local_shell::open(cols, rows, cwd, app_handle, state.sessions.clone())
         .map_err(StudioError::Process)
 }
 

--- a/apps/studio/src-tauri/src/commands/tiles.rs
+++ b/apps/studio/src-tauri/src/commands/tiles.rs
@@ -1,4 +1,5 @@
-//! Trusted-host tile helpers: browser profile discovery and process listing.
+//! Trusted-host tile helpers: browser profile discovery, process listing,
+//! and allowlisted program launch.
 //! These replace frontend `shell:allow-execute` / `Command.create('exec-sh')`.
 
 use std::fs;
@@ -8,6 +9,64 @@ use std::process::Command;
 use serde::Serialize;
 
 use super::error::StudioError;
+
+/// Basenames the frontend may ask the host to start. Paths, separators, and
+/// unknown names are rejected — this is not a general exec surface.
+const ALLOWED_TILE_PROGRAMS: &[&str] = &[
+    "zed",
+    "wt.exe",
+    "chrome.exe",
+    "msedge.exe",
+    "tmux",
+    "open",
+    "gnome-terminal",
+    "google-chrome",
+];
+
+/// True when `program` is an allowlisted basename (no path, no separators).
+pub fn is_allowed_tile_program(program: &str) -> bool {
+    if program.is_empty()
+        || program.contains('/')
+        || program.contains('\\')
+        || program.contains('\0')
+    {
+        return false;
+    }
+    let name = std::path::Path::new(program)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(program);
+    if name != program {
+        return false;
+    }
+    ALLOWED_TILE_PROGRAMS
+        .iter()
+        .any(|allowed| allowed.eq_ignore_ascii_case(program))
+}
+
+/// Launch an allowlisted tile program. Rejects free-form paths and unknown bins.
+#[tauri::command]
+pub fn launch_allowed_program(
+    program: String,
+    args: Option<Vec<String>>,
+) -> Result<(), StudioError> {
+    if !is_allowed_tile_program(&program) {
+        return Err(StudioError::Other(format!(
+            "program not allowlisted: {program}"
+        )));
+    }
+    let mut cmd = Command::new(&program);
+    if let Some(args) = args {
+        cmd.args(args);
+    }
+    #[cfg(target_os = "windows")]
+    {
+        crate::win_process::hide_std(&mut cmd);
+    }
+    cmd.spawn()
+        .map_err(|e| StudioError::Process(e.to_string()))?;
+    Ok(())
+}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -125,7 +184,13 @@ fn native_process_list() -> Result<String, StudioError> {
 
 fn parse_process_names(raw: &str) -> Vec<String> {
     // CSV tasklist on Windows: "Image Name","PID",...
-    if raw.contains("\",\"") || raw.lines().next().map(|l| l.starts_with('"')).unwrap_or(false) {
+    if raw.contains("\",\"")
+        || raw
+            .lines()
+            .next()
+            .map(|l| l.starts_with('"'))
+            .unwrap_or(false)
+    {
         return parse_tasklist_csv(raw);
     }
     raw.lines()
@@ -159,14 +224,8 @@ fn browser_data_dirs() -> Vec<(&'static str, PathBuf)> {
     {
         if let Ok(profile) = std::env::var("USERPROFILE") {
             let base = PathBuf::from(profile);
-            dirs.push((
-                "chrome",
-                base.join("AppData/Local/Google/Chrome/User Data"),
-            ));
-            dirs.push((
-                "edge",
-                base.join("AppData/Local/Microsoft/Edge/User Data"),
-            ));
+            dirs.push(("chrome", base.join("AppData/Local/Google/Chrome/User Data")));
+            dirs.push(("edge", base.join("AppData/Local/Microsoft/Edge/User Data")));
         }
     }
 
@@ -249,6 +308,29 @@ fn windows_path_to_wsl(win: &str) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rejects_unknown_and_path_programs() {
+        assert!(!is_allowed_tile_program(""));
+        assert!(!is_allowed_tile_program("/bin/bash"));
+        assert!(!is_allowed_tile_program(r"C:\Windows\System32\cmd.exe"));
+        assert!(!is_allowed_tile_program("../zed"));
+        assert!(!is_allowed_tile_program("zed/evil"));
+        assert!(!is_allowed_tile_program("curl"));
+        assert!(!is_allowed_tile_program("exec-sh"));
+    }
+
+    #[test]
+    fn accepts_allowlisted_basenames() {
+        assert!(is_allowed_tile_program("zed"));
+        assert!(is_allowed_tile_program("tmux"));
+        assert!(is_allowed_tile_program("chrome.exe"));
+        assert!(is_allowed_tile_program("wt.exe"));
+        assert!(is_allowed_tile_program("google-chrome"));
+        assert!(is_allowed_tile_program("gnome-terminal"));
+        assert!(is_allowed_tile_program("open"));
+        assert!(is_allowed_tile_program("msedge.exe"));
+    }
 
     #[test]
     fn parse_ps_comm_lines() {

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -195,6 +195,7 @@ pub fn run() {
             terminal::terminal_install,
             tiles::detect_browser_profiles,
             tiles::list_running_processes,
+            tiles::launch_allowed_program,
             launcher::focus_window,
             daemon_ctl::daemon_status,
             daemon_ctl::daemon_start,

--- a/apps/studio/src-tauri/src/local_shell.rs
+++ b/apps/studio/src-tauri/src/local_shell.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 
-use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
 use portable_pty::{CommandBuilder, MasterPty, NativePtySystem, PtySize, PtySystem};
 use serde::Serialize;
 use tauri::Emitter;
@@ -44,10 +44,10 @@ impl Default for LocalShellState {
     }
 }
 
-/// Pick the default shell program for the current OS when the caller hasn't
-/// specified one. On Windows we default to `wsl.exe` so users land in their
-/// WSL environment (RevDev's daily driver) instead of CMD. On other
-/// platforms we honour `$SHELL`, falling back to `/bin/bash`.
+/// Pick the login shell for the current OS. The frontend cannot override this.
+/// On Windows we default to `wsl.exe` so users land in their WSL environment
+/// (RevDev's daily driver) instead of CMD. On other platforms we honour
+/// `$SHELL`, falling back to `/bin/bash`.
 fn default_shell_program() -> String {
     if cfg!(target_os = "windows") {
         // `wsl.exe` is on PATH on every Windows 10/11 install that has WSL
@@ -67,15 +67,18 @@ fn wants_login_flag(shell: &str) -> bool {
         .and_then(|s| s.to_str())
         .unwrap_or(shell)
         .to_ascii_lowercase();
-    matches!(name.as_str(), "bash" | "zsh" | "sh" | "dash" | "ksh" | "fish")
+    matches!(
+        name.as_str(),
+        "bash" | "zsh" | "sh" | "dash" | "ksh" | "fish"
+    )
 }
 
 /// Open a local PTY shell. Returns session ID.
+/// The program is always host-selected — callers cannot pass a binary path.
 pub fn open(
     cols: u16,
     rows: u16,
     cwd: Option<String>,
-    shell_program: Option<String>,
     app_handle: tauri::AppHandle,
     state: Arc<Mutex<HashMap<String, LocalShellSession>>>,
 ) -> Result<String, String> {
@@ -93,7 +96,7 @@ pub fn open(
         .openpty(size)
         .map_err(|e| format!("Failed to open PTY: {e}"))?;
 
-    let shell = shell_program.unwrap_or_else(default_shell_program);
+    let shell = default_shell_program();
     let mut cmd = CommandBuilder::new(&shell);
     if wants_login_flag(&shell) {
         cmd.arg("--login");
@@ -120,9 +123,7 @@ pub fn open(
 
     // Store session
     {
-        let mut sessions = state
-            .lock()
-            .map_err(|e| format!("Lock poisoned: {e}"))?;
+        let mut sessions = state.lock().map_err(|e| format!("Lock poisoned: {e}"))?;
         sessions.insert(
             session_id.clone(),
             LocalShellSession {
@@ -170,4 +171,31 @@ pub fn open(
     });
 
     Ok(session_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_shell_is_host_selected_not_empty() {
+        let shell = default_shell_program();
+        assert!(!shell.is_empty(), "host must pick a login shell");
+        if cfg!(target_os = "windows") {
+            assert_eq!(shell, "wsl.exe");
+        } else {
+            assert!(
+                !shell.contains('\0'),
+                "login shell must be a real program path"
+            );
+        }
+    }
+
+    #[test]
+    fn wants_login_flag_only_for_posix_shells() {
+        assert!(wants_login_flag("/bin/bash"));
+        assert!(wants_login_flag("zsh"));
+        assert!(!wants_login_flag("wsl.exe"));
+        assert!(!wants_login_flag("powershell.exe"));
+    }
 }

--- a/apps/studio/src/__tests__/hooks/use-local-shell.test.ts
+++ b/apps/studio/src/__tests__/hooks/use-local-shell.test.ts
@@ -39,7 +39,7 @@ describe('useLocalShell', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('opens the shell with platform defaults when shellProgram is omitted', async () => {
+  it('opens the shell with host-selected platform defaults', async () => {
     vi.mocked(shellOpen).mockResolvedValueOnce('shell-session-1');
 
     const { result } = renderHook(() => useLocalShell());
@@ -48,13 +48,13 @@ describe('useLocalShell', () => {
       await result.current.open({ cols: 80, rows: 24 });
     });
 
-    expect(shellOpen).toHaveBeenCalledWith(80, 24, undefined, undefined);
+    expect(shellOpen).toHaveBeenCalledWith(80, 24, undefined);
     expect(result.current.sessionId).toBe('shell-session-1');
     expect(result.current.isOpen).toBe(true);
     expect(result.current.error).toBeNull();
   });
 
-  it('passes through explicit shellProgram and cwd', async () => {
+  it('passes cwd and never a free-form shell program', async () => {
     vi.mocked(shellOpen).mockResolvedValueOnce('shell-session-2');
 
     const { result } = renderHook(() => useLocalShell());
@@ -64,11 +64,13 @@ describe('useLocalShell', () => {
         cols: 120,
         rows: 40,
         cwd: '/home/user/proj',
-        shellProgram: 'wsl.exe',
       });
     });
 
-    expect(shellOpen).toHaveBeenCalledWith(120, 40, '/home/user/proj', 'wsl.exe');
+    expect(shellOpen).toHaveBeenCalledWith(120, 40, '/home/user/proj');
+    expect(shellOpen).toHaveBeenCalledTimes(1);
+    const args = vi.mocked(shellOpen).mock.calls[0];
+    expect(args).toHaveLength(3);
   });
 
   it('records the error message when shell_open rejects', async () => {

--- a/apps/studio/src/__tests__/lib/tiles.test.ts
+++ b/apps/studio/src/__tests__/lib/tiles.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockOpen, mockLaunchAllowedProgram } = vi.hoisted(() => ({
+  mockOpen: vi.fn(),
+  mockLaunchAllowedProgram: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@tauri-apps/plugin-shell', () => ({
+  open: mockOpen,
+}));
+
+vi.mock('../../lib/invoke', () => ({
+  launchAllowedProgram: mockLaunchAllowedProgram,
+  detectBrowserProfiles: vi.fn(),
+}));
+
+import { launchTile, type TileDefinition } from '../../lib/tiles';
+
+describe('launchTile', () => {
+  beforeEach(() => {
+    mockOpen.mockReset();
+    mockLaunchAllowedProgram.mockReset();
+    mockLaunchAllowedProgram.mockResolvedValue(undefined);
+  });
+
+  it('opens URL tiles through the scoped shell plugin', async () => {
+    const tile: TileDefinition = {
+      id: 'github',
+      label: 'GitHub',
+      category: 'accounts',
+      action: { type: 'url', url: 'https://github.com/RevealUIStudio' },
+    };
+
+    await launchTile(tile);
+
+    expect(mockOpen).toHaveBeenCalledWith('https://github.com/RevealUIStudio');
+    expect(mockLaunchAllowedProgram).not.toHaveBeenCalled();
+  });
+
+  it('does not pass a free-form program path to the shell plugin', async () => {
+    const tile: TileDefinition = {
+      id: 'zed',
+      label: 'Zed',
+      category: 'editor',
+      action: { type: 'shell', program: 'zed', args: ['.'] },
+    };
+
+    await launchTile(tile);
+
+    expect(mockLaunchAllowedProgram).toHaveBeenCalledWith('zed', ['.']);
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+});
+
+describe('Studio Tauri shell capabilities', () => {
+  it('does not grant unscoped shell execute or unscoped open', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const raw = readFileSync(join(here, '../../../src-tauri/capabilities/default.json'), 'utf8');
+    const cap = JSON.parse(raw) as { permissions: unknown[] };
+    const perms = cap.permissions.map((p) => (typeof p === 'string' ? p : JSON.stringify(p)));
+
+    expect(perms).not.toContain('shell:allow-execute');
+    expect(perms).not.toContain('shell:allow-spawn');
+    expect(perms).not.toContain('shell:allow-open');
+    expect(perms).toContain('shell:default');
+  });
+});

--- a/apps/studio/src/hooks/use-local-shell.ts
+++ b/apps/studio/src/hooks/use-local-shell.ts
@@ -28,7 +28,6 @@ export interface LocalShellOpenParams {
   cols: number;
   rows: number;
   cwd?: string;
-  shellProgram?: string;
 }
 
 export function useLocalShell(options: UseLocalShellOptions = {}) {
@@ -59,7 +58,7 @@ export function useLocalShell(options: UseLocalShellOptions = {}) {
     async (params: LocalShellOpenParams) => {
       setState((prev) => ({ ...prev, opening: true, error: null }));
       try {
-        const id = await shellOpen(params.cols, params.rows, params.cwd, params.shellProgram);
+        const id = await shellOpen(params.cols, params.rows, params.cwd);
         sessionIdRef.current = id;
 
         const unlistenOut = await listen<ShellOutputEventPayload>('shell_output', (event) => {

--- a/apps/studio/src/hooks/use-tiles.ts
+++ b/apps/studio/src/hooks/use-tiles.ts
@@ -168,7 +168,7 @@ export function useTiles(): UseTilesReturn {
     }
 
     // Not running or focus failed — launch normally
-    launchTile(tile);
+    await launchTile(tile);
     const next = recordRecentLaunch(prefs, tile.id);
     updatePrefs(next);
   };

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -236,6 +236,7 @@ const MOCK_DATA: Record<string, unknown> = {
     browser: string;
   }>,
   list_running_processes: [] as string[],
+  launch_allowed_program: undefined,
   inference_profile_get: {
     tier: 'idle',
     provider: null,
@@ -1152,17 +1153,11 @@ export function sshBookmarkDelete(id: string): Promise<void> {
 
 // ── Local Shell ─────────────────────────────────────────────────────────────
 
-export function shellOpen(
-  cols: number,
-  rows: number,
-  cwd?: string,
-  shellProgram?: string,
-): Promise<string> {
+export function shellOpen(cols: number, rows: number, cwd?: string): Promise<string> {
   return invoke<string>('shell_open', {
     cols,
     rows,
     cwd: cwd ?? null,
-    shellProgram: shellProgram ?? null,
   });
 }
 
@@ -1433,6 +1428,13 @@ export function detectBrowserProfiles(): Promise<BrowserProfileRow[]> {
 
 export function listRunningProcesses(): Promise<string[]> {
   return invoke<string[]>('list_running_processes');
+}
+
+export function launchAllowedProgram(program: string, args?: string[]): Promise<void> {
+  return invoke<void>('launch_allowed_program', {
+    program,
+    args: args ?? null,
+  });
 }
 
 // ── Harness Daemon ─────────────────────────────────────────────────────────

--- a/apps/studio/src/lib/tiles.ts
+++ b/apps/studio/src/lib/tiles.ts
@@ -1,4 +1,5 @@
 import { open } from '@tauri-apps/plugin-shell';
+import { launchAllowedProgram } from './invoke';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -321,13 +322,13 @@ export async function detectBrowserProfiles(): Promise<BrowserProfile[]> {
 
 // ── Launch ───────────────────────────────────────────────────────────────────
 
-export function launchTile(tile: TileDefinition): void {
+export async function launchTile(tile: TileDefinition): Promise<void> {
   const { action } = tile;
   if (action.type === 'url') {
-    open(action.url);
-  } else {
-    // shell:allow-open only — open the program/path, never arbitrary shell execute.
-    const args = action.args ? [action.program, ...action.args] : [action.program];
-    open(args.join(' '));
+    await open(action.url);
+    return;
   }
+  // Host-exec is allowlisted in Rust — never pass a free-form path to the
+  // shell plugin (no exec-sh, no unscoped open of a program).
+  await launchAllowedProgram(action.program, action.args);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes two 2026-08-21 P0s. No extra scope (bwrap confinement unchanged; Console stays experimental / not a hosted public service).

## P0 — Console SSH

`WithPublicKeyAuth` accepted every key and the default bind was `0.0.0.0:2222`. An unauthenticated session inherited `REVEALUI_API_TOKEN` and could drive Stripe checkout / OTP and the agent PTY proxy.

- Default `HOST` is `127.0.0.1`
- Process refuses to start unless `CONSOLE_AUTHORIZED_KEYS` is a non-empty OpenSSH allowlist
- Handshake public-key auth is that allowlist (unknown keys rejected)
- Agents mode still re-checks the file fail-closed
- Experimental warning kept

Tests: reject-unknown-key, empty/missing allowlist refuse-to-start, loopback default.

## P0 — Studio Tauri exec

`shell:allow-open` was unscoped; `shell_open` took an arbitrary program path; tile launches passed a free-form program string into the shell plugin (previously `exec-sh -c`).

- Capability is `shell:default` (URL-scheme-scoped open; no `allow-execute` / unscoped `allow-open`)
- `shell_open` no longer accepts a frontend program — host picks `wsl.exe` / `$SHELL`
- Tile shell launches go through `launch_allowed_program` (basename allowlist; paths rejected)

Tests: unknown-key-style program path rejection, loopback-equivalent capability assertion, frontend never passes a free-form program to the plugin.

## Verification

- `cd apps/console && go test ./...`
- `pnpm --filter studio exec vitest run src/__tests__/lib/tiles.test.ts src/__tests__/hooks/use-local-shell.test.ts`
- `cargo test --manifest-path apps/studio/src-tauri/Cargo.toml --lib`
- `pnpm --filter studio typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c07af24-a0ad-4808-be34-d37d1a8c6d87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c07af24-a0ad-4808-be34-d37d1a8c6d87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

