### PR TITLE
feat(daemon): GAP-349 P5 leftover kg_communities and Layer-3 reconcile

### DIFF
--- a/packages/daemon/src/__tests__/graph-communities.test.ts
+++ b/packages/daemon/src/__tests__/graph-communities.test.ts
@@ -7,12 +7,8 @@
 
 import { PGlite } from '@electric-sql/pglite';
 import { afterEach, describe, expect, it } from 'vitest';
-import {
-  communityIdFor,
-  connectedComponents,
-  graphCommunities,
-} from '../graph-communities.js';
 import { graphAddEpisode } from '../graph.js';
+import { communityIdFor, connectedComponents, graphCommunities } from '../graph-communities.js';
 import { migrate } from '../storage/migrate.js';
 
 const DB_TEST_TIMEOUT = 60_000;
@@ -98,7 +94,10 @@ describe('kg_communities (GAP-349 P5 leftover)', () => {
         { refresh: true },
         {
           complete: async () =>
-            JSON.stringify({ name: 'Electric proxy', summary: 'Retry policy for the Electric proxy.' }),
+            JSON.stringify({
+              name: 'Electric proxy',
+              summary: 'Retry policy for the Electric proxy.',
+            }),
         },
       );
       expect(first.computed).toBe(true);
@@ -117,7 +116,9 @@ describe('kg_communities (GAP-349 P5 leftover)', () => {
       const refreshed = await graphCommunities(
         db,
         { refresh: true },
-        { complete: async () => JSON.stringify({ name: 'Proxy cluster', summary: 'Second pass.' }) },
+        {
+          complete: async () => JSON.stringify({ name: 'Proxy cluster', summary: 'Second pass.' }),
+        },
       );
       expect(refreshed.computed).toBe(true);
       expect(refreshed.invalidated).toBeGreaterThan(0);

--- a/packages/daemon/src/__tests__/graph-communities.test.ts
+++ b/packages/daemon/src/__tests__/graph-communities.test.ts
@@ -1,0 +1,160 @@
+/**
+ * GAP-349 P5 leftover — kg_communities clustering + LLM summaries.
+ *
+ * Connected components are deterministic. Summaries use an injected completer
+ * (`@revealui/ai` in production). Refresh invalidates prior rows; never deletes.
+ */
+
+import { PGlite } from '@electric-sql/pglite';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  communityIdFor,
+  connectedComponents,
+  graphCommunities,
+} from '../graph-communities.js';
+import { graphAddEpisode } from '../graph.js';
+import { migrate } from '../storage/migrate.js';
+
+const DB_TEST_TIMEOUT = 60_000;
+
+async function boot(): Promise<PGlite> {
+  const db = new PGlite();
+  await migrate(db);
+  return db;
+}
+
+describe('connectedComponents', () => {
+  it('groups an edge pair and leaves an isolated node alone', () => {
+    const groups = connectedComponents(
+      ['a', 'b', 'c'],
+      [
+        { sourceId: 'a', targetId: 'b' },
+        { sourceId: 'b', targetId: 'a' },
+      ],
+    );
+    expect(groups[0]).toEqual(['a', 'b']);
+    expect(groups[1]).toEqual(['c']);
+  });
+
+  it('community ids are stable for the same member set', () => {
+    expect(communityIdFor(['n1', 'n2'])).toBe(communityIdFor(['n1', 'n2']));
+    expect(communityIdFor(['n1', 'n2'])).not.toBe(communityIdFor(['n1']));
+    expect(communityIdFor(['n1'], '2026-08-31T00:00:00.000Z')).not.toBe(communityIdFor(['n1']));
+  });
+});
+
+describe('kg_communities (GAP-349 P5 leftover)', () => {
+  let db: PGlite;
+
+  afterEach(async () => {
+    await db?.close().catch(() => {});
+  });
+
+  it(
+    'clusters connected nodes, writes LLM summaries, and invalidates on refresh',
+    async () => {
+      db = await boot();
+      await graphAddEpisode(
+        db,
+        {
+          episodeType: 'agent-fact',
+          source: 'test',
+          content: 'proxy retries on 5xx',
+          nodes: [
+            {
+              kind: 'file',
+              name: 'electric-proxy.ts',
+              naturalKey: 'revealui/apps/admin/src/lib/api/electric-proxy.ts',
+              repo: 'revealui',
+            },
+            {
+              kind: 'concept',
+              name: 'Electric proxy retry',
+              naturalKey: 'concept:electric-proxy-retry',
+            },
+            {
+              kind: 'concept',
+              name: 'Unrelated isolated',
+              naturalKey: 'concept:isolated',
+            },
+          ],
+          edges: [
+            {
+              source: { kind: 'concept', naturalKey: 'concept:electric-proxy-retry' },
+              target: {
+                kind: 'file',
+                naturalKey: 'revealui/apps/admin/src/lib/api/electric-proxy.ts',
+              },
+              relation: 'documents',
+              fact: 'electric-proxy.ts retries with exponential backoff on 5xx',
+            },
+          ],
+        },
+        'test-site',
+      );
+
+      const first = await graphCommunities(
+        db,
+        { refresh: true },
+        {
+          complete: async () =>
+            JSON.stringify({ name: 'Electric proxy', summary: 'Retry policy for the Electric proxy.' }),
+        },
+      );
+      expect(first.computed).toBe(true);
+      expect(first.llm).toBe(true);
+      expect(first.communities.length).toBeGreaterThanOrEqual(2);
+      const named = first.communities.find((c) => c.name === 'Electric proxy');
+      expect(named?.summary).toContain('Retry policy');
+      expect(named?.nodeCount).toBeGreaterThanOrEqual(2);
+
+      const cached = await graphCommunities(db, {});
+      expect(cached.computed).toBe(false);
+      expect(cached.communities.map((c) => c.id).sort()).toEqual(
+        first.communities.map((c) => c.id).sort(),
+      );
+
+      const refreshed = await graphCommunities(
+        db,
+        { refresh: true },
+        { complete: async () => JSON.stringify({ name: 'Proxy cluster', summary: 'Second pass.' }) },
+      );
+      expect(refreshed.computed).toBe(true);
+      expect(refreshed.invalidated).toBeGreaterThan(0);
+
+      const current = await db.query<{ n: number }>(
+        `SELECT count(*)::int AS n FROM kg_communities WHERE invalidated_at IS NULL`,
+      );
+      const all = await db.query<{ n: number }>(`SELECT count(*)::int AS n FROM kg_communities`);
+      expect(current.rows[0]?.n).toBe(refreshed.communities.length);
+      expect(all.rows[0]?.n).toBeGreaterThan(current.rows[0]?.n ?? 0);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'falls back to a template summary when the completer fails',
+    async () => {
+      db = await boot();
+      await graphAddEpisode(
+        db,
+        {
+          episodeType: 'manual',
+          source: 'test',
+          content: 'solo node',
+          nodes: [{ kind: 'concept', name: 'Solo', naturalKey: 'concept:solo' }],
+        },
+        'test-site',
+      );
+      const result = await graphCommunities(
+        db,
+        { refresh: true },
+        { complete: async () => 'not-json' },
+      );
+      expect(result.computed).toBe(true);
+      expect(result.llm).toBe(false);
+      expect(result.communities[0]?.name).toContain('Solo');
+    },
+    DB_TEST_TIMEOUT,
+  );
+});

--- a/packages/daemon/src/__tests__/graph-reconcile.test.ts
+++ b/packages/daemon/src/__tests__/graph-reconcile.test.ts
@@ -1,0 +1,193 @@
+/**
+ * GAP-349 P5 leftover — Layer-3 shared_facts → kg episodes.
+ *
+ * Injected fact source (no hub). Heuristic reconcile is the production path.
+ * Superseded facts invalidate edges; rows are never deleted. Re-runs skip
+ * already-ingested sources.
+ */
+
+import { PGlite } from '@electric-sql/pglite';
+import { afterEach, describe, expect, it } from 'vitest';
+import { graphAddEpisode } from '../graph.js';
+import {
+  graphReconcile,
+  invalidateEdgesForEpisodeSource,
+  reconcileHeuristicLocal,
+  type SharedFactRow,
+} from '../graph-reconcile.js';
+import { migrate } from '../storage/migrate.js';
+
+const DB_TEST_TIMEOUT = 60_000;
+
+async function boot(): Promise<PGlite> {
+  const db = new PGlite();
+  await migrate(db);
+  return db;
+}
+
+const FACT_A: SharedFactRow = {
+  id: 'fact-a',
+  agentId: 'agent-1',
+  content: 'electric proxy retries on 5xx',
+  factType: 'discovery',
+  confidence: 0.9,
+  tags: ['kg'],
+  createdAt: '2026-08-30T00:00:00.000Z',
+  sessionId: 'sess-1',
+};
+
+const FACT_A_DUP: SharedFactRow = {
+  id: 'fact-a-dup',
+  agentId: 'agent-2',
+  content: 'Electric proxy retries on 5xx',
+  factType: 'discovery',
+  confidence: 0.8,
+  tags: ['kg'],
+  createdAt: '2026-08-30T00:01:00.000Z',
+  sessionId: 'sess-1',
+};
+
+describe('reconcileHeuristicLocal', () => {
+  it('collapses case-insensitive duplicate content', () => {
+    const result = reconcileHeuristicLocal([FACT_A, FACT_A_DUP]);
+    expect(result.canonicalFacts).toHaveLength(1);
+    expect(result.duplicates).toEqual([['fact-a', 'fact-a-dup']]);
+    expect(result.canonicalFacts[0]?.sourceFactIds).toEqual(['fact-a', 'fact-a-dup']);
+  });
+});
+
+describe('Layer-3 shared_facts reconcile (GAP-349 P5 leftover)', () => {
+  let db: PGlite;
+
+  afterEach(async () => {
+    await db?.close().catch(() => {});
+    delete process.env.POSTGRES_URL;
+    delete process.env.DATABASE_URL;
+  });
+
+  it(
+    'no-ops without a hub or injected source instead of inventing a store',
+    async () => {
+      db = await boot();
+      const result = await graphReconcile(db, {});
+      expect(result.hub).toBe(false);
+      expect(result.ingested).toBe(0);
+      expect(result.reason).toMatch(/no POSTGRES_URL/);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'ingests Layer-3 canonical facts as kg episodes and skips on re-run',
+    async () => {
+      db = await boot();
+      const first = await graphReconcile(
+        db,
+        { sessionId: 'sess-1' },
+        { fetchFacts: async () => [FACT_A, FACT_A_DUP] },
+      );
+      expect(first.hub).toBe(true);
+      expect(first.fetched).toBe(2);
+      expect(first.ingested).toBe(1);
+      expect(first.skipped).toBe(0);
+
+      const episodes = await db.query<{ source: string; content: string }>(
+        `SELECT source, content FROM kg_episodes`,
+      );
+      expect(episodes.rows).toHaveLength(1);
+      expect(episodes.rows[0]?.source).toBe('shared_facts:fact-a+fact-a-dup');
+      expect(episodes.rows[0]?.content).toMatch(/electric proxy retries/i);
+
+      const nodes = await db.query<{ natural_key: string }>(
+        `SELECT natural_key FROM kg_nodes WHERE kind = 'concept'`,
+      );
+      expect(nodes.rows.some((n) => n.natural_key.startsWith('shared-fact:'))).toBe(true);
+
+      const second = await graphReconcile(
+        db,
+        {},
+        { fetchFacts: async () => [FACT_A, FACT_A_DUP] },
+      );
+      expect(second.ingested).toBe(0);
+      expect(second.skipped).toBe(1);
+      const again = await db.query<{ n: number }>(`SELECT count(*)::int AS n FROM kg_episodes`);
+      expect(again.rows[0]?.n).toBe(1);
+    },
+    DB_TEST_TIMEOUT,
+  );
+
+  it(
+    'invalidates edges for superseded facts and never deletes them',
+    async () => {
+      db = await boot();
+      await graphAddEpisode(
+        db,
+        {
+          episodeType: 'memory',
+          source: 'shared_facts:old-fact',
+          content: 'old claim',
+          nodes: [
+            { kind: 'concept', name: 'Old', naturalKey: 'concept:old-claim' },
+            { kind: 'file', name: 'proxy.ts', naturalKey: 'repo/proxy.ts', repo: 'revdev' },
+          ],
+          edges: [
+            {
+              source: { kind: 'concept', naturalKey: 'concept:old-claim' },
+              target: { kind: 'file', naturalKey: 'repo/proxy.ts' },
+              relation: 'mentions',
+              fact: 'old claim about proxy.ts',
+            },
+          ],
+        },
+        'test-site',
+      );
+      const before = await db.query<{ id: string; invalid_at: string | null }>(
+        `SELECT id, invalid_at FROM kg_edges`,
+      );
+      expect(before.rows).toHaveLength(1);
+      expect(before.rows[0]?.invalid_at).toBeNull();
+
+      const invalidated = await invalidateEdgesForEpisodeSource(db, 'shared_facts:old-fact');
+      expect(invalidated).toBe(1);
+      const after = await db.query<{ id: string; invalid_at: string | null }>(
+        `SELECT id, invalid_at FROM kg_edges`,
+      );
+      expect(after.rows).toHaveLength(1);
+      expect(after.rows[0]?.invalid_at).not.toBeNull();
+      expect(after.rows[0]?.id).toBe(before.rows[0]?.id);
+
+      const result = await graphReconcile(
+        db,
+        {},
+        {
+          fetchFacts: async () => [
+            {
+              id: 'old-fact',
+              agentId: 'agent-1',
+              content: 'old claim',
+              factType: 'discovery',
+              confidence: 0.4,
+              tags: [],
+              supersededBy: 'new-fact',
+              createdAt: '2026-08-30T02:00:00.000Z',
+            },
+            {
+              id: 'new-fact',
+              agentId: 'agent-1',
+              content: 'updated claim',
+              factType: 'discovery',
+              confidence: 0.95,
+              tags: [],
+              createdAt: '2026-08-30T02:01:00.000Z',
+            },
+          ],
+        },
+      );
+      expect(result.invalidatedEdges).toBe(0);
+      expect(result.ingested).toBe(1);
+      const edgesStill = await db.query<{ n: number }>(`SELECT count(*)::int AS n FROM kg_edges`);
+      expect(edgesStill.rows[0]?.n).toBe(1);
+    },
+    DB_TEST_TIMEOUT,
+  );
+});

--- a/packages/daemon/src/__tests__/graph-reconcile.test.ts
+++ b/packages/daemon/src/__tests__/graph-reconcile.test.ts
@@ -103,11 +103,7 @@ describe('Layer-3 shared_facts reconcile (GAP-349 P5 leftover)', () => {
       );
       expect(nodes.rows.some((n) => n.natural_key.startsWith('shared-fact:'))).toBe(true);
 
-      const second = await graphReconcile(
-        db,
-        {},
-        { fetchFacts: async () => [FACT_A, FACT_A_DUP] },
-      );
+      const second = await graphReconcile(db, {}, { fetchFacts: async () => [FACT_A, FACT_A_DUP] });
       expect(second.ingested).toBe(0);
       expect(second.skipped).toBe(1);
       const again = await db.query<{ n: number }>(`SELECT count(*)::int AS n FROM kg_episodes`);

--- a/packages/daemon/src/__tests__/graph.test.ts
+++ b/packages/daemon/src/__tests__/graph.test.ts
@@ -39,20 +39,22 @@ describe('knowledge-graph replica (GAP-349 P5)', () => {
     'migration 0014 creates kg_* tables on a full migrate()',
     async () => {
       db = await boot();
-      expect(MIGRATIONS.at(-1)?.version).toBe(15);
-      expect(MIGRATIONS.at(-1)?.name).toBe('graph-sync-site');
+      expect(MIGRATIONS.at(-1)?.version).toBe(16);
+      expect(MIGRATIONS.at(-1)?.name).toBe('graph-communities');
       const tables = await db.query<{ table_name: string }>(
         `SELECT table_name FROM information_schema.tables
          WHERE table_schema = 'public' AND table_name LIKE 'kg_%'
          ORDER BY table_name`,
       );
       expect(tables.rows.map((r) => r.table_name)).toEqual([
+        'kg_communities',
         'kg_edge_episodes',
         'kg_edges',
         'kg_episodes',
         'kg_node_aliases',
         'kg_nodes',
         'kg_outbox',
+        'kg_reconcile_cursor',
         'kg_shape_cursors',
       ]);
       const meta = await db.query<{ table_name: string }>(

--- a/packages/daemon/src/graph-communities.ts
+++ b/packages/daemon/src/graph-communities.ts
@@ -1,0 +1,335 @@
+/**
+ * GAP-349 P5 leftover — kg_communities (connected-component clusters + LLM summaries).
+ *
+ * Class-3 derived state: recomputed locally, never Electric-synced. Prior
+ * community rows are invalidated (invalidated_at), never deleted.
+ *
+ * Clustering is deterministic union-find on the current graph. Summaries go
+ * through an injected completer; production wires `@revealui/ai` (no
+ * `@anthropic-ai/sdk`). Missing AI degrades to a template summary.
+ */
+
+import { createHash } from 'node:crypto';
+import type { PGlite } from '@electric-sql/pglite';
+import { makeExecutor } from '@revealui/knowledge-graph';
+import { createLogger } from '@revealui/utils/logger';
+
+const log = createLogger({ service: 'revdev-daemon-graph-communities' });
+
+const MAX_COMMUNITIES = 200;
+const MAX_SUMMARY_NODES = 24;
+const MAX_SUMMARY_FACTS = 40;
+
+export type CommunityCompleter = (prompt: string, userText: string) => Promise<string>;
+
+export interface GraphCommunity {
+  id: string;
+  name: string;
+  summary: string;
+  nodeIds: string[];
+  nodeCount: number;
+  algorithm: string;
+  computedAt: string;
+}
+
+export interface GraphCommunitiesResult {
+  communities: GraphCommunity[];
+  computed: boolean;
+  llm: boolean;
+  invalidated: number;
+}
+
+export interface GraphCommunitiesDeps {
+  complete?: CommunityCompleter;
+}
+
+export const COMMUNITY_SUMMARY_PROMPT = `You name and summarize a knowledge-graph community.
+Return ONLY valid JSON: { "name": string, "summary": string }
+Rules: name is 2-8 words; summary is 1-3 sentences; do not invent secrets.`;
+
+function kgExec(db: PGlite) {
+  return makeExecutor({
+    query: (text: string, params?: unknown[]) => db.query(text, params),
+  });
+}
+
+export function connectedComponents(
+  nodeIds: string[],
+  edges: Array<{ sourceId: string; targetId: string }>,
+): string[][] {
+  const parent = new Map<string, string>();
+  for (const id of nodeIds) parent.set(id, id);
+
+  const find = (id: string): string => {
+    let cur = parent.get(id) ?? id;
+    while (parent.get(cur) !== cur) {
+      const next = parent.get(cur) ?? cur;
+      parent.set(cur, parent.get(next) ?? next);
+      cur = next;
+    }
+    return cur;
+  };
+  const union = (a: string, b: string) => {
+    const pa = find(a);
+    const pb = find(b);
+    if (pa !== pb) parent.set(pa, pb);
+  };
+
+  for (const edge of edges) {
+    if (!parent.has(edge.sourceId) || !parent.has(edge.targetId)) continue;
+    union(edge.sourceId, edge.targetId);
+  }
+
+  const groups = new Map<string, string[]>();
+  for (const id of nodeIds) {
+    const root = find(id);
+    const list = groups.get(root) ?? [];
+    list.push(id);
+    groups.set(root, list);
+  }
+  return [...groups.values()]
+    .map((ids) => [...ids].sort())
+    .sort((a, b) => b.length - a.length || (a[0] ?? '').localeCompare(b[0] ?? ''));
+}
+
+export function communityIdFor(nodeIds: string[], computedAt?: string): string {
+  const hash = createHash('sha256').update(['community', ...nodeIds].join('\n')).digest('hex');
+  const stamp = computedAt ? `:${new Date(computedAt).getTime()}` : '';
+  return `community:${hash.slice(0, 32)}${stamp}`;
+}
+
+function templateSummary(
+  nodes: Array<{ name: string; kind: string; naturalKey: string }>,
+  facts: string[],
+): { name: string; summary: string } {
+  const labels = nodes.slice(0, 4).map((n) => n.name || n.naturalKey);
+  const name = labels.length > 0 ? labels.join(' / ') : 'empty community';
+  const factBit = facts[0] ? ` Leading fact: ${facts[0]}` : '';
+  return {
+    name: name.slice(0, 120),
+    summary: `${nodes.length} nodes (${nodes.map((n) => n.kind).join(', ') || 'none'}).${factBit}`,
+  };
+}
+
+function extractJsonObject(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('{')) return trimmed;
+  const start = trimmed.indexOf('{');
+  const end = trimmed.lastIndexOf('}');
+  if (start >= 0 && end > start) return trimmed.slice(start, end + 1);
+  return trimmed;
+}
+
+async function summarizeCommunity(
+  nodes: Array<{ name: string; kind: string; naturalKey: string }>,
+  facts: string[],
+  complete?: CommunityCompleter,
+): Promise<{ name: string; summary: string; llm: boolean }> {
+  const fallback = templateSummary(nodes, facts);
+  if (!complete) return { ...fallback, llm: false };
+  const userText = [
+    'Nodes:',
+    ...nodes.map((n) => `- [${n.kind}] ${n.name} (${n.naturalKey})`),
+    '',
+    'Facts:',
+    ...facts.map((f) => `- ${f}`),
+  ].join('\n');
+  try {
+    const raw = await complete(COMMUNITY_SUMMARY_PROMPT, userText);
+    const parsed = JSON.parse(extractJsonObject(raw)) as { name?: unknown; summary?: unknown };
+    const name = typeof parsed.name === 'string' && parsed.name.trim() ? parsed.name.trim() : fallback.name;
+    const summary =
+      typeof parsed.summary === 'string' && parsed.summary.trim() ? parsed.summary.trim() : fallback.summary;
+    return { name: name.slice(0, 200), summary: summary.slice(0, 4000), llm: true };
+  } catch (err) {
+    log.warn('community LLM summary fell back to template', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { ...fallback, llm: false };
+  }
+}
+
+export async function defaultCommunityCompleter(
+  prompt: string,
+  userText: string,
+): Promise<string> {
+  const { createLLMClientFromEnv } = (await import('@revealui/ai/llm/client')) as {
+    createLLMClientFromEnv: () => { chat: (messages: Array<{ role: string; content: string }>) => Promise<{ content: string }> };
+  };
+  const client = createLLMClientFromEnv();
+  const result = await client.chat([
+    { role: 'system', content: prompt },
+    { role: 'user', content: userText },
+  ]);
+  return result.content;
+}
+
+let cachedCompleter: CommunityCompleter | null | undefined;
+
+async function resolveCompleter(injected?: CommunityCompleter): Promise<CommunityCompleter | undefined> {
+  if (injected) return injected;
+  if (process.env.REVDEV_KG_COMMUNITY_LLM === '0') return undefined;
+  if (cachedCompleter !== undefined) return cachedCompleter ?? undefined;
+  try {
+    await import('@revealui/ai/llm/client');
+    cachedCompleter = defaultCommunityCompleter;
+    return cachedCompleter;
+  } catch {
+    cachedCompleter = null;
+    return undefined;
+  }
+}
+
+export async function listCommunities(db: PGlite, limit = 50): Promise<GraphCommunity[]> {
+  const exec = kgExec(db);
+  const rows = await exec.query<{
+    id: string;
+    name: string;
+    summary: string | null;
+    node_ids: unknown;
+    node_count: number;
+    algorithm: string;
+    computed_at: string;
+  }>(
+    `SELECT id, name, summary, node_ids, node_count, algorithm, computed_at
+     FROM kg_communities
+     WHERE invalidated_at IS NULL
+     ORDER BY node_count DESC, computed_at DESC
+     LIMIT $1`,
+    [limit],
+  );
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    summary: row.summary ?? '',
+    nodeIds: parseNodeIds(row.node_ids),
+    nodeCount: row.node_count,
+    algorithm: row.algorithm,
+    computedAt: row.computed_at,
+  }));
+}
+
+function parseNodeIds(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string');
+  if (typeof value === 'string' && value.length > 0) {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (Array.isArray(parsed)) return parsed.filter((v): v is string => typeof v === 'string');
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+export async function computeCommunities(
+  db: PGlite,
+  deps: GraphCommunitiesDeps = {},
+): Promise<{ communities: GraphCommunity[]; llm: boolean; invalidated: number }> {
+  const exec = kgExec(db);
+  const nodes = await exec.query<{
+    id: string;
+    kind: string;
+    name: string;
+    natural_key: string;
+  }>(
+    `SELECT id, kind, name, natural_key FROM kg_nodes WHERE deleted_at IS NULL`,
+  );
+  const edges = await exec.query<{ source_id: string; target_id: string; fact: string }>(
+    `SELECT source_id, target_id, fact FROM kg_edges
+     WHERE invalid_at IS NULL AND expired_at IS NULL`,
+  );
+
+  const clusters = connectedComponents(
+    nodes.map((n) => n.id),
+    edges.map((e) => ({ sourceId: e.source_id, targetId: e.target_id })),
+  ).slice(0, MAX_COMMUNITIES);
+
+  const nodeById = new Map(nodes.map((n) => [n.id, n]));
+  const factsByNode = new Map<string, string[]>();
+  for (const edge of edges) {
+    for (const id of [edge.source_id, edge.target_id]) {
+      const list = factsByNode.get(id) ?? [];
+      if (list.length < MAX_SUMMARY_FACTS) list.push(edge.fact);
+      factsByNode.set(id, list);
+    }
+  }
+
+  const complete = await resolveCompleter(deps.complete);
+  const computedAt = new Date().toISOString();
+  const communities: GraphCommunity[] = [];
+  let usedLlm = false;
+
+  for (const memberIds of clusters) {
+    const memberNodes = memberIds
+      .map((id) => nodeById.get(id))
+      .filter((n): n is (typeof nodes)[number] => n !== undefined)
+      .slice(0, MAX_SUMMARY_NODES);
+    const facts = [...new Set(memberIds.flatMap((id) => factsByNode.get(id) ?? []))].slice(
+      0,
+      MAX_SUMMARY_FACTS,
+    );
+    const labeled = await summarizeCommunity(
+      memberNodes.map((n) => ({ name: n.name, kind: n.kind, naturalKey: n.natural_key })),
+      facts,
+      complete,
+    );
+    if (labeled.llm) usedLlm = true;
+    communities.push({
+      id: communityIdFor(memberIds, computedAt),
+      name: labeled.name,
+      summary: labeled.summary,
+      nodeIds: memberIds,
+      nodeCount: memberIds.length,
+      algorithm: 'connected-components',
+      computedAt,
+    });
+  }
+
+  const prior = await exec.query<{ n: number }>(
+    `SELECT count(*)::int AS n FROM kg_communities WHERE invalidated_at IS NULL`,
+  );
+  await exec.query(`UPDATE kg_communities SET invalidated_at = $1::timestamptz WHERE invalidated_at IS NULL`, [
+    computedAt,
+  ]);
+
+  for (const community of communities) {
+    await exec.query(
+      `INSERT INTO kg_communities (id, name, summary, node_ids, node_count, algorithm, computed_at, invalidated_at)
+       VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7::timestamptz, NULL)
+       ON CONFLICT (id) DO NOTHING`,
+      [
+        community.id,
+        community.name,
+        community.summary,
+        JSON.stringify(community.nodeIds),
+        community.nodeCount,
+        community.algorithm,
+        community.computedAt,
+      ],
+    );
+  }
+
+  return { communities, llm: usedLlm, invalidated: prior[0]?.n ?? 0 };
+}
+
+export async function graphCommunities(
+  db: PGlite,
+  params: Record<string, unknown>,
+  deps: GraphCommunitiesDeps = {},
+): Promise<GraphCommunitiesResult> {
+  const limit =
+    typeof params.limit === 'number' ? Math.min(Math.max(1, params.limit), MAX_COMMUNITIES) : 50;
+  const refresh = params.refresh === true;
+  const existing = await listCommunities(db, limit);
+  if (!refresh && existing.length > 0) {
+    return { communities: existing, computed: false, llm: false, invalidated: 0 };
+  }
+  const computed = await computeCommunities(db, deps);
+  return {
+    communities: computed.communities.slice(0, limit),
+    computed: true,
+    llm: computed.llm,
+    invalidated: computed.invalidated,
+  };
+}

--- a/packages/daemon/src/graph-communities.ts
+++ b/packages/daemon/src/graph-communities.ts
@@ -93,7 +93,9 @@ export function connectedComponents(
 }
 
 export function communityIdFor(nodeIds: string[], computedAt?: string): string {
-  const hash = createHash('sha256').update(['community', ...nodeIds].join('\n')).digest('hex');
+  const hash = createHash('sha256')
+    .update(['community', ...nodeIds].join('\n'))
+    .digest('hex');
   const stamp = computedAt ? `:${new Date(computedAt).getTime()}` : '';
   return `community:${hash.slice(0, 32)}${stamp}`;
 }
@@ -137,9 +139,12 @@ async function summarizeCommunity(
   try {
     const raw = await complete(COMMUNITY_SUMMARY_PROMPT, userText);
     const parsed = JSON.parse(extractJsonObject(raw)) as { name?: unknown; summary?: unknown };
-    const name = typeof parsed.name === 'string' && parsed.name.trim() ? parsed.name.trim() : fallback.name;
+    const name =
+      typeof parsed.name === 'string' && parsed.name.trim() ? parsed.name.trim() : fallback.name;
     const summary =
-      typeof parsed.summary === 'string' && parsed.summary.trim() ? parsed.summary.trim() : fallback.summary;
+      typeof parsed.summary === 'string' && parsed.summary.trim()
+        ? parsed.summary.trim()
+        : fallback.summary;
     return { name: name.slice(0, 200), summary: summary.slice(0, 4000), llm: true };
   } catch (err) {
     log.warn('community LLM summary fell back to template', {
@@ -149,14 +154,17 @@ async function summarizeCommunity(
   }
 }
 
-export async function defaultCommunityCompleter(
-  prompt: string,
-  userText: string,
-): Promise<string> {
-  const { createLLMClientFromEnv } = (await import('@revealui/ai/llm/client')) as {
-    createLLMClientFromEnv: () => { chat: (messages: Array<{ role: string; content: string }>) => Promise<{ content: string }> };
+async function importAiSubpath(subpath: string): Promise<Record<string, unknown>> {
+  return (await import(`@revealui/ai/${subpath}`)) as Record<string, unknown>;
+}
+
+export async function defaultCommunityCompleter(prompt: string, userText: string): Promise<string> {
+  const mod = (await importAiSubpath('llm/client')) as {
+    createLLMClientFromEnv: () => {
+      chat: (messages: Array<{ role: string; content: string }>) => Promise<{ content: string }>;
+    };
   };
-  const client = createLLMClientFromEnv();
+  const client = mod.createLLMClientFromEnv();
   const result = await client.chat([
     { role: 'system', content: prompt },
     { role: 'user', content: userText },
@@ -166,12 +174,14 @@ export async function defaultCommunityCompleter(
 
 let cachedCompleter: CommunityCompleter | null | undefined;
 
-async function resolveCompleter(injected?: CommunityCompleter): Promise<CommunityCompleter | undefined> {
+async function resolveCompleter(
+  injected?: CommunityCompleter,
+): Promise<CommunityCompleter | undefined> {
   if (injected) return injected;
   if (process.env.REVDEV_KG_COMMUNITY_LLM === '0') return undefined;
   if (cachedCompleter !== undefined) return cachedCompleter ?? undefined;
   try {
-    await import('@revealui/ai/llm/client');
+    await importAiSubpath('llm/client');
     cachedCompleter = defaultCommunityCompleter;
     return cachedCompleter;
   } catch {
@@ -232,9 +242,7 @@ export async function computeCommunities(
     kind: string;
     name: string;
     natural_key: string;
-  }>(
-    `SELECT id, kind, name, natural_key FROM kg_nodes WHERE deleted_at IS NULL`,
-  );
+  }>(`SELECT id, kind, name, natural_key FROM kg_nodes WHERE deleted_at IS NULL`);
   const edges = await exec.query<{ source_id: string; target_id: string; fact: string }>(
     `SELECT source_id, target_id, fact FROM kg_edges
      WHERE invalid_at IS NULL AND expired_at IS NULL`,
@@ -289,9 +297,10 @@ export async function computeCommunities(
   const prior = await exec.query<{ n: number }>(
     `SELECT count(*)::int AS n FROM kg_communities WHERE invalidated_at IS NULL`,
   );
-  await exec.query(`UPDATE kg_communities SET invalidated_at = $1::timestamptz WHERE invalidated_at IS NULL`, [
-    computedAt,
-  ]);
+  await exec.query(
+    `UPDATE kg_communities SET invalidated_at = $1::timestamptz WHERE invalidated_at IS NULL`,
+    [computedAt],
+  );
 
   for (const community of communities) {
     await exec.query(

--- a/packages/daemon/src/graph-reconcile.ts
+++ b/packages/daemon/src/graph-reconcile.ts
@@ -126,6 +126,10 @@ export function reconcileHeuristicLocal(facts: SharedFactRow[]): ReconciliationR
   };
 }
 
+async function importAiSubpath(subpath: string): Promise<Record<string, unknown>> {
+  return (await import(`@revealui/ai/${subpath}`)) as Record<string, unknown>;
+}
+
 async function layer3Reconcile(
   facts: SharedFactRow[],
   deps: GraphReconcileDeps,
@@ -133,7 +137,7 @@ async function layer3Reconcile(
   if (deps.reconcile) return deps.reconcile(facts);
   if (deps.complete) {
     try {
-      const mod = (await import('@revealui/ai/memory/services')) as {
+      const mod = (await importAiSubpath('memory/services')) as {
         buildReconciliationPrompt: (facts: ReturnType<typeof asSharedFactInput>[]) => string;
         parseReconciliationResponse: (
           response: string,
@@ -150,7 +154,7 @@ async function layer3Reconcile(
     }
   }
   try {
-    const mod = (await import('@revealui/ai/memory/services')) as {
+    const mod = (await importAiSubpath('memory/services')) as {
       reconcileHeuristic: (facts: ReturnType<typeof asSharedFactInput>[]) => ReconciliationResult;
     };
     return mod.reconcileHeuristic(facts.map(asSharedFactInput));
@@ -339,7 +343,8 @@ export async function graphReconcile(
     invalidatedEdges += await invalidateEdgesForEpisodeSource(db, episodeSource([fact.id]));
   }
 
-  const reconciled = active.length > 0 ? await layer3Reconcile(active, deps) : reconcileHeuristicLocal([]);
+  const reconciled =
+    active.length > 0 ? await layer3Reconcile(active, deps) : reconcileHeuristicLocal([]);
   let ingested = 0;
   let skipped = 0;
 

--- a/packages/daemon/src/graph-reconcile.ts
+++ b/packages/daemon/src/graph-reconcile.ts
@@ -1,0 +1,453 @@
+/**
+ * GAP-349 P5 leftover — Layer-3 multi-agent-memory → kg episodes.
+ *
+ * Reads `shared_facts` (hub) or an injected fact source, runs Layer 3
+ * reconciliation (`@revealui/ai/memory` heuristic, optional LLM via
+ * `@revealui/ai`), and `ingestEpisode`s canonical facts. Superseded facts
+ * invalidate prior edges — never delete them.
+ *
+ * Scheduled from `onDaemonStarted`. Disabled when
+ * REVDEV_KG_RECONCILE_INTERVAL_MS=0 or when no hub/injected source exists.
+ * Does not fire a prod cron.
+ */
+
+import type { PGlite } from '@electric-sql/pglite';
+import { applyOp, ingestEpisode, makeExecutor, makePoolExecutor } from '@revealui/knowledge-graph';
+import { createLogger } from '@revealui/utils/logger';
+import { onDaemonStarted, onDaemonStopping } from './eviction.js';
+import { ensureGraphSiteId } from './graph-sync.js';
+import { resolvePostgresUrl } from './neon.js';
+
+const log = createLogger({ service: 'revdev-daemon-graph-reconcile' });
+
+const DEFAULT_INTERVAL_MS = 15 * 60 * 1000;
+const MAX_FACTS = 200;
+const CURSOR_SOURCE = 'shared_facts';
+
+export interface SharedFactRow {
+  id: string;
+  agentId: string;
+  content: string;
+  factType: string;
+  confidence: number;
+  tags: string[];
+  sourceRef?: Record<string, unknown> | null;
+  supersededBy?: string | null;
+  createdAt?: string;
+  sessionId?: string;
+}
+
+export interface ReconciledMemory {
+  content: string;
+  type: string;
+  sourceFactIds: string[];
+  confidence: number;
+}
+
+export interface Contradiction {
+  factIds: string[];
+  description: string;
+  resolution: string;
+}
+
+export interface ReconciliationResult {
+  canonicalFacts: ReconciledMemory[];
+  contradictions: Contradiction[];
+  duplicates: string[][];
+  summary: string;
+}
+
+export type SharedFactFetcher = (opts: {
+  sessionId?: string;
+  after?: { createdAt: string; id: string } | null;
+  limit: number;
+}) => Promise<SharedFactRow[]>;
+
+export type Layer3ReconcileFn = (facts: SharedFactRow[]) => Promise<ReconciliationResult>;
+
+export interface GraphReconcileDeps {
+  fetchFacts?: SharedFactFetcher;
+  reconcile?: Layer3ReconcileFn;
+  complete?: (prompt: string, userText: string) => Promise<string>;
+}
+
+export interface GraphReconcileResult {
+  hub: boolean;
+  fetched: number;
+  ingested: number;
+  skipped: number;
+  invalidatedEdges: number;
+  contradictions: number;
+  summary: string;
+  reason?: string;
+}
+
+function asSharedFactInput(row: SharedFactRow) {
+  return {
+    id: row.id,
+    agentId: row.agentId,
+    content: row.content,
+    factType: row.factType,
+    confidence: row.confidence,
+    tags: row.tags,
+    sourceRef: row.sourceRef,
+  };
+}
+
+/** Local copy of `@revealui/ai/memory` reconcileHeuristic (Layer 3 production path). */
+export function reconcileHeuristicLocal(facts: SharedFactRow[]): ReconciliationResult {
+  const seen = new Map<string, string[]>();
+  for (const fact of facts) {
+    const normalized = fact.content.toLowerCase().trim();
+    const existing = seen.get(normalized);
+    if (existing) existing.push(fact.id);
+    else seen.set(normalized, [fact.id]);
+  }
+  const canonicalFacts: ReconciledMemory[] = [];
+  const duplicates: string[][] = [];
+  for (const [, ids] of seen) {
+    if (ids.length > 1) duplicates.push(ids);
+    const sourceFact = facts.find((f) => f.id === ids[0]);
+    if (!sourceFact) continue;
+    const memoryType =
+      sourceFact.factType === 'bug' || sourceFact.factType === 'warning' ? 'warning' : 'fact';
+    canonicalFacts.push({
+      content: sourceFact.content,
+      type: memoryType,
+      sourceFactIds: ids,
+      confidence: sourceFact.confidence,
+    });
+  }
+  return {
+    canonicalFacts,
+    contradictions: [],
+    duplicates,
+    summary: `Reconciled ${facts.length} facts into ${canonicalFacts.length} canonical facts (${duplicates.length} duplicates).`,
+  };
+}
+
+async function layer3Reconcile(
+  facts: SharedFactRow[],
+  deps: GraphReconcileDeps,
+): Promise<ReconciliationResult> {
+  if (deps.reconcile) return deps.reconcile(facts);
+  if (deps.complete) {
+    try {
+      const mod = (await import('@revealui/ai/memory/services')) as {
+        buildReconciliationPrompt: (facts: ReturnType<typeof asSharedFactInput>[]) => string;
+        parseReconciliationResponse: (
+          response: string,
+          facts: ReturnType<typeof asSharedFactInput>[],
+        ) => ReconciliationResult;
+      };
+      const inputs = facts.map(asSharedFactInput);
+      const raw = await deps.complete(mod.buildReconciliationPrompt(inputs), '');
+      return mod.parseReconciliationResponse(raw, inputs);
+    } catch (err) {
+      log.warn('Layer-3 LLM reconcile fell back to heuristic', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  try {
+    const mod = (await import('@revealui/ai/memory/services')) as {
+      reconcileHeuristic: (facts: ReturnType<typeof asSharedFactInput>[]) => ReconciliationResult;
+    };
+    return mod.reconcileHeuristic(facts.map(asSharedFactInput));
+  } catch {
+    return reconcileHeuristicLocal(facts);
+  }
+}
+
+async function defaultFetchSharedFacts(opts: {
+  sessionId?: string;
+  after?: { createdAt: string; id: string } | null;
+  limit: number;
+}): Promise<SharedFactRow[]> {
+  const url = resolvePostgresUrl();
+  if (!url) return [];
+  const { createPool } = await import('@revealui/db/pool');
+  const pool = createPool({
+    connectionTimeoutMillis: 30_000,
+    queryTimeoutMillis: 60_000,
+    statementTimeoutMillis: 60_000,
+    max: 2,
+  });
+  const exec = makePoolExecutor(pool);
+  const params: unknown[] = [];
+  const where: string[] = [];
+  if (opts.sessionId) {
+    params.push(opts.sessionId);
+    where.push(`session_id = $${params.length}`);
+  }
+  if (opts.after?.createdAt) {
+    params.push(opts.after.createdAt, opts.after.id);
+    where.push(`(created_at, id) > ($${params.length - 1}::timestamptz, $${params.length})`);
+  }
+  params.push(opts.limit);
+  const sql = `SELECT id, agent_id, content, fact_type, confidence, tags, source_ref,
+                      superseded_by, created_at, session_id
+               FROM shared_facts
+               ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
+               ORDER BY created_at ASC, id ASC
+               LIMIT $${params.length}`;
+  const rows = await exec.query<{
+    id: string;
+    agent_id: string;
+    content: string;
+    fact_type: string;
+    confidence: number | string;
+    tags: unknown;
+    source_ref: unknown;
+    superseded_by: string | null;
+    created_at: string;
+    session_id: string;
+  }>(sql, params);
+  return rows.map((row) => ({
+    id: row.id,
+    agentId: row.agent_id,
+    content: row.content,
+    factType: row.fact_type,
+    confidence: typeof row.confidence === 'number' ? row.confidence : Number(row.confidence) || 1,
+    tags: Array.isArray(row.tags) ? row.tags.filter((t): t is string => typeof t === 'string') : [],
+    sourceRef:
+      row.source_ref && typeof row.source_ref === 'object' && !Array.isArray(row.source_ref)
+        ? (row.source_ref as Record<string, unknown>)
+        : null,
+    supersededBy: row.superseded_by,
+    createdAt: row.created_at,
+    sessionId: row.session_id,
+  }));
+}
+
+function kgExec(db: PGlite) {
+  return makeExecutor({
+    query: (text: string, params?: unknown[]) => db.query(text, params),
+  });
+}
+
+function episodeSource(factIds: string[]): string {
+  return `shared_facts:${[...factIds].sort().join('+')}`;
+}
+
+async function alreadyIngested(db: PGlite, source: string): Promise<boolean> {
+  const exec = kgExec(db);
+  const rows = await exec.query<{ n: number }>(
+    `SELECT count(*)::int AS n FROM kg_episodes WHERE source = $1`,
+    [source],
+  );
+  return (rows[0]?.n ?? 0) > 0;
+}
+
+export async function invalidateEdgesForEpisodeSource(
+  db: PGlite,
+  source: string,
+  invalidAt = new Date(),
+): Promise<number> {
+  const exec = kgExec(db);
+  const edges = await exec.query<{ id: string }>(
+    `SELECT g.id FROM kg_edges g
+     JOIN kg_edge_episodes ee ON ee.edge_id = g.id
+     JOIN kg_episodes e ON e.id = ee.episode_id
+     WHERE e.source = $1
+       AND (g.invalid_at IS NULL OR g.invalid_at > $2::timestamptz)`,
+    [source, invalidAt.toISOString()],
+  );
+  let invalidated = 0;
+  for (const edge of edges) {
+    await applyOp(
+      exec,
+      { t: 'invalidate', edgeId: edge.id, invalidAt: invalidAt.toISOString() },
+      { recordOutbox: true },
+    );
+    invalidated += 1;
+  }
+  return invalidated;
+}
+
+function conceptKey(content: string): string {
+  const slug = content
+    .toLowerCase()
+    .trim()
+    .slice(0, 80)
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+  return `shared-fact:${slug || 'untitled'}`;
+}
+
+export async function graphReconcile(
+  db: PGlite,
+  params: Record<string, unknown> = {},
+  deps: GraphReconcileDeps = {},
+): Promise<GraphReconcileResult> {
+  const siteId = await ensureGraphSiteId(db);
+  const sessionId = typeof params.sessionId === 'string' ? params.sessionId.trim() : undefined;
+  const limit =
+    typeof params.limit === 'number' ? Math.min(Math.max(1, params.limit), MAX_FACTS) : MAX_FACTS;
+  const fetchFacts = deps.fetchFacts ?? defaultFetchSharedFacts;
+  const hub = Boolean(resolvePostgresUrl()) || Boolean(deps.fetchFacts);
+
+  const cursorRows = await db.query<{ last_created_at: string | null; last_id: string | null }>(
+    `SELECT last_created_at, last_id FROM kg_reconcile_cursor WHERE source = $1`,
+    [CURSOR_SOURCE],
+  );
+  const after =
+    cursorRows.rows[0]?.last_created_at && cursorRows.rows[0]?.last_id
+      ? { createdAt: cursorRows.rows[0].last_created_at, id: cursorRows.rows[0].last_id }
+      : null;
+
+  let facts: SharedFactRow[] = [];
+  try {
+    facts = await fetchFacts({ sessionId, after, limit });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await db.query(
+      `INSERT INTO kg_reconcile_cursor (source, last_run_at, last_error)
+       VALUES ($1, now(), $2)
+       ON CONFLICT (source) DO UPDATE SET last_run_at = now(), last_error = EXCLUDED.last_error`,
+      [CURSOR_SOURCE, message],
+    );
+    return {
+      hub,
+      fetched: 0,
+      ingested: 0,
+      skipped: 0,
+      invalidatedEdges: 0,
+      contradictions: 0,
+      summary: '',
+      reason: message,
+    };
+  }
+
+  if (!hub && facts.length === 0) {
+    return {
+      hub: false,
+      fetched: 0,
+      ingested: 0,
+      skipped: 0,
+      invalidatedEdges: 0,
+      contradictions: 0,
+      summary: '',
+      reason: 'no POSTGRES_URL and no injected shared_facts source',
+    };
+  }
+
+  const superseded = facts.filter((f) => f.supersededBy);
+  const active = facts.filter((f) => !f.supersededBy);
+  let invalidatedEdges = 0;
+  for (const fact of superseded) {
+    invalidatedEdges += await invalidateEdgesForEpisodeSource(db, episodeSource([fact.id]));
+  }
+
+  const reconciled = active.length > 0 ? await layer3Reconcile(active, deps) : reconcileHeuristicLocal([]);
+  let ingested = 0;
+  let skipped = 0;
+
+  for (const canonical of reconciled.canonicalFacts) {
+    const source = episodeSource(canonical.sourceFactIds);
+    if (await alreadyIngested(db, source)) {
+      skipped += 1;
+      continue;
+    }
+    const name = canonical.content.slice(0, 80);
+    await ingestEpisode(
+      kgExec(db),
+      {
+        episode: {
+          episodeType: 'memory',
+          source,
+          siteId,
+          content: canonical.content,
+          contentRef: {
+            layer: 3,
+            type: canonical.type,
+            confidence: canonical.confidence,
+            factIds: canonical.sourceFactIds,
+          },
+          referenceTime: new Date(),
+        },
+        nodes: [
+          {
+            kind: 'concept',
+            name,
+            naturalKey: conceptKey(canonical.content),
+            summary: canonical.content,
+          },
+        ],
+        edges: [],
+      },
+      { recordOutbox: true },
+    );
+    ingested += 1;
+  }
+
+  const last = facts.at(-1);
+  await db.query(
+    `INSERT INTO kg_reconcile_cursor (source, last_created_at, last_id, last_run_at, last_error, ingested)
+     VALUES ($1, $2::timestamptz, $3, now(), NULL, $4)
+     ON CONFLICT (source) DO UPDATE SET
+       last_created_at = COALESCE(EXCLUDED.last_created_at, kg_reconcile_cursor.last_created_at),
+       last_id = COALESCE(EXCLUDED.last_id, kg_reconcile_cursor.last_id),
+       last_run_at = now(),
+       last_error = NULL,
+       ingested = kg_reconcile_cursor.ingested + EXCLUDED.ingested`,
+    [CURSOR_SOURCE, last?.createdAt ?? null, last?.id ?? null, ingested],
+  );
+
+  return {
+    hub,
+    fetched: facts.length,
+    ingested,
+    skipped,
+    invalidatedEdges,
+    contradictions: reconciled.contradictions.length,
+    summary: reconciled.summary,
+  };
+}
+
+let reconcileTimer: NodeJS.Timeout | null = null;
+
+export function reconcileIntervalMs(): number {
+  const raw = process.env.REVDEV_KG_RECONCILE_INTERVAL_MS?.trim();
+  if (raw === '0') return 0;
+  if (raw && /^\d+$/.test(raw)) return Number(raw);
+  return DEFAULT_INTERVAL_MS;
+}
+
+export function startReconcileLoop(db: PGlite, deps: GraphReconcileDeps = {}): void {
+  stopReconcileLoop();
+  const interval = reconcileIntervalMs();
+  if (interval <= 0) {
+    log.info('kg Layer-3 reconcile loop disabled (interval 0)');
+    return;
+  }
+  if (!resolvePostgresUrl() && !deps.fetchFacts) {
+    log.info('kg Layer-3 reconcile loop idle (no hub)');
+    return;
+  }
+  const firstDelay = Math.min(interval, 60_000);
+  const tick = () => {
+    void graphReconcile(db, {}, deps).catch((err) =>
+      log.warn('kg Layer-3 reconcile failed', { error: String(err) }),
+    );
+  };
+  setTimeout(tick, firstDelay).unref();
+  reconcileTimer = setInterval(tick, interval);
+  reconcileTimer.unref();
+  log.info('kg Layer-3 reconcile loop armed', { intervalMs: interval, firstDelayMs: firstDelay });
+}
+
+export function stopReconcileLoop(): void {
+  if (reconcileTimer) {
+    clearInterval(reconcileTimer);
+    reconcileTimer = null;
+  }
+}
+
+onDaemonStarted(async (db) => {
+  startReconcileLoop(db);
+});
+
+onDaemonStopping(() => {
+  stopReconcileLoop();
+});

--- a/packages/daemon/src/graph.ts
+++ b/packages/daemon/src/graph.ts
@@ -5,7 +5,7 @@
  * ingestEpisode run against PGlite. graph.outbox.push replays unpushed ops
  * to the Neon hub when POSTGRES_URL is set (class-1/2 merge, no extra CRDT
  * library). P5b: Electric down-sync + hub anti-entropy live in graph-sync.ts.
- * Communities and Layer-3 reconcile stay later P5 slices.
+ * P5 leftover: kg_communities + Layer-3 shared_facts reconcile.
  *
  * Extends `@revealui/knowledge-graph` (published 0.1.8; 0.1.9 pulls unpublished
  * `@revealui/ts-strada`). Do not fork DDL.
@@ -32,6 +32,8 @@ import {
 } from '@revealui/knowledge-graph';
 import { resolveNaturalKey } from '@revealui/knowledge-graph/ingest';
 import { createLogger } from '@revealui/utils/logger';
+import { graphCommunities } from './graph-communities.js';
+import { graphReconcile } from './graph-reconcile.js';
 import { ensureGraphSiteId, graphSyncPull } from './graph-sync.js';
 import { resolvePostgresUrl } from './neon.js';
 import { registerHandler } from './server.js';
@@ -106,6 +108,7 @@ export async function graphStatus(db: PGlite): Promise<{
       'kg_edge_episodes',
       'kg_node_aliases',
       'kg_outbox',
+      'kg_communities',
     ],
     nodes: nodes[0]?.n ?? 0,
     edges: edges[0]?.n ?? 0,
@@ -457,3 +460,7 @@ registerHandler('graph.addEpisode', async (params, db, ctx) =>
 registerHandler('graph.outbox.push', async (_params, db) => graphOutboxPush(db));
 
 registerHandler('graph.sync.pull', async (params, db) => graphSyncPull(db, params));
+
+registerHandler('graph.communities', async (params, db) => graphCommunities(db, params));
+
+registerHandler('graph.reconcile', async (params, db) => graphReconcile(db, params));

--- a/packages/daemon/src/license.ts
+++ b/packages/daemon/src/license.ts
@@ -146,7 +146,8 @@ const EXEMPT_METHODS = new Set([
   'graph.at',
   'graph.context',
   'graph.addEpisode',
-  // graph.sync.pull / graph.outbox.push contact the hub — Pro floor.
+  'graph.communities',
+  // graph.sync.pull / graph.outbox.push / graph.reconcile contact the hub — Pro floor.
 ]);
 
 /**

--- a/packages/daemon/src/migrations/0016-graph-communities.ts
+++ b/packages/daemon/src/migrations/0016-graph-communities.ts
@@ -1,0 +1,38 @@
+/**
+ * Migration 0016 — kg_communities + Layer-3 reconcile cursor (GAP-349 P5 leftover).
+ *
+ * Communities are class-3 derived state (never Electric-synced). Rows are
+ * invalidated, not deleted. The reconcile cursor remembers how far the
+ * shared_facts → kg_episodes loop has read.
+ */
+
+import type { Migration } from '../storage/migrate.js';
+
+export const MIGRATION_0016: Migration = {
+  version: 16,
+  name: 'graph-communities',
+  sql: `
+    CREATE TABLE IF NOT EXISTS kg_communities (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      summary TEXT,
+      node_ids JSONB NOT NULL DEFAULT '[]',
+      node_count INTEGER NOT NULL DEFAULT 0,
+      algorithm TEXT NOT NULL DEFAULT 'connected-components',
+      computed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      invalidated_at TIMESTAMPTZ
+    );
+    CREATE INDEX IF NOT EXISTS kg_communities_current_idx
+      ON kg_communities (computed_at DESC)
+      WHERE invalidated_at IS NULL;
+
+    CREATE TABLE IF NOT EXISTS kg_reconcile_cursor (
+      source TEXT PRIMARY KEY,
+      last_created_at TIMESTAMPTZ,
+      last_id TEXT,
+      last_run_at TIMESTAMPTZ,
+      last_error TEXT,
+      ingested INTEGER NOT NULL DEFAULT 0
+    );
+  `,
+};

--- a/packages/daemon/src/migrations/index.ts
+++ b/packages/daemon/src/migrations/index.ts
@@ -31,6 +31,7 @@ import { MIGRATION_0012 } from './0012-session-fidelity-snapshots.js';
 import { MIGRATION_0013 } from './0013-goals.js';
 import { MIGRATION_0014 } from './0014-knowledge-graph-replica.js';
 import { MIGRATION_0015 } from './0015-graph-sync-site.js';
+import { MIGRATION_0016 } from './0016-graph-communities.js';
 
 export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0001,
@@ -48,4 +49,5 @@ export const MIGRATIONS: readonly Migration[] = [
   MIGRATION_0013,
   MIGRATION_0014,
   MIGRATION_0015,
+  MIGRATION_0016,
 ];

--- a/packages/daemon/src/permission.ts
+++ b/packages/daemon/src/permission.ts
@@ -164,6 +164,8 @@ export const METHOD_ACTION_CLASS = new Map<string, ActionClass>([
   ['graph.addEpisode', 'routine'],
   ['graph.outbox.push', 'consequential'],
   ['graph.sync.pull', 'consequential'],
+  ['graph.communities', 'routine'],
+  ['graph.reconcile', 'consequential'],
   // Inner tools of skills.invoke (not standalone RPCs). Bash is a shell, so
   // critical: auto mode still requires approval (policy floor). Reads stay routine.
   ['skills.tool.Read', 'routine'],

--- a/packages/daemon/src/validation/schemas.ts
+++ b/packages/daemon/src/validation/schemas.ts
@@ -563,6 +563,20 @@ export const schemas: Record<string, z.ZodType> = {
       actorAgentId,
     })
     .passthrough(),
+  'graph.communities': z
+    .object({
+      refresh: z.boolean().optional(),
+      limit: z.number().int().min(1).max(200).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
+  'graph.reconcile': z
+    .object({
+      sessionId: z.string().max(MAX_NAME_LENGTH).optional(),
+      limit: z.number().int().min(1).max(200).optional(),
+      actorAgentId,
+    })
+    .passthrough(),
 
   // -- Health -----------------------------------------------------------------
   // Both handlers (`server.ts:registerHandler('harness.health', ...)` and

--- a/packages/protocol/src/methods.ts
+++ b/packages/protocol/src/methods.ts
@@ -183,4 +183,6 @@ export const RPC_METHODS = {
   'graph.addEpisode': 'graph.addEpisode',
   'graph.outbox.push': 'graph.outbox.push',
   'graph.sync.pull': 'graph.sync.pull',
+  'graph.communities': 'graph.communities',
+  'graph.reconcile': 'graph.reconcile',
 } as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Closes

Does **not** close GAP-349. Owner fleet scan (`revkg scan --fleet`) and 30-day PIT history are still required for full close.

## Summary

P5a (`revdev#428`) shipped the PGlite replica + `graph.*` RPC. P5b (`revdev#432`) shipped Electric down-sync + durable `graph_site`. This leftover slice adds the two pieces those PRs explicitly deferred:

- **`kg_communities`** — connected-component clusters on the current (non-invalidated) graph, LLM name/summary via `@revealui/ai` (injected completer in tests; template fallback if AI is missing). Class-3 derived: local only, not Electric-synced. Refresh **invalidates** prior rows; never deletes.
- **Layer-3 reconcile loop** — reads multi-agent-memory `shared_facts`, runs Layer 3 (`@revealui/ai/memory` `reconcileHeuristic`, optional LLM), and `ingestEpisode`s canonical facts with source `shared_facts:<ids>`. Superseded facts invalidate prior edges (invalidate-not-delete). Scheduled from `onDaemonStarted` (`REVDEV_KG_RECONCILE_INTERVAL_MS`, default 15m, `0` disables). No-op without hub or an injected source. Does not fire prod cron.

New RPC: `graph.communities` (free, local) and `graph.reconcile` (Pro floor — hub contact).

## Verified first (code-over-docs)

- P1–P4, MCP, skill, bridge `kg_*` already on `origin/test`.
- P5a = `#428`. P5b = `#432` (`611d62d`) already on `origin/test`. This PR stays off `graph-sync.ts` except importing `ensureGraphSiteId`.
- `@revealui/knowledge-graph` stays at published `0.1.8`. No `@revealui/ts-strada`. No `@anthropic-ai/sdk`.

## Still owner ops for GAP-349 close

- Owner `revkg scan --fleet` (and `--publish` when intended).
- 30-day PIT history / owner fleet scan verification.
- Do not promote `test` → `main` as part of this slice.

## Files touched

- `packages/daemon/src/graph-communities.ts` (new)
- `packages/daemon/src/graph-reconcile.ts` (new)
- `packages/daemon/src/migrations/0016-graph-communities.ts` (new)
- `packages/daemon/src/migrations/index.ts`
- `packages/daemon/src/graph.ts` (handler hooks + status table list)
- `packages/daemon/src/validation/schemas.ts`
- `packages/daemon/src/permission.ts`
- `packages/daemon/src/license.ts`
- `packages/protocol/src/methods.ts`
- `packages/daemon/src/__tests__/graph-communities.test.ts` (new)
- `packages/daemon/src/__tests__/graph-reconcile.test.ts` (new)
- `packages/daemon/src/__tests__/graph.test.ts` (schema v16)

## Test plan

- [x] `pnpm --filter @revdev/protocol build && pnpm --filter @revdev/daemon exec vitest run src/__tests__/graph-communities.test.ts src/__tests__/graph-reconcile.test.ts src/__tests__/graph.test.ts src/__tests__/rpc-contract.test.ts src/__tests__/permission.test.ts src/__tests__/graph-sync.test.ts src/__tests__/guard.test.ts` — 149 passed
- [x] `pnpm --filter @revdev/daemon typecheck`
- [x] biome on the new/changed TS files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62a1ef26-a699-42a1-974f-9781e50fc12e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62a1ef26-a699-42a1-974f-9781e50fc12e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

