### PR TITLE
feat(daemon): GAP-349 P5b Electric down-sync and durable site id

### DIFF
--- a/packages/daemon/src/__tests__/graph-sync.test.ts
+++ b/packages/daemon/src/__tests__/graph-sync.test.ts
@@ -1,0 +1,174 @@
+/**
+ * GAP-349 P5b — Electric down-sync + hub anti-entropy.
+ *
+ * Delete ops from Electric are skipped (invalidate-not-delete). Hub snapshot
+ * merges invalid_at with LEAST. No Electric/hub → no-op, does not invent a store.
+ */
+
+import { PGlite } from '@electric-sql/pglite';
+import { afterEach, describe, expect, it } from 'vitest';
+import { graphStatus } from '../graph.js';
+import { applyHubRow, ensureGraphSiteId, graphSyncPull, type ShapePage } from '../graph-sync.js';
+import { migrate } from '../storage/migrate.js';
+
+const DB_TEST_TIMEOUT = 60_000;
+
+async function boot(): Promise<PGlite> {
+  const db = new PGlite();
+  await migrate(db);
+  return db;
+}
+
+const NODE = {
+  id: 'node-file-1',
+  kind: 'file',
+  name: 'graph-sync.ts',
+  natural_key: 'revdev/packages/daemon/src/graph-sync.ts',
+  repo: 'revdev',
+  summary: 'Electric down-sync',
+  search_text: 'graph-sync electric down-sync',
+  attributes: {},
+  first_seen_at: '2026-08-19T00:00:00.000Z',
+  last_confirmed_at: '2026-08-19T00:00:00.000Z',
+};
+
+const EDGE = {
+  id: 'edge-1',
+  source_id: 'node-file-1',
+  target_id: 'node-file-1',
+  relation: 'mentions',
+  fact: 'graph-sync.ts implements Electric down-sync',
+  repo: 'revdev',
+  attributes: {},
+  valid_at: '2026-08-19T00:00:00.000Z',
+  invalid_at: null as string | null,
+  expired_at: null as string | null,
+};
+
+describe('knowledge-graph down-sync (GAP-349 P5b)', () => {
+  let db: PGlite;
+
+  afterEach(async () => {
+    await db?.close().catch(() => {});
+    delete process.env.ELECTRIC_SERVICE_URL;
+    delete process.env.ELECTRIC_SECRET;
+    delete process.env.REVDEV_KG_SITE_ID;
+    delete process.env.REVDEV_KG_REPOS;
+  });
+
+  it(
+    'persists siteId on graph_site and returns the same id on later status',
+    async () => {
+      process.env.REVDEV_KG_SITE_ID = 'daemon:p5b-test';
+      db = await boot();
+      const first = await ensureGraphSiteId(db);
+      expect(first).toBe('daemon:p5b-test');
+      delete process.env.REVDEV_KG_SITE_ID;
+      const second = await ensureGraphSiteId(db, 'daemon:should-not-win');
+      expect(second).toBe('daemon:p5b-test');
+      const status = await graphStatus(db);
+      expect(status.siteId).toBe('daemon:p5b-test');
+      expect(status.electricConfigured).toBe(false);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'no-ops without Electric or hub instead of inventing a second store',
+    async () => {
+      db = await boot();
+      const result = await graphSyncPull(db, { repos: ['revdev'] });
+      expect(result.applied).toBe(0);
+      expect(result.electricConfigured).toBe(false);
+      expect(result.hubConfigured).toBe(false);
+      expect(result.reason).toMatch(/no ELECTRIC_SERVICE_URL/);
+      const status = await graphStatus(db);
+      expect(status.nodes).toBe(0);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'applies Electric insert/update and skips delete',
+    async () => {
+      process.env.ELECTRIC_SERVICE_URL = 'http://electric.test';
+      db = await boot();
+      const pages: ShapePage[] = [
+        {
+          messages: [
+            { headers: { operation: 'insert' }, value: NODE },
+            { headers: { operation: 'insert' }, value: EDGE },
+            { headers: { operation: 'delete' }, value: { id: 'node-file-1' } },
+            { headers: { control: 'up-to-date' } },
+          ],
+          offset: '0_0',
+          handle: 'h1',
+          upToDate: true,
+        },
+      ];
+      const result = await graphSyncPull(
+        db,
+        { repos: ['revdev'] },
+        {
+          fetchShapePage: async (url) => {
+            expect(
+              url.searchParams.get('table') === 'kg_nodes' ||
+                url.searchParams.get('table') === 'kg_edges',
+            ).toBe(true);
+            expect(url.searchParams.get('where')).toContain('revdev');
+            return pages[0] ?? { messages: [], upToDate: true };
+          },
+        },
+      );
+      expect(result.skippedDeletes).toBeGreaterThan(0);
+      expect(result.applied).toBeGreaterThan(0);
+      const status = await graphStatus(db);
+      expect(status.nodes).toBe(1);
+      expect(status.edges).toBe(1);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'hub snapshot merges invalid_at with LEAST (anti-entropy)',
+    async () => {
+      db = await boot();
+      await applyHubRow(db, 'kg_nodes', NODE);
+      await applyHubRow(db, 'kg_edges', EDGE);
+      const invalidated = {
+        ...EDGE,
+        invalid_at: '2026-08-20T00:00:00.000Z',
+      };
+      const result = await graphSyncPull(
+        db,
+        { repos: ['revdev'] },
+        {
+          snapshotTable: async (table) => {
+            if (table === 'kg_nodes') return [NODE];
+            if (table === 'kg_edges') return [invalidated];
+            return [];
+          },
+        },
+      );
+      expect(result.applied).toBeGreaterThan(0);
+      const rows = await db.query<{ invalid_at: string | null }>(
+        `SELECT invalid_at FROM kg_edges WHERE id = $1`,
+        [EDGE.id],
+      );
+      expect(rows.rows[0]?.invalid_at).not.toBeNull();
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'refuses to pull when no repos are in scope',
+    async () => {
+      process.env.ELECTRIC_SERVICE_URL = 'http://electric.test';
+      db = await boot();
+      const result = await graphSyncPull(db, {});
+      expect(result.applied).toBe(0);
+      expect(result.reason).toMatch(/no repos/);
+    },
+    DB_TEST_TIMEOUT,
+  );
+});

--- a/packages/daemon/src/__tests__/graph.test.ts
+++ b/packages/daemon/src/__tests__/graph.test.ts
@@ -39,8 +39,8 @@ describe('knowledge-graph replica (GAP-349 P5)', () => {
     'migration 0014 creates kg_* tables on a full migrate()',
     async () => {
       db = await boot();
-      expect(MIGRATIONS.at(-1)?.version).toBe(14);
-      expect(MIGRATIONS.at(-1)?.name).toBe('knowledge-graph-replica');
+      expect(MIGRATIONS.at(-1)?.version).toBe(15);
+      expect(MIGRATIONS.at(-1)?.name).toBe('graph-sync-site');
       const tables = await db.query<{ table_name: string }>(
         `SELECT table_name FROM information_schema.tables
          WHERE table_schema = 'public' AND table_name LIKE 'kg_%'
@@ -53,7 +53,14 @@ describe('knowledge-graph replica (GAP-349 P5)', () => {
         'kg_node_aliases',
         'kg_nodes',
         'kg_outbox',
+        'kg_shape_cursors',
       ]);
+      const meta = await db.query<{ table_name: string }>(
+        `SELECT table_name FROM information_schema.tables
+         WHERE table_schema = 'public' AND table_name IN ('graph_site', 'kg_shape_cursors')
+         ORDER BY table_name`,
+      );
+      expect(meta.rows.map((r) => r.table_name)).toEqual(['graph_site', 'kg_shape_cursors']);
     },
     DB_TEST_TIMEOUT,
   );

--- a/packages/daemon/src/graph-sync.ts
+++ b/packages/daemon/src/graph-sync.ts
@@ -1,0 +1,603 @@
+/**
+ * GAP-349 P5b — Electric down-sync + hub anti-entropy into the PGlite replica.
+ *
+ * Spec §8.2: Electric is the DOWN direction (read-only shapes). Writes still
+ * go outbox-up. Class-1/2 merge SQL applies hub rows; Electric *delete*
+ * operations are skipped because kg edges/nodes are invalidate-not-delete.
+ *
+ * Does not log ELECTRIC_SECRET or connection URLs.
+ */
+
+import { hostname } from 'node:os';
+import type { PGlite } from '@electric-sql/pglite';
+import { createLogger } from '@revealui/utils/logger';
+import { resolvePostgresUrl } from './neon.js';
+
+const log = createLogger({ service: 'revdev-daemon-graph-sync' });
+
+const SHAPE_TABLES = ['kg_nodes', 'kg_edges'] as const;
+const SNAPSHOT_TABLES = [
+  'kg_episodes',
+  'kg_nodes',
+  'kg_edges',
+  'kg_edge_episodes',
+  'kg_node_aliases',
+] as const;
+const MAX_REPOS = 32;
+const MAX_SHAPE_PAGES = 40;
+const REPO_ID = /^[a-zA-Z0-9._-]{1,128}$/;
+
+export type ShapeTable = (typeof SHAPE_TABLES)[number];
+export type SnapshotTable = (typeof SNAPSHOT_TABLES)[number];
+
+export interface ShapeMessage {
+  headers?: { operation?: string; control?: string };
+  value?: Record<string, unknown>;
+  key?: unknown;
+}
+
+export interface ShapePage {
+  messages: ShapeMessage[];
+  offset?: string;
+  handle?: string;
+  upToDate: boolean;
+}
+
+export interface GraphSyncDeps {
+  fetchShapePage?: (url: URL) => Promise<ShapePage>;
+  snapshotTable?: (table: SnapshotTable, repos: string[]) => Promise<Record<string, unknown>[]>;
+}
+
+export interface GraphSyncPullResult {
+  siteId: string;
+  repos: string[];
+  electricConfigured: boolean;
+  hubConfigured: boolean;
+  applied: number;
+  skippedDeletes: number;
+  errors: number;
+  electric: Record<string, { pages: number; applied: number }>;
+  snapshot: Record<string, { rows: number; applied: number }>;
+  reason?: string;
+}
+
+export function resolveElectricServiceUrl(): string {
+  const raw = process.env.ELECTRIC_SERVICE_URL?.trim() || process.env.ELECTRIC_URL?.trim() || '';
+  return raw.replace(/\/+$/, '');
+}
+
+export function isRepoIdentifier(value: string): boolean {
+  return REPO_ID.test(value);
+}
+
+export function sanitizeRepos(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  const out: string[] = [];
+  for (const raw of values) {
+    if (typeof raw !== 'string') continue;
+    const trimmed = raw.trim();
+    if (!isRepoIdentifier(trimmed)) continue;
+    if (!out.includes(trimmed)) out.push(trimmed);
+    if (out.length >= MAX_REPOS) break;
+  }
+  return out;
+}
+
+export async function ensureGraphSiteId(db: PGlite, preferred?: string): Promise<string> {
+  const existing = await db.query<{ site_id: string }>(
+    `SELECT site_id FROM graph_site WHERE singleton = $1`,
+    ['local'],
+  );
+  const found = existing.rows[0]?.site_id?.trim();
+  if (found) return found;
+  const siteId =
+    preferred?.trim() || process.env.REVDEV_KG_SITE_ID?.trim() || `daemon:${hostname()}`;
+  await db.query(
+    `INSERT INTO graph_site (singleton, site_id) VALUES ($1, $2)
+     ON CONFLICT (singleton) DO NOTHING`,
+    ['local', siteId],
+  );
+  const again = await db.query<{ site_id: string }>(
+    `SELECT site_id FROM graph_site WHERE singleton = $1`,
+    ['local'],
+  );
+  return again.rows[0]?.site_id?.trim() || siteId;
+}
+
+export async function resolveSyncRepos(
+  db: PGlite,
+  params: Record<string, unknown>,
+): Promise<string[]> {
+  const fromParams = sanitizeRepos(params.repos);
+  if (fromParams.length > 0) return fromParams;
+  const envList = process.env.REVDEV_KG_REPOS?.split(',') ?? [];
+  const fromEnv = sanitizeRepos(envList);
+  if (fromEnv.length > 0) return fromEnv;
+  const roots = await db.query<{ real_path: string }>(`SELECT real_path FROM project_roots`);
+  const fromRoots: string[] = [];
+  for (const row of roots.rows) {
+    const base = row.real_path.split('/').filter(Boolean).at(-1);
+    if (base && isRepoIdentifier(base) && !fromRoots.includes(base)) fromRoots.push(base);
+    if (fromRoots.length >= MAX_REPOS) break;
+  }
+  return fromRoots;
+}
+
+function electricWhere(repos: string[]): string | undefined {
+  if (repos.length === 0) return undefined;
+  const quoted = repos.map((r) => `'${r}'`).join(',');
+  return `repo IN (${quoted})`;
+}
+
+function headerValue(headers: Headers, name: string): string | undefined {
+  const direct = headers.get(name);
+  if (direct) return direct;
+  const lower = name.toLowerCase();
+  for (const [key, value] of headers.entries()) {
+    if (key.toLowerCase() === lower) return value;
+  }
+  return undefined;
+}
+
+function parseShapeBody(body: unknown): ShapeMessage[] {
+  if (Array.isArray(body)) return body as ShapeMessage[];
+  if (typeof body === 'string') {
+    const trimmed = body.trim();
+    if (!trimmed) return [];
+    if (trimmed.startsWith('[')) {
+      const parsed: unknown = JSON.parse(trimmed);
+      return Array.isArray(parsed) ? (parsed as ShapeMessage[]) : [];
+    }
+    const messages: ShapeMessage[] = [];
+    for (const line of trimmed.split('\n')) {
+      if (!line.trim()) continue;
+      messages.push(JSON.parse(line) as ShapeMessage);
+    }
+    return messages;
+  }
+  return [];
+}
+
+export async function defaultFetchShapePage(url: URL): Promise<ShapePage> {
+  const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  if (!response.ok) {
+    throw new Error(`electric shape HTTP ${response.status}`);
+  }
+  const text = await response.text();
+  let body: unknown = text;
+  try {
+    body = JSON.parse(text) as unknown;
+  } catch {
+    body = text;
+  }
+  const messages = parseShapeBody(body);
+  const upToDate = messages.some(
+    (m) => m.headers?.control === 'up-to-date' || m.headers?.control === 'must-refetch',
+  );
+  return {
+    messages,
+    offset: headerValue(response.headers, 'electric-offset'),
+    handle: headerValue(response.headers, 'electric-handle'),
+    upToDate,
+  };
+}
+
+function asIso(value: unknown): string | null {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString();
+  if (typeof value === 'string' && value.length > 0) {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d.toISOString();
+  }
+  return null;
+}
+
+function asText(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asJson(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function pick(row: Record<string, unknown>, ...keys: string[]): unknown {
+  for (const key of keys) {
+    if (row[key] !== undefined) return row[key];
+  }
+  return undefined;
+}
+
+export async function applyHubRow(
+  db: PGlite,
+  table: SnapshotTable,
+  row: Record<string, unknown>,
+): Promise<void> {
+  switch (table) {
+    case 'kg_episodes': {
+      const id = asText(pick(row, 'id'));
+      const episodeType = asText(pick(row, 'episode_type', 'episodeType'));
+      const source = asText(pick(row, 'source'));
+      const siteId = asText(pick(row, 'site_id', 'siteId'));
+      const referenceTime = asIso(pick(row, 'reference_time', 'referenceTime'));
+      if (!id || !episodeType || !source || !siteId || !referenceTime) return;
+      await db.query(
+        `INSERT INTO kg_episodes (id, episode_type, source, site_id, content, content_ref, reference_time)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::timestamptz)
+         ON CONFLICT (id) DO NOTHING`,
+        [
+          id,
+          episodeType,
+          source,
+          siteId,
+          asText(pick(row, 'content')),
+          JSON.stringify(asJson(pick(row, 'content_ref', 'contentRef'))),
+          referenceTime,
+        ],
+      );
+      return;
+    }
+    case 'kg_nodes': {
+      const id = asText(pick(row, 'id'));
+      const kind = asText(pick(row, 'kind'));
+      const name = asText(pick(row, 'name'));
+      const naturalKey = asText(pick(row, 'natural_key', 'naturalKey'));
+      const firstSeen =
+        asIso(pick(row, 'first_seen_at', 'firstSeenAt')) ?? new Date().toISOString();
+      const lastConfirmed = asIso(pick(row, 'last_confirmed_at', 'lastConfirmedAt')) ?? firstSeen;
+      if (!id || !kind || !name || !naturalKey) return;
+      const searchText = asText(pick(row, 'search_text', 'searchText')) ?? `${name} ${naturalKey}`;
+      await db.query(
+        `INSERT INTO kg_nodes
+           (id, kind, name, natural_key, repo, summary, search_text, attributes,
+            first_seen_at, last_confirmed_at, deleted_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9::timestamptz, $10::timestamptz, $11::timestamptz)
+         ON CONFLICT (id) DO UPDATE SET
+           name = EXCLUDED.name,
+           repo = COALESCE(EXCLUDED.repo, kg_nodes.repo),
+           summary = COALESCE(EXCLUDED.summary, kg_nodes.summary),
+           search_text = EXCLUDED.search_text,
+           attributes = kg_nodes.attributes || EXCLUDED.attributes,
+           first_seen_at = LEAST(kg_nodes.first_seen_at, EXCLUDED.first_seen_at),
+           last_confirmed_at = GREATEST(kg_nodes.last_confirmed_at, EXCLUDED.last_confirmed_at),
+           deleted_at = LEAST(kg_nodes.deleted_at, EXCLUDED.deleted_at)`,
+        [
+          id,
+          kind,
+          name,
+          naturalKey,
+          asText(pick(row, 'repo')),
+          asText(pick(row, 'summary')),
+          searchText,
+          JSON.stringify(asJson(pick(row, 'attributes'))),
+          firstSeen,
+          lastConfirmed,
+          asIso(pick(row, 'deleted_at', 'deletedAt')),
+        ],
+      );
+      return;
+    }
+    case 'kg_edges': {
+      const id = asText(pick(row, 'id'));
+      const sourceId = asText(pick(row, 'source_id', 'sourceId'));
+      const targetId = asText(pick(row, 'target_id', 'targetId'));
+      const relation = asText(pick(row, 'relation'));
+      const fact = asText(pick(row, 'fact'));
+      const validAt = asIso(pick(row, 'valid_at', 'validAt')) ?? new Date().toISOString();
+      if (!id || !sourceId || !targetId || !relation || !fact) return;
+      await db.query(
+        `INSERT INTO kg_edges
+           (id, source_id, target_id, relation, fact, repo, attributes, valid_at, invalid_at, expired_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::timestamptz, $9::timestamptz, $10::timestamptz)
+         ON CONFLICT (id) DO NOTHING`,
+        [
+          id,
+          sourceId,
+          targetId,
+          relation,
+          fact,
+          asText(pick(row, 'repo')),
+          JSON.stringify(asJson(pick(row, 'attributes'))),
+          validAt,
+          asIso(pick(row, 'invalid_at', 'invalidAt')),
+          asIso(pick(row, 'expired_at', 'expiredAt')),
+        ],
+      );
+      const invalidAt = asIso(pick(row, 'invalid_at', 'invalidAt'));
+      if (invalidAt) {
+        await db.query(
+          `UPDATE kg_edges SET invalid_at = LEAST(invalid_at, $2::timestamptz) WHERE id = $1`,
+          [id, invalidAt],
+        );
+      }
+      const expiredAt = asIso(pick(row, 'expired_at', 'expiredAt'));
+      if (expiredAt) {
+        await db.query(
+          `UPDATE kg_edges SET expired_at = LEAST(expired_at, $2::timestamptz) WHERE id = $1`,
+          [id, expiredAt],
+        );
+      }
+      return;
+    }
+    case 'kg_edge_episodes': {
+      const edgeId = asText(pick(row, 'edge_id', 'edgeId'));
+      const episodeId = asText(pick(row, 'episode_id', 'episodeId'));
+      if (!edgeId || !episodeId) return;
+      await db.query(
+        `INSERT INTO kg_edge_episodes (edge_id, episode_id) VALUES ($1, $2)
+         ON CONFLICT DO NOTHING`,
+        [edgeId, episodeId],
+      );
+      return;
+    }
+    case 'kg_node_aliases': {
+      const alias = asText(pick(row, 'alias'));
+      const nodeId = asText(pick(row, 'node_id', 'nodeId'));
+      if (!alias || !nodeId) return;
+      await db.query(
+        `INSERT INTO kg_node_aliases (alias, node_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+        [alias, nodeId],
+      );
+    }
+  }
+}
+
+function isDeleteOp(operation: string | undefined): boolean {
+  if (!operation) return false;
+  const op = operation.toLowerCase();
+  return op === 'delete' || op === 'remove';
+}
+
+async function loadCursor(
+  db: PGlite,
+  table: string,
+): Promise<{ handle: string | null; offset: string }> {
+  const rows = await db.query<{ handle: string | null; shape_offset: string }>(
+    `SELECT handle, shape_offset FROM kg_shape_cursors WHERE table_name = $1`,
+    [table],
+  );
+  return { handle: rows.rows[0]?.handle ?? null, offset: rows.rows[0]?.shape_offset ?? '-1' };
+}
+
+async function saveCursor(
+  db: PGlite,
+  table: string,
+  handle: string | undefined,
+  offset: string | undefined,
+  error?: string,
+): Promise<void> {
+  await db.query(
+    `INSERT INTO kg_shape_cursors (table_name, handle, shape_offset, last_pulled_at, last_error)
+     VALUES ($1, $2, $3, now(), $4)
+     ON CONFLICT (table_name) DO UPDATE SET
+       handle = COALESCE(EXCLUDED.handle, kg_shape_cursors.handle),
+       shape_offset = EXCLUDED.shape_offset,
+       last_pulled_at = now(),
+       last_error = EXCLUDED.last_error`,
+    [table, handle ?? null, offset ?? '-1', error ?? null],
+  );
+}
+
+function shapeUrl(table: ShapeTable, repos: string[], offset: string, handle: string | null): URL {
+  const base = resolveElectricServiceUrl();
+  const url = new URL(`${base}/v1/shape`);
+  url.searchParams.set('table', table);
+  url.searchParams.set('offset', offset);
+  if (handle) url.searchParams.set('handle', handle);
+  const secret = process.env.ELECTRIC_SECRET?.trim();
+  if (secret) url.searchParams.set('secret', secret);
+  const sourceId = process.env.ELECTRIC_SOURCE_ID?.trim();
+  if (sourceId) url.searchParams.set('source_id', sourceId);
+  const where = electricWhere(repos);
+  if (where) url.searchParams.set('where', where);
+  return url;
+}
+
+async function pullShapeTable(
+  db: PGlite,
+  table: ShapeTable,
+  repos: string[],
+  deps: GraphSyncDeps,
+  stats: { applied: number; skippedDeletes: number; errors: number },
+): Promise<{ pages: number; applied: number }> {
+  const fetchPage = deps.fetchShapePage ?? defaultFetchShapePage;
+  let { handle, offset } = await loadCursor(db, table);
+  let pages = 0;
+  let applied = 0;
+  try {
+    for (let i = 0; i < MAX_SHAPE_PAGES; i += 1) {
+      const page = await fetchPage(shapeUrl(table, repos, offset, handle));
+      pages += 1;
+      if (page.handle) handle = page.handle;
+      if (page.offset) offset = page.offset;
+      for (const message of page.messages) {
+        if (message.headers?.control) continue;
+        if (isDeleteOp(message.headers?.operation)) {
+          stats.skippedDeletes += 1;
+          continue;
+        }
+        if (!message.value) continue;
+        try {
+          await applyHubRow(db, table, message.value);
+          applied += 1;
+          stats.applied += 1;
+        } catch (err) {
+          stats.errors += 1;
+          log.warn('kg shape row apply failed', {
+            table,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      await saveCursor(db, table, handle ?? undefined, offset, undefined);
+      if (page.upToDate || !page.offset) break;
+    }
+  } catch (err) {
+    stats.errors += 1;
+    const message = err instanceof Error ? err.message : String(err);
+    await saveCursor(db, table, handle ?? undefined, offset, message);
+    log.warn('kg shape pull failed', { table, error: message });
+  }
+  return { pages, applied };
+}
+
+async function defaultSnapshotTable(
+  table: SnapshotTable,
+  repos: string[],
+): Promise<Record<string, unknown>[]> {
+  const url = resolvePostgresUrl();
+  if (!url) return [];
+  const { createPool } = await import('@revealui/db/pool');
+  const { makePoolExecutor } = await import('@revealui/knowledge-graph');
+  const pool = createPool({
+    connectionTimeoutMillis: 30_000,
+    queryTimeoutMillis: 60_000,
+    statementTimeoutMillis: 60_000,
+    max: 2,
+  });
+  const exec = makePoolExecutor(pool);
+  const repoFilter = repos.length > 0;
+  switch (table) {
+    case 'kg_nodes':
+      return repoFilter
+        ? exec.query(`SELECT * FROM kg_nodes WHERE repo = ANY($1)`, [repos])
+        : exec.query(`SELECT * FROM kg_nodes`);
+    case 'kg_edges':
+      return repoFilter
+        ? exec.query(`SELECT * FROM kg_edges WHERE repo = ANY($1)`, [repos])
+        : exec.query(`SELECT * FROM kg_edges`);
+    case 'kg_episodes':
+      return repoFilter
+        ? exec.query(
+            `SELECT e.* FROM kg_episodes e
+             WHERE e.id IN (
+               SELECT ee.episode_id FROM kg_edge_episodes ee
+               JOIN kg_edges g ON g.id = ee.edge_id
+               WHERE g.repo = ANY($1)
+             )`,
+            [repos],
+          )
+        : exec.query(`SELECT * FROM kg_episodes`);
+    case 'kg_edge_episodes':
+      return repoFilter
+        ? exec.query(
+            `SELECT ee.* FROM kg_edge_episodes ee
+             JOIN kg_edges g ON g.id = ee.edge_id
+             WHERE g.repo = ANY($1)`,
+            [repos],
+          )
+        : exec.query(`SELECT * FROM kg_edge_episodes`);
+    case 'kg_node_aliases':
+      return repoFilter
+        ? exec.query(
+            `SELECT a.* FROM kg_node_aliases a
+             JOIN kg_nodes n ON n.id = a.node_id
+             WHERE n.repo = ANY($1)`,
+            [repos],
+          )
+        : exec.query(`SELECT * FROM kg_node_aliases`);
+  }
+}
+
+export async function graphSyncPull(
+  db: PGlite,
+  params: Record<string, unknown>,
+  deps: GraphSyncDeps = {},
+): Promise<GraphSyncPullResult> {
+  const siteId = await ensureGraphSiteId(db);
+  const repos = await resolveSyncRepos(db, params);
+  const electricConfigured = Boolean(resolveElectricServiceUrl());
+  const hubConfigured = Boolean(resolvePostgresUrl());
+  const stats = { applied: 0, skippedDeletes: 0, errors: 0 };
+  const electric: GraphSyncPullResult['electric'] = {};
+  const snapshot: GraphSyncPullResult['snapshot'] = {};
+
+  if (!electricConfigured && !hubConfigured && !deps.fetchShapePage && !deps.snapshotTable) {
+    return {
+      siteId,
+      repos,
+      electricConfigured,
+      hubConfigured,
+      applied: 0,
+      skippedDeletes: 0,
+      errors: 0,
+      electric,
+      snapshot,
+      reason: 'no ELECTRIC_SERVICE_URL and no POSTGRES_URL',
+    };
+  }
+  if (repos.length === 0 && params.scope !== 'all') {
+    return {
+      siteId,
+      repos,
+      electricConfigured,
+      hubConfigured,
+      applied: 0,
+      skippedDeletes: 0,
+      errors: 0,
+      electric,
+      snapshot,
+      reason: 'no repos (pass repos[], REVDEV_KG_REPOS, project_roots, or scope=all)',
+    };
+  }
+
+  if (electricConfigured || deps.fetchShapePage) {
+    for (const table of SHAPE_TABLES) {
+      electric[table] = await pullShapeTable(db, table, repos, deps, stats);
+    }
+  }
+
+  if (hubConfigured || deps.snapshotTable) {
+    const snap = deps.snapshotTable ?? defaultSnapshotTable;
+    for (const table of SNAPSHOT_TABLES) {
+      try {
+        const rows = await snap(table, repos);
+        let applied = 0;
+        for (const row of rows) {
+          try {
+            await applyHubRow(db, table, row);
+            applied += 1;
+            stats.applied += 1;
+          } catch (err) {
+            stats.errors += 1;
+            log.warn('kg snapshot row apply failed', {
+              table,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+        snapshot[table] = { rows: rows.length, applied };
+      } catch (err) {
+        stats.errors += 1;
+        snapshot[table] = { rows: 0, applied: 0 };
+        log.warn('kg snapshot failed', {
+          table,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  return {
+    siteId,
+    repos,
+    electricConfigured,
+    hubConfigured,
+    applied: stats.applied,
+    skippedDeletes: stats.skippedDeletes,
+    errors: stats.errors,
+    electric,
+    snapshot,
+  };
+}

--- a/packages/daemon/src/graph.ts
+++ b/packages/daemon/src/graph.ts
@@ -4,7 +4,8 @@
  * GAP-349 P5 / spec §8.2: local kg_* tables + kg_outbox; reads and
  * ingestEpisode run against PGlite. graph.outbox.push replays unpushed ops
  * to the Neon hub when POSTGRES_URL is set (class-1/2 merge, no extra CRDT
- * library). Communities and Electric down-sync stay later P5 slices.
+ * library). P5b: Electric down-sync + hub anti-entropy live in graph-sync.ts.
+ * Communities and Layer-3 reconcile stay later P5 slices.
  *
  * Extends `@revealui/knowledge-graph` (published 0.1.8; 0.1.9 pulls unpublished
  * `@revealui/ts-strada`). Do not fork DDL.
@@ -31,6 +32,7 @@ import {
 } from '@revealui/knowledge-graph';
 import { resolveNaturalKey } from '@revealui/knowledge-graph/ingest';
 import { createLogger } from '@revealui/utils/logger';
+import { ensureGraphSiteId, graphSyncPull } from './graph-sync.js';
 import { resolvePostgresUrl } from './neon.js';
 import { registerHandler } from './server.js';
 
@@ -84,9 +86,11 @@ export async function graphStatus(db: PGlite): Promise<{
   episodes: number;
   outboxPending: number;
   hubConfigured: boolean;
+  electricConfigured: boolean;
   siteId: string;
 }> {
   const exec = kgExecutorFromPglite(db);
+  const siteId = await ensureGraphSiteId(db);
   const [nodes, edges, episodes, pending] = await Promise.all([
     exec.query<{ n: number }>('SELECT count(*)::int AS n FROM kg_nodes'),
     exec.query<{ n: number }>('SELECT count(*)::int AS n FROM kg_edges'),
@@ -108,7 +112,10 @@ export async function graphStatus(db: PGlite): Promise<{
     episodes: episodes[0]?.n ?? 0,
     outboxPending: pending[0]?.n ?? 0,
     hubConfigured: Boolean(resolvePostgresUrl()),
-    siteId: resolveGraphSiteId({}),
+    electricConfigured: Boolean(
+      process.env.ELECTRIC_SERVICE_URL?.trim() || process.env.ELECTRIC_URL?.trim(),
+    ),
+    siteId,
   };
 }
 
@@ -444,7 +451,9 @@ registerHandler('graph.at', async (params, db) => graphAt(db, params));
 registerHandler('graph.context', async (params, db) => graphContext(db, params));
 
 registerHandler('graph.addEpisode', async (params, db, ctx) =>
-  graphAddEpisode(db, params, resolveGraphSiteId(params, ctx)),
+  graphAddEpisode(db, params, await ensureGraphSiteId(db, resolveGraphSiteId(params, ctx))),
 );
 
 registerHandler('graph.outbox.push', async (_params, db) => graphOutboxPush(db));
+
+registerHandler('graph.sync.pull', async (params, db) => graphSyncPull(db, params));

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -146,6 +146,7 @@ const EXEMPT_METHODS = new Set([
   'graph.at',
   'graph.context',
   'graph.addEpisode',
+  // graph.sync.pull / graph.outbox.push contact the hub — Pro floor.
 ]);
 
 /**
@@ -183,7 +184,7 @@ export const METHOD_MIN_TIER = new Map<string, LicenseTier>([
  */
 export const LICENSE_TIER_HELP = `License tiers (method gate; source: EXEMPT_METHODS + METHOD_MIN_TIER):
   free         Sessions, single-repo file/git, local inference run, harness.health, graph.* replica (except outbox.push)
-  pro          Multi-agent coordination (mail, tasks, files.*, goal.*, agent.*, merge.*, worktree, events, harness.prune, graph.outbox.push, …)
+  pro          Multi-agent coordination (mail, tasks, files.*, goal.*, agent.*, merge.*, worktree, events, harness.prune, graph.outbox.push, graph.sync.pull, …)
   max          + full AI memory (memory.*) and local-model management (inference.pull/delete/start/stop)
   enterprise   Same method surface as max; commercial terms differ (founder daily-driver JWT for goal spine)`;
 

--- a/packages/daemon/src/migrations/0015-graph-sync-site.ts
+++ b/packages/daemon/src/migrations/0015-graph-sync-site.ts
@@ -1,0 +1,28 @@
+/**
+ * Migration 0015 — durable graph site id + Electric shape cursors (GAP-349 P5b).
+ *
+ * Spec §8.2: each replica gets a durable siteId (not only hostname/env),
+ * and down-sync remembers Electric handle/offset for anti-entropy resume.
+ * Singleton graph_site is one row per daemon, not per agent_identity.
+ */
+
+import type { Migration } from '../storage/migrate.js';
+
+export const MIGRATION_0015: Migration = {
+  version: 15,
+  name: 'graph-sync-site',
+  sql: `
+    CREATE TABLE IF NOT EXISTS graph_site (
+      singleton TEXT PRIMARY KEY CHECK (singleton = 'local'),
+      site_id TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE TABLE IF NOT EXISTS kg_shape_cursors (
+      table_name TEXT PRIMARY KEY,
+      handle TEXT,
+      shape_offset TEXT NOT NULL DEFAULT '-1',
+      last_pulled_at TIMESTAMPTZ,
+      last_error TEXT
+    );
+  `,
+};

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -30,6 +30,7 @@ import { MIGRATION_0011 } from './0011-spawned-agent-identity.js';
 import { MIGRATION_0012 } from './0012-session-fidelity-snapshots.js';
 import { MIGRATION_0013 } from './0013-goals.js';
 import { MIGRATION_0014 } from './0014-knowledge-graph-replica.js';
+import { MIGRATION_0015 } from './0015-graph-sync-site.js';
 
 export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0001,
@@ -46,4 +47,5 @@ export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0012,
   MIGRATION_0013,
   MIGRATION_0014,
+  MIGRATION_0015,
 ];

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -163,6 +163,7 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['graph.context', 'routine'],
   ['graph.addEpisode', 'routine'],
   ['graph.outbox.push', 'consequential'],
+  ['graph.sync.pull', 'consequential'],
   // Inner tools of skills.invoke (not standalone RPCs). Bash is a shell, so
   // critical: auto mode still requires approval (policy floor). Reads stay routine.
   ['skills.tool.Read', 'routine'],

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -556,6 +556,13 @@ export const schemas: Record<string, z.ZodType> = {
     })
     .passthrough(),
   'graph.outbox.push': z.object({ actorAgentId }).passthrough(),
+  'graph.sync.pull': z
+    .object({
+      repos: z.array(z.string().max(128)).max(32).optional(),
+      scope: z.enum(['all']).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
 
   // -- Health -----------------------------------------------------------------
   // Both handlers (`server.ts:registerHandler('harness.health', ...)` and

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -182,4 +182,5 @@ export const RPC_METHODS = {
   'graph.context': 'graph.context',
   'graph.addEpisode': 'graph.addEpisode',
   'graph.outbox.push': 'graph.outbox.push',
+  'graph.sync.pull': 'graph.sync.pull',
 } as const;


### PR DESCRIPTION
## Closes

Partial GAP-349 P5 (spec §8.2 remainder). Does not close the gap.

## Summary

P5a (`revdev#428`) shipped the PGlite replica and outbox-up. This adds the down direction:

- `graph.sync.pull` — Electric shapes for `kg_nodes` / `kg_edges` (repo-scoped), then hub SQL anti-entropy snapshot for episodes, edges, aliases.
- Electric delete ops are skipped (invalidate-not-delete).
- Durable `graph_site` singleton (migration 0015). `REVDEV_KG_SITE_ID` / hostname only seed the first row.
- Hub contact is Pro-floor (`graph.outbox.push` / `graph.sync.pull`). Local replica reads stay free.

## Tests

`pnpm --filter @revdev/protocol build && pnpm --filter @revdev/daemon exec vitest run src/__tests__/graph.test.ts src/__tests__/graph-sync.test.ts src/__tests__/rpc-contract.test.ts src/__tests__/permission.test.ts`

## Not in this PR

- `kg_communities` + LLM summaries
- Layer-3 `shared_facts` reconcile loop
- Owner `revkg scan --fleet`

## Peers

Stay off `packages/daemon/src/graph.ts` and `graph-sync.ts` until this lands.