### PR TITLE
feat(studio): 0.2.12 daily-driver plus dogfood Phase 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,30 @@ Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
 
+## [0.2.12] — 2026-08-29
+
 ### Security
 
 - Bump Studio `jsonwebtoken` 9.3.1 → 10.4.0 (GHSA-h395-gr6q-cpjc / CVE-2026-25537).
+
+### Fixed
+
+- **Complete Setup is reachable.** The wizard no longer waits for WSL + Nix +
+  DevPod + git identity before Complete. Linux/macOS `check_setup` never
+  reports those as green, so a Tauri daily-driver could only Skip (session
+  dismiss) and never persist into a real session. Complete still calls
+  `daemon_setup` (real IPC in Tauri; Vite `MOCK_DATA` stays browser-only).
+- **Agent connect no longer dumps to Setup.** Pipe EOF / spawn failures used
+  to say the daemon was down and send the operator back to Setup. Connect
+  Agent restages the relay and retries.
+
+### Changed
+
+- Studio-dogfood Phase 4: shadow `components/ui` lives under
+  `components/adapters` with a Studio-only Biome `noRestrictedImports` ban
+  ([#347](https://github.com/RevealUIStudio/revdev/pull/347)).
+
+[0.2.12]: https://github.com/RevealUIStudio/revdev/releases/tag/studio-v0.2.12
 
 ## [0.2.11] — 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Pre-1.0 across the board:
 
 | Component | Status | How to use it today |
 |---|---|---|
-| **Studio** | Buildable, unsigned | Local: `pnpm --filter studio tauri build`. Public GitHub Releases are live — latest `studio-v0.2.11` (2026-08-16; macOS · Linux · Windows). Tag pipeline: `.github/workflows/studio-release.yml`. macOS/Windows OS code-signing is still unsigned/ad-hoc (Tauri updater `.sig` files are not Apple/Microsoft signatures). Dogfooding `@revealui/presentation` Phase 1+2 done; Phase 3+4 in flight. |
+| **Studio** | Buildable, unsigned | Local: `pnpm --filter studio tauri build`. Public GitHub Releases are live — latest `studio-v0.2.11` (2026-08-16; macOS · Linux · Windows). `test` is at untagged 0.2.12 (tag waits for the operator). Tag pipeline: `.github/workflows/studio-release.yml`. macOS/Windows OS code-signing is still unsigned/ad-hoc (Tauri updater `.sig` files are not Apple/Microsoft signatures). Dogfooding `@revealui/presentation` Phase 1+2+4 done; Phase 3 residual `orange-*` sweep still open. |
 | **Console** | Buildable | `cd apps/console && go build -o ../../rvui .`. Tag pipeline: `.github/workflows/console-release.yml`. Public tag `console-v0.2.0` (2026-07-17). |
 | **Harness Daemon** | Buildable, not published | Build with `pnpm --filter @revdev/daemon build`. `node packages/daemon/dist/cli.js --detach` returns in <1s; child runs in its own session and PGID. Boot survival via `pnpm --filter @revdev/daemon setup:systemd` (systemd-user unit; requires `loginctl enable-linger` on WSL). |
 

--- a/apps/studio/src/__tests__/components/SetupWizard.test.tsx
+++ b/apps/studio/src/__tests__/components/SetupWizard.test.tsx
@@ -83,13 +83,38 @@ describe('SetupWizard', () => {
 
   it('enables Complete Setup when all checks pass', () => {
     renderWizard();
-    const completeButton = screen.getByText('Complete Setup').closest('button');
-    expect(completeButton).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Complete Setup' })).not.toBeDisabled();
+  });
+
+  it('enables Complete Setup when environment checks are still incomplete', () => {
+    vi.mocked(useSetup).mockReturnValueOnce({
+      status: {
+        wsl_running: false,
+        nix_installed: false,
+        devbox_mounted: false,
+        git_name: '',
+        git_email: '',
+      },
+      loading: false,
+      error: null,
+      gitName: '',
+      gitEmail: '',
+      saving: false,
+      mounting: false,
+      refresh: vi.fn(),
+      saveGitIdentity: vi.fn(),
+      doMount: vi.fn(),
+      setGitName: vi.fn(),
+      setGitEmail: vi.fn(),
+    } as unknown as ReturnType<typeof useSetup>);
+
+    renderWizard();
+    expect(screen.getByRole('button', { name: 'Complete Setup' })).not.toBeDisabled();
   });
 
   it('completing setup installs the WSL relay then marks complete', async () => {
     const { onComplete, onDismiss } = renderWizard();
-    fireEvent.click(screen.getByText('Complete Setup'));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete Setup' }));
     await waitFor(() => {
       expect(daemonSetup).toHaveBeenCalledTimes(1);
       expect(markSetupComplete).toHaveBeenCalled();
@@ -98,10 +123,41 @@ describe('SetupWizard', () => {
     expect(onDismiss).not.toHaveBeenCalled();
   });
 
+  it('completing with incomplete checks still provisions then marks complete', async () => {
+    vi.mocked(useSetup).mockReturnValueOnce({
+      status: {
+        wsl_running: false,
+        nix_installed: false,
+        devbox_mounted: false,
+        git_name: '',
+        git_email: '',
+      },
+      loading: false,
+      error: null,
+      gitName: '',
+      gitEmail: '',
+      saving: false,
+      mounting: false,
+      refresh: vi.fn(),
+      saveGitIdentity: vi.fn(),
+      doMount: vi.fn(),
+      setGitName: vi.fn(),
+      setGitEmail: vi.fn(),
+    } as unknown as ReturnType<typeof useSetup>);
+
+    const { onComplete } = renderWizard();
+    fireEvent.click(screen.getByRole('button', { name: 'Complete Setup' }));
+    await waitFor(() => {
+      expect(daemonSetup).toHaveBeenCalledTimes(1);
+      expect(markSetupComplete).toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('does not mark complete when relay install fails', async () => {
     vi.mocked(daemonSetup).mockRejectedValueOnce(new Error('wslpath failed'));
     const { onComplete } = renderWizard();
-    fireEvent.click(screen.getByText('Complete Setup'));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete Setup' }));
     expect(await screen.findByText('wslpath failed')).toBeInTheDocument();
     expect(markSetupComplete).not.toHaveBeenCalled();
     expect(onComplete).not.toHaveBeenCalled();

--- a/apps/studio/src/__tests__/lib/invoke.test.ts
+++ b/apps/studio/src/__tests__/lib/invoke.test.ts
@@ -99,6 +99,12 @@ describe('invoke bridge (browser mode)', () => {
     expect(result).toHaveProperty('git_email');
   });
 
+  it('daemonSetup returns mock string in browser mode', async () => {
+    const { daemonSetup } = await import('../../lib/invoke');
+    const result = await daemonSetup();
+    expect(typeof result).toBe('string');
+  });
+
   it('setGitIdentity resolves void', async () => {
     const { setGitIdentity } = await import('../../lib/invoke');
     await expect(setGitIdentity('Test', 'test@example.com')).resolves.toBeUndefined();

--- a/apps/studio/src/components/setup/SetupWizard.tsx
+++ b/apps/studio/src/components/setup/SetupWizard.tsx
@@ -27,6 +27,9 @@ export default function SetupWizard({ onComplete, onDismiss }: SetupWizardProps)
   const [provisioning, setProvisioning] = useState(false);
   const [provisionError, setProvisionError] = useState<string | null>(null);
 
+  // Checklist rows are environment hints, not a gate. Linux/macOS check_setup
+  // never reports wsl_running or a mounted Studio drive, so requiring allDone
+  // made Complete Setup unreachable on a Tauri daily-driver.
   const allDone =
     setup.status?.wsl_running &&
     setup.status?.nix_installed &&
@@ -74,7 +77,7 @@ export default function SetupWizard({ onComplete, onDismiss }: SetupWizardProps)
               variant="primary"
               size="lg"
               onClick={handleComplete}
-              disabled={!allDone || provisioning}
+              disabled={provisioning}
               loading={provisioning}
             >
               Complete Setup
@@ -84,9 +87,10 @@ export default function SetupWizard({ onComplete, onDismiss }: SetupWizardProps)
       >
         <div className="space-y-4">
           <p className="text-sm leading-relaxed text-fg-muted">
-            This checklist sets up WSL, Nix, DevPod, and git identity. Completing Setup installs the
-            agent relay in WSL. Skip hides the wizard for this launch. Agent Approvals live under
-            Agent in the sidebar.
+            Completing Setup installs the agent relay (no-op on native Unix) and continues into
+            Studio. WSL, Nix, DevPod, and git identity are optional checks — they do not block
+            Complete. Skip hides the wizard for this launch. Agent Approvals live under Agent in the
+            sidebar.
           </p>
           {setup.loading && !setup.status && (
             <p className="text-sm text-fg-muted">Checking environment...</p>

--- a/apps/studio/src/lib/invoke.ts
+++ b/apps/studio/src/lib/invoke.ts
@@ -135,6 +135,7 @@ const MOCK_DATA: Record<string, unknown> = {
   // Void / string commands return simple defaults
   mount_devbox: 'Mounted (mock)',
   unmount_devbox: 'Unmounted (mock)',
+  daemon_setup: 'Relay installed (mock)',
   start_app: 'Started (mock)',
   stop_app: 'Stopped (mock)',
   ssh_connect: 'mock-session-id',

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -107,14 +107,14 @@ Phases 0–4 are shipped: best-effort daemon→Neon dual-write for sessions/mail
 
 ### W4 — Studio dogfood: adopt `@revealui/presentation`
 
-Phase 1 (token foundation) shipped 2026-05-16 via [#67](https://github.com/RevealUIStudio/revdev/pull/67)/[#68](https://github.com/RevealUIStudio/revdev/pull/68). Phase 2 shims landed on `test` (PR series through [#297](https://github.com/RevealUIStudio/revdev/pull/297)): shadow `components/ui/*` are thin wrappers over `@revealui/presentation` ^0.9.1 (StatusDot, PanelHeader, Tooltip, ErrorAlert, Badge, Button, Card, Input, Dialog, Modal; ConfirmDialog is Studio-local).
+Phase 1 (token foundation) shipped 2026-05-16 via [#67](https://github.com/RevealUIStudio/revdev/pull/67)/[#68](https://github.com/RevealUIStudio/revdev/pull/68). Phase 2 shims landed on `test` (PR series through [#297](https://github.com/RevealUIStudio/revdev/pull/297)). Phase 4 relocated those wrappers to `src/components/adapters/` and banned `components/ui` via Studio-only Biome `noRestrictedImports` ([#347](https://github.com/RevealUIStudio/revdev/pull/347)): StatusDot, PanelHeader, Tooltip, ErrorAlert, Badge, Button, Card, Input, Dialog, Modal; ConfirmDialog stays a Studio composition over Modal.
 
 | Phase | Scope | Status |
 |---|---|---|
 | 1 | Token foundation (`tokens.css`) | ✅ **SHIPPED** |
 | 2 | Shim shadow primitives over `@revealui/presentation` | ✅ **SHIPPED** (2026-07) |
 | 3 | Sweep residual `orange-*` in render code (tip: terminal cursor only) to semantic tokens | **OPEN** (small) |
-| 4 | Delete the shadow library + Biome `noRestrictedImports` guard | **OPEN** (after Phase 3) |
+| 4 | Relocate shadow library to `components/adapters` + Biome `noRestrictedImports` guard | ✅ **SHIPPED** ([#347](https://github.com/RevealUIStudio/revdev/pull/347)) |
 
 Carve-outs that stay: `codemirror`/`@codemirror/*` (editor) and `@xterm/*` (terminal). Operational sequencing: internal `studio-dogfood` lane (membership under frontend-excellence initiative for brand; daily-driver program does not dual-claim the lane).
 


### PR DESCRIPTION
## Summary

Studio 0.2.12 daily-driver on `test` only. No tag. No promote.

1. **Dogfood Phase 4** — `apps/studio/src/components/ui/` is already gone on `test` ([#347](https://github.com/RevealUIStudio/revdev/pull/347), 2026-08-02). Wrappers live in `components/adapters/`. ConfirmDialog stays a Studio composition over Modal. The Studio-only Biome `noRestrictedImports` ban is already in `biome.json`. This PR does not invent a second move; it updates PLAN/README so they stop saying Phase 3+4 are in flight. Phase 3 residual `orange-*` sweep stays open. Adapter layer is not deleted.

2. **Fake Setup dead-end** — Complete Setup was `disabled={!allDone}` where `allDone` required WSL + Nix + DevPod + git identity. Linux/macOS `check_setup` never reports `wsl_running` or a mounted Studio drive, and browser `MOCK_DATA.check_setup` has `devbox_mounted: false`, so Complete was unreachable. Skip only hid the wizard for that launch, so a Tauri daily-driver never persisted `setupComplete` into a real session. Complete is now reachable, still calls `daemon_setup`, and still does not mark complete when relay install fails. Vite `MOCK_DATA.daemon_setup` is browser-only (`!isTauri()`).

3. **Version honesty** — `package.json` / `tauri.conf.json` / `Cargo.toml` were already 0.2.12 untagged. CHANGELOG `[Unreleased]` (jsonwebtoken CVE) is now `[0.2.12] — 2026-08-29`, plus the Setup fix and the Agent-connect dump already on `test` via #427.

## Do not

- Tag `studio-v0.2.12` or cut a GitHub Release
- Promote to `main`
- OS-sign (H7/H8)
- Flip GAP-294 off shadow
- Rename the app/repo to RevDev
- Touch revealui, agency, revealui-jv, or `/home/joshua-v-dev/revfleet/.jv`

## Test plan

- [x] `pnpm --filter studio exec vitest run src/__tests__/components/SetupWizard.test.tsx src/__tests__/lib/invoke.test.ts` (54 passed)
- [x] `biome check` on the touched Studio files
- [ ] CI on this PR
