### PR TITLE
Rename desktop app display name to RevDev

### DIFF
--- a/.github/workflows/studio-release.yml
+++ b/.github/workflows/studio-release.yml
@@ -112,7 +112,7 @@ jobs:
           tauriScript: pnpm tauri
           args: --target ${{ matrix.rust_target }}
           tagName: ${{ github.ref_name }}
-          releaseName: "RevealUI Studio ${{ github.ref_name }}"
+          releaseName: "RevDev ${{ github.ref_name }}"
           releaseBody: "See the [changelog](https://github.com/RevealUIStudio/revdev/blob/main/CHANGELOG.md) for details."
           releaseDraft: ${{ github.event_name == 'workflow_dispatch' && inputs.draft || false }}
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Changelog
 
-All notable changes to RevealUI Studio are documented in this file.
+All notable changes to RevDev are documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Dates are ISO 8601 (UTC).
 
 ## [Unreleased]
+
+### Changed
+
+- Desktop app display name is **RevDev** (was “RevealUI Studio”) so the native
+  app is not confused with the company (RevealUI Studio). Window title, tray,
+  Start Menu / NSIS / MSI DisplayName, `productName`, about, login, sidebar,
+  setup, and terminal chrome now say RevDev. Bundle identifier
+  `dev.revealui.studio` and updater endpoints are unchanged so 0.2.12 installs
+  can still update. No version bump, no GitHub Release, no OS signing.
 
 ## [0.2.12] — 2026-08-29
 

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -1,4 +1,4 @@
-# RevealUI Studio
+# RevDev
 
 > **Status:** Functional — connects to the harness daemon, 506 frontend tests passing. **Prebuilt binaries are published** on [GitHub Releases](https://github.com/RevealUIStudio/revdev/releases) (first release `studio-v0.1.0`, 2026-07-02; macOS · Linux · Windows). macOS builds are currently **unsigned / ad-hoc**, so Gatekeeper blocks the first launch — **right-click the app → Open** (or `System Settings → Privacy & Security → Open Anyway`) once to run it. In-app auto-update is **configured**. New `studio-v*` tags publish a `latest.json` feed to the `studio-latest` GitHub release. `releases.revealui.com` is still a 404 (owner DNS/Vercel alias); the GitHub feed is the fallback. macOS/Windows OS code-signing is still unsigned (GAP-273).
 >

--- a/apps/studio/build-windows.ps1
+++ b/apps/studio/build-windows.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-  Build RevealUI Studio (Tauri) for Windows and produce an NSIS installer.
+  Build RevDev (Tauri) for Windows and produce an NSIS installer.
 
 .DESCRIPTION
   Run this from Windows PowerShell in the repo root or apps/studio directory.
@@ -41,7 +41,7 @@ if (-not (Test-Path (Join-Path $studioDir 'src-tauri'))) {
 
 Write-Host ""
 Write-Host "╔══════════════════════════════════════════╗" -ForegroundColor Cyan
-Write-Host "║     RevealUI Studio — Windows Build      ║" -ForegroundColor Cyan
+Write-Host "║          RevDev — Windows Build          ║" -ForegroundColor Cyan
 Write-Host "╚══════════════════════════════════════════╝" -ForegroundColor Cyan
 Write-Host ""
 

--- a/apps/studio/index.html
+++ b/apps/studio/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>RevealUI Studio</title>
+    <title>RevDev</title>
   </head>
   <body class="bg-surface-0 text-fg font-sans antialiased">
     <div id="root"></div>

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.12"
 edition = "2021"
 license = "LicenseRef-RevealUI-Commercial"
 authors = ["RevealUI Studio <noreply@revealui.com>"]
-description = "RevealUI Studio — native AI experience: agent coordination hub, local inference management"
+description = "RevDev — native AI experience: agent coordination hub, local inference management"
 
 [lib]
 name = "studio_lib"

--- a/apps/studio/src-tauri/capabilities/default.json
+++ b/apps/studio/src-tauri/capabilities/default.json
@@ -1,6 +1,6 @@
 {
   "identifier": "default",
-  "description": "Default capabilities for RevealUI Studio",
+  "description": "Default capabilities for RevDev",
   "windows": ["main"],
   "permissions": [
     "core:default",

--- a/apps/studio/src-tauri/src/commands/deploy/email.rs
+++ b/apps/studio/src-tauri/src/commands/deploy/email.rs
@@ -58,10 +58,10 @@ pub async fn resend_send_test(api_key: String, to_email: String) -> Result<bool,
         .post("https://api.resend.com/emails")
         .bearer_auth(&api_key)
         .json(&serde_json::json!({
-            "from": "RevealUI Studio <noreply@resend.dev>",
+            "from": "RevDev <noreply@resend.dev>",
             "to": [to_email],
-            "subject": "RevealUI Studio — Email Test",
-            "text": "Your email configuration is working. This is a test from RevealUI Studio setup wizard."
+            "subject": "RevDev — Email Test",
+            "text": "Your email configuration is working. This is a test from the RevDev setup wizard."
         }))
         .send()
         .await?;
@@ -90,7 +90,7 @@ pub async fn smtp_send_test(
     };
 
     // Use the SMTP user as the "from" address — self-hosters won't have noreply@revealui.com
-    let from_addr = format!("RevealUI Studio <{}>", user);
+    let from_addr = format!("RevDev <{}>", user);
     let email = Message::builder()
         .from(
             from_addr
@@ -100,8 +100,8 @@ pub async fn smtp_send_test(
         .to(to_email
             .parse::<Mailbox>()
             .map_err(|e| StudioError::Other(format!("Invalid to address: {e}")))?)
-        .subject("RevealUI — SMTP Test")
-        .body("This is a test email from RevealUI Studio.".to_string())
+        .subject("RevDev — SMTP Test")
+        .body("This is a test email from RevDev.".to_string())
         .map_err(|e| StudioError::Other(format!("Build email: {e}")))?;
 
     let creds = Credentials::new(user, pass);
@@ -174,7 +174,7 @@ fn chrono_like_now() -> String {
 
 fn rfc2822_raw(from: &str, to: &str) -> Result<String, StudioError> {
     let message = format!(
-        "From: {from}\r\nTo: {to}\r\nSubject: RevealUI Studio email test\r\n\r\nYour Gmail configuration is working. This is a test from the RevealUI Studio deploy wizard.\r\n"
+        "From: {from}\r\nTo: {to}\r\nSubject: RevDev email test\r\n\r\nYour Gmail configuration is working. This is a test from the RevDev deploy wizard.\r\n"
     );
     use base64::Engine;
     Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(message.as_bytes()))

--- a/apps/studio/src-tauri/src/lib.rs
+++ b/apps/studio/src-tauri/src/lib.rs
@@ -206,7 +206,7 @@ pub fn run() {
             updater::install_update,
         ])
         .build(tauri::generate_context!())
-        .expect("error while running RevealUI Studio")
+        .expect("error while running RevDev")
         .run(|app, event| {
             if matches!(event, tauri::RunEvent::Exit) {
                 spawner::kill_all(app.state::<SpawnerState>().sessions.clone());

--- a/apps/studio/src-tauri/src/presentment.rs
+++ b/apps/studio/src-tauri/src/presentment.rs
@@ -87,7 +87,7 @@ pub fn present_main_window<R: tauri::Runtime>(app: &AppHandle<R>) -> Result<(), 
     };
 
     if cfg!(debug_assertions) {
-        let _ = win.set_title("RevealUI Studio (dev)");
+        let _ = win.set_title("RevDev (dev)");
     }
 
     let monitor =

--- a/apps/studio/src-tauri/src/tray.rs
+++ b/apps/studio/src-tauri/src/tray.rs
@@ -18,7 +18,7 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
 
     TrayIconBuilder::new()
         .icon(icon)
-        .tooltip("RevealUI Studio")
+        .tooltip("RevDev")
         .menu(&menu)
         // Right-click opens menu; left-click focuses the window.
         .show_menu_on_left_click(false)
@@ -56,7 +56,7 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
 }
 
 fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
-    let show = MenuItem::with_id(app, "show", "Show RevealUI Studio", true, None::<&str>)?;
+    let show = MenuItem::with_id(app, "show", "Show RevDev", true, None::<&str>)?;
     let launcher = MenuItem::with_id(
         app,
         "launcher",
@@ -69,7 +69,7 @@ fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     let unmount =
         MenuItem::with_id(app, "unmount", "Unmount Studio Drive", true, None::<&str>)?;
     let sep2 = PredefinedMenuItem::separator(app)?;
-    let quit = MenuItem::with_id(app, "quit", "Quit RevealUI Studio", true, None::<&str>)?;
+    let quit = MenuItem::with_id(app, "quit", "Quit RevDev", true, None::<&str>)?;
 
     Menu::with_items(
         app,

--- a/apps/studio/src-tauri/tauri.conf.json
+++ b/apps/studio/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
-  "productName": "RevealUI Studio",
+  "productName": "RevDev",
   "version": "0.2.12",
   "identifier": "dev.revealui.studio",
   "build": {
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "RevealUI Studio",
+        "title": "RevDev",
         "width": 1100,
         "height": 750,
         "center": true,

--- a/apps/studio/src/__tests__/components/LoginScreen.test.tsx
+++ b/apps/studio/src/__tests__/components/LoginScreen.test.tsx
@@ -49,7 +49,7 @@ describe('LoginScreen', () => {
   it('leads with local work, not a cloud login wall', () => {
     renderGate();
 
-    expect(screen.getByText('RevealUI Studio')).toBeInTheDocument();
+    expect(screen.getByText('RevDev')).toBeInTheDocument();
     expect(screen.getByText(/start locally without an account/)).toBeInTheDocument();
     expect(screen.getByText('Work on this machine')).toBeInTheDocument();
     expect(screen.getByText('Sign in with email')).toBeInTheDocument();

--- a/apps/studio/src/__tests__/components/SetupWizard.test.tsx
+++ b/apps/studio/src/__tests__/components/SetupWizard.test.tsx
@@ -55,9 +55,9 @@ describe('SetupWizard', () => {
     vi.mocked(daemonSetup).mockResolvedValue('ok');
   });
 
-  it('renders "Setup RevealUI Studio" title', () => {
+  it('renders "Setup RevDev" title', () => {
     renderWizard();
-    expect(screen.getByText('Setup RevealUI Studio')).toBeInTheDocument();
+    expect(screen.getByText('Setup RevDev')).toBeInTheDocument();
     expect(screen.getByText(/Agent Approvals live under Agent in the sidebar/)).toBeInTheDocument();
   });
 

--- a/apps/studio/src/__tests__/components/Sidebar.test.tsx
+++ b/apps/studio/src/__tests__/components/Sidebar.test.tsx
@@ -58,7 +58,7 @@ describe('Sidebar', () => {
   it('renders the brand name', () => {
     render(<Sidebar currentPage="dashboard" onNavigate={vi.fn()} />);
 
-    expect(screen.getByText('RevealUI Studio')).toBeInTheDocument();
+    expect(screen.getByText('RevDev')).toBeInTheDocument();
   });
 
   it('calls onNavigate when a nav item is clicked', () => {

--- a/apps/studio/src/__tests__/lib/terminal-sanitize.test.ts
+++ b/apps/studio/src/__tests__/lib/terminal-sanitize.test.ts
@@ -3,7 +3,7 @@ import { sanitizeTerminalLine } from '../../lib/terminal-sanitize';
 
 describe('sanitizeTerminalLine', () => {
   it('passes printable ASCII through unchanged', () => {
-    expect(sanitizeTerminalLine('RevealUI Studio Terminal')).toBe('RevealUI Studio Terminal');
+    expect(sanitizeTerminalLine('RevDev Terminal')).toBe('RevDev Terminal');
   });
 
   it('keeps \\t, \\n, \\r', () => {

--- a/apps/studio/src/components/auth/LoginScreen.tsx
+++ b/apps/studio/src/components/auth/LoginScreen.tsx
@@ -102,7 +102,7 @@ export default function LoginScreen() {
       <div className="flex h-screen w-screen items-center justify-center bg-surface-0">
         <div className="w-full max-w-md space-y-6 rounded-xl border border-edge bg-surface-1 p-8">
           <div className="text-center">
-            <h1 className="text-lg font-semibold text-fg">RevealUI Studio</h1>
+            <h1 className="text-lg font-semibold text-fg">RevDev</h1>
             <p className="mt-2 text-sm leading-relaxed text-fg-muted">
               Studio is the desktop app for the RevDev daemon on this machine. You can start locally
               without an account.
@@ -157,7 +157,7 @@ export default function LoginScreen() {
     <div className="flex h-screen w-screen items-center justify-center bg-surface-0">
       <div className="w-full max-w-sm space-y-6 rounded-xl border border-edge bg-surface-1 p-8">
         <div className="text-center">
-          <h1 className="text-lg font-semibold text-fg">RevealUI Studio</h1>
+          <h1 className="text-lg font-semibold text-fg">RevDev</h1>
           <p className="mt-1 text-sm text-fg-muted">
             {showOtp ? 'Enter the 6-digit code from your email' : 'Sign in to a RevealUI account'}
           </p>

--- a/apps/studio/src/components/layout/AppShell.tsx
+++ b/apps/studio/src/components/layout/AppShell.tsx
@@ -64,7 +64,7 @@ export default function AppShell({ currentPage, onNavigate, children, padless }:
             >
               <IconMenu size="md" />
             </Button>
-            <span className="text-sm font-semibold text-fg">RevealUI Studio</span>
+            <span className="text-sm font-semibold text-fg">RevDev</span>
           </div>
 
           <main className={`flex-1 ${padless ? 'overflow-hidden' : 'overflow-y-auto p-3 md:p-6'}`}>

--- a/apps/studio/src/components/layout/Sidebar.tsx
+++ b/apps/studio/src/components/layout/Sidebar.tsx
@@ -103,7 +103,7 @@ export default function Sidebar({ currentPage, onNavigate }: SidebarProps) {
     <aside className="flex h-full w-56 flex-col border-r border-edge bg-surface-1">
       <div className="flex items-center gap-2 border-b border-edge px-4 py-4">
         <RevealUIMark className="size-8 shrink-0 text-fg" title="RevealUI" />
-        <span className="text-sm font-semibold">RevealUI Studio</span>
+        <span className="text-sm font-semibold">RevDev</span>
       </div>
       <nav className="flex-1 space-y-1 overflow-y-auto px-2 py-3" aria-label="Studio">
         {NAV_GROUPS.map((group) => {

--- a/apps/studio/src/components/settings/SettingsPanel.tsx
+++ b/apps/studio/src/components/settings/SettingsPanel.tsx
@@ -179,6 +179,10 @@ export default function SettingsPanel() {
         <Card header={<h2 className="text-sm font-semibold text-fg">About</h2>}>
           <div className="flex flex-col gap-4">
             <div className="flex items-center justify-between">
+              <span className="text-sm text-fg-muted">App</span>
+              <span className="text-sm text-fg-muted">RevDev</span>
+            </div>
+            <div className="flex items-center justify-between">
               <span className="text-sm text-fg-muted">Version</span>
               <span className="text-sm text-fg-muted">{appVersion}</span>
             </div>

--- a/apps/studio/src/components/setup/SetupWizard.tsx
+++ b/apps/studio/src/components/setup/SetupWizard.tsx
@@ -64,7 +64,7 @@ export default function SetupWizard({ onComplete, onDismiss }: SetupWizardProps)
   return (
     <>
       <Modal
-        title="Setup RevealUI Studio"
+        title="Setup RevDev"
         open={true}
         onClose={handleSkip}
         maxWidth="lg"

--- a/apps/studio/src/components/terminal/TerminalPanel.tsx
+++ b/apps/studio/src/components/terminal/TerminalPanel.tsx
@@ -157,7 +157,7 @@ function SshTerminalPanel() {
                 onResize={handleTerminalResize}
                 terminalRef={terminalRef}
                 welcome={[
-                  '\x1b[1;33mRevealUI Studio Terminal\x1b[0m',
+                  '\x1b[1;33mRevDev Terminal\x1b[0m',
                   '\x1b[90mConnect to an SSH server using the form above.\x1b[0m',
                   '',
                 ]}

--- a/apps/studio/src/lib/auth-api.ts
+++ b/apps/studio/src/lib/auth-api.ts
@@ -66,7 +66,7 @@ function getDeviceId(): string {
 
 function getDeviceName(): string {
   const platform = navigator.platform || 'Unknown';
-  return `RevealUI Studio (${platform})`;
+  return `RevDev (${platform})`;
 }
 
 function endpoint(apiUrl: string, path: string): string {

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,6 +1,6 @@
-# Getting Started with RevDev Studio
+# Getting Started with RevDev
 
-RevDev Studio is a native desktop app for AI agent coordination. It connects to the RevDev Harness Daemon for multi-agent session management, file reservations, task coordination, and local inference.
+RevDev is a native desktop app for AI agent coordination. It connects to the RevDev Harness Daemon for multi-agent session management, file reservations, task coordination, and local inference.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-Common issues and fixes for RevDev Studio and the Harness Daemon.
+Common issues and fixes for RevDev and the Harness Daemon.
 
 ---
 
@@ -216,12 +216,12 @@ Look for `revdev_daemon_rpc_duration_seconds` histogram — if p99 > 1s, the dat
 
 ## macOS-Specific Issues
 
-### "RevealUI Studio is damaged and can't be opened"
+### "RevDev is damaged and can't be opened"
 
 The app needs to be notarized. If you downloaded from GitHub Releases and see this:
 
 ```bash
-xattr -cr /Applications/RevealUI\ Studio.app
+xattr -cr /Applications/RevDev.app
 ```
 
 ### Daemon doesn't start via launchd


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renames the native desktop app’s **user-visible** name from “RevealUI Studio” to **RevDev** so the product is not confused with the company (RevealUI Studio / REVEALUI STUDIO L.L.C.).

Targets `test` only. No release tag, no GitHub Release, no version bump, no OS signing (H7/H8 stay parked). RevDev is not listed for sale.

### What users will see as RevDev
- Window title (`tauri.conf.json` `productName` + window `title`, plus the WSL-dev title override)
- Start Menu / NSIS / MSI DisplayName (via Tauri `productName`)
- Tray tooltip and Show/Quit menu items
- Login, sidebar, mobile chrome, setup wizard, terminal banner
- Settings → About app name
- Deploy-wizard test email From/Subject/body that named this app
- Studio README heading, getting-started / Gatekeeper troubleshooting, changelog

### Left unchanged (on purpose)
- Bundle identifier `dev.revealui.studio`
- Updater endpoints and pubkey (so 0.2.12 installs can still update)
- Version `0.2.12` — do not retag `studio-v0.2.12`
- Cargo crate / binary `revealui-studio` (not user-visible; avoids a silent updater/binary-name break)
- npm package `studio` and all `@revealui/*` packages
- Company legal name, Cargo `authors`, git-identity mocks (`RevealUI Studio`)
- Circuit-R / RevealUI mark (not Faceted-R)
- Public catalog SKUs; no store/sales copy
- Repo name `RevealUIStudio/revdev`

Branch is `feat/rename-desktop-app-revdev-5415` because the repo `branch-naming-convention` ruleset rejects `cursor/**` (creation restricted to `feat/**`, `fix/**`, `chore/**`, …). Started from `origin/test`. Did not use `feat/studio-dogfood-p4`.

## Test plan
- [x] Frontend tests for login / sidebar / setup / terminal sanitize (and the rest of `src/__tests__/components`): 49 files, 381 passed
- [x] Confirm `tauri.conf.json` identifier `dev.revealui.studio` + updater endpoints unchanged
- [x] Confirm no version bump, no release tag, no OS-signing workflow changes beyond the future `releaseName` string
- [ ] Next Windows/macOS/Linux bundle (when owner builds) identifies as RevDev in window title and installer DisplayName

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3cd3be0-1490-420c-a197-dca568d85415?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3cd3be0-1490-420c-a197-dca568d85415&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

